### PR TITLE
Fix #2766 - silence unknown sysctl values

### DIFF
--- a/lib/facter/util/manufacturer.rb
+++ b/lib/facter/util/manufacturer.rb
@@ -55,7 +55,7 @@ module Facter::Manufacturer
             Facter.add(facterkey) do
                 confine :kernel => :openbsd
                 setcode do
-                    Facter::Util::Resolution.exec("sysctl -n " + sysctlkey)
+                    Facter::Util::Resolution.exec("sysctl -n #{sysctlkey} 2>/dev/null")
                 end
             end
         end


### PR DESCRIPTION
On certain hardware models it is possible that some sysctl values
we are looking for are not present. The error messages about the
missing values were printed to stderr and hence were visible to
the user. These messages should not be visible, so we redirect
stderr to /dev/null.

This is another attempt to fix #2766 - tests are missing because there are no tests for that part, afaics.
