### PR TITLE
(#6728) Facter improperly detects openvzve on CloudLinux systems

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -1,15 +1,26 @@
 module Facter::Util::Virtual
     def self.openvz?
-        FileTest.directory?("/proc/vz")
+        FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
     end
 
+    # So one can either have #6728 work on OpenVZ or Cloudlinux. Whoo.
     def self.openvz_type
-        return nil unless self.openvz?
-        if FileTest.exists?("/proc/vz/version")
-            result = "openvzhn"
-        else
-            result = "openvzve"
-        end
+      return false unless self.openvz?
+      return false unless FileTest.exists?( '/proc/self/status' )
+
+      envid = Facter::Util::Resolution.exec( 'grep "envID" /proc/self/status' )
+      if envid =~ /^envID:\s+0$/i
+        return 'openvzhn'
+      elsif envid =~ /^envID:\s+(\d+)$/i
+        return 'openvzve'
+      else
+        return 'unknown'
+      end
+    end
+
+    # Cloudlinux uses OpenVZ to a degree, but always has an empty /proc/vz/
+    def self.openvz_cloudlinux?
+      Dir.glob( '/proc/vz/*' ).empty?
     end
 
     def self.zone?

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -9,19 +9,35 @@ describe Facter::Util::Virtual do
     end
     it "should detect openvz" do
         FileTest.stubs(:directory?).with("/proc/vz").returns(true)
+        Dir.stubs(:glob).with("/proc/vz/*").returns(['vzquota'])
         Facter::Util::Virtual.should be_openvz
     end
 
-    it "should identify openvzhn when version file exists" do
+    it "should not detect openvz when /proc/vz/ is empty" do
+        FileTest.stubs(:directory?).with("/proc/vz").returns(true)
+        Dir.stubs(:glob).with("/proc/vz/*").returns([])
+        Facter::Util::Virtual.should_not be_openvz
+    end
+
+    it "should identify openvzhn when /proc/self/status has envID of 0" do
         Facter::Util::Virtual.stubs(:openvz?).returns(true)
-        FileTest.stubs(:exists?).with("/proc/vz/version").returns(true)
+        FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  0")
         Facter::Util::Virtual.openvz_type().should == "openvzhn"
     end
 
-    it "should identify openvzve when no version file exists" do
+    it "should identify openvzve when /proc/self/status has envID of 0" do
         Facter::Util::Virtual.stubs(:openvz?).returns(true)
-        FileTest.stubs(:exists?).with("/proc/vz/version").returns(false)
+        FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  666")
         Facter::Util::Virtual.openvz_type().should == "openvzve"
+    end
+
+    it "should identify unknown when /proc/self/status has no envID" do
+        Facter::Util::Virtual.stubs(:openvz?).returns(true)
+        FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("")
+        Facter::Util::Virtual.openvz_type().should == "unknown"
     end
 
     it "should identify Solaris zones when non-global zone" do


### PR DESCRIPTION
Update the OpenVZ fact to be slightly more resilient in it's checking of
OpenVZ, so it doesn't clash with CloudLinux's LVE container system.

It checks if /proc/vz/ actually has anything in it, which if it doesn't,
is Cloudlinux. Uses the better OpenVZ detection methodology from #2242,
which is reading /proc/self/status for the envID which OpenVZ uses.
