### PR TITLE
Clear messages between test runs

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -24,7 +24,7 @@ module Facter
     include Comparable
     include Enumerable
 
-    FACTERVERSION = '1.6.1rc'
+    FACTERVERSION = '1.6.1'
     # = Facter
     # Functions as a hash of 'facts' you might care about about your
     # system, such as mac address, IP address, Video card, etc.
@@ -157,6 +157,12 @@ module Facter
     def self.clear
         Facter.flush
         Facter.reset
+    end
+
+    # Clear all messages. Used only in testing. Can't add to self.clear
+    # because we don't want to warn multiple times for items that are warnonce'd
+    def self.clear_messages
+        @@messages.clear
     end
 
     # Set debugging on or off.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,5 +20,6 @@ RSpec.configure do |config|
   config.before :each do
     Facter::Util::Loader.any_instance.stubs(:load_all)
     Facter.clear
+    Facter.clear_messages
   end
 end


### PR DESCRIPTION
If the spec tests are run more than once in a row, some tests
will fail because messages are not reset between tests. This
adds a method to facter.rb to clear_messages and calls it before
each test. Also, facter version fixed to not include a string.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
