### PR TITLE
(#9457) Fix logic for domain fact so hostname, then dnsdomainname and fin

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -23,12 +23,14 @@ Facter.add(:domain) do
         # Get the domain from various sources; the order of these
         # steps is important
 
-        if name = Facter::Util::Resolution.exec('hostname')
-          if name =~ /.*?\.(.+$)/
+        if name = Facter::Util::Resolution.exec('hostname') and 
+            name =~ /.*?\.(.+$)/
+
             $1
-          end
-        elsif domain = Facter::Util::Resolution.exec('dnsdomainname')
-          domain if domain =~ /.+\..+/
+        elsif domain = Facter::Util::Resolution.exec('dnsdomainname') and 
+            domain =~ /.+\..+/
+
+            domain
         elsif FileTest.exists?("/etc/resolv.conf")
             domain = nil
             search = nil

--- a/spec/unit/domain_spec.rb
+++ b/spec/unit/domain_spec.rb
@@ -14,15 +14,15 @@ describe "Domain name facts" do
     end
 
     it "should fall back to the dnsdomainname binary" do
-      Facter::Util::Resolution.stubs(:exec).with("hostname")
+      Facter::Util::Resolution.expects(:exec).with("hostname").returns("myhost")
       Facter::Util::Resolution.expects(:exec).with("dnsdomainname").returns("example.com")
       Facter.fact(:domain).value.should == "example.com"
     end
 
 
     it "should fall back to /etc/resolv.conf" do
-      Facter::Util::Resolution.stubs(:exec).with("hostname").at_least_once
-      Facter::Util::Resolution.stubs(:exec).with("dnsdomainname").at_least_once
+      Facter::Util::Resolution.expects(:exec).with("hostname").at_least_once.returns("myhost")
+      Facter::Util::Resolution.expects(:exec).with("dnsdomainname").at_least_once.returns("")
       File.expects(:open).with('/etc/resolv.conf').at_least_once
       Facter.fact(:domain).value
     end


### PR DESCRIPTION
(#9457) Fix logic for domain fact so hostname, then dnsdomainname and finally resolv.conf is used.

A recent commit changed the logic for how this fall-through logic was
working. I've fixed the logic and added more coverage to pick up on this.
