### PR TITLE
(#2344) VMware version parsing fix

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -139,8 +139,8 @@ Facter.add("virtual") do
                 end
             end
             
-            if FileTest.exists?("/usr/lib/vmware/bin/vmware-vmx")
-                result = "vmware_server"
+            if output = Facter::Util::Resolution.exec("vmware -v")
+                result = output.sub(/(\S+)\s+(\S+).*/) { | text | "#{$1}_#{$2}"}.downcase
             end
         end
 
@@ -163,7 +163,7 @@ Facter.add("is_virtual") do
     confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD}
 
     setcode do
-        physical_types = %w{physical xen0 vmware_server openvzhn}
+        physical_types = %w{physical xen0 vmware_server vmware_workstation openvzhn}
 
         if physical_types.include? Facter.value(:virtual)
             "false"

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -72,7 +72,7 @@ describe "Virtual fact" do
   describe "on Linux" do
 
       before do
-        FileTest.expects(:exists?).with("/usr/lib/vmware/bin/vmware-vmx").returns false
+        Facter::Util::Resolution.expects(:exec).with("vmware -v").returns false
         Facter.fact(:operatingsystem).stubs(:value).returns(true)
         Facter.fact(:architecture).stubs(:value).returns(true)
       end
@@ -137,6 +137,10 @@ describe "Virtual fact" do
 
   end
   describe "on Solaris" do
+      before(:each) do
+          Facter::Util::Resolution.expects(:exec).with("vmware -v").returns false
+      end
+
       it "should be vmware with VMWare vendor name from prtdiag" do
           Facter.fact(:kernel).stubs(:value).returns("SunOS")
           Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)


### PR DESCRIPTION
VMware detection should not be file base. This will cause workstation
to be incorrectly dectected as server. This implements the fix
suggested, using 'vmware -v' to grab the correct vmware version.
It also fixed the spec tests to correctly expect the vmware -v
exec.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
