### PR TITLE
(#9178) Add Oracle Linux identification

### DIFF
--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -12,5 +12,5 @@
 
 Facter.add(:hardwareisa) do
     setcode 'uname -p'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD OEL OracleLinux OVS GNU/kFreeBSD}
 end

--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -15,7 +15,7 @@
 require 'facter'
 
 Facter.add("lsbmajdistrelease") do
-    confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OracleLinux OVS GNU/kFreeBSD}
     setcode do
         if /(\d*)\./i =~ Facter.value(:lsbdistrelease)
             result=$1

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -10,7 +10,7 @@
 require 'facter/util/macaddress'
 
 Facter.add(:macaddress) do
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OracleLinux OVS GNU/kFreeBSD}
     setcode do
         ether = []
         output = %x{/sbin/ifconfig -a}

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -37,6 +37,8 @@ Facter.add(:operatingsystem) do
             "MeeGo"
         elsif FileTest.exists?("/etc/arch-release")
             "Archlinux"
+        elsif FileTest.exists?("/etc/oracle-release")
+            "OracleLinux"
         elsif FileTest.exists?("/etc/enterprise-release")
             if FileTest.exists?("/etc/ovs-release")
                 "OVS"

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -16,7 +16,7 @@
 #
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{CentOS Fedora oel ovs RedHat MeeGo Scientific SLC}
+    confine :operatingsystem => %w{CentOS Fedora oel ovs OracleLinux RedHat MeeGo Scientific SLC}
     setcode do
         case Facter.value(:operatingsystem)
         when "CentOS", "RedHat", "Scientific", "SLC"
@@ -25,6 +25,8 @@ Facter.add(:operatingsystemrelease) do
             releasefile = "/etc/fedora-release"
         when "MeeGo"
             releasefile = "/etc/meego-release"
+        when "OracleLinux"
+            releasefile = "/etc/oracle-release"
         when "OEL", "oel"
             releasefile = "/etc/enterprise-release"
         when "OVS", "ovs"

--- a/lib/facter/uniqueid.rb
+++ b/lib/facter/uniqueid.rb
@@ -1,4 +1,4 @@
 Facter.add(:uniqueid) do
     setcode 'hostid'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OVS GNU/kFreeBSD}
+    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OracleLinux OVS GNU/kFreeBSD}
 end

--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -15,15 +15,16 @@ describe "Operating System Release fact" do
     end
 
     test_cases = {
-        "CentOS"     => "/etc/redhat-release",
-        "RedHat"     => "/etc/redhat-release",
-        "Scientific" => "/etc/redhat-release",
-        "Fedora"     => "/etc/fedora-release",
-        "MeeGo"      => "/etc/meego-release",
-        "OEL"        => "/etc/enterprise-release",
-        "oel"        => "/etc/enterprise-release",
-        "OVS"        => "/etc/ovs-release",
-        "ovs"        => "/etc/ovs-release",
+        "CentOS"      => "/etc/redhat-release",
+        "RedHat"      => "/etc/redhat-release",
+        "Scientific"  => "/etc/redhat-release",
+        "Fedora"      => "/etc/fedora-release",
+        "MeeGo"       => "/etc/meego-release",
+        "OEL"         => "/etc/enterprise-release",
+        "oel"         => "/etc/enterprise-release",
+        "OVS"         => "/etc/ovs-release",
+        "ovs"         => "/etc/ovs-release",
+        "OracleLinux" => "/etc/oracle-release",
     }
 
     test_cases.each do |system, file|


### PR DESCRIPTION
Adds support for Oracle Linux identification and enables facts that are
confined by the operatingsystem fact.

This pull request supercedes https://github.com/puppetlabs/facter/pull/32
