### PR TITLE
(#9517) Fix physicalprocessorcount on windows

### DIFF
--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -59,6 +59,6 @@ Facter.add('physicalprocessorcount') do
   confine :kernel => :windows
   setcode do
     require 'facter/util/wmi'
-    Facter::Util::WMI.execquery("select Name from Win32_Processor").length
+    Facter::Util::WMI.execquery("select Name from Win32_Processor").Count
   end
 end

--- a/spec/unit/physicalprocessorcount_spec.rb
+++ b/spec/unit/physicalprocessorcount_spec.rb
@@ -42,7 +42,9 @@ describe "Physical processor count facts" do
         Facter.fact(:kernel).stubs(:value).returns("windows")
 
         require 'facter/util/wmi'
-        Facter::Util::WMI.stubs(:execquery).with("select Name from Win32_Processor").returns(Array.new(4))
+        ole = stub 'WIN32OLE'
+        Facter::Util::WMI.expects(:execquery).with("select Name from Win32_Processor").returns(ole)
+        ole.stubs(:Count).returns(4)
 
         Facter.fact(:physicalprocessorcount).value.should == 4
     end


### PR DESCRIPTION
A broken test led to a broken fact. The WMI.execquery was incorrectly stubbed
to return an array when the actual WMI.execquery does not return an array. This
means that length, which works on arrays, does not work with WMI.execquery.
This fixes both the fact and the test. The test is unfortunately lifted to a
higher level, but it has the benefit of being correct.

Thanks to Eric Stonfer for the fact fix.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
