### PR TITLE
Ticket/9787 rspec format

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format s
 --colour


### PR DESCRIPTION
Current running rake spec in facter means we get the document output which is
very verbose. Unfortunately we are forcing this in our .rspec file so you
can’t override it on a user by user basis with ~/.rspec for example.

I think we should not define —format, which means the default is progress
(which is less verbose and better for the average Joe and hacker who just
wants red light/green light) and then if people really want document format
they can override this in their own ~/.rspec file.

This way its the best of both worlds – more meaningful defaults and allowing
user overrides.
