### PR TITLE
Add Scientific Linux CERN detection to facter. Fixes #9260

### DIFF
--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -12,5 +12,5 @@
 
 Facter.add(:hardwareisa) do
     setcode 'uname -p'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD OEL OVS GNU/kFreeBSD}
 end

--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -15,7 +15,7 @@
 require 'facter'
 
 Facter.add("lsbmajdistrelease") do
-    confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SuSE SLES Debian Ubuntu Gentoo OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OVS GNU/kFreeBSD}
     setcode do
         if /(\d*)\./i =~ Facter.value(:lsbdistrelease)
             result=$1

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -10,7 +10,7 @@
 require 'facter/util/macaddress'
 
 Facter.add(:macaddress) do
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SuSE SLES Debian Gentoo Ubuntu OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OVS GNU/kFreeBSD}
     setcode do
         ether = []
         output = %x{/sbin/ifconfig -a}

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -51,6 +51,8 @@ Facter.add(:operatingsystem) do
             txt = File.read("/etc/redhat-release")
             if txt =~ /centos/i
                 "CentOS"
+            elsif txt =~ /CERN/
+                "SLC"
             elsif txt =~ /scientific/i 
                 "Scientific"
             else

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -16,10 +16,10 @@
 #
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{CentOS Fedora oel ovs RedHat MeeGo Scientific}
+    confine :operatingsystem => %w{CentOS Fedora oel ovs RedHat MeeGo Scientific SLC}
     setcode do
         case Facter.value(:operatingsystem)
-        when "CentOS", "RedHat", "Scientific"
+        when "CentOS", "RedHat", "Scientific", "SLC"
             releasefile = "/etc/redhat-release"
         when "Fedora"
             releasefile = "/etc/fedora-release"

--- a/lib/facter/uniqueid.rb
+++ b/lib/facter/uniqueid.rb
@@ -1,4 +1,4 @@
 Facter.add(:uniqueid) do
     setcode 'hostid'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SuSE SLES Debian Ubuntu Gentoo AIX OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OVS GNU/kFreeBSD}
 end


### PR DESCRIPTION
Hi -- patch to close #9260 

have gone for the commonly used 'SLC' as a one-word description of Scientific Linux CERN and added it to the various constraint parts. 
