### PR TITLE
Identify OracleLinux properly

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -22,6 +22,8 @@ Facter.add(:operatingsystem) do
             "Mandrake"
         elsif FileTest.exists?("/etc/arch-release")
             "Archlinux"
+        elsif FileTest.exists?("/etc/oracle-release")
+            "OracleLinux"
         elsif FileTest.exists?("/etc/enterprise-release")
             if FileTest.exists?("/etc/ovs-release")
                 "OVS"

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -27,6 +27,18 @@ Facter.add(:operatingsystemrelease) do
 end
 
 Facter.add(:operatingsystemrelease) do
+    confine :operatingsystem => :OracleLinux
+    setcode do
+        File::open("/etc/oracle-release", "r") do |f|
+            line = f.readline.chomp
+            if line =~ /release (\d+)/
+                $1
+            end
+        end
+    end
+end
+
+Facter.add(:operatingsystemrelease) do
     confine :operatingsystem => :oel
     setcode do
         File::open("/etc/enterprise-release", "r") do |f|


### PR DESCRIPTION
This change adds the ability for facter to identify Oracle Linux 5
Update 6 and Oracle Linux 6 and higher as "OracleLinux"
