### PR TITLE
Next - JSON support

### DIFF
--- a/bin/facter
+++ b/bin/facter
@@ -6,7 +6,7 @@
 #
 # = Usage
 #
-#   facter [-d|--debug] [-h|--help] [-p|--puppet] [-v|--version] [-y|--yaml] [fact] [fact] [...]
+#   facter [-d|--debug] [-h|--help] [-p|--puppet] [-v|--version] [-y|--yaml] [-j|--json] [fact] [fact] [...]
 #
 # = Description
 #
@@ -20,6 +20,9 @@
 #
 # yaml::
 #   Emit facts in YAML format.
+#
+# json::
+#   Emit facts in JSON format.
 #
 # puppet::
 #   Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.

--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -31,6 +31,18 @@ module Facter
         exit(0)
       end
 
+      # Print the facts as JSON and exit
+      if options[:json]
+        begin
+          require 'json'
+          puts JSON.dump(facts)
+          exit(0)
+        rescue LoadError
+          $stderr.puts "You do not have JSON support in your version of Ruby. JSON output disabled"
+          exit(1)
+        end
+      end
+
       # Print the value of a single fact, otherwise print a list sorted by fact
       # name and separated by "=>"
       if facts.length == 1
@@ -58,6 +70,7 @@ module Facter
       options = {}
       OptionParser.new do |opts|
         opts.on("-y", "--yaml")   { |v| options[:yaml]   = v }
+        opts.on("-j", "--json")   { |v| options[:json]   = v }
         opts.on(      "--trace")  { |v| options[:trace]  = v }
         opts.on("-d", "--debug")  { |v| Facter.debugging(1) }
         opts.on("-t", "--timing") { |v| Facter.timing(1) }


### PR DESCRIPTION
Here's the same change applied to Next.

Ran into a weird issue. I'm not sure if it's RVM related. I'm now getting a LoadError with the new application.rb layout in mri 1.8.7 and the json gem. The native json in 1.9.1 works fine. 1.9.2 throws some deprecation warnings and an Undef error for vlans but those are outside of my change. They happen in YAML output as well.

Any idea on the LoadError in 1.8.7?
