### PR TITLE
Ticket/master/7957 fix is virtual fact on openvz host node

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -158,7 +158,7 @@ Facter.add("is_virtual") do
     confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD}
 
     setcode do
-        physical_types = %w{physical xen0 vmware_server}
+        physical_types = %w{physical xen0 vmware_server openvzhn}
 
         if physical_types.include? Facter.value(:virtual)
             "false"

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -182,7 +182,7 @@ describe "is_virtual fact" do
         Facter.fact(:is_virtual).value.should == "true"
     end
 
-    it "should be true when running on openvz" do
+    it "should be true when running on openvzve" do
         Facter.fact(:kernel).stubs(:value).returns("Linux")
         Facter.fact(:virtual).stubs(:value).returns("openvzve")
         Facter.fact(:is_virtual).value.should == "true"
@@ -227,6 +227,11 @@ describe "is_virtual fact" do
 
     it "should be false on vmware_server" do
         Facter.fact(:virtual).stubs(:value).returns("vmware_server")
+        Facter.fact(:is_virtual).value.should == "false"
+    end
+
+    it "should be false on openvz host nodes" do
+        Facter.fact(:virtual).stubs(:value).returns("openvzhn")
         Facter.fact(:is_virtual).value.should == "false"
     end
 end


### PR DESCRIPTION
Added openvzhn as a recognized non-virtual value for the is_virtual fact. Patch is based on branch https://github.com/adrienthebo/facter/commits/ticket/master/9059-fix_is_virtual_fact_on_vmware_server in pull request https://github.com/puppetlabs/facter/pull/34
