### PR TITLE
Change count to length for compatibility

### DIFF
--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -59,6 +59,6 @@ Facter.add('physicalprocessorcount') do
   confine :kernel => :windows
   setcode do
     require 'facter/util/wmi'
-    Facter::Util::WMI.execquery("select Name from Win32_Processor").count
+    Facter::Util::WMI.execquery("select Name from Win32_Processor").length
   end
 end


### PR DESCRIPTION
In physicalprocessorcount, .length should be used instead of
.count as .count is not supported on ruby <= 1.8.6. This was
causing test failures on ruby 1.8.5.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
