### PR TITLE
Cleaned up Arch Linux detection routine

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -45,8 +45,6 @@ Facter.add(:operatingsystem) do
             else
                 "OEL"
             end
-        elsif FileTest.exists?("/etc/arch-release")
-            "Arch"
         elsif FileTest.exists?("/etc/vmware-release")
             "VMWareESX"
         elsif FileTest.exists?("/etc/redhat-release")


### PR DESCRIPTION
During operating system detection we have an unreachable elsif clause
for the Arch Linux systems.
