### PR TITLE
Add support for Mageia to operatingsystem.rb and operatingsystemrelease.rb

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -29,6 +29,8 @@ Facter.add(:operatingsystem) do
             "Gentoo"
         elsif FileTest.exists?("/etc/fedora-release")
             "Fedora"
+        elsif FileTest.exists?("/etc/mageia-release")
+            "Mageia"
         elsif FileTest.exists?("/etc/mandriva-release")
             "Mandriva"
         elsif FileTest.exists?("/etc/mandrake-release")

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -9,6 +9,7 @@
 #   On Suse, derivatives, parses '/etc/SuSE-release' for a selection of version
 #   information.
 #   On Slackware, parses '/etc/slackware-version'.
+#   On Mageia, parses '/etc/mageia-release' for the release version.
 #   
 #   On all remaining systems, returns the 'kernelrelease' value.
 #
@@ -83,6 +84,16 @@ Facter.add(:operatingsystemrelease) do
     setcode do
         release = Facter::Util::Resolution.exec('cat /etc/slackware-version')
         if release =~ /Slackware ([0-9.]+)/
+            $1
+        end
+    end
+end
+
+Facter.add(:operatingsystemrelease) do
+    confine :operatingsystem => %w{Mageia}
+    setcode do
+        release = Facter::Util::Resolution.exec('cat /etc/mageia-release')
+        if release =~ /Mageia release ([0-9.]+)/
             $1
         end
     end


### PR DESCRIPTION
This commit adds support for Mageia to operatingsystem.rb and operatingsystemrelease.rb.

Mageia is a new Linux distribution, with a first version released in June 2011 :
http://www.mageia.org/en/
