### PR TITLE
Ticket/9786 additional rake spec aliases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,11 @@ task :default do
     sh %{rake -T}
 end
 
+# Aliases for spec
+task :test    => [:spec]
+task :tests   => [:spec]
+task :specs   => [:spec]
+
 RSpec::Core::RakeTask.new do |t|
     t.pattern ='spec/{unit,integration}/**/*_spec.rb'
     t.fail_on_error = true


### PR DESCRIPTION
These are just convenience aliases:
- test: because it makes sense to alias test to spec
- specs & tests: to support rvm specs and tests respectively.
