### PR TITLE
Ticket/master/7726

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -189,7 +189,7 @@ if Facter.value(:kernel) == "SunOS"
     end
 
     # Total memory size available from prtconf
-    pconf = Facter::Util::Resolution.exec('/usr/sbin/prtconf')
+    pconf = Facter::Util::Resolution.exec('/usr/sbin/prtconf 2>/dev/null')
     phymem = ""
     pconf.each_line do |line|
         if line =~ /^Memory size:\s+(\d+) Megabytes/


### PR DESCRIPTION
prtconf will output an error message when run inside a zone, which
clutters up facter output. Redirected the stderr to /dev/null.
