### PR TITLE
(maint) Remove global var from domain and hostname

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -23,13 +23,13 @@ Facter.add(:domain) do
         # Get the domain from various sources; the order of these
         # steps is important
 
-        Facter.value(:hostname)
-        next $domain if defined? $domain and ! $domain.nil?
-
-        domain = Facter::Util::Resolution.exec('dnsdomainname')
-        next domain if domain =~ /.+\..+/
-
-        if FileTest.exists?("/etc/resolv.conf")
+        if name = Facter::Util::Resolution.exec('hostname')
+          if name =~ /.*?\.(.+$)/
+            $1
+          end
+        elsif domain = Facter::Util::Resolution.exec('dnsdomainname')
+          domain if domain =~ /.+\..+/
+        elsif FileTest.exists?("/etc/resolv.conf")
             domain = nil
             search = nil
             File.open("/etc/resolv.conf") { |file|
@@ -44,7 +44,6 @@ Facter.add(:domain) do
             next domain if domain
             next search if search
         end
-        nil
     end
 end
 

--- a/lib/facter/hostname.rb
+++ b/lib/facter/hostname.rb
@@ -14,25 +14,20 @@
 Facter.add(:hostname, :ldapname => "cn") do
     setcode do
         hostname = nil
-        name = Facter::Util::Resolution.exec('hostname') or nil
-        if name
-            if name =~ /^([\w-]+)\.(.+)$/
+        if name = Facter::Util::Resolution.exec('hostname')
+            if name =~ /(.*?)\./
                 hostname = $1
-                # the Domain class uses this
-                $domain = $2
             else
                 hostname = name
             end
-            hostname
-        else
-            nil
         end
+        hostname
     end
 end
 
 Facter.add(:hostname) do
     confine :kernel => :darwin, :kernelrelease => "R7"
     setcode do
-        %x{/usr/sbin/scutil --get LocalHostName}
+        Facter::Util::Resolution.exec('/usr/sbin/scutil --get LocalHostName')
     end
 end

--- a/spec/unit/domain_spec.rb
+++ b/spec/unit/domain_spec.rb
@@ -1,0 +1,73 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe "Domain name facts" do
+
+  describe "on linux" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+    end
+
+    it "should use the hostname binary" do
+      Facter::Util::Resolution.expects(:exec).with("hostname").returns "test.example.com"
+      Facter.fact(:domain).value.should == "example.com"
+    end
+
+    it "should fall back to the dnsdomainname binary" do
+      Facter::Util::Resolution.stubs(:exec).with("hostname")
+      Facter::Util::Resolution.expects(:exec).with("dnsdomainname").returns("example.com")
+      Facter.fact(:domain).value.should == "example.com"
+    end
+
+
+    it "should fall back to /etc/resolv.conf" do
+      Facter::Util::Resolution.stubs(:exec).with("hostname").at_least_once
+      Facter::Util::Resolution.stubs(:exec).with("dnsdomainname").at_least_once
+      File.expects(:open).with('/etc/resolv.conf').at_least_once
+      Facter.fact(:domain).value
+    end
+
+    it "should attempt to resolve facts in a specific order" do
+      seq = sequence('domain')
+      Facter::Util::Resolution.stubs(:exec).with("hostname").in_sequence(seq).at_least_once
+      Facter::Util::Resolution.stubs(:exec).with("dnsdomainname").in_sequence(seq).at_least_once
+      File.expects(:open).with('/etc/resolv.conf').in_sequence(seq).at_least_once
+      Facter.fact(:domain).value
+    end
+
+    describe "when using /etc/resolv.conf" do
+      before do
+        Facter::Util::Resolution.stubs(:exec).with("hostname")
+        Facter::Util::Resolution.stubs(:exec).with("dnsdomainname")
+        @mock_file = mock()
+        File.stubs(:open).with("/etc/resolv.conf").yields(@mock_file)
+      end
+
+      it "should use the domain field over the search field" do
+        lines = [
+          "nameserver 4.2.2.1",
+          "search example.org",
+          "domain example.com",
+        ]
+        @mock_file.expects(:each).multiple_yields(*lines)
+        Facter.fact(:domain).value.should == 'example.com'
+      end
+
+      it "should fall back to the search field" do
+        lines = [
+          "nameserver 4.2.2.1",
+          "search example.org",
+        ]
+        @mock_file.expects(:each).multiple_yields(*lines)
+        Facter.fact(:domain).value.should == 'example.org'
+      end
+
+      it "should use the first domain in the search field" do
+        lines = [
+          "search example.org example.net",
+        ]
+        @f.expects(:each).multiple_yields(*lines)
+        Facter.fact(:domain).value.should == 'example.org'
+      end
+    end
+  end
+end

--- a/spec/unit/hostname_spec.rb
+++ b/spec/unit/hostname_spec.rb
@@ -1,0 +1,38 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe "Hostname facts" do
+
+  describe "on linux" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:kernelrelease).stubs(:value).returns("2.6")
+    end
+
+    it "should use the hostname command" do
+      Facter::Util::Resolution.expects(:exec).with('hostname').at_least_once
+      Facter.fact(:hostname).value.should be_nil
+    end
+
+    it "should use hostname as the fact if unqualified" do
+      Facter::Util::Resolution.stubs(:exec).with('hostname').returns('host1')
+      Facter.fact(:hostname).value.should == "host1"
+    end
+
+    it "should truncate the domain name if qualified" do
+      Facter::Util::Resolution.stubs(:exec).with('hostname').returns('host1.example.com')
+      Facter.fact(:hostname).value.should == "host1"
+    end
+  end
+
+  describe "on darwin release R7" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter.fact(:kernelrelease).stubs(:value).returns("R7")
+    end
+
+    it "should use scutil to get the hostname" do
+      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/scutil --get LocalHostName').returns("host1")
+      Facter.fact(:hostname).value.should == "host1"
+    end
+  end
+end


### PR DESCRIPTION
The hostname and domain facts were tightly coupled because the hostname
fact was setting a global variable that the domain fact was using.
Removed the logic from the hostname fact that was setting the global
variable and moved it into the domain fact.

Added tests to verify the behavior of the hostname facts and the domain
facts.
