### PR TITLE
Ticket/master/8240 correct domain resolv conf regex

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -34,9 +34,9 @@ Facter.add(:domain) do
             search = nil
             File.open("/etc/resolv.conf") { |file|
                 file.each { |line|
-                    if line =~ /domain\s+(\S+)/
+                    if line =~ /^\s*domain\s+(\S+)/
                         domain = $1
-                    elsif line =~ /search\s+(\S+)/
+                    elsif line =~ /^\s*search\s+(\S+)/
                         search = $1
                     end
                 }

--- a/spec/unit/domain_spec.rb
+++ b/spec/unit/domain_spec.rb
@@ -69,6 +69,29 @@ describe "Domain name facts" do
         @mock_file.expects(:each).multiple_yields(*lines)
         Facter.fact(:domain).value.should == 'example.org'
       end
+
+      # Test permutations of domain and search
+      [
+        ["domain domain", "domain"],
+        ["domain search", "search"],
+        ["search domain", "domain"],
+        ["search search", "search"],
+        ["search domain notdomain", "domain"],
+        [["#search notdomain","search search"], "search"],
+        [["# search notdomain","search search"], "search"],
+        [["#domain notdomain","domain domain"], "domain"],
+        [["# domain notdomain","domain domain"], "domain"],
+      ].each do |tuple|
+        field  = tuple[0]
+        expect = tuple[1]
+        it "should return #{expect} from \"#{field}\"" do
+          lines = [
+            field
+          ].flatten
+          @mock_file.expects(:each).multiple_yields(*lines)
+          Facter.fact(:domain).value.should == expect
+        end
+      end
     end
   end
 


### PR DESCRIPTION
If given a search field of "search domain invalid", "invalid" would be
returned as the domain, when it should have been domain, due to
incorrect line anchoring. Added tests and corrected the regexes.

This branch is based on https://github.com/adrienthebo/facter/tree/maint/master/remove_domain_global_variable
