### PR TITLE
(#8491) Fixed repeated loading of files

### DIFF
--- a/lib/facter/util/loader.rb
+++ b/lib/facter/util/loader.rb
@@ -2,6 +2,11 @@ require 'facter'
 
 # Load facts on demand.
 class Facter::Util::Loader
+
+    def initialize
+      @loaded = []
+    end
+
     # Load all resolutions for a single fact.
     def load(fact)
         # Now load from the search path
@@ -68,10 +73,16 @@ class Facter::Util::Loader
     end
 
     def load_file(file)
+        return if @loaded.include? file
         # We have to specify Kernel.load, because we have a load method.
         begin
+            # Store the file path so we don't try to reload it
+            @loaded << file
             Kernel.load(file)
         rescue ScriptError => detail
+            # Don't store the path if the file can't be loaded
+            # in case it's loadable later on.
+            @loaded.delete(file)
             warn "Error loading fact #{file} #{detail}"
         end
     end

--- a/spec/fixtures/unit/util/loader/nosuchfact.rb
+++ b/spec/fixtures/unit/util/loader/nosuchfact.rb
@@ -1,0 +1,1 @@
+Facter.value(:nosuchfact)

--- a/spec/unit/util/loader_spec.rb
+++ b/spec/unit/util/loader_spec.rb
@@ -280,4 +280,12 @@ describe Facter::Util::Loader do
             @loader.load_all
         end
     end
+
+    it "should load facts on the facter search path only once" do
+        facterlibdir = File.expand_path(File.dirname(__FILE__) + '../../../fixtures/unit/util/loader')
+        with_env 'FACTERLIB' => facterlibdir do
+            Facter::Util::Loader.new.load_all
+            Facter.value(:nosuchfact).should be_nil
+        end
+    end
 end


### PR DESCRIPTION
If a fact file referenced an unresolvable fact, or a fact that would be
later in the search path than the fact file, facter would attempt to
load and resolve that fact first and recurse into the same file.

The loader now stores the path of every file it has attempted to load,
and before loading a new file it will ensure that the file has not been
loaded before.
