### PR TITLE
Add sshecdsakey fact (patch for issue #9830)

### DIFF
--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -12,7 +12,7 @@
 ##
 
 ["/etc/ssh","/usr/local/etc/ssh","/etc","/usr/local/etc"].each do |dir|
-    {"SSHDSAKey" => "ssh_host_dsa_key.pub", "SSHRSAKey" => "ssh_host_rsa_key.pub"}.each do |name,file|
+    {"SSHDSAKey" => "ssh_host_dsa_key.pub", "SSHRSAKey" => "ssh_host_rsa_key.pub", "SSHECDSAKey" => "ssh_host_ecdsa_key.pub"}.each do |name,file|
         Facter.add(name) do
             setcode do
                 value = nil


### PR DESCRIPTION
 From version 5.7 onward, openssh has support for elliptic curve DSA keys[1,2].
 This commit adds a fact for those keytypes.

 1 - http://openssh.org/txt/release-5.7
 2 - http://tools.ietf.org/html/rfc5656
