### PR TITLE
added OS support for Amazon Linux

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -73,6 +73,8 @@ Facter.add(:operatingsystem) do
             "Slamd64"
         elsif FileTest.exists?("/etc/slackware-version")
             "Slackware"
+        elsif Facter.value(:lsbdistdescription) =~ /Amazon Linux/
+            "Amazon"
         end
     end
 end

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -9,6 +9,7 @@
 #   On Suse, derivatives, parses '/etc/SuSE-release' for a selection of version
 #   information.
 #   On Slackware, parses '/etc/slackware-version'.
+#   On Amazon Linux, returns the 'lsbdistrelease' value.
 #   
 #   On all remaining systems, returns the 'kernelrelease' value.
 #
@@ -120,6 +121,11 @@ Facter.add(:operatingsystemrelease) do
             "unknown"
         end
     end
+end
+
+Facter.add(:operatingsystemrelease) do
+    confine :operatingsystem => %W{Amazon}
+    setcode do Facter[:lsbdistrelease].value end
 end
 
 Facter.add(:operatingsystemrelease) do


### PR DESCRIPTION
Updated operatingsystem and operatingsystemrelease facts to support Amazon Linux. I called it "Amazon" even though it's a CentOS derivative (and is binary compatible with CentOS 5) as some package names at least do differ from CentOS. 
