### PR TITLE
Fix up ec2 facts on centos

### DIFF
--- a/lib/facter/arp.rb
+++ b/lib/facter/arp.rb
@@ -8,7 +8,7 @@ Facter.add(:arp) do
       arp = ""
       output.each_line do |s|
         if s =~ /^\S+\s\S+\s\S+\s(\S+)\s\S+\s\S+\s\S+$/
-          arp = $1
+          arp = $1.downcase
           break # stops on the first match
         end
       end


### PR DESCRIPTION
CentOS 5.4 arp gives the arp output as uppercase; downcase it so we're ensured a match
