### PR TITLE
(#4228) Ensure MAC address octets have leading zeroes.

### DIFF
--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -13,11 +13,11 @@ Facter.add(:macaddress) do
     confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OVS GNU/kFreeBSD}
     setcode do
         ether = []
-        output = %x{/sbin/ifconfig -a}
+        output = Facter::Util::Resolution.exec("/sbin/ifconfig -a")
         output.each_line do |s|
             ether.push($1) if s =~ /(?:ether|HWaddr) (\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/
         end
-        ether[0]
+        Facter::Util::Macaddress.standardize(ether[0])
     end
 end
 
@@ -29,7 +29,7 @@ Facter.add(:macaddress) do
         output.each_line do |s|
             ether.push($1) if s =~ /(?:SPLA)\s+(\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2})/
         end
-        ether[0]
+        Facter::Util::Macaddress.standardize(ether[0])
     end
 end
 
@@ -37,13 +37,13 @@ Facter.add(:macaddress) do
     confine :operatingsystem => %w{FreeBSD OpenBSD}
     setcode do
     ether = []
-        output = %x{/sbin/ifconfig}
+        output = Facter::Util::Resolution.exec("/sbin/ifconfig")
         output.each_line do |s|
             if s =~ /(?:ether|lladdr)\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
                 ether.push($1)
             end
         end
-        ether[0]
+        Facter::Util::Macaddress.standardize(ether[0])
     end
 end
 
@@ -71,7 +71,7 @@ Facter.add(:macaddress) do
                 end
             end
         end
-        ether[0]
+        Facter::Util::Macaddress.standardize(ether[0])
     end
 end
 

--- a/lib/facter/util/macaddress.rb
+++ b/lib/facter/util/macaddress.rb
@@ -2,6 +2,10 @@
 #
 module Facter::Util::Macaddress
 
+  def self.standardize(macaddress)
+    macaddress.split(":").map{|x| "0#{x}"[-2..-1]}.join(":")
+  end
+
   module Darwin
     def self.macaddress
       iface = default_interface

--- a/spec/unit/macaddress_spec.rb
+++ b/spec/unit/macaddress_spec.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+$basedir = File.expand_path(File.dirname(__FILE__) + '/..')
+require File.join($basedir, 'spec_helper')
+
+require 'facter'
+
+def ifconfig_fixture(filename)
+  ifconfig = File.new(File.join($basedir, 'fixtures', 'ifconfig', filename)).read
+end
+
+def netsh_fixture(filename)
+  ifconfig = File.new(File.join($basedir, 'fixtures', 'netsh', filename)).read
+end
+
+describe "macaddress fact" do
+  before do
+    Facter::Util::Config.stubs(:is_windows?).returns(false)
+  end
+
+  it "should return macaddress information for Linux" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
+      returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces'))
+
+    Facter.value(:macaddress).should == "00:12:3f:be:22:01"
+  end
+ 
+  it "should return macaddress information for BSD" do
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig').
+      returns(ifconfig_fixture('bsd_ifconfig_all_with_multiple_interfaces'))
+
+    Facter.value(:macaddress).should == "00:0b:db:93:09:67"
+  end
+  
+end

--- a/spec/unit/util/macaddress_spec.rb
+++ b/spec/unit/util/macaddress_spec.rb
@@ -4,6 +4,16 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 require 'facter/util/macaddress'
 
+describe "standardized MAC address" do
+  it "should have zeroes added if missing" do
+    Facter::Util::Macaddress::standardize("0:ab:cd:e:12:3").should == "00:ab:cd:0e:12:03"
+  end
+  
+  it "should be identical if each octet already has two digits" do
+    Facter::Util::Macaddress::standardize("00:ab:cd:0e:12:03").should == "00:ab:cd:0e:12:03"
+  end
+end
+
 describe "Darwin", :unless => Facter.value(:operatingsystem) == 'windows' do
   test_cases = [
     # version,           iface, real macaddress,     fallback macaddress


### PR DESCRIPTION
Implements Facter::Util::Macaddress.standardize and passes output values to it to ensure MAC addresses are output in a standard format.
Adds some basic test coverage for macaddress.rb.
