### PR TITLE
(maint) Add kernel stubbing for is_virtual fact spec

### DIFF
--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -226,11 +226,13 @@ describe "is_virtual fact" do
     end
 
     it "should be false on vmware_server" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
         Facter.fact(:virtual).stubs(:value).returns("vmware_server")
         Facter.fact(:is_virtual).value.should == "false"
     end
 
     it "should be false on openvz host nodes" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
         Facter.fact(:virtual).stubs(:value).returns("openvzhn")
         Facter.fact(:is_virtual).value.should == "false"
     end


### PR DESCRIPTION
The kernel fact needs to be stubbed out since the virtual fact does not
yet support windows.
