### PR TITLE
SELinux spec test fix for ubuntu

### DIFF
--- a/spec/unit/selinux_spec.rb
+++ b/spec/unit/selinux_spec.rb
@@ -38,6 +38,7 @@ describe "SELinux facts" do
 
     it "should return an SELinux policy version" do
        Facter.fact(:selinux).stubs(:value).returns("true")
+       FileTest.stubs(:exists?).with("/proc/self/mountinfo").returns false
 
        File.stubs(:read).with("/selinux/policyvers").returns("")
 


### PR DESCRIPTION
On systems with a /proc/self/mountinfo but without an selinuxfs
filesystem, the "should return an SELinux policy version" test would fail.
This patch stubs it so this file doesn't exist, and the selinux mount point
is correctly calculated.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
