### PR TITLE
Ticket/6728 fix openvz cloudlinux misidentification

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -13,14 +13,13 @@ module Facter::Util::Virtual
         return 'openvzhn'
       elsif envid =~ /^envID:\s+(\d+)$/i
         return 'openvzve'
-      else
-        return 'unknown'
       end
     end
 
-    # Cloudlinux uses OpenVZ to a degree, but always has an empty /proc/vz/
+    # Cloudlinux uses OpenVZ to a degree, but always has an empty /proc/vz/ and
+    # has /proc/lve/list present
     def self.openvz_cloudlinux?
-      Dir.glob( '/proc/vz/*' ).empty?
+      FileTest.file?("/proc/lve/list") or Dir.glob('/proc/vz/*').empty?
     end
 
     def self.zone?

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -10,10 +10,17 @@ describe Facter::Util::Virtual do
     it "should detect openvz" do
         FileTest.stubs(:directory?).with("/proc/vz").returns(true)
         Dir.stubs(:glob).with("/proc/vz/*").returns(['vzquota'])
+        Facter::Util::Virtual.stubs(:openvz_cloudlinux?).returns(false)
         Facter::Util::Virtual.should be_openvz
     end
 
+    it "should not detect openvz when /proc/lve/list is present" do
+        FileTest.stubs(:file?).with("/proc/lve/list").returns(true)
+        Facter::Util::Virtual.should_not be_openvz
+    end
+
     it "should not detect openvz when /proc/vz/ is empty" do
+        FileTest.stubs(:file?).with("/proc/lve/list").returns(false)
         FileTest.stubs(:directory?).with("/proc/vz").returns(true)
         Dir.stubs(:glob).with("/proc/vz/*").returns([])
         Facter::Util::Virtual.should_not be_openvz
@@ -33,11 +40,11 @@ describe Facter::Util::Virtual do
         Facter::Util::Virtual.openvz_type().should == "openvzve"
     end
 
-    it "should identify unknown when /proc/self/status has no envID" do
+    it "should not attempt to identify openvz when /proc/self/status has no envID" do
         Facter::Util::Virtual.stubs(:openvz?).returns(true)
         FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
         Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("")
-        Facter::Util::Virtual.openvz_type().should == "unknown"
+        Facter::Util::Virtual.openvz_type().should be_nil
     end
 
     it "should identify Solaris zones when non-global zone" do


### PR DESCRIPTION
Adds detection for cloudlinux instances to avoid misidentifying it as openvz.
