### PR TITLE
(#9183) Add support for Alpine linux detection

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -73,6 +73,8 @@ Facter.add(:operatingsystem) do
             "Slamd64"
         elsif FileTest.exists?("/etc/slackware-version")
             "Slackware"
+        elsif FileTest.exists?("/etc/alpine-release")
+            "Alpine"
         end
     end
 end

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -123,5 +123,12 @@ Facter.add(:operatingsystemrelease) do
 end
 
 Facter.add(:operatingsystemrelease) do
+  confine :operatingsystem => :Alpine
+  setcode do
+    File.read('/etc/alpine-release')
+  end
+end
+
+Facter.add(:operatingsystemrelease) do
     setcode do Facter[:kernelrelease].value end
 end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -52,4 +52,14 @@ describe "Operating System fact" do
 
         Facter.fact(:operatingsystem).value.should == "VMWareESX"
     end
+
+    it "should identify Alpine Linux" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      
+      FileTest.stubs(:exists?).returns false
+      
+      FileTest.expects(:exists?).with("/etc/alpine-release").returns true
+
+      Facter.fact(:operatingsystem).value.should == "Alpine"
+    end
 end

--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -46,4 +46,13 @@ describe "Operating System Release fact" do
 
         Facter.fact(:operatingsystemrelease).value
     end
+
+    it "for Alpine it should use the contents of /etc/alpine-release" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        Facter.fact(:operatingsystem).stubs(:value).returns("Alpine")
+
+        File.expects(:read).with("/etc/alpine-release").returns("foo")
+
+        Facter.fact(:operatingsystemrelease).value.should == "foo"
+    end
 end


### PR DESCRIPTION
Adds support for Alpine Linux operatingsystem and operatingsystemrelease
facts, by relying on the presence and contents of /etc/alpine-release.

Thanks to Jon Auer for this patch.

Signed-off-by: Adrien Thebo adrien@puppetlabs.com
