### PR TITLE
Ticket/9555 fix whitespace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'rubygems'
 require 'rspec'
 require 'rspec/core/rake_task'
 begin
-    require 'rcov'
+  require 'rcov'
 rescue LoadError
 end
 
@@ -18,48 +18,48 @@ require 'rake/packagetask'
 require 'rake/gempackagetask'
 
 module Facter
-    FACTERVERSION = File.read('lib/facter.rb')[/FACTERVERSION *= *'(.*)'/,1] or fail "Couldn't find FACTERVERSION"
+  FACTERVERSION = File.read('lib/facter.rb')[/FACTERVERSION *= *'(.*)'/,1] or fail "Couldn't find FACTERVERSION"
 end
 
 FILES = FileList[
-    '[A-Z]*',
-    'install.rb',
-    'bin/**/*',
-    'lib/**/*',
-    'conf/**/*',
-    'etc/**/*',
-    'spec/**/*'
+  '[A-Z]*',
+  'install.rb',
+  'bin/**/*',
+  'lib/**/*',
+  'conf/**/*',
+  'etc/**/*',
+  'spec/**/*'
 ]
 
 spec = Gem::Specification.new do |spec|
-    spec.platform = Gem::Platform::RUBY
-    spec.name = 'facter'
-    spec.files = FILES.to_a
-    spec.executables = %w{facter}
-    spec.version = Facter::FACTERVERSION
-    spec.summary = 'Facter, a system inventory tool'
-    spec.author = 'Puppet Labs'
-    spec.email = 'info@puppetlabs.com'
-    spec.homepage = 'http://puppetlabs.com'
-    spec.rubyforge_project = 'facter'
-    spec.has_rdoc = true
-    spec.rdoc_options <<
-        '--title' <<  'Facter - System Inventory Tool' <<
-        '--main' << 'README' <<
-        '--line-numbers'
+  spec.platform = Gem::Platform::RUBY
+  spec.name = 'facter'
+  spec.files = FILES.to_a
+  spec.executables = %w{facter}
+  spec.version = Facter::FACTERVERSION
+  spec.summary = 'Facter, a system inventory tool'
+  spec.author = 'Puppet Labs'
+  spec.email = 'info@puppetlabs.com'
+  spec.homepage = 'http://puppetlabs.com'
+  spec.rubyforge_project = 'facter'
+  spec.has_rdoc = true
+  spec.rdoc_options <<
+    '--title' <<  'Facter - System Inventory Tool' <<
+    '--main' << 'README' <<
+    '--line-numbers'
 end
 
 Rake::PackageTask.new("facter", Facter::FACTERVERSION) do |pkg|
-    pkg.package_dir = 'pkg'
-    pkg.need_tar_gz = true
-    pkg.package_files = FILES.to_a
+  pkg.package_dir = 'pkg'
+  pkg.need_tar_gz = true
+  pkg.package_files = FILES.to_a
 end
 
 Rake::GemPackageTask.new(spec) do |pkg|
 end
 
 task :default do
-    sh %{rake -T}
+  sh %{rake -T}
 end
 
 # Aliases for spec
@@ -68,15 +68,15 @@ task :tests   => [:spec]
 task :specs   => [:spec]
 
 RSpec::Core::RakeTask.new do |t|
-    t.pattern ='spec/{unit,integration}/**/*_spec.rb'
-    t.fail_on_error = true
+  t.pattern ='spec/{unit,integration}/**/*_spec.rb'
+  t.fail_on_error = true
 end
 
 RSpec::Core::RakeTask.new('spec:rcov') do |t|
-    t.pattern ='spec/{unit,integration}/**/*_spec.rb'
-    t.fail_on_error = true
-    if defined?(Rcov)
-        t.rcov = true
-        t.rcov_opts = ['--exclude', 'spec/*,test/*,results/*,/usr/lib/*,/usr/local/lib/*,gems/*']
-    end
+  t.pattern ='spec/{unit,integration}/**/*_spec.rb'
+  t.fail_on_error = true
+  if defined?(Rcov)
+    t.rcov = true
+    t.rcov_opts = ['--exclude', 'spec/*,test/*,results/*,/usr/lib/*,/usr/local/lib/*,gems/*']
+  end
 end

--- a/acceptance/tests/ticket_7039_facter_multiple_facts_one_file.rb
+++ b/acceptance/tests/ticket_7039_facter_multiple_facts_one_file.rb
@@ -2,15 +2,15 @@ test_name "#7039: Facter having issue handling multiple facts in a single file"
 
 fact_file= %q{
 Facter.add(:test_fact1) do
-    setcode do
-        "test fact 1"
-    end
+  setcode do
+    "test fact 1"
+  end
 end
 
 Facter.add(:test_fact2) do
-    setcode do
-        "test fact 2"
-    end
+  setcode do
+    "test fact 2"
+  end
 end
 }
 
@@ -20,12 +20,12 @@ create_remote_file(agent1, '/tmp/test_facts.rb', fact_file )
 
 step "Agent: Verify test_fact1 from /tmp/test_facts.rb"
 on(agent1, "export FACTERLIB=/tmp && facter --puppet test_fact1") do
-    fail_test "Fact 1 not returned by facter --puppet test_fact1" unless
-      stdout.include? 'test fact 1'
+  fail_test "Fact 1 not returned by facter --puppet test_fact1" unless
+    stdout.include? 'test fact 1'
 end
 
 step "Agent: Verify test_fact2 from /tmp/test_facts.rb"
 on(agent1, "export FACTERLIB=/tmp && facter --puppet test_fact2") do
-    fail_test "Fact 1 not returned by facter --puppet test_fact2" unless
-      stdout.include? 'test fact 2'
+  fail_test "Fact 1 not returned by facter --puppet test_fact2" unless
+    stdout.include? 'test fact 2'
 end

--- a/documentation/custom.page
+++ b/documentation/custom.page
@@ -12,10 +12,10 @@ search through your environment for any variables whose names start with
 As a simple example, here is how I publish my home directory to Puppet:
 
    Facter.add("home") do
-        setcode do
-            ENV['HOME']
-        end
-    end 
+     setcode do
+       ENV['HOME']
+     end
+   end 
 
 I have ~/lib/ruby in my $RUBYLIB environment variable, so I just created
 ~/lib/ruby/facter and dropped the above code into a ``home.rb`` file

--- a/install.rb
+++ b/install.rb
@@ -12,23 +12,23 @@
 # In most cases, if you have a typical project layout, you will need to do
 # absolutely nothing to make this work for you. This layout is:
 #
-#   bin/    # executable files -- "commands"
-#   lib/    # the source of the library
+#   bin/  # executable files -- "commands"
+#   lib/  # the source of the library
 #   tests/  # unit tests
 #
 # The default behaviour:
 # 1) Run all unit test files (ending in .rb) found in all directories under
-#    tests/.
+#  tests/.
 # 2) Build Rdoc documentation from all files in bin/ (excluding .bat and .cmd),
-#    all .rb files in lib/, ./README, ./ChangeLog, and ./Install.
+#  all .rb files in lib/, ./README, ./ChangeLog, and ./Install.
 # 3) Build ri documentation from all files in bin/ (excluding .bat and .cmd),
-#    and all .rb files in lib/. This is disabled by default on Win32.
+#  and all .rb files in lib/. This is disabled by default on Win32.
 # 4) Install commands from bin/ into the Ruby bin directory. On Windows, if a
-#    if a corresponding batch file (.bat or .cmd) exists in the bin directory,
-#    it will be copied over as well. Otherwise, a batch file (always .bat) will
-#    be created to run the specified command.
+#  if a corresponding batch file (.bat or .cmd) exists in the bin directory,
+#  it will be copied over as well. Otherwise, a batch file (always .bat) will
+#  be created to run the specified command.
 # 5) Install all library files ending in .rb from lib/ into Ruby's
-#    site_lib/version directory.
+#  site_lib/version directory.
 #
 #++
 
@@ -39,23 +39,23 @@ require 'optparse'
 require 'ostruct'
 
 begin
-    require 'rdoc/rdoc'
-    $haverdoc = true
+  require 'rdoc/rdoc'
+  $haverdoc = true
 rescue LoadError
-    puts "Missing rdoc; skipping documentation"
-    $haverdoc = false
+  puts "Missing rdoc; skipping documentation"
+  $haverdoc = false
 end
 
 begin
-    if $haverdoc
-       rst2man = %x{which rst2man.py}
-       $haveman = true
-    else
-       $haveman = false
-    end
+  if $haverdoc
+     rst2man = %x{which rst2man.py}
+     $haveman = true
+  else
+     $haveman = false
+  end
 rescue
-    puts "Missing rst2man; skipping man page creation"
-    $haveman = false
+  puts "Missing rst2man; skipping man page creation"
+  $haveman = false
 end
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
@@ -67,66 +67,66 @@ PREREQS = %w{openssl xmlrpc/client xmlrpc/server cgi}
 InstallOptions = OpenStruct.new
 
 def glob(list)
-    g = list.map { |i| Dir.glob(i) }
-    g.flatten!
-    g.compact!
-    g.reject! { |e| e =~ /\.svn/ }
-    g
+  g = list.map { |i| Dir.glob(i) }
+  g.flatten!
+  g.compact!
+  g.reject! { |e| e =~ /\.svn/ }
+  g
 end
 
 # Set these values to what you want installed.
 sbins = glob(%w{sbin/*})
 bins  = glob(%w{bin/*})
 rdoc  = glob(%w{bin/* sbin/* lib/**/*.rb README README-library CHANGELOG TODO Install}).reject { |e| e=~ /\.(bat|cmd)$/ }
-ri    = glob(%w(bin/*.rb sbin/* lib/**/*.rb)).reject { |e| e=~ /\.(bat|cmd)$/ }
+ri  = glob(%w(bin/*.rb sbin/* lib/**/*.rb)).reject { |e| e=~ /\.(bat|cmd)$/ }
 man   = glob(%w{man/man8/*})
 libs  = glob(%w{lib/**/*.rb lib/**/*.py})
 tests = glob(%w{tests/**/*.rb})
 
 def do_bins(bins, target, strip = 's?bin/')
-    bins.each do |bf|
-        obf = bf.gsub(/#{strip}/, '')
-            install_binfile(bf, obf, target)
-    end
+  bins.each do |bf|
+    obf = bf.gsub(/#{strip}/, '')
+      install_binfile(bf, obf, target)
+  end
 end
 
 def do_libs(libs, strip = 'lib/')
-    libs.each do |lf|
-        olf = File.join(InstallOptions.site_dir, lf.gsub(/#{strip}/, ''))
-        op = File.dirname(olf)
-        FileUtils.makedirs(op, {:mode => 0755, :verbose => true})
-        FileUtils.chmod(0755, op)
-        FileUtils.install(lf, olf, {:mode => 0644, :verbose => true})
-    end
+  libs.each do |lf|
+    olf = File.join(InstallOptions.site_dir, lf.gsub(/#{strip}/, ''))
+    op = File.dirname(olf)
+    FileUtils.makedirs(op, {:mode => 0755, :verbose => true})
+    FileUtils.chmod(0755, op)
+    FileUtils.install(lf, olf, {:mode => 0644, :verbose => true})
+  end
 end
 
 def do_man(man, strip = 'man/')
   if (InstallOptions.man == true)  
-    man.each do |mf|
-	omf = File.join(InstallOptions.man_dir, mf.gsub(/#{strip}/, ''))
-	om = File.dirname(omf)
-	FileUtils.makedirs(om, {:mode => 0755, :verbose => true})
-	FileUtils.chmod(0755, om)
-	FileUtils.install(mf, omf, {:mode => 0644, :verbose => true})
-	gzip = %x{which gzip}
-	gzip.chomp!
-	%x{#{gzip} -f #{omf}}
-    end
+  man.each do |mf|
+    omf = File.join(InstallOptions.man_dir, mf.gsub(/#{strip}/, ''))
+    om = File.dirname(omf)
+    FileUtils.makedirs(om, {:mode => 0755, :verbose => true})
+    FileUtils.chmod(0755, om)
+    FileUtils.install(mf, omf, {:mode => 0644, :verbose => true})
+    gzip = %x{which gzip}
+    gzip.chomp!
+    %x{#{gzip} -f #{omf}}
+  end
   else
-    puts "Skipping Man Page Generation"
+  puts "Skipping Man Page Generation"
   end
 end
 
 # Verify that all of the prereqs are installed
 def check_prereqs
-    PREREQS.each { |pre|
-        begin
-            require pre
-        rescue LoadError
-            puts "Could not load #{pre} Ruby library; cannot install"
-            exit -1
-        end
-    }
+  PREREQS.each { |pre|
+    begin
+      require pre
+    rescue LoadError
+      puts "Could not load #{pre} Ruby library; cannot install"
+      exit -1
+    end
+  }
 end
 
 def is_windows?
@@ -137,160 +137,160 @@ end
 # Prepare the file installation.
 #
 def prepare_installation
-    # Only try to do docs if we're sure they have rdoc
-    if $haverdoc
-        InstallOptions.rdoc  = true
-        if is_windows?
-            InstallOptions.ri  = false
-        else
-            InstallOptions.ri  = true
-        end
+  # Only try to do docs if we're sure they have rdoc
+  if $haverdoc
+    InstallOptions.rdoc  = true
+    if is_windows?
+      InstallOptions.ri  = false
     else
-        InstallOptions.rdoc  = false
-        InstallOptions.ri  = false
+      InstallOptions.ri  = true
+    end
+  else
+    InstallOptions.rdoc  = false
+    InstallOptions.ri  = false
+  end
+
+
+  if $haveman
+    InstallOptions.man = true
+    if is_windows?
+      InstallOptions.man  = false
+    end
+  else
+    InstallOptions.man = false
+  end
+
+  InstallOptions.tests = true
+
+  ARGV.options do |opts|
+    opts.banner = "Usage: #{File.basename($0)} [options]"
+    opts.separator ""
+    opts.on('--[no-]rdoc', 'Prevents the creation of RDoc output.', 'Default on.') do |onrdoc|
+      InstallOptions.rdoc = onrdoc
+    end
+    opts.on('--[no-]ri', 'Prevents the creation of RI output.', 'Default off on mswin32.') do |onri|
+      InstallOptions.ri = onri
+    end
+    opts.on('--[no-]man', 'Presents the creation of man pages.', 'Default on.') do |onman|
+    InstallOptions.man = onman
+    end
+    opts.on('--[no-]tests', 'Prevents the execution of unit tests.', 'Default on.') do |ontest|
+      InstallOptions.tests = ontest
+    end
+    opts.on('--destdir[=OPTIONAL]', 'Installation prefix for all targets', 'Default essentially /') do |destdir|
+      InstallOptions.destdir = destdir
+    end
+    opts.on('--bindir[=OPTIONAL]', 'Installation directory for binaries', 'overrides Config::CONFIG["bindir"]') do |bindir|
+      InstallOptions.bindir = bindir
+    end
+    opts.on('--sbindir[=OPTIONAL]', 'Installation directory for system binaries', 'overrides Config::CONFIG["sbindir"]') do |sbindir|
+      InstallOptions.sbindir = sbindir
+    end
+    opts.on('--sitelibdir[=OPTIONAL]', 'Installation directory for libraries', 'overrides Config::CONFIG["sitelibdir"]') do |sitelibdir|
+      InstallOptions.sitelibdir = sitelibdir
+    end
+    opts.on('--mandir[=OPTIONAL]', 'Installation directory for man pages', 'overrides Config::CONFIG["mandir"]') do |mandir|
+      InstallOptions.mandir = mandir
+    end
+    opts.on('--quick', 'Performs a quick installation. Only the', 'installation is done.') do |quick|
+      InstallOptions.rdoc   = false
+      InstallOptions.ri   = false
+      InstallOptions.tests  = false
+    end
+    opts.on('--full', 'Performs a full installation. All', 'optional installation steps are run.') do |full|
+      InstallOptions.rdoc   = true
+      InstallOptions.ri   = true
+      InstallOptions.tests  = true
+    end
+    opts.separator("")
+    opts.on_tail('--help', "Shows this help text.") do
+      $stderr.puts opts
+      exit
     end
 
+    opts.parse!
+  end
 
-    if $haveman
-        InstallOptions.man = true
-        if is_windows?
-            InstallOptions.man  = false
-        end
-    else
-        InstallOptions.man = false
+  tmpdirs = [ENV['TMP'], ENV['TEMP'], "/tmp", "/var/tmp", "."]
+
+  version = [Config::CONFIG["MAJOR"], Config::CONFIG["MINOR"]].join(".")
+  libdir = File.join(Config::CONFIG["libdir"], "ruby", version)
+
+  # Mac OS X 10.5 and higher declare bindir and sbindir as
+  # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin
+  # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/sbin
+  # which is not generally where people expect executables to be installed
+  # These settings are appropriate defaults for all OS X versions.
+  if RUBY_PLATFORM =~ /^universal-darwin[\d\.]+$/
+    Config::CONFIG['bindir'] = "/usr/bin"
+    Config::CONFIG['sbindir'] = "/usr/sbin"
+  end
+
+  if not InstallOptions.bindir.nil?
+    bindir = InstallOptions.bindir
+  else
+    bindir = Config::CONFIG['bindir']
+  end
+
+  if not InstallOptions.sbindir.nil?
+    sbindir = InstallOptions.sbindir
+  else
+    sbindir = Config::CONFIG['sbindir']
+  end
+
+  if not InstallOptions.sitelibdir.nil?
+    sitelibdir = InstallOptions.sitelibdir
+  else
+    sitelibdir = Config::CONFIG["sitelibdir"]
+    if sitelibdir.nil?
+      sitelibdir = $:.find { |x| x =~ /site_ruby/ }
+      if sitelibdir.nil?
+        sitelibdir = File.join(libdir, "site_ruby")
+      elsif sitelibdir !~ Regexp.quote(version)
+        sitelibdir = File.join(sitelibdir, version)
+      end
     end
+  end
 
-    InstallOptions.tests = true
+  if not InstallOptions.mandir.nil?
+    mandir = InstallOptions.mandir
+  else
+    mandir = Config::CONFIG['mandir']
+  end
 
-    ARGV.options do |opts|
-        opts.banner = "Usage: #{File.basename($0)} [options]"
-        opts.separator ""
-        opts.on('--[no-]rdoc', 'Prevents the creation of RDoc output.', 'Default on.') do |onrdoc|
-            InstallOptions.rdoc = onrdoc
-        end
-        opts.on('--[no-]ri', 'Prevents the creation of RI output.', 'Default off on mswin32.') do |onri|
-            InstallOptions.ri = onri
-        end
-        opts.on('--[no-]man', 'Presents the creation of man pages.', 'Default on.') do |onman|
-        InstallOptions.man = onman
-        end
-        opts.on('--[no-]tests', 'Prevents the execution of unit tests.', 'Default on.') do |ontest|
-            InstallOptions.tests = ontest
-        end
-        opts.on('--destdir[=OPTIONAL]', 'Installation prefix for all targets', 'Default essentially /') do |destdir|
-            InstallOptions.destdir = destdir
-        end
-        opts.on('--bindir[=OPTIONAL]', 'Installation directory for binaries', 'overrides Config::CONFIG["bindir"]') do |bindir|
-            InstallOptions.bindir = bindir
-        end
-        opts.on('--sbindir[=OPTIONAL]', 'Installation directory for system binaries', 'overrides Config::CONFIG["sbindir"]') do |sbindir|
-            InstallOptions.sbindir = sbindir
-        end
-        opts.on('--sitelibdir[=OPTIONAL]', 'Installation directory for libraries', 'overrides Config::CONFIG["sitelibdir"]') do |sitelibdir|
-            InstallOptions.sitelibdir = sitelibdir
-        end
-        opts.on('--mandir[=OPTIONAL]', 'Installation directory for man pages', 'overrides Config::CONFIG["mandir"]') do |mandir|
-            InstallOptions.mandir = mandir
-        end
-        opts.on('--quick', 'Performs a quick installation. Only the', 'installation is done.') do |quick|
-            InstallOptions.rdoc   = false
-            InstallOptions.ri     = false
-            InstallOptions.tests  = false
-        end
-        opts.on('--full', 'Performs a full installation. All', 'optional installation steps are run.') do |full|
-            InstallOptions.rdoc   = true
-            InstallOptions.ri     = true
-            InstallOptions.tests  = true
-        end
-        opts.separator("")
-        opts.on_tail('--help', "Shows this help text.") do
-            $stderr.puts opts
-            exit
-        end
+  # To be deprecated once people move over to using --destdir option
+  if (destdir = ENV['DESTDIR'])
+    warn "DESTDIR is deprecated. Use --destdir instead."
+    bindir = join(destdir, bindir)
+    sbindir = join(destdir, sbindir)
+    mandir = join(destdir, mandir)
+    sitelibdir = join(destdir, sitelibdir)
 
-        opts.parse!
-    end
+    FileUtils.makedirs(bindir)
+    FileUtils.makedirs(sbindir)
+    FileUtils.makedirs(mandir)
+    FileUtils.makedirs(sitelibdir)
+    # This is the new way forward
+  elsif (destdir = InstallOptions.destdir)
+    bindir = join(destdir, bindir)
+    sbindir = join(destdir, sbindir)
+    mandir = join(destdir, mandir)
+    sitelibdir = join(destdir, sitelibdir)
 
-    tmpdirs = [ENV['TMP'], ENV['TEMP'], "/tmp", "/var/tmp", "."]
+    FileUtils.makedirs(bindir)
+    FileUtils.makedirs(sbindir)
+    FileUtils.makedirs(mandir)
+    FileUtils.makedirs(sitelibdir)
+  end
 
-    version = [Config::CONFIG["MAJOR"], Config::CONFIG["MINOR"]].join(".")
-    libdir = File.join(Config::CONFIG["libdir"], "ruby", version)
+  tmpdirs << bindir
 
-    # Mac OS X 10.5 and higher declare bindir and sbindir as
-    # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin
-    # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/sbin
-    # which is not generally where people expect executables to be installed
-    # These settings are appropriate defaults for all OS X versions.
-    if RUBY_PLATFORM =~ /^universal-darwin[\d\.]+$/
-      Config::CONFIG['bindir'] = "/usr/bin"
-      Config::CONFIG['sbindir'] = "/usr/sbin"
-    end
-
-    if not InstallOptions.bindir.nil?
-        bindir = InstallOptions.bindir
-    else
-        bindir = Config::CONFIG['bindir']
-    end
-
-    if not InstallOptions.sbindir.nil?
-        sbindir = InstallOptions.sbindir
-    else
-        sbindir = Config::CONFIG['sbindir']
-    end
-
-    if not InstallOptions.sitelibdir.nil?
-        sitelibdir = InstallOptions.sitelibdir
-    else
-        sitelibdir = Config::CONFIG["sitelibdir"]
-        if sitelibdir.nil?
-            sitelibdir = $:.find { |x| x =~ /site_ruby/ }
-            if sitelibdir.nil?
-                sitelibdir = File.join(libdir, "site_ruby")
-            elsif sitelibdir !~ Regexp.quote(version)
-                sitelibdir = File.join(sitelibdir, version)
-            end
-        end
-    end
-
-    if not InstallOptions.mandir.nil?
-        mandir = InstallOptions.mandir
-    else
-        mandir = Config::CONFIG['mandir']
-    end
-
-    # To be deprecated once people move over to using --destdir option
-    if (destdir = ENV['DESTDIR'])
-        warn "DESTDIR is deprecated. Use --destdir instead."
-        bindir = join(destdir, bindir)
-        sbindir = join(destdir, sbindir)
-        mandir = join(destdir, mandir)
-        sitelibdir = join(destdir, sitelibdir)
-
-        FileUtils.makedirs(bindir)
-        FileUtils.makedirs(sbindir)
-        FileUtils.makedirs(mandir)
-        FileUtils.makedirs(sitelibdir)
-        # This is the new way forward
-    elsif (destdir = InstallOptions.destdir)
-        bindir = join(destdir, bindir)
-        sbindir = join(destdir, sbindir)
-        mandir = join(destdir, mandir)
-        sitelibdir = join(destdir, sitelibdir)
-
-        FileUtils.makedirs(bindir)
-        FileUtils.makedirs(sbindir)
-        FileUtils.makedirs(mandir)
-        FileUtils.makedirs(sitelibdir)
-    end
-
-    tmpdirs << bindir
-
-    InstallOptions.tmp_dirs = tmpdirs.compact
-    InstallOptions.site_dir = sitelibdir
-    InstallOptions.bin_dir  = bindir
-    InstallOptions.sbin_dir = sbindir
-    InstallOptions.lib_dir  = libdir
-    InstallOptions.man_dir  = mandir
+  InstallOptions.tmp_dirs = tmpdirs.compact
+  InstallOptions.site_dir = sitelibdir
+  InstallOptions.bin_dir  = bindir
+  InstallOptions.sbin_dir = sbindir
+  InstallOptions.lib_dir  = libdir
+  InstallOptions.man_dir  = mandir
 end
 
 ##
@@ -307,69 +307,69 @@ end
 # Build the rdoc documentation. Also, try to build the RI documentation.
 #
 def build_rdoc(files)
-    return unless $haverdoc
-    begin
-        r = RDoc::RDoc.new
-        r.document(["--main", "README", "--title",
-            "Puppet -- Site Configuration Management", "--line-numbers"] + files)
-    rescue RDoc::RDocError => e
-        $stderr.puts e.message
-    rescue Exception => e
-        $stderr.puts "Couldn't build RDoc documentation\n#{e.message}"
-    end
+  return unless $haverdoc
+  begin
+    r = RDoc::RDoc.new
+    r.document(["--main", "README", "--title",
+      "Puppet -- Site Configuration Management", "--line-numbers"] + files)
+  rescue RDoc::RDocError => e
+    $stderr.puts e.message
+  rescue Exception => e
+    $stderr.puts "Couldn't build RDoc documentation\n#{e.message}"
+  end
 end
 
 def build_ri(files)
-    return unless $haverdoc
-    begin
-        ri = RDoc::RDoc.new
-        #ri.document(["--ri-site", "--merge"] + files)
-        ri.document(["--ri-site"] + files)
-    rescue RDoc::RDocError => e
-        $stderr.puts e.message
-    rescue Exception => e
-        $stderr.puts "Couldn't build Ri documentation\n#{e.message}"
-        $stderr.puts "Continuing with install..."
-    end
+  return unless $haverdoc
+  begin
+    ri = RDoc::RDoc.new
+    #ri.document(["--ri-site", "--merge"] + files)
+    ri.document(["--ri-site"] + files)
+  rescue RDoc::RDocError => e
+    $stderr.puts e.message
+  rescue Exception => e
+    $stderr.puts "Couldn't build Ri documentation\n#{e.message}"
+    $stderr.puts "Continuing with install..."
+  end
 end
 
 def build_man(bins)
-    return unless $haveman
-    begin
-        # Locate rst2man
-        rst2man = %x{which rst2man.py}
-        rst2man.chomp!
-        bins.each do |bin|
-            b = bin.gsub( "bin/", "")
-            %x{#{bin} --help > ./#{b}.rst}
-            %x{#{rst2man} ./#{b}.rst ./man/man8/#{b}.8}
-            File.unlink("./#{b}.rst")
-        end
-    rescue SystemCallError
-        $stderr.puts "Couldn't build man pages: " + $!
-        $stderr.puts "Continuing with install..."
+  return unless $haveman
+  begin
+    # Locate rst2man
+    rst2man = %x{which rst2man.py}
+    rst2man.chomp!
+    bins.each do |bin|
+      b = bin.gsub( "bin/", "")
+      %x{#{bin} --help > ./#{b}.rst}
+      %x{#{rst2man} ./#{b}.rst ./man/man8/#{b}.8}
+      File.unlink("./#{b}.rst")
     end
+  rescue SystemCallError
+    $stderr.puts "Couldn't build man pages: " + $!
+    $stderr.puts "Continuing with install..."
+  end
 end
 
 def run_tests(test_list)
-    begin
-        require 'test/unit/ui/console/testrunner'
-        $:.unshift "lib"
-        test_list.each do |test|
-            next if File.directory?(test)
-            require test
-        end
-
-        tests = []
-        ObjectSpace.each_object { |o| tests << o if o.kind_of?(Class) }
-        tests.delete_if { |o| !o.ancestors.include?(Test::Unit::TestCase) }
-        tests.delete_if { |o| o == Test::Unit::TestCase }
-
-        tests.each { |test| Test::Unit::UI::Console::TestRunner.run(test) }
-        $:.shift
-    rescue LoadError
-        puts "Missing testrunner library; skipping tests"
+  begin
+    require 'test/unit/ui/console/testrunner'
+    $:.unshift "lib"
+    test_list.each do |test|
+      next if File.directory?(test)
+      require test
     end
+
+    tests = []
+    ObjectSpace.each_object { |o| tests << o if o.kind_of?(Class) }
+    tests.delete_if { |o| !o.ancestors.include?(Test::Unit::TestCase) }
+    tests.delete_if { |o| o == Test::Unit::TestCase }
+
+    tests.each { |test| Test::Unit::UI::Console::TestRunner.run(test) }
+    $:.shift
+  rescue LoadError
+    puts "Missing testrunner library; skipping tests"
+  end
 end
 
 ##
@@ -378,57 +378,57 @@ end
 # (e.g., bin/rdoc becomes rdoc); the shebang line handles running it. Under
 # windows, we add an '.rb' extension and let file associations do their stuff.
 def install_binfile(from, op_file, target)
-    tmp_dir = nil
-    InstallOptions.tmp_dirs.each do |t|
-        if File.directory?(t) and File.writable?(t)
-            tmp_dir = t
-            break
-        end
+  tmp_dir = nil
+  InstallOptions.tmp_dirs.each do |t|
+    if File.directory?(t) and File.writable?(t)
+      tmp_dir = t
+      break
+    end
+  end
+
+  fail "Cannot find a temporary directory" unless tmp_dir
+  tmp_file = File.join(tmp_dir, '_tmp')
+  ruby = File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name'])
+
+  File.open(from) do |ip|
+    File.open(tmp_file, "w") do |op|
+      ruby = File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name'])
+      op.puts "#!#{ruby}"
+      contents = ip.readlines
+      if contents[0] =~ /^#!/
+        contents.shift
+      end
+      op.write contents.join()
+    end
+  end
+
+  if is_windows?
+    installed_wrapper = false
+
+    if File.exists?("#{from}.bat")
+      FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
+      installed_wrapper = true
     end
 
-    fail "Cannot find a temporary directory" unless tmp_dir
-    tmp_file = File.join(tmp_dir, '_tmp')
-    ruby = File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name'])
-
-    File.open(from) do |ip|
-        File.open(tmp_file, "w") do |op|
-            ruby = File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name'])
-            op.puts "#!#{ruby}"
-            contents = ip.readlines
-            if contents[0] =~ /^#!/
-                contents.shift
-            end
-            op.write contents.join()
-        end
+    if File.exists?("#{from}.cmd")
+      FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :verbose => true)
+      installed_wrapper = true
     end
 
-    if is_windows?
-        installed_wrapper = false
+    if not installed_wrapper
+      tmp_file2 = File.join(tmp_dir, '_tmp_wrapper')
+      cwn = File.join(Config::CONFIG['bindir'], op_file)
+      cwv = CMD_WRAPPER.gsub('<ruby>', ruby.gsub(%r{/}) { "\\" }).gsub!('<command>', cwn.gsub(%r{/}) { "\\" } )
 
-        if File.exists?("#{from}.bat")
-            FileUtils.install("#{from}.bat", File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
-            installed_wrapper = true
-        end
+      File.open(tmp_file2, "wb") { |cw| cw.puts cwv }
+      FileUtils.install(tmp_file2, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
 
-        if File.exists?("#{from}.cmd")
-            FileUtils.install("#{from}.cmd", File.join(target, "#{op_file}.cmd"), :mode => 0755, :verbose => true)
-            installed_wrapper = true
-        end
-
-        if not installed_wrapper
-            tmp_file2 = File.join(tmp_dir, '_tmp_wrapper')
-            cwn = File.join(Config::CONFIG['bindir'], op_file)
-            cwv = CMD_WRAPPER.gsub('<ruby>', ruby.gsub(%r{/}) { "\\" }).gsub!('<command>', cwn.gsub(%r{/}) { "\\" } )
-
-            File.open(tmp_file2, "wb") { |cw| cw.puts cwv }
-            FileUtils.install(tmp_file2, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
-
-            File.unlink(tmp_file2)
-            installed_wrapper = true
-        end
+      File.unlink(tmp_file2)
+      installed_wrapper = true
     end
-    FileUtils.install(tmp_file, File.join(target, op_file), :mode => 0755, :verbose => true)
-    File.unlink(tmp_file)
+  end
+  FileUtils.install(tmp_file, File.join(target, op_file), :mode => 0755, :verbose => true)
+  File.unlink(tmp_file)
 end
 
 CMD_WRAPPER = <<-EOS

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -15,233 +15,233 @@
 # limitations under the License.
 
 module Facter
-    # This is just so the other classes have the constant.
-    module Util; end
+  # This is just so the other classes have the constant.
+  module Util; end
 
-    require 'facter/util/fact'
-    require 'facter/util/collection'
+  require 'facter/util/fact'
+  require 'facter/util/collection'
 
-    include Comparable
-    include Enumerable
+  include Comparable
+  include Enumerable
 
-    FACTERVERSION = '1.6.1'
-    # = Facter
-    # Functions as a hash of 'facts' you might care about about your
-    # system, such as mac address, IP address, Video card, etc.
-    # returns them dynamically
+  FACTERVERSION = '1.6.1'
+  # = Facter
+  # Functions as a hash of 'facts' you might care about about your
+  # system, such as mac address, IP address, Video card, etc.
+  # returns them dynamically
 
-    # == Synopsis
-    #
-    # Generally, treat <tt>Facter</tt> as a hash:
-    # == Example
-    # require 'facter'
-    # puts Facter['operatingsystem']
-    #
+  # == Synopsis
+  #
+  # Generally, treat <tt>Facter</tt> as a hash:
+  # == Example
+  # require 'facter'
+  # puts Facter['operatingsystem']
+  #
 
-    # Set LANG to force i18n to C
-    #
-    ENV['LANG'] = 'C'
+  # Set LANG to force i18n to C
+  #
+  ENV['LANG'] = 'C'
 
-    GREEN = "[0;32m"
-    RESET = "[0m"
-    @@debug = 0
-    @@timing = 0
-    @@messages = {}
+  GREEN = "[0;32m"
+  RESET = "[0m"
+  @@debug = 0
+  @@timing = 0
+  @@messages = {}
 
-    # module methods
+  # module methods
 
-    def self.collection
-        unless defined?(@collection) and @collection
-            @collection = Facter::Util::Collection.new
-        end
-        @collection
+  def self.collection
+    unless defined?(@collection) and @collection
+      @collection = Facter::Util::Collection.new
+    end
+    @collection
+  end
+
+  # Return the version of the library.
+  def self.version
+    return FACTERVERSION
+  end
+
+  # Add some debugging
+  def self.debug(string)
+    if string.nil?
+      return
+    end
+    if self.debugging?
+      puts GREEN + string + RESET
+    end
+  end
+
+  def self.debugging?
+    @@debug != 0
+  end
+
+  # show the timing information
+  def self.show_time(string)
+    puts "#{GREEN}#{string}#{RESET}" if string and Facter.timing?
+  end
+
+  def self.timing?
+    @@timing != 0
+  end
+
+  # Return a fact object by name.  If you use this, you still have to call
+  # 'value' on it to retrieve the actual value.
+  def self.[](name)
+    collection.fact(name)
+  end
+
+  class << self
+    [:fact, :flush, :list, :value].each do |method|
+      define_method(method) do |*args|
+        collection.send(method, *args)
+      end
     end
 
-    # Return the version of the library.
-    def self.version
-        return FACTERVERSION
-    end
-
-    # Add some debugging
-    def self.debug(string)
-        if string.nil?
-            return
-        end
-        if self.debugging?
-            puts GREEN + string + RESET
-        end
-    end
-
-    def self.debugging?
-        @@debug != 0
-    end
-
-    # show the timing information
-    def self.show_time(string)
-        puts "#{GREEN}#{string}#{RESET}" if string and Facter.timing?
-    end
-
-    def self.timing?
-        @@timing != 0
-    end
-
-    # Return a fact object by name.  If you use this, you still have to call
-    # 'value' on it to retrieve the actual value.
-    def self.[](name)
-        collection.fact(name)
-    end
-
-    class << self
-        [:fact, :flush, :list, :value].each do |method|
-            define_method(method) do |*args|
-                collection.send(method, *args)
-            end
-        end
-
-        [:list, :to_hash].each do |method|
-            define_method(method) do |*args|
-                collection.load_all
-                collection.send(method, *args)
-            end
-        end
-    end
-
-
-    # Add a resolution mechanism for a named fact.  This does not distinguish
-    # between adding a new fact and adding a new way to resolve a fact.
-    def self.add(name, options = {}, &block)
-        collection.add(name, options, &block)
-    end
-
-    def self.each
-        # Make sure all facts are loaded.
+    [:list, :to_hash].each do |method|
+      define_method(method) do |*args|
         collection.load_all
-
-        collection.each do |*args|
-            yield(*args)
-        end
+        collection.send(method, *args)
+      end
     end
+  end
 
-    class << self
-        # Allow users to call fact names directly on the Facter class,
-        # either retrieving the value or comparing it to an existing value.
-        def method_missing(name, *args)
-            question = false
-            if name.to_s =~ /\?$/
-                question = true
-                name = name.to_s.sub(/\?$/,'')
+
+  # Add a resolution mechanism for a named fact.  This does not distinguish
+  # between adding a new fact and adding a new way to resolve a fact.
+  def self.add(name, options = {}, &block)
+    collection.add(name, options, &block)
+  end
+
+  def self.each
+    # Make sure all facts are loaded.
+    collection.load_all
+
+    collection.each do |*args|
+      yield(*args)
+    end
+  end
+
+  class << self
+    # Allow users to call fact names directly on the Facter class,
+    # either retrieving the value or comparing it to an existing value.
+    def method_missing(name, *args)
+      question = false
+      if name.to_s =~ /\?$/
+        question = true
+        name = name.to_s.sub(/\?$/,'')
+      end
+
+      if fact = collection.fact(name)
+        if question
+          value = fact.value.downcase
+          args.each do |arg|
+            if arg.to_s.downcase == value
+              return true
             end
+          end
 
-            if fact = collection.fact(name)
-                if question
-                    value = fact.value.downcase
-                    args.each do |arg|
-                        if arg.to_s.downcase == value
-                            return true
-                        end
-                    end
-
-                    # If we got this far, there was no match.
-                    return false
-                else
-                    return fact.value
-                end
-            else
-                # Else, fail like a normal missing method.
-                raise NoMethodError, "Could not find fact '%s'" % name
-            end
-        end
-    end
-
-    # Clear all facts.  Mostly used for testing.
-    def self.clear
-        Facter.flush
-        Facter.reset
-    end
-
-    # Clear all messages. Used only in testing. Can't add to self.clear
-    # because we don't want to warn multiple times for items that are warnonce'd
-    def self.clear_messages
-        @@messages.clear
-    end
-
-    # Set debugging on or off.
-    def self.debugging(bit)
-        if bit
-            case bit
-            when TrueClass; @@debug = 1
-            when FalseClass; @@debug = 0
-            when Fixnum
-                if bit > 0
-                    @@debug = 1
-                else
-                    @@debug = 0
-                end
-            when String;
-                if bit.downcase == 'off'
-                    @@debug = 0
-                else
-                    @@debug = 1
-                end
-            else
-                @@debug = 0
-            end
+          # If we got this far, there was no match.
+          return false
         else
-            @@debug = 0
+          return fact.value
         end
+      else
+        # Else, fail like a normal missing method.
+        raise NoMethodError, "Could not find fact '%s'" % name
+      end
     end
+  end
 
-    # Set timing on or off.
-    def self.timing(bit)
-        if bit
-            case bit
-            when TrueClass; @@timing = 1
-            when Fixnum
-                if bit > 0
-                    @@timing = 1
-                else
-                    @@timing = 0
-                end
-            end
+  # Clear all facts.  Mostly used for testing.
+  def self.clear
+    Facter.flush
+    Facter.reset
+  end
+
+  # Clear all messages. Used only in testing. Can't add to self.clear
+  # because we don't want to warn multiple times for items that are warnonce'd
+  def self.clear_messages
+    @@messages.clear
+  end
+
+  # Set debugging on or off.
+  def self.debugging(bit)
+    if bit
+      case bit
+      when TrueClass; @@debug = 1
+      when FalseClass; @@debug = 0
+      when Fixnum
+        if bit > 0
+          @@debug = 1
         else
-            @@timing = 0
+          @@debug = 0
         end
-    end
-
-    def self.warn(msg)
-        if Facter.debugging? and msg and not msg.empty?
-            msg = [msg] unless msg.respond_to? :each
-            msg.each { |line| Kernel.warn line }
+      when String;
+        if bit.downcase == 'off'
+          @@debug = 0
+        else
+          @@debug = 1
         end
+      else
+        @@debug = 0
+      end
+    else
+      @@debug = 0
     end
+  end
 
-    # Warn once.
-    def self.warnonce(msg)
-        if msg and not msg.empty? and @@messages[msg].nil?
-            @@messages[msg] = true
-            Kernel.warn(msg)
+  # Set timing on or off.
+  def self.timing(bit)
+    if bit
+      case bit
+      when TrueClass; @@timing = 1
+      when Fixnum
+        if bit > 0
+          @@timing = 1
+        else
+          @@timing = 0
         end
+      end
+    else
+      @@timing = 0
     end
+  end
 
-    # Remove them all.
-    def self.reset
-        @collection = nil
+  def self.warn(msg)
+    if Facter.debugging? and msg and not msg.empty?
+      msg = [msg] unless msg.respond_to? :each
+      msg.each { |line| Kernel.warn line }
     end
+  end
 
-    # Load all of the default facts, and then everything from disk.
-    def self.loadfacts
-        collection.load_all
+  # Warn once.
+  def self.warnonce(msg)
+    if msg and not msg.empty? and @@messages[msg].nil?
+      @@messages[msg] = true
+      Kernel.warn(msg)
     end
+  end
 
-    @search_path = []
+  # Remove them all.
+  def self.reset
+    @collection = nil
+  end
 
-    # Register a directory to search through.
-    def self.search(*dirs)
-        @search_path += dirs
-    end
+  # Load all of the default facts, and then everything from disk.
+  def self.loadfacts
+    collection.load_all
+  end
 
-    # Return our registered search directories.
-    def self.search_path
-        @search_path.dup
-    end
+  @search_path = []
+
+  # Register a directory to search through.
+  def self.search(*dirs)
+    @search_path += dirs
+  end
+
+  # Return our registered search directories.
+  def self.search_path
+    @search_path.dup
+  end
 end

--- a/lib/facter/Cfkey.rb
+++ b/lib/facter/Cfkey.rb
@@ -14,29 +14,29 @@
 ##
 
 Facter.add(:Cfkey) do
-    setcode do
-        value = nil
-        ["/usr/local/etc/cfkey.pub",
-            "/etc/cfkey.pub",
-            "/var/cfng/keys/localhost.pub",
-            "/var/cfengine/ppkeys/localhost.pub",
-            "/var/lib/cfengine/ppkeys/localhost.pub",
-            "/var/lib/cfengine2/ppkeys/localhost.pub"
-        ].each do |file|
-            if FileTest.file?(file)
-                File.open(file) { |openfile|
-                    value = openfile.readlines.reject { |line|
-                        line =~ /PUBLIC KEY/
-                    }.collect { |line|
-                        line.chomp
-                    }.join("")
-                }
-            end
-            if value
-                break
-            end
-        end
-
-        value
+  setcode do
+    value = nil
+    ["/usr/local/etc/cfkey.pub",
+      "/etc/cfkey.pub",
+      "/var/cfng/keys/localhost.pub",
+      "/var/cfengine/ppkeys/localhost.pub",
+      "/var/lib/cfengine/ppkeys/localhost.pub",
+      "/var/lib/cfengine2/ppkeys/localhost.pub"
+    ].each do |file|
+      if FileTest.file?(file)
+        File.open(file) { |openfile|
+          value = openfile.readlines.reject { |line|
+            line =~ /PUBLIC KEY/
+          }.collect { |line|
+            line.chomp
+          }.join("")
+        }
+      end
+      if value
+        break
+      end
     end
+
+    value
+  end
 end

--- a/lib/facter/architecture.rb
+++ b/lib/facter/architecture.rb
@@ -12,27 +12,27 @@
 #
 
 Facter.add(:architecture) do
-    setcode do
-        model = Facter.value(:hardwaremodel)
-        case model
-        # most linuxen use "x86_64"
-        when "x86_64"
-            case Facter.value(:operatingsystem)
-            when "Debian", "Gentoo", "GNU/kFreeBSD", "Ubuntu"
-                "amd64"
-            else
-                model
-            end
-        when /(i[3456]86|pentium)/
-            case Facter.value(:operatingsystem)
-            when "Gentoo"
-                "x86"
-            else
-                "i386"
-            end
-        else
-            model
-        end
+  setcode do
+    model = Facter.value(:hardwaremodel)
+    case model
+      # most linuxen use "x86_64"
+    when "x86_64"
+      case Facter.value(:operatingsystem)
+      when "Debian", "Gentoo", "GNU/kFreeBSD", "Ubuntu"
+        "amd64"
+      else
+        model
+      end
+    when /(i[3456]86|pentium)/
+      case Facter.value(:operatingsystem)
+      when "Gentoo"
+        "x86"
+      else
+        "i386"
+      end
+    else
+      model
     end
+  end
 end
 

--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -19,45 +19,45 @@
 #
 
 Facter.add(:domain) do
-    setcode do
-        # Get the domain from various sources; the order of these
-        # steps is important
+  setcode do
+    # Get the domain from various sources; the order of these
+    # steps is important
 
-        if name = Facter::Util::Resolution.exec('hostname') and 
-            name =~ /.*?\.(.+$)/
+    if name = Facter::Util::Resolution.exec('hostname') and 
+      name =~ /.*?\.(.+$)/
 
-            $1
-        elsif domain = Facter::Util::Resolution.exec('dnsdomainname') and 
-            domain =~ /.+\..+/
+      $1
+    elsif domain = Facter::Util::Resolution.exec('dnsdomainname') and 
+      domain =~ /.+\..+/
 
-            domain
-        elsif FileTest.exists?("/etc/resolv.conf")
-            domain = nil
-            search = nil
-            File.open("/etc/resolv.conf") { |file|
-                file.each { |line|
-                    if line =~ /^\s*domain\s+(\S+)/
-                        domain = $1
-                    elsif line =~ /^\s*search\s+(\S+)/
-                        search = $1
-                    end
-                }
-            }
-            next domain if domain
-            next search if search
-        end
+      domain
+    elsif FileTest.exists?("/etc/resolv.conf")
+      domain = nil
+      search = nil
+      File.open("/etc/resolv.conf") { |file|
+        file.each { |line|
+          if line =~ /^\s*domain\s+(\S+)/
+            domain = $1
+          elsif line =~ /^\s*search\s+(\S+)/
+            search = $1
+          end
+        }
+      }
+      next domain if domain
+      next search if search
     end
+  end
 end
 
 Facter.add(:domain) do
-    confine :kernel => :windows
-    setcode do
-        require 'facter/util/wmi'
-        domain = ""
-        Facter::Util::WMI.execquery("select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True").each { |nic|
-            domain = nic.DNSDomain
-            break
-        }
-        domain
-    end
+  confine :kernel => :windows
+  setcode do
+    require 'facter/util/wmi'
+    domain = ""
+    Facter::Util::WMI.execquery("select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True").each { |nic|
+      domain = nic.DNSDomain
+      break
+    }
+    domain
+  end
 end

--- a/lib/facter/facterversion.rb
+++ b/lib/facter/facterversion.rb
@@ -8,5 +8,5 @@
 #
 
 Facter.add(:facterversion) do
-    setcode { Facter::FACTERVERSION.to_s }
+  setcode { Facter::FACTERVERSION.to_s }
 end

--- a/lib/facter/fqdn.rb
+++ b/lib/facter/fqdn.rb
@@ -10,13 +10,13 @@
 #
 
 Facter.add(:fqdn) do
-    setcode do
-        host = Facter.value(:hostname)
-        domain = Facter.value(:domain)
-        if host and domain
-            [host, domain].join(".")
-        else
-            nil
-        end
+  setcode do
+    host = Facter.value(:hostname)
+    domain = Facter.value(:domain)
+    if host and domain
+      [host, domain].join(".")
+    else
+      nil
     end
+  end
 end

--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -11,6 +11,6 @@
 #
 
 Facter.add(:hardwareisa) do
-    setcode 'uname -p'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD DragonFly OEL OracleLinux OVS GNU/kFreeBSD}
+  setcode 'uname -p'
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD DragonFly OEL OracleLinux OVS GNU/kFreeBSD}
 end

--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -12,23 +12,23 @@
 #
 
 Facter.add(:hardwaremodel) do
-    setcode 'uname -m'
+  setcode 'uname -m'
 end
 
 Facter.add(:hardwaremodel) do
-    confine :operatingsystem => :aix
-    setcode do
-        model = Facter::Util::Resolution.exec('lsattr -El sys0 -a modelname')
-        if model =~ /modelname\s(\S+)\s/
-            $1
-        end
+  confine :operatingsystem => :aix
+  setcode do
+    model = Facter::Util::Resolution.exec('lsattr -El sys0 -a modelname')
+    if model =~ /modelname\s(\S+)\s/
+      $1
     end
+  end
 end
 
 Facter.add(:hardwaremodel) do
-    confine :operatingsystem => :windows
-    setcode do
-        require 'rbconfig'
-        Config::CONFIG['host_cpu']
-    end
+  confine :operatingsystem => :windows
+  setcode do
+    require 'rbconfig'
+    Config::CONFIG['host_cpu']
+  end
 end

--- a/lib/facter/hostname.rb
+++ b/lib/facter/hostname.rb
@@ -12,22 +12,22 @@
 #
 
 Facter.add(:hostname, :ldapname => "cn") do
-    setcode do
-        hostname = nil
-        if name = Facter::Util::Resolution.exec('hostname')
-            if name =~ /(.*?)\./
-                hostname = $1
-            else
-                hostname = name
-            end
-        end
-        hostname
+  setcode do
+    hostname = nil
+    if name = Facter::Util::Resolution.exec('hostname')
+      if name =~ /(.*?)\./
+        hostname = $1
+      else
+        hostname = name
+      end
     end
+    hostname
+  end
 end
 
 Facter.add(:hostname) do
-    confine :kernel => :darwin, :kernelrelease => "R7"
-    setcode do
-        Facter::Util::Resolution.exec('/usr/sbin/scutil --get LocalHostName')
-    end
+  confine :kernel => :darwin, :kernelrelease => "R7"
+  setcode do
+    Facter::Util::Resolution.exec('/usr/sbin/scutil --get LocalHostName')
+  end
 end

--- a/lib/facter/id.rb
+++ b/lib/facter/id.rb
@@ -12,10 +12,10 @@
 #
 
 Facter.add(:id) do
-    setcode "whoami"
+  setcode "whoami"
 end
 
 Facter.add(:id) do
-    confine :kernel => :SunOS
-    setcode "/usr/xpg4/bin/id -un"
+  confine :kernel => :SunOS
+  setcode "/usr/xpg4/bin/id -un"
 end

--- a/lib/facter/interfaces.rb
+++ b/lib/facter/interfaces.rb
@@ -20,22 +20,22 @@ require 'facter/util/ip'
 # is missing.
 
 Facter.add(:interfaces) do
-    confine :kernel => Facter::Util::IP.supported_platforms
-    setcode do
-        Facter::Util::IP.get_interfaces.collect { |iface| Facter::Util::IP.alphafy(iface) }.join(",")
-    end
+  confine :kernel => Facter::Util::IP.supported_platforms
+  setcode do
+    Facter::Util::IP.get_interfaces.collect { |iface| Facter::Util::IP.alphafy(iface) }.join(",")
+  end
 end
 
 Facter::Util::IP.get_interfaces.each do |interface|
 
-    # Make a fact for each detail of each interface.  Yay.
-    #   There's no point in confining these facts, since we wouldn't be able to create
-    # them if we weren't running on a supported platform.
-    %w{ipaddress ipaddress6 macaddress netmask}.each do |label|
-        Facter.add(label + "_" + Facter::Util::IP.alphafy(interface)) do
-            setcode do
-                Facter::Util::IP.get_interface_value(interface, label)
-            end
-        end
+  # Make a fact for each detail of each interface.  Yay.
+  #   There's no point in confining these facts, since we wouldn't be able to create
+  # them if we weren't running on a supported platform.
+  %w{ipaddress ipaddress6 macaddress netmask}.each do |label|
+    Facter.add(label + "_" + Facter::Util::IP.alphafy(interface)) do
+      setcode do
+        Facter::Util::IP.get_interface_value(interface, label)
+      end
     end
+  end
 end

--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -23,138 +23,138 @@
 #
 
 Facter.add(:ipaddress) do
-    confine :kernel => :linux
-    setcode do
-        ip = nil
-        output = %x{/sbin/ifconfig}
+  confine :kernel => :linux
+  setcode do
+    ip = nil
+    output = %x{/sbin/ifconfig}
 
-        output.split(/^\S/).each { |str|
-            if str =~ /inet addr:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-                tmp = $1
-                unless tmp =~ /^127\./
-                    ip = tmp
-                    break
-                end
-            end
-        }
+    output.split(/^\S/).each { |str|
+      if str =~ /inet addr:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+        tmp = $1
+        unless tmp =~ /^127\./
+          ip = tmp
+          break
+        end
+      end
+    }
 
-        ip
-    end
+    ip
+  end
 end
 
 Facter.add(:ipaddress) do
-    confine :kernel => %w{FreeBSD OpenBSD Darwin DragonFly}
-    setcode do
-        ip = nil
-        output = %x{/sbin/ifconfig}
+  confine :kernel => %w{FreeBSD OpenBSD Darwin DragonFly}
+  setcode do
+    ip = nil
+    output = %x{/sbin/ifconfig}
 
-        output.split(/^\S/).each { |str|
-            if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-                tmp = $1
-                unless tmp =~ /^127\./
-                    ip = tmp
-                    break
-                end
-            end
-        }
+    output.split(/^\S/).each { |str|
+      if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+        tmp = $1
+        unless tmp =~ /^127\./
+          ip = tmp
+          break
+        end
+      end
+    }
 
-        ip
-    end
+    ip
+  end
 end
 
 Facter.add(:ipaddress) do
-    confine :kernel => %w{NetBSD SunOS}
-    setcode do
-        ip = nil
-        output = %x{/sbin/ifconfig -a}
+  confine :kernel => %w{NetBSD SunOS}
+  setcode do
+    ip = nil
+    output = %x{/sbin/ifconfig -a}
 
-        output.split(/^\S/).each { |str|
-            if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-                tmp = $1
-                unless tmp =~ /^127\./ or tmp == "0.0.0.0"
-                    ip = tmp
-                    break
-                end
-            end
-        }
+    output.split(/^\S/).each { |str|
+      if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+        tmp = $1
+        unless tmp =~ /^127\./ or tmp == "0.0.0.0"
+          ip = tmp
+          break
+        end
+      end
+    }
 
-        ip
-    end
+    ip
+  end
 end
 
 Facter.add(:ipaddress) do
-    confine :kernel => %w{AIX}
-    setcode do
-        ip = nil
-        output = %x{/usr/sbin/ifconfig -a}
+  confine :kernel => %w{AIX}
+  setcode do
+    ip = nil
+    output = %x{/usr/sbin/ifconfig -a}
 
-        output.split(/^\S/).each { |str|
-            if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-                tmp = $1
-                unless tmp =~ /^127\./
-                    ip = tmp
-                    break
-                end
-            end
-        }
+    output.split(/^\S/).each { |str|
+      if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+        tmp = $1
+        unless tmp =~ /^127\./
+          ip = tmp
+          break
+        end
+      end
+    }
 
-        ip
-    end
+    ip
+  end
 end
 
 Facter.add(:ipaddress) do
-    confine :kernel => %w{windows}
-    setcode do
-        require 'socket'
-        IPSocket.getaddress(Socket.gethostname)
-    end
+  confine :kernel => %w{windows}
+  setcode do
+    require 'socket'
+    IPSocket.getaddress(Socket.gethostname)
+  end
 end
 
 Facter.add(:ipaddress, :ldapname => "iphostnumber", :timeout => 2) do
-    setcode do
-        if Facter.value(:kernel) == 'windows'
-            require 'win32/resolv'
-        else
-            require 'resolv'
-        end
-        
-        begin
-            if hostname = Facter.value(:hostname)
-                if Facter.value(:kernel) == 'windows'
-                    ip = Win32::Resolv.get_resolv_info.last[0]
-                else
-                    ip = Resolv.getaddress(hostname)                
-                end
-                unless ip == "127.0.0.1"
-                    ip
-                end
-            else
-                nil
-            end
-        rescue Resolv::ResolvError
-            nil
-        rescue NoMethodError # i think this is a bug in resolv.rb?
-            nil
-        end
+  setcode do
+    if Facter.value(:kernel) == 'windows'
+      require 'win32/resolv'
+    else
+      require 'resolv'
     end
+    
+    begin
+      if hostname = Facter.value(:hostname)
+        if Facter.value(:kernel) == 'windows'
+          ip = Win32::Resolv.get_resolv_info.last[0]
+        else
+          ip = Resolv.getaddress(hostname)        
+        end
+        unless ip == "127.0.0.1"
+          ip
+        end
+      else
+        nil
+      end
+    rescue Resolv::ResolvError
+      nil
+    rescue NoMethodError # i think this is a bug in resolv.rb?
+      nil
+    end
+  end
 end
 
 Facter.add(:ipaddress, :timeout => 2) do
-    setcode do
-        if hostname = Facter.value(:hostname)
-            # we need Hostname to exist for this to work
-            host = nil
-            if host = Facter::Util::Resolution.exec("host #{hostname}")
-                list = host.chomp.split(/\s/)
-                if defined? list[-1] and
-                        list[-1] =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/
-                    list[-1]
-                end
-            else
-                nil
-            end
-        else
-            nil
+  setcode do
+    if hostname = Facter.value(:hostname)
+      # we need Hostname to exist for this to work
+      host = nil
+      if host = Facter::Util::Resolution.exec("host #{hostname}")
+        list = host.chomp.split(/\s/)
+        if defined? list[-1] and
+          list[-1] =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/
+          list[-1]
         end
+      else
+        nil
+      end
+    else
+      nil
     end
+  end
 end

--- a/lib/facter/iphostnumber.rb
+++ b/lib/facter/iphostnumber.rb
@@ -10,20 +10,20 @@
 #
 
 Facter.add(:iphostnumber) do
-    confine :kernel => :darwin, :kernelrelease => "R6"
-    setcode do
-        %x{/usr/sbin/scutil --get LocalHostName}
-    end
+  confine :kernel => :darwin, :kernelrelease => "R6"
+  setcode do
+    %x{/usr/sbin/scutil --get LocalHostName}
+  end
 end
 Facter.add(:iphostnumber) do
-    confine :kernel => :darwin, :kernelrelease => "R6"
-    setcode do
-        ether = nil
-        output = %x{/sbin/ifconfig}
+  confine :kernel => :darwin, :kernelrelease => "R6"
+  setcode do
+    ether = nil
+    output = %x{/sbin/ifconfig}
 
-        output =~ /HWaddr (\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
-        ether = $1
+    output =~ /HWaddr (\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
+    ether = $1
 
-        ether
-    end
+    ether
+  end
 end

--- a/lib/facter/kernel.rb
+++ b/lib/facter/kernel.rb
@@ -10,13 +10,13 @@
 #
 
 Facter.add(:kernel) do
-    setcode do
-        require 'facter/util/config'
+  setcode do
+    require 'facter/util/config'
 
-        if Facter::Util::Config.is_windows?
-            'windows'
-        else
-            Facter::Util::Resolution.exec("uname -s")
-        end
+    if Facter::Util::Config.is_windows?
+      'windows'
+    else
+      Facter::Util::Resolution.exec("uname -s")
     end
+  end
 end

--- a/lib/facter/kernelmajversion.rb
+++ b/lib/facter/kernelmajversion.rb
@@ -9,7 +9,7 @@
 #
 
 Facter.add("kernelmajversion") do
-    setcode do
-        Facter.value(:kernelversion).split('.')[0..1].join('.')
-    end
+  setcode do
+    Facter.value(:kernelversion).split('.')[0..1].join('.')
+  end
 end

--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -12,23 +12,23 @@
 #
 
 Facter.add(:kernelrelease) do
-    setcode 'uname -r'
+  setcode 'uname -r'
 end
 
 Facter.add(:kernelrelease) do
-    confine :kernel => :aix
-    setcode 'oslevel -s'
+  confine :kernel => :aix
+  setcode 'oslevel -s'
 end
 
 Facter.add(:kernelrelease) do
-    confine :kernel => %{windows}
-    setcode do
-        require 'facter/util/wmi'
-        version = ""
-        Facter::Util::WMI.execquery("SELECT Version from Win32_OperatingSystem").each do |ole|
-            version = "#{ole.Version}"
-            break
-        end
-        version
+  confine :kernel => %{windows}
+  setcode do
+    require 'facter/util/wmi'
+    version = ""
+    Facter::Util::WMI.execquery("SELECT Version from Win32_OperatingSystem").each do |ole|
+      version = "#{ole.Version}"
+      break
     end
+    version
+  end
 end

--- a/lib/facter/kernelversion.rb
+++ b/lib/facter/kernelversion.rb
@@ -11,12 +11,12 @@
 #
 
 Facter.add("kernelversion") do
-    setcode do
-        Facter['kernelrelease'].value.split('-')[0]
-    end
+  setcode do
+    Facter['kernelrelease'].value.split('-')[0]
+  end
 end
 
 Facter.add("kernelversion") do
-    confine :kernel => :sunos
-    setcode 'uname -v'
+  confine :kernel => :sunos
+  setcode 'uname -v'
 end

--- a/lib/facter/lsb.rb
+++ b/lib/facter/lsb.rb
@@ -20,20 +20,20 @@
    "LSBDistDescription" => %r{^Description:\t(.*)$},
    "LSBDistCodeName"    => %r{^Codename:\t(.*)$}
 }.each do |fact, pattern|
-    Facter.add(fact) do
-        confine :kernel => [ :linux, :"gnu/kfreebsd" ]
-        setcode do
-            unless defined?(lsbdata) and defined?(lsbtime) and (Time.now.to_i - lsbtime.to_i < 5)
-                type = nil
-                lsbtime = Time.now
-                lsbdata = Facter::Util::Resolution.exec('lsb_release -a 2>/dev/null')
-            end
+  Facter.add(fact) do
+    confine :kernel => [ :linux, :"gnu/kfreebsd" ]
+    setcode do
+      unless defined?(lsbdata) and defined?(lsbtime) and (Time.now.to_i - lsbtime.to_i < 5)
+        type = nil
+        lsbtime = Time.now
+        lsbdata = Facter::Util::Resolution.exec('lsb_release -a 2>/dev/null')
+      end
 
-            if pattern.match(lsbdata)
-                $1
-            else
-                nil
-            end
-        end
+      if pattern.match(lsbdata)
+        $1
+      else
+        nil
+      end
     end
+  end
 end

--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -15,13 +15,13 @@
 require 'facter'
 
 Facter.add("lsbmajdistrelease") do
-    confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OracleLinux OVS GNU/kFreeBSD}
-    setcode do
-        if /(\d*)\./i =~ Facter.value(:lsbdistrelease)
-            result=$1
-        else
-            result=Facter.value(:lsbdistrelease)
-        end
-        result
+  confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OracleLinux OVS GNU/kFreeBSD}
+  setcode do
+    if /(\d*)\./i =~ Facter.value(:lsbdistrelease)
+      result=$1
+    else
+      result=Facter.value(:lsbdistrelease)
     end
+    result
+  end
 end

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -10,69 +10,69 @@
 require 'facter/util/macaddress'
 
 Facter.add(:macaddress) do
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OracleLinux OVS GNU/kFreeBSD}
-    setcode do
-        ether = []
-        output = Facter::Util::Resolution.exec("/sbin/ifconfig -a")
-        output.each_line do |s|
-            ether.push($1) if s =~ /(?:ether|HWaddr) (\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/
-        end
-        Facter::Util::Macaddress.standardize(ether[0])
-    end
-end
-
-Facter.add(:macaddress) do
-    confine :operatingsystem => "Solaris"
-    setcode do
-        ether = []
-        output = Facter::Util::Resolution.exec("/usr/bin/netstat -np")
-        output.each_line do |s|
-            ether.push($1) if s =~ /(?:SPLA)\s+(\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2})/
-        end
-        Facter::Util::Macaddress.standardize(ether[0])
-    end
-end
-
-Facter.add(:macaddress) do
-    confine :operatingsystem => %w{FreeBSD OpenBSD DragonFly}
-    setcode do
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OracleLinux OVS GNU/kFreeBSD}
+  setcode do
     ether = []
-        output = Facter::Util::Resolution.exec("/sbin/ifconfig")
-        output.each_line do |s|
-            if s =~ /(?:ether|lladdr)\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
-                ether.push($1)
-            end
-        end
-        Facter::Util::Macaddress.standardize(ether[0])
+    output = Facter::Util::Resolution.exec("/sbin/ifconfig -a")
+    output.each_line do |s|
+      ether.push($1) if s =~ /(?:ether|HWaddr) (\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/
     end
+    Facter::Util::Macaddress.standardize(ether[0])
+  end
 end
 
 Facter.add(:macaddress) do
-    confine :kernel => :darwin
-    setcode { Facter::Util::Macaddress::Darwin.macaddress }
+  confine :operatingsystem => "Solaris"
+  setcode do
+    ether = []
+    output = Facter::Util::Resolution.exec("/usr/bin/netstat -np")
+    output.each_line do |s|
+      ether.push($1) if s =~ /(?:SPLA)\s+(\w{2}:\w{2}:\w{2}:\w{2}:\w{2}:\w{2})/
+    end
+    Facter::Util::Macaddress.standardize(ether[0])
+  end
 end
 
 Facter.add(:macaddress) do
-    confine :kernel => %w{AIX}
-    setcode do
-        ether = []
-        ip = nil
-        output = %x{/usr/sbin/ifconfig -a}
-        output.each_line do |str|
-            if str =~ /([a-z]+\d+): flags=/
-                devname = $1
-                unless devname =~ /lo0/
-                    output2 = %x{/usr/bin/entstat #{devname}}
-                    output2.each_line do |str2|
-                        if str2 =~ /^Hardware Address: (\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/
-                            ether.push($1)
-                        end
-                    end
-                end
-            end
-        end
-        Facter::Util::Macaddress.standardize(ether[0])
+  confine :operatingsystem => %w{FreeBSD OpenBSD DragonFly}
+  setcode do
+    ether = []
+    output = Facter::Util::Resolution.exec("/sbin/ifconfig")
+    output.each_line do |s|
+      if s =~ /(?:ether|lladdr)\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
+        ether.push($1)
+      end
     end
+    Facter::Util::Macaddress.standardize(ether[0])
+  end
+end
+
+Facter.add(:macaddress) do
+  confine :kernel => :darwin
+  setcode { Facter::Util::Macaddress::Darwin.macaddress }
+end
+
+Facter.add(:macaddress) do
+  confine :kernel => %w{AIX}
+  setcode do
+    ether = []
+    ip = nil
+    output = %x{/usr/sbin/ifconfig -a}
+    output.each_line do |str|
+      if str =~ /([a-z]+\d+): flags=/
+        devname = $1
+        unless devname =~ /lo0/
+          output2 = %x{/usr/bin/entstat #{devname}}
+          output2.each_line do |str2|
+            if str2 =~ /^Hardware Address: (\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/
+              ether.push($1)
+            end
+          end
+        end
+      end
+    end
+    Facter::Util::Macaddress.standardize(ether[0])
+  end
 end
 
 Facter.add(:macaddress) do

--- a/lib/facter/macosx.rb
+++ b/lib/facter/macosx.rb
@@ -27,30 +27,30 @@
 require 'facter/util/macosx'
 
 if Facter.value(:kernel) == "Darwin"
-    Facter::Util::Macosx.hardware_overview.each do |fact, value|
-        Facter.add("sp_#{fact}") do
-            confine :kernel => :darwin
-            setcode do
-                value.to_s
-            end
-        end
+  Facter::Util::Macosx.hardware_overview.each do |fact, value|
+    Facter.add("sp_#{fact}") do
+      confine :kernel => :darwin
+      setcode do
+        value.to_s
+      end
     end
+  end
 
-    Facter::Util::Macosx.os_overview.each do |fact, value|
-        Facter.add("sp_#{fact}") do
-            confine :kernel => :darwin
-            setcode do
-                value.to_s
-            end
-        end
+  Facter::Util::Macosx.os_overview.each do |fact, value|
+    Facter.add("sp_#{fact}") do
+      confine :kernel => :darwin
+      setcode do
+        value.to_s
+      end
     end
+  end
 
-    Facter::Util::Macosx.sw_vers.each do |fact, value|
-        Facter.add(fact) do
-            confine :kernel => :darwin
-            setcode do
-                value
-            end
-        end
+  Facter::Util::Macosx.sw_vers.each do |fact, value|
+    Facter.add(fact) do
+      confine :kernel => :darwin
+      setcode do
+        value
+      end
     end
+  end
 end

--- a/lib/facter/manufacturer.rb
+++ b/lib/facter/manufacturer.rb
@@ -19,39 +19,39 @@
 require 'facter/util/manufacturer'
 
 if Facter.value(:kernel) == "OpenBSD"
-    mfg_keys = {
-        'hw.vendor'   => 'manufacturer',
-        'hw.product'  => 'productname',
-        'hw.serialno' => 'serialnumber'
-    }
+  mfg_keys = {
+    'hw.vendor'   => 'manufacturer',
+    'hw.product'  => 'productname',
+    'hw.serialno' => 'serialnumber'
+  }
 
-    Facter::Manufacturer.sysctl_find_system_info(mfg_keys)
+  Facter::Manufacturer.sysctl_find_system_info(mfg_keys)
 elsif Facter.value(:kernel) == "Darwin" 
-    mfg_keys = {
-        'hw.model'   => 'productname'
-    }
-    Facter::Manufacturer.sysctl_find_system_info(mfg_keys)
+  mfg_keys = {
+    'hw.model'   => 'productname'
+  }
+  Facter::Manufacturer.sysctl_find_system_info(mfg_keys)
 elsif Facter.value(:kernel) == "SunOS" and Facter.value(:hardwareisa) == "sparc"
-    Facter::Manufacturer.prtdiag_sparc_find_system_info()
+  Facter::Manufacturer.prtdiag_sparc_find_system_info()
 elsif Facter.value(:kernel) == "windows"
-    win32_keys = {
-        'manufacturer' => ['Manufacturer', 'Bios'],
-        'serialNumber' => ['Serialnumber', 'Bios'],
-        'productname'  => ['Name', 'ComputerSystemProduct']
-    }
-    Facter::Manufacturer.win32_find_system_info(win32_keys)
+  win32_keys = {
+    'manufacturer' => ['Manufacturer', 'Bios'],
+    'serialNumber' => ['Serialnumber', 'Bios'],
+    'productname'  => ['Name', 'ComputerSystemProduct']
+  }
+  Facter::Manufacturer.win32_find_system_info(win32_keys)
 else
-    query = {
-        '[Ss]ystem [Ii]nformation' => [
-            { 'Manufacturer:'      => 'manufacturer' },
-            { 'Product(?: Name)?:' => 'productname' },
-            { 'Serial Number:'     => 'serialnumber' }
-        ],
-        '(Chassis Information|system enclosure or chassis)' => [
-            { '(?:Chassis )?Type:' => 'type' }
-        ]
-    }
+  query = {
+    '[Ss]ystem [Ii]nformation' => [
+      { 'Manufacturer:'    => 'manufacturer' },
+      { 'Product(?: Name)?:' => 'productname' },
+      { 'Serial Number:'   => 'serialnumber' }
+    ],
+    '(Chassis Information|system enclosure or chassis)' => [
+      { '(?:Chassis )?Type:' => 'type' }
+    ]
+  }
 
-    Facter::Manufacturer.dmi_find_system_info(query)
+  Facter::Manufacturer.dmi_find_system_info(query)
 end
 

--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -29,180 +29,180 @@ require 'facter/util/memory'
     :SwapSize   => "SwapTotal",
     :SwapFree   => "SwapFree"
 }.each do |fact, name|
-    Facter.add(fact) do
-        confine :kernel => [ :linux, :"gnu/kfreebsd" ]
-        setcode do
-            Facter::Memory.meminfo_number(name)
-        end
+  Facter.add(fact) do
+    confine :kernel => [ :linux, :"gnu/kfreebsd" ]
+    setcode do
+      Facter::Memory.meminfo_number(name)
     end
+  end
 end
 
 Facter.add("SwapSize") do
-    confine :kernel => :Darwin
-    setcode do
+  confine :kernel => :Darwin
+  setcode do
     swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
     swaptotal = 0
     if swap =~ /total = (\S+)/ then swaptotal = $1; end
-      swaptotal
-    end
+    swaptotal
+  end
 end
 
 Facter.add("SwapFree") do
-    confine :kernel => :Darwin
-    setcode do
+  confine :kernel => :Darwin
+  setcode do
     swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
     swapfree = 0
     if swap =~ /free = (\S+)/ then swapfree = $1; end
-      swapfree
-    end
+    swapfree
+  end
 end
 
 Facter.add("SwapEncrypted") do
-    confine :kernel => :Darwin
-    setcode do
+  confine :kernel => :Darwin
+  setcode do
     swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
     encrypted = false
     if swap =~ /\(encrypted\)/ then encrypted = true; end
-      encrypted
-    end
+    encrypted
+  end
 end
 
 if Facter.value(:kernel) == "AIX" and Facter.value(:id) == "root"
-    swap = Facter::Util::Resolution.exec('swap -l')
-    swapfree, swaptotal = 0, 0
-    swap.each_line do |dev|
-      if dev =~ /^\/\S+\s.*\s+(\S+)MB\s+(\S+)MB/
-        swaptotal += $1.to_i
-        swapfree  += $2.to_i
-      end
+  swap = Facter::Util::Resolution.exec('swap -l')
+  swapfree, swaptotal = 0, 0
+  swap.each_line do |dev|
+    if dev =~ /^\/\S+\s.*\s+(\S+)MB\s+(\S+)MB/
+      swaptotal += $1.to_i
+      swapfree  += $2.to_i
     end
+  end
 
-    Facter.add("SwapSize") do
-        confine :kernel => :aix
-        setcode do
-            Facter::Memory.scale_number(swaptotal.to_f,"MB")
-        end
+  Facter.add("SwapSize") do
+    confine :kernel => :aix
+    setcode do
+      Facter::Memory.scale_number(swaptotal.to_f,"MB")
     end
+  end
 
-    Facter.add("SwapFree") do
-        confine :kernel => :aix
-        setcode do
-            Facter::Memory.scale_number(swapfree.to_f,"MB")
-        end
+  Facter.add("SwapFree") do
+    confine :kernel => :aix
+    setcode do
+      Facter::Memory.scale_number(swapfree.to_f,"MB")
     end
+  end
 end
 
 if Facter.value(:kernel) == "OpenBSD"
-    swap = Facter::Util::Resolution.exec('swapctl -s')
-    swapfree, swaptotal = 0, 0
-    if swap =~ /^total: (\d+)k bytes allocated = \d+k used, (\d+)k available$/
-        swaptotal = $1.to_i
-        swapfree  = $2.to_i
-    end
+  swap = Facter::Util::Resolution.exec('swapctl -s')
+  swapfree, swaptotal = 0, 0
+  if swap =~ /^total: (\d+)k bytes allocated = \d+k used, (\d+)k available$/
+    swaptotal = $1.to_i
+    swapfree  = $2.to_i
+  end
 
-    Facter.add("SwapSize") do
-        confine :kernel => :openbsd
-        setcode do
-            Facter::Memory.scale_number(swaptotal.to_f,"kB")
-        end
+  Facter.add("SwapSize") do
+    confine :kernel => :openbsd
+    setcode do
+      Facter::Memory.scale_number(swaptotal.to_f,"kB")
     end
+  end
 
-    Facter.add("SwapFree") do
-        confine :kernel => :openbsd
-        setcode do
-            Facter::Memory.scale_number(swapfree.to_f,"kB")
-        end
+  Facter.add("SwapFree") do
+    confine :kernel => :openbsd
+    setcode do
+      Facter::Memory.scale_number(swapfree.to_f,"kB")
     end
+  end
 
-    Facter::Memory.vmstat_find_free_memory()
+  Facter::Memory.vmstat_find_free_memory()
 
-    Facter.add("MemoryTotal") do
-        confine :kernel => :openbsd
-        memtotal = Facter::Util::Resolution.exec("sysctl hw.physmem | cut -d'=' -f2")
-        setcode do
-            Facter::Memory.scale_number(memtotal.to_f,"")
-        end
+  Facter.add("MemoryTotal") do
+    confine :kernel => :openbsd
+    memtotal = Facter::Util::Resolution.exec("sysctl hw.physmem | cut -d'=' -f2")
+    setcode do
+      Facter::Memory.scale_number(memtotal.to_f,"")
     end
+  end
 end
 
 if Facter.value(:kernel) == "Darwin"
-    swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
-    swapfree, swaptotal = 0, 0
-    unless swap.empty?
-        # Parse the line:
-        # vm.swapusage: total = 128.00M  used = 0.37M  free = 127.63M  (encrypted)
-        if swap =~ /total\s=\s(\S+)\s+used\s=\s(\S+)\s+free\s=\s(\S+)\s/
-            swaptotal += $1.to_i
-            swapfree  += $3.to_i
-        end
+  swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
+  swapfree, swaptotal = 0, 0
+  unless swap.empty?
+    # Parse the line:
+    # vm.swapusage: total = 128.00M  used = 0.37M  free = 127.63M  (encrypted)
+    if swap =~ /total\s=\s(\S+)\s+used\s=\s(\S+)\s+free\s=\s(\S+)\s/
+      swaptotal += $1.to_i
+      swapfree  += $3.to_i
     end
+  end
 
-    Facter.add("SwapSize") do
-        confine :kernel => :Darwin
-        setcode do
-            Facter::Memory.scale_number(swaptotal.to_f,"MB")
-        end
+  Facter.add("SwapSize") do
+    confine :kernel => :Darwin
+    setcode do
+      Facter::Memory.scale_number(swaptotal.to_f,"MB")
     end
+  end
 
-    Facter.add("SwapFree") do
-        confine :kernel => :Darwin
-        setcode do
-            Facter::Memory.scale_number(swapfree.to_f,"MB")
-        end
+  Facter.add("SwapFree") do
+    confine :kernel => :Darwin
+    setcode do
+      Facter::Memory.scale_number(swapfree.to_f,"MB")
     end
+  end
 
-    Facter::Memory.vmstat_darwin_find_free_memory()
+  Facter::Memory.vmstat_darwin_find_free_memory()
 
-    Facter.add("MemoryTotal") do
-        confine :kernel => :Darwin
-        memtotal = Facter::Util::Resolution.exec("sysctl hw.memsize | cut -d':' -f2")
-        setcode do
-            Facter::Memory.scale_number(memtotal.to_f,"")
-        end
+  Facter.add("MemoryTotal") do
+    confine :kernel => :Darwin
+    memtotal = Facter::Util::Resolution.exec("sysctl hw.memsize | cut -d':' -f2")
+    setcode do
+      Facter::Memory.scale_number(memtotal.to_f,"")
     end
+  end
 end
 
 if Facter.value(:kernel) == "SunOS"
-    swap = Facter::Util::Resolution.exec('/usr/sbin/swap -l')
-    swapfree, swaptotal = 0, 0
-    swap.each_line do |dev|
-        if dev =~ /^\/\S+\s.*\s+(\d+)\s+(\d+)$/
-            swaptotal += $1.to_i / 2
-            swapfree  += $2.to_i / 2
-        end
+  swap = Facter::Util::Resolution.exec('/usr/sbin/swap -l')
+  swapfree, swaptotal = 0, 0
+  swap.each_line do |dev|
+    if dev =~ /^\/\S+\s.*\s+(\d+)\s+(\d+)$/
+      swaptotal += $1.to_i / 2
+      swapfree  += $2.to_i / 2
     end
+  end
 
-    Facter.add("SwapSize") do
-        confine :kernel => :sunos
-        setcode do
-            Facter::Memory.scale_number(swaptotal.to_f,"kB")
-        end
+  Facter.add("SwapSize") do
+    confine :kernel => :sunos
+    setcode do
+      Facter::Memory.scale_number(swaptotal.to_f,"kB")
     end
+  end
 
-    Facter.add("SwapFree") do
-        confine :kernel => :sunos
-        setcode do
-            Facter::Memory.scale_number(swapfree.to_f,"kB")
-        end
+  Facter.add("SwapFree") do
+    confine :kernel => :sunos
+    setcode do
+      Facter::Memory.scale_number(swapfree.to_f,"kB")
     end
+  end
 
-    # Total memory size available from prtconf
-    pconf = Facter::Util::Resolution.exec('/usr/sbin/prtconf 2>/dev/null')
-    phymem = ""
-    pconf.each_line do |line|
-        if line =~ /^Memory size:\s+(\d+) Megabytes/
-            phymem = $1
-        end
+  # Total memory size available from prtconf
+  pconf = Facter::Util::Resolution.exec('/usr/sbin/prtconf 2>/dev/null')
+  phymem = ""
+  pconf.each_line do |line|
+    if line =~ /^Memory size:\s+(\d+) Megabytes/
+      phymem = $1
     end
+  end
 
-    Facter.add("MemorySize") do
-        confine :kernel => :sunos
-        setcode do
-            Facter::Memory.scale_number(phymem.to_f,"MB")
-        end
+  Facter.add("MemorySize") do
+    confine :kernel => :sunos
+    setcode do
+      Facter::Memory.scale_number(phymem.to_f,"MB")
     end
+  end
 
-    Facter::Memory.vmstat_find_free_memory()
+  Facter::Memory.vmstat_find_free_memory()
 end
 
 if Facter.value(:kernel) == "windows"
@@ -234,31 +234,31 @@ if Facter.value(:kernel) == "windows"
 end
 
 Facter.add("SwapSize") do
-    confine :kernel => :dragonfly
-    setcode do
-        page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
-        swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
-        Facter::Memory.scale_number(swaptotal.to_f,"")
-    end
+  confine :kernel => :dragonfly
+  setcode do
+    page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
+    swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
+    Facter::Memory.scale_number(swaptotal.to_f,"")
+  end
 end
 
 Facter.add("SwapFree") do
-    confine :kernel => :dragonfly
-    setcode do
-        page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
-        swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
-        swap_anon_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_anon_use").to_f * page_size
-        swap_cache_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_cache_use").to_f * page_size
-        swapfree = swaptotal - swap_anon_use - swap_cache_use
-        Facter::Memory.scale_number(swapfree.to_f,"")
-    end
+  confine :kernel => :dragonfly
+  setcode do
+    page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
+    swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
+    swap_anon_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_anon_use").to_f * page_size
+    swap_cache_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_cache_use").to_f * page_size
+    swapfree = swaptotal - swap_anon_use - swap_cache_use
+    Facter::Memory.scale_number(swapfree.to_f,"")
+  end
 end
 
 Facter.add("MemoryTotal") do
-    confine :kernel => :dragonfly
-    setcode do
-        Facter::Memory.vmstat_find_free_memory()
-        memtotal = Facter::Util::Resolution.exec("sysctl -n hw.physmem")
-        Facter::Memory.scale_number(memtotal.to_f,"")
-    end
+  confine :kernel => :dragonfly
+  setcode do
+    Facter::Memory.vmstat_find_free_memory()
+    memtotal = Facter::Util::Resolution.exec("sysctl -n hw.physmem")
+    Facter::Memory.scale_number(memtotal.to_f,"")
+  end
 end

--- a/lib/facter/netmask.rb
+++ b/lib/facter/netmask.rb
@@ -18,9 +18,9 @@
 require 'facter/util/netmask'
 
 Facter.add("netmask") do
-    confine :kernel => [ :sunos, :linux, :freebsd, :openbsd, :netbsd, :darwin, :"gnu/kfreebsd", :dragonfly ]
-    setcode do
-        Facter::NetMask.get_netmask
-    end
+  confine :kernel => [ :sunos, :linux, :freebsd, :openbsd, :netbsd, :darwin, :"gnu/kfreebsd", :dragonfly ]
+  setcode do
+    Facter::NetMask.get_netmask
+  end
 end
 

--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -13,9 +13,9 @@
 require 'facter/util/ip'
 
 Facter::Util::IP.get_interfaces.each do |interface|
-    Facter.add("network_" + Facter::Util::IP.alphafy(interface)) do
-        setcode do
-            Facter::Util::IP.get_network_value(interface)
-        end 
+  Facter.add("network_" + Facter::Util::IP.alphafy(interface)) do
+    setcode do
+      Facter::Util::IP.get_network_value(interface)
     end 
+  end 
 end

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -14,87 +14,87 @@
 require 'facter/lsb'
 
 Facter.add(:operatingsystem) do
-    confine :kernel => :sunos
-    setcode do "Solaris" end
+  confine :kernel => :sunos
+  setcode do "Solaris" end
 end
 
 Facter.add(:operatingsystem) do
-    confine :kernel => :linux
-    setcode do
-        if Facter.value(:lsbdistid) == "Ubuntu"
-           "Ubuntu"
-        elsif FileTest.exists?("/etc/debian_version")
-            "Debian"
-        elsif FileTest.exists?("/etc/gentoo-release")
-            "Gentoo"
-        elsif FileTest.exists?("/etc/fedora-release")
-            "Fedora"
-        elsif FileTest.exists?("/etc/mandriva-release")
-            "Mandriva"
-        elsif FileTest.exists?("/etc/mandrake-release")
-            "Mandrake"
-        elsif FileTest.exists?("/etc/meego-release")
-            "MeeGo"
-        elsif FileTest.exists?("/etc/arch-release")
-            "Archlinux"
-        elsif FileTest.exists?("/etc/oracle-release")
-            "OracleLinux"
-        elsif FileTest.exists?("/etc/enterprise-release")
-            if FileTest.exists?("/etc/ovs-release")
-                "OVS"
-            else
-                "OEL"
-            end
-        elsif FileTest.exists?("/etc/arch-release")
-            "Arch"
-        elsif FileTest.exists?("/etc/vmware-release")
-            "VMWareESX"
-        elsif FileTest.exists?("/etc/redhat-release")
-            txt = File.read("/etc/redhat-release")
-            if txt =~ /centos/i
-                "CentOS"
-            elsif txt =~ /CERN/
-                "SLC"
-            elsif txt =~ /scientific/i 
-                "Scientific"
-            elsif txt =~ /^cloudlinux/i
-                "CloudLinux"
-            else
-                "RedHat"
-            end
-        elsif FileTest.exists?("/etc/SuSE-release")
-            txt = File.read("/etc/SuSE-release")
-            if txt =~ /^SUSE LINUX Enterprise Server/i
-                "SLES"
-            elsif txt =~ /^SUSE LINUX Enterprise Desktop/i
-                "SLED"
-            elsif txt =~ /^openSUSE/i
-                "OpenSuSE"
-            else
-                "SuSE"
-            end
-        elsif FileTest.exists?("/etc/bluewhite64-version")
-            "Bluewhite64"
-        elsif FileTest.exists?("/etc/slamd64-version")
-            "Slamd64"
-        elsif FileTest.exists?("/etc/slackware-version")
-            "Slackware"
-        elsif FileTest.exists?("/etc/alpine-release")
-            "Alpine"
-        elsif Facter.value(:lsbdistdescription) =~ /Amazon Linux/
-            "Amazon"
-        end
+  confine :kernel => :linux
+  setcode do
+    if Facter.value(:lsbdistid) == "Ubuntu"
+       "Ubuntu"
+    elsif FileTest.exists?("/etc/debian_version")
+      "Debian"
+    elsif FileTest.exists?("/etc/gentoo-release")
+      "Gentoo"
+    elsif FileTest.exists?("/etc/fedora-release")
+      "Fedora"
+    elsif FileTest.exists?("/etc/mandriva-release")
+      "Mandriva"
+    elsif FileTest.exists?("/etc/mandrake-release")
+      "Mandrake"
+    elsif FileTest.exists?("/etc/meego-release")
+      "MeeGo"
+    elsif FileTest.exists?("/etc/arch-release")
+      "Archlinux"
+    elsif FileTest.exists?("/etc/oracle-release")
+      "OracleLinux"
+    elsif FileTest.exists?("/etc/enterprise-release")
+      if FileTest.exists?("/etc/ovs-release")
+        "OVS"
+      else
+        "OEL"
+      end
+    elsif FileTest.exists?("/etc/arch-release")
+      "Arch"
+    elsif FileTest.exists?("/etc/vmware-release")
+      "VMWareESX"
+    elsif FileTest.exists?("/etc/redhat-release")
+      txt = File.read("/etc/redhat-release")
+      if txt =~ /centos/i
+        "CentOS"
+      elsif txt =~ /CERN/
+        "SLC"
+      elsif txt =~ /scientific/i 
+        "Scientific"
+      elsif txt =~ /^cloudlinux/i
+        "CloudLinux"
+      else
+        "RedHat"
+      end
+    elsif FileTest.exists?("/etc/SuSE-release")
+      txt = File.read("/etc/SuSE-release")
+      if txt =~ /^SUSE LINUX Enterprise Server/i
+        "SLES"
+      elsif txt =~ /^SUSE LINUX Enterprise Desktop/i
+        "SLED"
+      elsif txt =~ /^openSUSE/i
+        "OpenSuSE"
+      else
+        "SuSE"
+      end
+    elsif FileTest.exists?("/etc/bluewhite64-version")
+      "Bluewhite64"
+    elsif FileTest.exists?("/etc/slamd64-version")
+      "Slamd64"
+    elsif FileTest.exists?("/etc/slackware-version")
+      "Slackware"
+    elsif FileTest.exists?("/etc/alpine-release")
+      "Alpine"
+    elsif Facter.value(:lsbdistdescription) =~ /Amazon Linux/
+      "Amazon"
     end
+  end
 end
 
 Facter.add(:operatingsystem) do
-    confine :kernel => "VMkernel"
-    setcode do
-        "ESXi"
-    end
+  confine :kernel => "VMkernel"
+  setcode do
+    "ESXi"
+  end
 end
 
 Facter.add(:operatingsystem) do
-    # Default to just returning the kernel as the operating system
-    setcode do Facter[:kernel].value end
+  # Default to just returning the kernel as the operating system
+  setcode do Facter[:kernel].value end
 end

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -17,112 +17,112 @@
 #
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{CentOS Fedora oel ovs OracleLinux RedHat MeeGo Scientific SLC CloudLinux}
-    setcode do
-        case Facter.value(:operatingsystem)
-        when "CentOS", "RedHat", "Scientific", "SLC", "CloudLinux"
-            releasefile = "/etc/redhat-release"
-        when "Fedora"
-            releasefile = "/etc/fedora-release"
-        when "MeeGo"
-            releasefile = "/etc/meego-release"
-        when "OracleLinux"
-            releasefile = "/etc/oracle-release"
-        when "OEL", "oel"
-            releasefile = "/etc/enterprise-release"
-        when "OVS", "ovs"
-            releasefile = "/etc/ovs-release"
-        end
-        File::open(releasefile, "r") do |f|
-            line = f.readline.chomp
-            if line =~ /\(Rawhide\)$/
-                "Rawhide"
-            elsif line =~ /release (\d[\d.]*)/
-                $1
-            end
-        end
+  confine :operatingsystem => %w{CentOS Fedora oel ovs OracleLinux RedHat MeeGo Scientific SLC CloudLinux}
+  setcode do
+    case Facter.value(:operatingsystem)
+    when "CentOS", "RedHat", "Scientific", "SLC", "CloudLinux"
+      releasefile = "/etc/redhat-release"
+    when "Fedora"
+      releasefile = "/etc/fedora-release"
+    when "MeeGo"
+      releasefile = "/etc/meego-release"
+    when "OracleLinux"
+      releasefile = "/etc/oracle-release"
+    when "OEL", "oel"
+      releasefile = "/etc/enterprise-release"
+    when "OVS", "ovs"
+      releasefile = "/etc/ovs-release"
     end
+    File::open(releasefile, "r") do |f|
+      line = f.readline.chomp
+      if line =~ /\(Rawhide\)$/
+        "Rawhide"
+      elsif line =~ /release (\d[\d.]*)/
+        $1
+      end
+    end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{Debian}
-    setcode do
-        release = Facter::Util::Resolution.exec('cat /etc/debian_version')
-    end
+  confine :operatingsystem => %w{Debian}
+  setcode do
+    release = Facter::Util::Resolution.exec('cat /etc/debian_version')
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{Ubuntu}
-    setcode do
-        release = Facter::Util::Resolution.exec('cat /etc/issue')
-        if release =~ /Ubuntu (\d+.\d+)/
-            $1
-        end
+  confine :operatingsystem => %w{Ubuntu}
+  setcode do
+    release = Facter::Util::Resolution.exec('cat /etc/issue')
+    if release =~ /Ubuntu (\d+.\d+)/
+      $1
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{SLES SLED OpenSuSE}
-    setcode do
-        releasefile = Facter::Util::Resolution.exec('cat /etc/SuSE-release')
-        if releasefile =~ /^VERSION\s*=\s*(\d+)/
-            releasemajor = $1
-            if releasefile =~ /^PATCHLEVEL\s*=\s*(\d+)/
-                releaseminor = $1
-            elsif releasefile =~ /^VERSION\s=.*.(\d+)/
-                releaseminor = $1
-            else
-                releaseminor = "0"
-            end
-            releasemajor + "." + releaseminor
-        else
-            "unknown"
-        end
+  confine :operatingsystem => %w{SLES SLED OpenSuSE}
+  setcode do
+    releasefile = Facter::Util::Resolution.exec('cat /etc/SuSE-release')
+    if releasefile =~ /^VERSION\s*=\s*(\d+)/
+      releasemajor = $1
+      if releasefile =~ /^PATCHLEVEL\s*=\s*(\d+)/
+        releaseminor = $1
+      elsif releasefile =~ /^VERSION\s=.*.(\d+)/
+        releaseminor = $1
+      else
+        releaseminor = "0"
+      end
+      releasemajor + "." + releaseminor
+    else
+      "unknown"
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{Slackware}
-    setcode do
-        release = Facter::Util::Resolution.exec('cat /etc/slackware-version')
-        if release =~ /Slackware ([0-9.]+)/
-            $1
-        end
+  confine :operatingsystem => %w{Slackware}
+  setcode do
+    release = Facter::Util::Resolution.exec('cat /etc/slackware-version')
+    if release =~ /Slackware ([0-9.]+)/
+      $1
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{Bluewhite64}
-    setcode do
-        releasefile = Facter::Util::Resolution.exec('cat /etc/bluewhite64-version')
-        if releasefile =~ /^\s*\w+\s+(\d+)\.(\d+)/
-            $1 + "." + $2
-        else
-            "unknown"
-        end
+  confine :operatingsystem => %w{Bluewhite64}
+  setcode do
+    releasefile = Facter::Util::Resolution.exec('cat /etc/bluewhite64-version')
+    if releasefile =~ /^\s*\w+\s+(\d+)\.(\d+)/
+      $1 + "." + $2
+    else
+      "unknown"
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{VMwareESX}
-    setcode do
-        release = Facter::Util::Resolution.exec('vmware -v')
-        if release =~ /VMware ESX .*?(\d.*)/
-            $1
-        end
+  confine :operatingsystem => %w{VMwareESX}
+  setcode do
+    release = Facter::Util::Resolution.exec('vmware -v')
+    if release =~ /VMware ESX .*?(\d.*)/
+      $1
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %w{Slamd64}
-    setcode do
-        releasefile = Facter::Util::Resolution.exec('cat /etc/slamd64-version')
-        if releasefile =~ /^\s*\w+\s+(\d+)\.(\d+)/
-            $1 + "." + $2
-        else
-            "unknown"
-        end
+  confine :operatingsystem => %w{Slamd64}
+  setcode do
+    releasefile = Facter::Util::Resolution.exec('cat /etc/slamd64-version')
+    if releasefile =~ /^\s*\w+\s+(\d+)\.(\d+)/
+      $1 + "." + $2
+    else
+      "unknown"
     end
+  end
 end
 
 Facter.add(:operatingsystemrelease) do
@@ -133,10 +133,10 @@ Facter.add(:operatingsystemrelease) do
 end
 
 Facter.add(:operatingsystemrelease) do
-    confine :operatingsystem => %W{Amazon}
-    setcode do Facter[:lsbdistrelease].value end
+  confine :operatingsystem => %W{Amazon}
+  setcode do Facter[:lsbdistrelease].value end
 end
 
 Facter.add(:operatingsystemrelease) do
-    setcode do Facter[:kernelrelease].value end
+  setcode do Facter[:kernelrelease].value end
 end

--- a/lib/facter/path.rb
+++ b/lib/facter/path.rb
@@ -8,7 +8,7 @@
 #
 
 Facter.add(:path) do
-    setcode do
-        ENV['PATH']
-    end
+  setcode do
+    ENV['PATH']
+  end
 end

--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -57,10 +57,10 @@ Facter.add("ProcessorCount") do
 end
 
 Facter.add("Processor") do
-    confine :kernel => :openbsd
-    setcode do
-        Facter::Util::Resolution.exec("uname -p")
-    end
+  confine :kernel => :openbsd
+  setcode do
+    Facter::Util::Resolution.exec("uname -p")
+  end
 end
 
 Facter.add("ProcessorCount") do

--- a/lib/facter/ps.rb
+++ b/lib/facter/ps.rb
@@ -11,12 +11,12 @@
 #
 
 Facter.add(:ps) do
-    setcode do 'ps -ef' end
+  setcode do 'ps -ef' end
 end
 
 Facter.add(:ps) do
-    confine :operatingsystem => %w{FreeBSD NetBSD OpenBSD Darwin DragonFly}
-    setcode do 'ps auxwww' end
+  confine :operatingsystem => %w{FreeBSD NetBSD OpenBSD Darwin DragonFly}
+  setcode do 'ps auxwww' end
 end
 
 Facter.add(:ps) do

--- a/lib/facter/puppetversion.rb
+++ b/lib/facter/puppetversion.rb
@@ -9,12 +9,12 @@
 #
 
 Facter.add(:puppetversion) do
-    setcode do
-        begin
-            require 'puppet'
-            Puppet::PUPPETVERSION.to_s
-        rescue LoadError
-            nil
-        end
+  setcode do
+    begin
+      require 'puppet'
+      Puppet::PUPPETVERSION.to_s
+    rescue LoadError
+      nil
     end
+  end
 end

--- a/lib/facter/rubysitedir.rb
+++ b/lib/facter/rubysitedir.rb
@@ -9,10 +9,10 @@
 #
 
 Facter.add :rubysitedir do
-    setcode do
-        version = RUBY_VERSION.to_s.sub(/\.\d+$/, '')
-        $:.find do |dir|
-            dir =~ /#{File.join("site_ruby", version)}$/
-        end
+  setcode do
+    version = RUBY_VERSION.to_s.sub(/\.\d+$/, '')
+    $:.find do |dir|
+      dir =~ /#{File.join("site_ruby", version)}$/
     end
+  end
 end

--- a/lib/facter/rubyversion.rb
+++ b/lib/facter/rubyversion.rb
@@ -8,5 +8,5 @@
 #
 
 Facter.add(:rubyversion) do
-    setcode { RUBY_VERSION.to_s }
+  setcode { RUBY_VERSION.to_s }
 end

--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -12,20 +12,20 @@
 ##
 
 ["/etc/ssh","/usr/local/etc/ssh","/etc","/usr/local/etc"].each do |dir|
-    {"SSHDSAKey" => "ssh_host_dsa_key.pub", "SSHRSAKey" => "ssh_host_rsa_key.pub", "SSHECDSAKey" => "ssh_host_ecdsa_key.pub"}.each do |name,file|
-        Facter.add(name) do
-            setcode do
-                value = nil
-                filepath = File.join(dir,file)
-                if FileTest.file?(filepath)
-                    begin
-                        File.open(filepath) { |f| value = f.read.chomp.split(/\s+/)[1] }
-                    rescue
-                        value = nil
-                    end
-                end
-                value
-            end # end of proc
-        end # end of add
-    end # end of hash each
+  {"SSHDSAKey" => "ssh_host_dsa_key.pub", "SSHRSAKey" => "ssh_host_rsa_key.pub", "SSHECDSAKey" => "ssh_host_ecdsa_key.pub"}.each do |name,file|
+    Facter.add(name) do
+      setcode do
+        value = nil
+        filepath = File.join(dir,file)
+        if FileTest.file?(filepath)
+          begin
+            File.open(filepath) { |f| value = f.read.chomp.split(/\s+/)[1] }
+          rescue
+            value = nil
+          end
+        end
+        value
+      end # end of proc
+    end # end of add
+  end # end of hash each
 end # end of dir each

--- a/lib/facter/timezone.rb
+++ b/lib/facter/timezone.rb
@@ -8,7 +8,7 @@
 #
 
 Facter.add("timezone") do
-     setcode do
-         Time.new.zone
-     end
+  setcode do
+    Time.new.zone
+  end
 end

--- a/lib/facter/uniqueid.rb
+++ b/lib/facter/uniqueid.rb
@@ -1,4 +1,4 @@
 Facter.add(:uniqueid) do
-    setcode 'hostid'
-    confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OracleLinux OVS GNU/kFreeBSD}
+  setcode 'hostid'
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OracleLinux OVS GNU/kFreeBSD}
 end

--- a/lib/facter/util/collection.rb
+++ b/lib/facter/util/collection.rb
@@ -5,126 +5,126 @@ require 'facter/util/loader'
 # Manage which facts exist and how we access them.  Largely just a wrapper
 # around a hash of facts.
 class Facter::Util::Collection
-    # Return a fact object by name.  If you use this, you still have to call
-    # 'value' on it to retrieve the actual value.
-    def [](name)
-        value(name)
+  # Return a fact object by name.  If you use this, you still have to call
+  # 'value' on it to retrieve the actual value.
+  def [](name)
+    value(name)
+  end
+
+  # Add a resolution mechanism for a named fact.  This does not distinguish
+  # between adding a new fact and adding a new way to resolve a fact.
+  def add(name, options = {}, &block)
+    name = canonize(name)
+
+    unless fact = @facts[name]
+      fact = Facter::Util::Fact.new(name)
+
+      @facts[name] = fact
     end
 
-    # Add a resolution mechanism for a named fact.  This does not distinguish
-    # between adding a new fact and adding a new way to resolve a fact.
-    def add(name, options = {}, &block)
-        name = canonize(name)
+    # Set any fact-appropriate options.
+    options.each do |opt, value|
+      method = opt.to_s + "="
+      if fact.respond_to?(method)
+        fact.send(method, value)
+        options.delete(opt)
+      end
+    end
 
-        unless fact = @facts[name]
-            fact = Facter::Util::Fact.new(name)
-
-            @facts[name] = fact
+    if block
+      resolve = fact.add(&block)
+      # Set any resolve-appropriate options
+      options.each do |opt, value|
+        method = opt.to_s + "="
+        if resolve.respond_to?(method)
+          resolve.send(method, value)
+          options.delete(opt)
         end
-
-        # Set any fact-appropriate options.
-        options.each do |opt, value|
-            method = opt.to_s + "="
-            if fact.respond_to?(method)
-                fact.send(method, value)
-                options.delete(opt)
-            end
-        end
-
-        if block
-            resolve = fact.add(&block)
-            # Set any resolve-appropriate options
-            options.each do |opt, value|
-                method = opt.to_s + "="
-                if resolve.respond_to?(method)
-                    resolve.send(method, value)
-                    options.delete(opt)
-                end
-            end
-        end
-
-        unless options.empty?
-            raise ArgumentError, "Invalid facter option(s) %s" % options.keys.collect { |k| k.to_s }.join(",")
-        end
-
-        return fact
+      end
     end
 
-    include Enumerable
-
-    # Iterate across all of the facts.
-    def each
-        @facts.each do |name, fact|
-            value = fact.value
-            unless value.nil?
-                yield name.to_s, value
-            end
-        end
+    unless options.empty?
+      raise ArgumentError, "Invalid facter option(s) %s" % options.keys.collect { |k| k.to_s }.join(",")
     end
 
-    # Return a fact by name.
-    def fact(name)
-        name = canonize(name)
+    return fact
+  end
 
-        # Try to load the fact if necessary
-        loader.load(name) unless @facts[name]
+  include Enumerable
 
-        # Try HARDER
-        loader.load_all unless @facts[name]
-
-        @facts[name]
+  # Iterate across all of the facts.
+  def each
+    @facts.each do |name, fact|
+      value = fact.value
+      unless value.nil?
+        yield name.to_s, value
+      end
     end
+  end
 
-    # Flush all cached values.
-    def flush
-        @facts.each { |name, fact| fact.flush }
+  # Return a fact by name.
+  def fact(name)
+    name = canonize(name)
+
+    # Try to load the fact if necessary
+    loader.load(name) unless @facts[name]
+
+    # Try HARDER
+    loader.load_all unless @facts[name]
+
+    @facts[name]
+  end
+
+  # Flush all cached values.
+  def flush
+    @facts.each { |name, fact| fact.flush }
+  end
+
+  def initialize
+    @facts = Hash.new
+  end
+
+  # Return a list of all of the facts.
+  def list
+    return @facts.keys
+  end
+
+  # Load all known facts.
+  def load_all
+    loader.load_all
+  end
+
+  # The thing that loads facts if we don't have them.
+  def loader
+    unless defined?(@loader)
+      @loader = Facter::Util::Loader.new
     end
+    @loader
+  end
 
-    def initialize
-        @facts = Hash.new
+  # Return a hash of all of our facts.
+  def to_hash
+    @facts.inject({}) do |h, ary|
+      value = ary[1].value
+      if ! value.nil?
+        # For backwards compatibility, convert the fact name to a string.
+        h[ary[0].to_s] = value
+      end
+      h
     end
+  end
 
-    # Return a list of all of the facts.
-    def list
-        return @facts.keys
+  def value(name)
+    if fact = fact(name)
+      fact.value
     end
+  end
 
-    # Load all known facts.
-    def load_all
-        loader.load_all
-    end
+  private
 
-    # The thing that loads facts if we don't have them.
-    def loader
-        unless defined?(@loader)
-            @loader = Facter::Util::Loader.new
-        end
-        @loader
-    end
-
-    # Return a hash of all of our facts.
-    def to_hash
-        @facts.inject({}) do |h, ary|
-            value = ary[1].value
-            if ! value.nil?
-                # For backwards compatibility, convert the fact name to a string.
-                h[ary[0].to_s] = value
-            end
-            h
-        end
-    end
-
-    def value(name)
-        if fact = fact(name)
-            fact.value
-        end
-    end
-
-    private
-
-    # Provide a consistent means of getting the exact same fact name
-    # every time.
-    def canonize(name)
-        name.to_s.downcase.to_sym
-    end
+  # Provide a consistent means of getting the exact same fact name
+  # every time.
+  def canonize(name)
+    name.to_s.downcase.to_sym
+  end
 end

--- a/lib/facter/util/confine.rb
+++ b/lib/facter/util/confine.rb
@@ -4,38 +4,38 @@
 require 'facter/util/values'
 
 class Facter::Util::Confine
-    attr_accessor :fact, :values
+  attr_accessor :fact, :values
 
-    include Facter::Util::Values
+  include Facter::Util::Values
 
-    # Add the restriction.  Requires the fact name, an operator, and the value
-    # we're comparing to.
-    def initialize(fact, *values)
-        raise ArgumentError, "The fact name must be provided" unless fact
-        raise ArgumentError, "One or more values must be provided" if values.empty?
-        @fact = fact
-        @values = values
+  # Add the restriction.  Requires the fact name, an operator, and the value
+  # we're comparing to.
+  def initialize(fact, *values)
+    raise ArgumentError, "The fact name must be provided" unless fact
+    raise ArgumentError, "One or more values must be provided" if values.empty?
+    @fact = fact
+    @values = values
+  end
+
+  def to_s
+    return "'%s' '%s'" % [@fact, @values.join(",")]
+  end
+
+  # Evaluate the fact, returning true or false.
+  def true?
+    unless fact = Facter[@fact]
+      Facter.debug "No fact for %s" % @fact
+      return false
     end
+    value = convert(fact.value)
 
-    def to_s
-        return "'%s' '%s'" % [@fact, @values.join(",")]
+    return false if value.nil?
+
+    @values.each do |v|
+      v = convert(v)
+      next unless v.class == value.class
+      return true if value == v
     end
-
-    # Evaluate the fact, returning true or false.
-    def true?
-        unless fact = Facter[@fact]
-            Facter.debug "No fact for %s" % @fact
-            return false
-        end
-        value = convert(fact.value)
-
-        return false if value.nil?
-
-        @values.each do |v|
-            v = convert(v)
-            next unless v.class == value.class
-            return true if value == v
-        end
-        return false
-    end
+    return false
+  end
 end

--- a/lib/facter/util/fact.rb
+++ b/lib/facter/util/fact.rb
@@ -2,119 +2,119 @@ require 'facter'
 require 'facter/util/resolution'
 
 class Facter::Util::Fact
-    TIMEOUT = 5
+  TIMEOUT = 5
 
-    attr_accessor :name, :ldapname
+  attr_accessor :name, :ldapname
 
-    # Create a new fact, with no resolution mechanisms.
-    def initialize(name, options = {})
-        @name = name.to_s.downcase.intern
+  # Create a new fact, with no resolution mechanisms.
+  def initialize(name, options = {})
+    @name = name.to_s.downcase.intern
 
-        # LAK:NOTE: This is slow for many options, but generally we won't have any and at
-        # worst we'll have one.  If we add more, this should be made more efficient.
-        options.each do |name, value|
-            case name
-            when :ldapname; self.ldapname = value
-            else
-                raise ArgumentError, "Invalid fact option '%s'" % name
-            end
-        end
-
-        @ldapname ||= @name.to_s
-
-        @resolves = []
-        @searching = false
-
-        @value = nil
+    # LAK:NOTE: This is slow for many options, but generally we won't have any and at
+    # worst we'll have one.  If we add more, this should be made more efficient.
+    options.each do |name, value|
+      case name
+      when :ldapname; self.ldapname = value
+      else
+        raise ArgumentError, "Invalid fact option '%s'" % name
+      end
     end
 
-    # Add a new resolution mechanism.  This requires a block, which will then
-    # be evaluated in the context of the new mechanism.
-    def add(&block)
-        raise ArgumentError, "You must pass a block to Fact<instance>.add" unless block_given?
+    @ldapname ||= @name.to_s
 
-        resolve = Facter::Util::Resolution.new(@name)
+    @resolves = []
+    @searching = false
 
-        resolve.instance_eval(&block)
+    @value = nil
+  end
 
-        @resolves << resolve
+  # Add a new resolution mechanism.  This requires a block, which will then
+  # be evaluated in the context of the new mechanism.
+  def add(&block)
+    raise ArgumentError, "You must pass a block to Fact<instance>.add" unless block_given?
 
-        # Immediately sort the resolutions, so that we always have
-        # a sorted list for looking up values.
-        @resolves.sort! { |a, b| b.weight <=> a.weight }
+    resolve = Facter::Util::Resolution.new(@name)
 
-        return resolve
+    resolve.instance_eval(&block)
+
+    @resolves << resolve
+
+    # Immediately sort the resolutions, so that we always have
+    # a sorted list for looking up values.
+    @resolves.sort! { |a, b| b.weight <=> a.weight }
+
+    return resolve
+  end
+
+  # Flush any cached values.
+  def flush
+    @value = nil
+    @suitable = nil
+  end
+
+  # Return the value for a given fact.  Searches through all of the mechanisms
+  # and returns either the first value or nil.
+  def value
+    return @value if @value
+
+    if @resolves.length == 0
+      Facter.debug "No resolves for %s" % @name
+      return nil
     end
 
-    # Flush any cached values.
-    def flush
-        @value = nil
-        @suitable = nil
+    searching do
+      @value = nil
+
+      foundsuits = false
+      @value = @resolves.inject(nil) { |result, resolve|
+        next unless resolve.suitable?
+        foundsuits = true
+
+        tmp = resolve.value
+
+        break tmp unless tmp.nil? or tmp == ""
+      }
+
+      unless foundsuits
+        Facter.debug "Found no suitable resolves of %s for %s" % [@resolves.length, @name]
+      end
     end
 
-    # Return the value for a given fact.  Searches through all of the mechanisms
-    # and returns either the first value or nil.
-    def value
-        return @value if @value
+    if @value.nil?
+      # nothing
+      Facter.debug("value for %s is still nil" % @name)
+      return nil
+    else
+      return @value
+    end
+  end
 
-        if @resolves.length == 0
-            Facter.debug "No resolves for %s" % @name
-            return nil
-        end
+  private
 
-        searching do
-            @value = nil
+  # Are we in the midst of a search?
+  def searching?
+    @searching
+  end
 
-            foundsuits = false
-            @value = @resolves.inject(nil) { |result, resolve|
-                next unless resolve.suitable?
-                foundsuits = true
+  # Lock our searching process, so we never ge stuck in recursion.
+  def searching
+    if searching?
+      Facter.debug "Caught recursion on %s" % @name
 
-                tmp = resolve.value
-
-                break tmp unless tmp.nil? or tmp == ""
-            }
-
-            unless foundsuits
-                Facter.debug "Found no suitable resolves of %s for %s" % [@resolves.length, @name]
-            end
-        end
-
-        if @value.nil?
-            # nothing
-            Facter.debug("value for %s is still nil" % @name)
-            return nil
-        else
-            return @value
-        end
+      # return a cached value if we've got it
+      if @value
+        return @value
+      else
+        return nil
+      end
     end
 
-    private
-
-    # Are we in the midst of a search?
-    def searching?
-        @searching
+    # If we've gotten this far, we're not already searching, so go ahead and do so.
+    @searching = true
+    begin
+      yield
+    ensure
+      @searching = false
     end
-
-    # Lock our searching process, so we never ge stuck in recursion.
-    def searching
-        if searching?
-            Facter.debug "Caught recursion on %s" % @name
-
-            # return a cached value if we've got it
-            if @value
-                return @value
-            else
-                return nil
-            end
-        end
-
-        # If we've gotten this far, we're not already searching, so go ahead and do so.
-        @searching = true
-        begin
-            yield
-        ensure
-            @searching = false
-        end
-    end
+  end
 end

--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -1,202 +1,202 @@
 # A base module for collecting IP-related
 # information from all kinds of platforms.
 module Facter::Util::IP
-    # A map of all the different regexes that work for
-    # a given platform or set of platforms.
-    REGEX_MAP = {
-        :linux => {
-            :ipaddress  => /inet addr:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
-            :ipaddress6 => /inet6 addr: ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
-            :macaddress => /(?:ether|HWaddr)\s+(\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/,
-            :netmask    => /Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-        },
-        :bsd   => {
-            :aliases    => [:openbsd, :netbsd, :freebsd, :darwin, :"gnu/kfreebsd", :dragonfly],
-            :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
-            :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
-            :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
-            :netmask    => /netmask\s+0x(\w{8})/
-        },
-        :sunos => {
-            :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
-            :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
-            :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
-            :netmask    => /netmask\s+(\w{8})/
-        },
-        :"hp-ux" => {
-            :ipaddress  => /\s+inet (\S+)\s.*/,
-            :macaddress => /(\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/,
-            :netmask    => /.*\s+netmask (\S+)\s.*/
-        },
-        :windows => {
-            :ipaddress  => /\s+IP Address:\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
-            :ipaddress6 => /Address ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
-            :netmask    => /\s+Subnet Prefix:\s+\S+\s+\(mask ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\)/
-        }
+  # A map of all the different regexes that work for
+  # a given platform or set of platforms.
+  REGEX_MAP = {
+    :linux => {
+      :ipaddress  => /inet addr:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
+      :ipaddress6 => /inet6 addr: ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
+      :macaddress => /(?:ether|HWaddr)\s+(\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/,
+      :netmask  => /Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+    },
+    :bsd   => {
+      :aliases  => [:openbsd, :netbsd, :freebsd, :darwin, :"gnu/kfreebsd", :dragonfly],
+      :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
+      :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
+      :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
+      :netmask  => /netmask\s+0x(\w{8})/
+    },
+    :sunos => {
+      :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
+      :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
+      :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
+      :netmask  => /netmask\s+(\w{8})/
+    },
+    :"hp-ux" => {
+      :ipaddress  => /\s+inet (\S+)\s.*/,
+      :macaddress => /(\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/,
+      :netmask  => /.*\s+netmask (\S+)\s.*/
+    },
+    :windows => {
+      :ipaddress  => /\s+IP Address:\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
+      :ipaddress6 => /Address ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
+      :netmask  => /\s+Subnet Prefix:\s+\S+\s+\(mask ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\)/
     }
+  }
 
-    # Convert an interface name into purely alphanumeric characters.
-    def self.alphafy(interface)
-        interface.gsub(/[^a-z0-9_]/i, '_')
+  # Convert an interface name into purely alphanumeric characters.
+  def self.alphafy(interface)
+    interface.gsub(/[^a-z0-9_]/i, '_')
+  end
+
+  def self.convert_from_hex?(kernel)
+    kernels_to_convert = [:sunos, :openbsd, :netbsd, :freebsd, :darwin, :"hp-ux", :"gnu/kfreebsd", :dragonfly]
+    kernels_to_convert.include?(kernel)
+  end
+
+  def self.supported_platforms
+    REGEX_MAP.inject([]) do |result, tmp|
+      key, map = tmp
+      if map[:aliases]
+        result += map[:aliases]
+      else
+        result << key
+      end
+      result
+    end
+  end
+
+  def self.get_interfaces
+    return [] unless output = Facter::Util::IP.get_all_interface_output()
+
+    # windows interface names contain spaces and are quoted and can appear multiple
+    # times as ipv4 and ipv6
+    return output.scan(/\s* connected\s*(\S.*)/).flatten.uniq if Facter.value(:kernel) == 'windows'
+
+    # Our regex appears to be stupid, in that it leaves colons sitting
+    # at the end of interfaces.  So, we have to trim those trailing
+    # characters.  I tried making the regex better but supporting all
+    # platforms with a single regex is probably a bit too much.
+    output.scan(/^\S+/).collect { |i| i.sub(/:$/, '') }.uniq
+  end
+
+  def self.get_all_interface_output
+    case Facter.value(:kernel)
+    when 'Linux', 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
+      output = %x{/sbin/ifconfig -a}
+    when 'SunOS'
+      output = %x{/usr/sbin/ifconfig -a}
+    when 'HP-UX'
+      output = %x{/bin/netstat -in | sed -e 1d}
+    when 'windows'
+      output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ip show interface|
+      output += %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ipv6 show interface|
+    end
+    output
+  end
+
+  def self.get_single_interface_output(interface)
+    output = ""
+    case Facter.value(:kernel)
+    when 'Linux', 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
+      output = %x{/sbin/ifconfig #{interface}}
+    when 'SunOS'
+      output = %x{/usr/sbin/ifconfig #{interface}}
+    when 'HP-UX'
+       mac = ""
+       ifc = %x{/usr/sbin/ifconfig #{interface}}
+       %x{/usr/sbin/lanscan}.scan(/(\dx\S+).*UP\s+(\w+\d+)/).each {|i| mac = i[0] if i.include?(interface) }
+       mac = mac.sub(/0x(\S+)/,'\1').scan(/../).join(":")
+       output = ifc + "\n" + mac
+    end
+    output
+  end
+
+  def self.get_output_for_interface_and_label(interface, label)
+    return get_single_interface_output(interface) unless Facter.value(:kernel) == 'windows'
+
+    if label == 'ipaddress6'
+      output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ipv6 show address \"#{interface}\"|
+    else
+      output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ip show address \"#{interface}\"|
+    end
+    output
+  end
+
+  def self.get_bonding_master(interface)
+    if Facter.value(:kernel) != 'Linux'
+      return nil
+    end
+    # We need ip instead of ifconfig because it will show us
+    # the bonding master device.
+    if not FileTest.executable?("/sbin/ip")
+      return nil
+    end
+    # A bonding interface can never be an alias interface. Alias
+    # interfaces do have a colon in their name and the ip link show
+    # command throws an error message when we pass it an alias
+    # interface.
+    if interface =~ /:/
+      return nil
+    end
+    regex = /SLAVE[,>].* (bond[0-9]+)/
+      ethbond = regex.match(%x{/sbin/ip link show #{interface}})
+    if ethbond
+      device = ethbond[1]
+    else
+      device = nil
+    end
+    device
+  end
+
+  def self.get_interface_value(interface, label)
+    tmp1 = []
+
+    kernel = Facter.value(:kernel).downcase.to_sym
+
+    # If it's not directly in the map or aliased in the map, then we don't know how to deal with it.
+    unless map = REGEX_MAP[kernel] || REGEX_MAP.values.find { |tmp| tmp[:aliases] and tmp[:aliases].include?(kernel) }
+      return []
     end
 
-    def self.convert_from_hex?(kernel)
-        kernels_to_convert = [:sunos, :openbsd, :netbsd, :freebsd, :darwin, :"hp-ux", :"gnu/kfreebsd", :dragonfly]
-        kernels_to_convert.include?(kernel)
-    end
+    # Pull the correct regex out of the map.
+    regex = map[label.to_sym]
 
-    def self.supported_platforms
-        REGEX_MAP.inject([]) do |result, tmp|
-            key, map = tmp
-            if map[:aliases]
-                result += map[:aliases]
-            else
-                result << key
+    # Linux changes the MAC address reported via ifconfig when an ethernet interface
+    # becomes a slave of a bonding device to the master MAC address.
+    # We have to dig a bit to get the original/real MAC address of the interface.
+    bonddev = get_bonding_master(interface)
+    if label == 'macaddress' and bonddev
+      bondinfo = IO.readlines("/proc/net/bonding/#{bonddev}")
+      hwaddrre = /^Slave Interface: #{interface}\n[^\n].+?\nPermanent HW addr: (([0-9a-fA-F]{2}:?)*)$/m
+      value = hwaddrre.match(bondinfo.to_s)[1].upcase
+    else
+      output_int = get_output_for_interface_and_label(interface, label)
+
+      output_int.each_line do |s|
+        if s =~ regex
+          value = $1
+            if label == 'netmask' && convert_from_hex?(kernel)
+              value = value.scan(/../).collect do |byte| byte.to_i(16) end.join('.')
             end
-            result
+          tmp1.push(value)
         end
+      end
+
+      if tmp1
+        value = tmp1.shift
+      end
     end
+  end
 
-    def self.get_interfaces
-        return [] unless output = Facter::Util::IP.get_all_interface_output()
+  def self.get_network_value(interface)
+    require 'ipaddr'
 
-        # windows interface names contain spaces and are quoted and can appear multiple
-        # times as ipv4 and ipv6
-        return output.scan(/\s* connected\s*(\S.*)/).flatten.uniq if Facter.value(:kernel) == 'windows'
+    ipaddress = get_interface_value(interface, "ipaddress")
+    netmask = get_interface_value(interface, "netmask")
 
-        # Our regex appears to be stupid, in that it leaves colons sitting
-        # at the end of interfaces.  So, we have to trim those trailing
-        # characters.  I tried making the regex better but supporting all
-        # platforms with a single regex is probably a bit too much.
-        output.scan(/^\S+/).collect { |i| i.sub(/:$/, '') }.uniq
+    if ipaddress && netmask
+      ip = IPAddr.new(ipaddress, Socket::AF_INET)
+      subnet = IPAddr.new(netmask, Socket::AF_INET)
+      network = ip.mask(subnet.to_s).to_s
     end
+  end
 
-    def self.get_all_interface_output
-        case Facter.value(:kernel)
-        when 'Linux', 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
-            output = %x{/sbin/ifconfig -a}
-        when 'SunOS'
-            output = %x{/usr/sbin/ifconfig -a}
-        when 'HP-UX'
-            output = %x{/bin/netstat -in | sed -e 1d}
-        when 'windows'
-          output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ip show interface|
-          output += %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ipv6 show interface|
-        end
-        output
+  def self.get_arp_value(interface)
+    arp = Facter::Util::Resolution.exec("arp -en -i #{interface} | sed -e 1d")
+    if arp =~ /^\S+\s+\w+\s+(\S+)\s+\w\s+\S+$/
+     return $1
     end
-
-    def self.get_single_interface_output(interface)
-        output = ""
-        case Facter.value(:kernel)
-        when 'Linux', 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
-            output = %x{/sbin/ifconfig #{interface}}
-        when 'SunOS'
-            output = %x{/usr/sbin/ifconfig #{interface}}
-        when 'HP-UX'
-           mac = ""
-           ifc = %x{/usr/sbin/ifconfig #{interface}}
-           %x{/usr/sbin/lanscan}.scan(/(\dx\S+).*UP\s+(\w+\d+)/).each {|i| mac = i[0] if i.include?(interface) }
-           mac = mac.sub(/0x(\S+)/,'\1').scan(/../).join(":")
-           output = ifc + "\n" + mac
-        end
-        output
-    end
-
-    def self.get_output_for_interface_and_label(interface, label)
-        return get_single_interface_output(interface) unless Facter.value(:kernel) == 'windows'
-
-        if label == 'ipaddress6'
-          output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ipv6 show address \"#{interface}\"|
-        else
-          output = %x|#{ENV['SYSTEMROOT']}/system32/netsh interface ip show address \"#{interface}\"|
-        end
-        output
-    end
-
-    def self.get_bonding_master(interface)
-        if Facter.value(:kernel) != 'Linux'
-            return nil
-        end
-        # We need ip instead of ifconfig because it will show us
-        # the bonding master device.
-        if not FileTest.executable?("/sbin/ip")
-            return nil
-        end
-        # A bonding interface can never be an alias interface. Alias
-        # interfaces do have a colon in their name and the ip link show
-        # command throws an error message when we pass it an alias
-        # interface.
-        if interface =~ /:/
-            return nil
-        end
-        regex = /SLAVE[,>].* (bond[0-9]+)/
-            ethbond = regex.match(%x{/sbin/ip link show #{interface}})
-        if ethbond
-            device = ethbond[1]
-        else
-            device = nil
-        end
-        device
-    end
-
-    def self.get_interface_value(interface, label)
-        tmp1 = []
-
-        kernel = Facter.value(:kernel).downcase.to_sym
-
-        # If it's not directly in the map or aliased in the map, then we don't know how to deal with it.
-        unless map = REGEX_MAP[kernel] || REGEX_MAP.values.find { |tmp| tmp[:aliases] and tmp[:aliases].include?(kernel) }
-            return []
-        end
-
-        # Pull the correct regex out of the map.
-        regex = map[label.to_sym]
-
-        # Linux changes the MAC address reported via ifconfig when an ethernet interface
-        # becomes a slave of a bonding device to the master MAC address.
-        # We have to dig a bit to get the original/real MAC address of the interface.
-        bonddev = get_bonding_master(interface)
-        if label == 'macaddress' and bonddev
-            bondinfo = IO.readlines("/proc/net/bonding/#{bonddev}")
-            hwaddrre = /^Slave Interface: #{interface}\n[^\n].+?\nPermanent HW addr: (([0-9a-fA-F]{2}:?)*)$/m
-            value = hwaddrre.match(bondinfo.to_s)[1].upcase
-        else
-            output_int = get_output_for_interface_and_label(interface, label)
-
-            output_int.each_line do |s|
-                if s =~ regex
-                    value = $1
-                        if label == 'netmask' && convert_from_hex?(kernel)
-                            value = value.scan(/../).collect do |byte| byte.to_i(16) end.join('.')
-                        end
-                    tmp1.push(value)
-                end
-            end
-
-            if tmp1
-                value = tmp1.shift
-            end
-        end
-    end
-
-    def self.get_network_value(interface)
-        require 'ipaddr'
-
-        ipaddress = get_interface_value(interface, "ipaddress")
-        netmask = get_interface_value(interface, "netmask")
-
-        if ipaddress && netmask
-            ip = IPAddr.new(ipaddress, Socket::AF_INET)
-            subnet = IPAddr.new(netmask, Socket::AF_INET)
-            network = ip.mask(subnet.to_s).to_s
-        end
-    end
-
-    def self.get_arp_value(interface)
-        arp = Facter::Util::Resolution.exec("arp -en -i #{interface} | sed -e 1d")
-        if arp =~ /^\S+\s+\w+\s+(\S+)\s+\w\s+\S+$/
-         return $1
-        end
-    end
+  end
 end

--- a/lib/facter/util/loader.rb
+++ b/lib/facter/util/loader.rb
@@ -3,110 +3,110 @@ require 'facter'
 # Load facts on demand.
 class Facter::Util::Loader
 
-    def initialize
-      @loaded = []
+  def initialize
+    @loaded = []
+  end
+
+  # Load all resolutions for a single fact.
+  def load(fact)
+    # Now load from the search path
+    shortname = fact.to_s.downcase
+    load_env(shortname)
+
+    filename = shortname + ".rb"
+    search_path.each do |dir|
+      # Load individual files
+      file = File.join(dir, filename)
+
+      load_file(file) if FileTest.exist?(file)
+
+      # And load any directories matching the name
+      factdir = File.join(dir, shortname)
+      load_dir(factdir) if FileTest.directory?(factdir)
     end
+  end
 
-    # Load all resolutions for a single fact.
-    def load(fact)
-        # Now load from the search path
-        shortname = fact.to_s.downcase
-        load_env(shortname)
+  # Load all facts from all directories.
+  def load_all
+    return if defined?(@loaded_all)
 
-        filename = shortname + ".rb"
-        search_path.each do |dir|
-            # Load individual files
-            file = File.join(dir, filename)
+    load_env
 
-            load_file(file) if FileTest.exist?(file)
+    search_path.each do |dir|
+      next unless FileTest.directory?(dir)
 
-            # And load any directories matching the name
-            factdir = File.join(dir, shortname)
-            load_dir(factdir) if FileTest.directory?(factdir)
+      Dir.entries(dir).sort.each do |file|
+        path = File.join(dir, file)
+        if File.directory?(path)
+          load_dir(path)
+        elsif file =~ /\.rb$/
+          load_file(File.join(dir, file))
         end
+      end
     end
 
-    # Load all facts from all directories.
-    def load_all
-        return if defined?(@loaded_all)
+    @loaded_all = true
+  end
 
-        load_env
-
-        search_path.each do |dir|
-            next unless FileTest.directory?(dir)
-
-            Dir.entries(dir).sort.each do |file|
-                path = File.join(dir, file)
-                if File.directory?(path)
-                    load_dir(path)
-                elsif file =~ /\.rb$/
-                    load_file(File.join(dir, file))
-                end
-            end
-        end
-
-        @loaded_all = true
+  # The list of directories we're going to search through for facts.
+  def search_path
+    result = []
+    result += $LOAD_PATH.collect { |d| File.join(d, "facter") }
+    if ENV.include?("FACTERLIB")
+      result += ENV["FACTERLIB"].split(":")
     end
 
-    # The list of directories we're going to search through for facts.
-    def search_path
-        result = []
-        result += $LOAD_PATH.collect { |d| File.join(d, "facter") }
-        if ENV.include?("FACTERLIB")
-            result += ENV["FACTERLIB"].split(":")
-        end
+    # This allows others to register additional paths we should search.
+    result += Facter.search_path
 
-        # This allows others to register additional paths we should search.
-        result += Facter.search_path
+    result
+  end
 
-        result
+  private
+
+  def load_dir(dir)
+    return if dir =~ /\/\.+$/ or dir =~ /\/util$/ or dir =~ /\/lib$/
+
+    Dir.entries(dir).find_all { |f| f =~ /\.rb$/ }.sort.each do |file|
+      load_file(File.join(dir, file))
     end
+  end
 
-    private
-
-    def load_dir(dir)
-        return if dir =~ /\/\.+$/ or dir =~ /\/util$/ or dir =~ /\/lib$/
-
-        Dir.entries(dir).find_all { |f| f =~ /\.rb$/ }.sort.each do |file|
-            load_file(File.join(dir, file))
-        end
+  def load_file(file)
+    return if @loaded.include? file
+    # We have to specify Kernel.load, because we have a load method.
+    begin
+      # Store the file path so we don't try to reload it
+      @loaded << file
+      Kernel.load(file)
+    rescue ScriptError => detail
+      # Don't store the path if the file can't be loaded
+      # in case it's loadable later on.
+      @loaded.delete(file)
+      warn "Error loading fact #{file} #{detail}"
     end
+  end
 
-    def load_file(file)
-        return if @loaded.include? file
-        # We have to specify Kernel.load, because we have a load method.
-        begin
-            # Store the file path so we don't try to reload it
-            @loaded << file
-            Kernel.load(file)
-        rescue ScriptError => detail
-            # Don't store the path if the file can't be loaded
-            # in case it's loadable later on.
-            @loaded.delete(file)
-            warn "Error loading fact #{file} #{detail}"
-        end
+  # Load facts from the environment.  If no name is provided,
+  # all will be loaded.
+  def load_env(fact = nil)
+    # Load from the environment, if possible
+    ENV.each do |name, value|
+      # Skip anything that doesn't match our regex.
+      next unless name =~ /^facter_?(\w+)$/i
+      env_name = $1
+
+      # If a fact name was specified, skip anything that doesn't
+      # match it.
+      next if fact and env_name != fact
+
+      Facter.add($1) do
+        has_weight 1_000_000
+        setcode { value }
+      end
+
+      # Short-cut, if we are only looking for one value.
+      break if fact
     end
-
-    # Load facts from the environment.  If no name is provided,
-    # all will be loaded.
-    def load_env(fact = nil)
-        # Load from the environment, if possible
-        ENV.each do |name, value|
-            # Skip anything that doesn't match our regex.
-            next unless name =~ /^facter_?(\w+)$/i
-            env_name = $1
-
-            # If a fact name was specified, skip anything that doesn't
-            # match it.
-            next if fact and env_name != fact
-
-            Facter.add($1) do
-                has_weight 1_000_000
-                setcode { value }
-            end
-
-            # Short-cut, if we are only looking for one value.
-            break if fact
-        end
-    end
+  end
 end

--- a/lib/facter/util/macosx.rb
+++ b/lib/facter/util/macosx.rb
@@ -6,56 +6,56 @@
 ##
 
 module Facter::Util::Macosx
-    require 'thread'
-    require 'facter/util/plist'
-    require 'facter/util/resolution'
+  require 'thread'
+  require 'facter/util/plist'
+  require 'facter/util/resolution'
 
-    # JJM I'd really like to dynamically generate these methods
-    # by looking at the _name key of the _items dict for each _dataType
+  # JJM I'd really like to dynamically generate these methods
+  # by looking at the _name key of the _items dict for each _dataType
 
-    def self.profiler_xml(data_field)
-        Facter::Util::Resolution.exec("/usr/sbin/system_profiler -xml #{data_field}")
+  def self.profiler_xml(data_field)
+    Facter::Util::Resolution.exec("/usr/sbin/system_profiler -xml #{data_field}")
+  end
+
+  def self.intern_xml(xml)
+    return nil unless xml
+    Plist::parse_xml(xml)
+  end
+
+  # Return an xml result, modified as we need it.
+  def self.profiler_data(data_field)
+    begin
+      return nil unless parsed_xml = intern_xml(profiler_xml(data_field))
+      return nil unless data = parsed_xml[0]['_items'][0]
+      data.delete '_name'
+      data
+    rescue
+      return nil
     end
+  end
 
-    def self.intern_xml(xml)
-        return nil unless xml
-        Plist::parse_xml(xml)
-    end
+  def self.hardware_overview
+    profiler_data("SPHardwareDataType")
+  end
 
-    # Return an xml result, modified as we need it.
-    def self.profiler_data(data_field)
-        begin
-            return nil unless parsed_xml = intern_xml(profiler_xml(data_field))
-            return nil unless data = parsed_xml[0]['_items'][0]
-            data.delete '_name'
-            data
-        rescue
-            return nil
-        end
-    end
+  def self.os_overview
+    profiler_data("SPSoftwareDataType")
+  end
 
-    def self.hardware_overview
-        profiler_data("SPHardwareDataType")
+  def self.sw_vers
+    ver = Hash.new
+    [ "productName", "productVersion", "buildVersion" ].each do |option|
+      ver["macosx_#{option}"] = Facter::Util::Resolution.exec("/usr/bin/sw_vers -#{option}").strip
     end
-
-    def self.os_overview
-        profiler_data("SPSoftwareDataType")
+    productversion = ver["macosx_productVersion"]
+    if not productversion.nil?
+      versions = productversion.scan(/(\d+)\.(\d+)\.*(\d*)/)[0]
+      ver["macosx_productversion_major"] = "#{versions[0]}.#{versions[1]}"
+      if versions[2].empty?  # 10.x should be treated as 10.x.0
+        versions[2] = "0"
+      end
+      ver["macosx_productversion_minor"] = versions[2]
     end
-
-    def self.sw_vers
-        ver = Hash.new
-        [ "productName", "productVersion", "buildVersion" ].each do |option|
-            ver["macosx_#{option}"] = Facter::Util::Resolution.exec("/usr/bin/sw_vers -#{option}").strip
-        end
-        productversion = ver["macosx_productVersion"]
-        if not productversion.nil?
-            versions = productversion.scan(/(\d+)\.(\d+)\.*(\d*)/)[0]
-            ver["macosx_productversion_major"] = "#{versions[0]}.#{versions[1]}"
-            if versions[2].empty?  # 10.x should be treated as 10.x.0
-                versions[2] = "0"
-            end
-            ver["macosx_productversion_minor"] = versions[2]
-        end
-        ver
-    end
+    ver
+  end
 end

--- a/lib/facter/util/manufacturer.rb
+++ b/lib/facter/util/manufacturer.rb
@@ -3,103 +3,103 @@
 
 module Facter::Manufacturer
 
-    def self.get_dmi_table()
-        case Facter.value(:kernel)
-        when 'Linux', 'GNU/kFreeBSD'
-            return nil unless FileTest.exists?("/usr/sbin/dmidecode")
+  def self.get_dmi_table()
+    case Facter.value(:kernel)
+    when 'Linux', 'GNU/kFreeBSD'
+      return nil unless FileTest.exists?("/usr/sbin/dmidecode")
 
-            output=%x{/usr/sbin/dmidecode 2>/dev/null}
-        when 'FreeBSD'
-            return nil unless FileTest.exists?("/usr/local/sbin/dmidecode")
+      output=%x{/usr/sbin/dmidecode 2>/dev/null}
+    when 'FreeBSD'
+      return nil unless FileTest.exists?("/usr/local/sbin/dmidecode")
 
-            output=%x{/usr/local/sbin/dmidecode 2>/dev/null}
-        when 'NetBSD'
-            return nil unless FileTest.exists?("/usr/pkg/sbin/dmidecode")
+      output=%x{/usr/local/sbin/dmidecode 2>/dev/null}
+    when 'NetBSD'
+      return nil unless FileTest.exists?("/usr/pkg/sbin/dmidecode")
 
-            output=%x{/usr/pkg/sbin/dmidecode 2>/dev/null}
-        when 'SunOS'
-            return nil unless FileTest.exists?("/usr/sbin/smbios")
+      output=%x{/usr/pkg/sbin/dmidecode 2>/dev/null}
+    when 'SunOS'
+      return nil unless FileTest.exists?("/usr/sbin/smbios")
 
-            output=%x{/usr/sbin/smbios 2>/dev/null}
-        else
-            output=nil
-        end
-        return output
+      output=%x{/usr/sbin/smbios 2>/dev/null}
+    else
+      output=nil
     end
+    return output
+  end
 
-    def self.dmi_find_system_info(name)
-        splitstr=  Facter.value(:kernel) ==  'SunOS' ? "ID    SIZE TYPE" : /^Handle/
-        output = self.get_dmi_table()
-        return if output.nil?
-        name.each_pair do |key,v|
-            v.each do |v2|
-                v2.each_pair do |value,facterkey|
-                    output.split(splitstr).each do |line|
-                        if line =~ /#{key}/ and line =~ /\n\s+#{value} (.+)\n/
-                            result = $1.strip
-                            Facter.add(facterkey) do
-                                confine :kernel => [ :linux, :freebsd, :netbsd, :sunos, :"gnu/kfreebsd" ]
-                                setcode do
-                                    result
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-
-    def self.sysctl_find_system_info(name)
-        name.each do |sysctlkey,facterkey|
-            Facter.add(facterkey) do
-                confine :kernel => [:openbsd, :darwin]
+  def self.dmi_find_system_info(name)
+    splitstr=  Facter.value(:kernel) ==  'SunOS' ? "ID  SIZE TYPE" : /^Handle/
+    output = self.get_dmi_table()
+    return if output.nil?
+    name.each_pair do |key,v|
+      v.each do |v2|
+        v2.each_pair do |value,facterkey|
+          output.split(splitstr).each do |line|
+            if line =~ /#{key}/ and line =~ /\n\s+#{value} (.+)\n/
+              result = $1.strip
+              Facter.add(facterkey) do
+                confine :kernel => [ :linux, :freebsd, :netbsd, :sunos, :"gnu/kfreebsd" ]
                 setcode do
-                    Facter::Util::Resolution.exec("sysctl -n #{sysctlkey} 2>/dev/null")
+                  result
                 end
+              end
             end
-        end
-    end
-
-    def self.prtdiag_sparc_find_system_info()
-        # Parses prtdiag for a SPARC architecture string, won't work with Solaris x86
-        output = Facter::Util::Resolution.exec('/usr/sbin/prtdiag')
-
-        # System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server
-        sysconfig = output.split("\n")[0]
-        if sysconfig =~ /^System Configuration:\s+(.+?)\s+(sun\d+\S+)\s+(.+)/ then
-            Facter.add('manufacturer') do
-                setcode do
-                    $1
-                end
-            end
-            Facter.add('productname') do
-                setcode do
-                    $3
-                end
-            end
-        end
-
-        Facter.add('serialnumber') do
-          setcode do
-            Facter::Util::Resolution.exec("/usr/sbin/sneep")
           end
         end
+      end
+    end
+  end
+
+  def self.sysctl_find_system_info(name)
+    name.each do |sysctlkey,facterkey|
+      Facter.add(facterkey) do
+        confine :kernel => [:openbsd, :darwin]
+        setcode do
+          Facter::Util::Resolution.exec("sysctl -n #{sysctlkey} 2>/dev/null")
+        end
+      end
+    end
+  end
+
+  def self.prtdiag_sparc_find_system_info()
+    # Parses prtdiag for a SPARC architecture string, won't work with Solaris x86
+    output = Facter::Util::Resolution.exec('/usr/sbin/prtdiag')
+
+    # System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server
+    sysconfig = output.split("\n")[0]
+    if sysconfig =~ /^System Configuration:\s+(.+?)\s+(sun\d+\S+)\s+(.+)/ then
+      Facter.add('manufacturer') do
+        setcode do
+          $1
+        end
+      end
+      Facter.add('productname') do
+        setcode do
+          $3
+        end
+      end
     end
 
-    def self.win32_find_system_info(name)
-        require 'facter/util/wmi'
-        value = ""
-        wmi = Facter::Util::WMI.connect()
-        name.each do |facterkey, win32key|
-            query = wmi.ExecQuery("select * from Win32_#{win32key.last}")
-            Facter.add(facterkey) do
-                confine :kernel => :windows
-                setcode do
-                    query.each { |x| value = x.__send__( (win32key.first).to_sym) }
-                    value
-                end
-            end
-        end
+    Facter.add('serialnumber') do
+      setcode do
+        Facter::Util::Resolution.exec("/usr/sbin/sneep")
+      end
     end
+  end
+
+  def self.win32_find_system_info(name)
+    require 'facter/util/wmi'
+    value = ""
+    wmi = Facter::Util::WMI.connect()
+    name.each do |facterkey, win32key|
+      query = wmi.ExecQuery("select * from Win32_#{win32key.last}")
+      Facter.add(facterkey) do
+        confine :kernel => :windows
+        setcode do
+          query.each { |x| value = x.__send__( (win32key.first).to_sym) }
+          value
+        end
+      end
+    end
+  end
 end

--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -3,83 +3,83 @@
 ##
 
 module Facter::Memory
-    require 'thread'
+  require 'thread'
 
-    def self.meminfo_number(tag)
-        memsize = ""
-        Thread::exclusive do
-            size, scale = [0, ""]
-            File.readlines("/proc/meminfo").each do |l|
-                size, scale = [$1.to_f, $2] if l =~ /^#{tag}:\s+(\d+)\s+(\S+)/
-                # MemoryFree == memfree + cached + buffers
-                #  (assume scales are all the same as memfree)
-                if tag == "MemFree" &&
-                    l =~ /^(?:Buffers|Cached):\s+(\d+)\s+(?:\S+)/
-                    size += $1.to_f
-                end
-            end
-            memsize = scale_number(size, scale)
+  def self.meminfo_number(tag)
+    memsize = ""
+    Thread::exclusive do
+      size, scale = [0, ""]
+      File.readlines("/proc/meminfo").each do |l|
+        size, scale = [$1.to_f, $2] if l =~ /^#{tag}:\s+(\d+)\s+(\S+)/
+        # MemoryFree == memfree + cached + buffers
+        #  (assume scales are all the same as memfree)
+        if tag == "MemFree" &&
+          l =~ /^(?:Buffers|Cached):\s+(\d+)\s+(?:\S+)/
+          size += $1.to_f
         end
-
-        memsize
+      end
+      memsize = scale_number(size, scale)
     end
 
-    def self.scale_number(size, multiplier)
-        suffixes = ['', 'kB', 'MB', 'GB', 'TB']
+    memsize
+  end
 
-        s = suffixes.shift
-        while s != multiplier
-            s = suffixes.shift
-        end
+  def self.scale_number(size, multiplier)
+    suffixes = ['', 'kB', 'MB', 'GB', 'TB']
 
-        while size > 1024.0
-            size /= 1024.0
-            s = suffixes.shift
-        end
-
-        return "%.2f %s" % [size, s]
+    s = suffixes.shift
+    while s != multiplier
+      s = suffixes.shift
     end
 
-    def self.vmstat_find_free_memory()
-        row = Facter::Util::Resolution.exec('vmstat').split("\n")[-1]
-        if row =~ /^\s*\d+\s*\d+\s*\d+\s*\d+\s*(\d+)/
-            Facter.add("MemoryFree") do
-                memfree = $1
-                setcode do
-                    Facter::Memory.scale_number(memfree.to_f, "kB")
-                end
-            end
-        end
+    while size > 1024.0
+      size /= 1024.0
+      s = suffixes.shift
     end
 
-    # Darwin had to be different. It's generally opaque with how much RAM it is
-    # using, and this figure could be improved upon too I fear.
-    # Parses the output of "vm_stat", takes the pages free & pages speculative
-    # and multiples that by the page size (also given in output). Ties in with
-    # what activity monitor outputs for free memory.
-    def self.vmstat_darwin_find_free_memory()
+    return "%.2f %s" % [size, s]
+  end
 
-        memfree = 0
-        pagesize = 0
-        memspecfree = 0
-
-        vmstats = Facter::Util::Resolution.exec('vm_stat')
-        vmstats.each_line do |vmline|
-          case
-            when vmline =~ /page\ssize\sof\s(\d+)\sbytes/
-              pagesize = $1.to_i
-            when vmline =~ /^Pages\sfree:\s+(\d+)\./
-              memfree = $1.to_i
-            when vmline =~ /^Pages\sspeculative:\s+(\d+)\./
-              memspecfree = $1.to_i
-          end
+  def self.vmstat_find_free_memory()
+    row = Facter::Util::Resolution.exec('vmstat').split("\n")[-1]
+    if row =~ /^\s*\d+\s*\d+\s*\d+\s*\d+\s*(\d+)/
+      Facter.add("MemoryFree") do
+        memfree = $1
+        setcode do
+          Facter::Memory.scale_number(memfree.to_f, "kB")
         end
-
-        freemem = ( memfree + memspecfree ) * pagesize
-        Facter.add("MemoryFree") do
-          setcode do
-            Facter::Memory.scale_number(freemem.to_f, "")
-          end
-        end
+      end
     end
+  end
+
+  # Darwin had to be different. It's generally opaque with how much RAM it is
+  # using, and this figure could be improved upon too I fear.
+  # Parses the output of "vm_stat", takes the pages free & pages speculative
+  # and multiples that by the page size (also given in output). Ties in with
+  # what activity monitor outputs for free memory.
+  def self.vmstat_darwin_find_free_memory()
+
+    memfree = 0
+    pagesize = 0
+    memspecfree = 0
+
+    vmstats = Facter::Util::Resolution.exec('vm_stat')
+    vmstats.each_line do |vmline|
+      case
+      when vmline =~ /page\ssize\sof\s(\d+)\sbytes/
+        pagesize = $1.to_i
+      when vmline =~ /^Pages\sfree:\s+(\d+)\./
+        memfree = $1.to_i
+      when vmline =~ /^Pages\sspeculative:\s+(\d+)\./
+        memspecfree = $1.to_i
+      end
+    end
+
+    freemem = ( memfree + memspecfree ) * pagesize
+    Facter.add("MemoryFree") do
+      setcode do
+        Facter::Memory.scale_number(freemem.to_f, "")
+      end
+    end
+  end
 end

--- a/lib/facter/util/netmask.rb
+++ b/lib/facter/util/netmask.rb
@@ -1,40 +1,40 @@
 module Facter::NetMask
-    def self.get_netmask
-        netmask = nil;
-        ipregex = %r{(\d{1,3}\.){3}\d{1,3}}
+  def self.get_netmask
+    netmask = nil;
+    ipregex = %r{(\d{1,3}\.){3}\d{1,3}}
 
-        ops = nil
-        case Facter.value(:kernel)
-        when 'Linux'
-            ops = {
-                :ifconfig => '/sbin/ifconfig',
-                :regex => %r{\s+ inet\saddr: #{Facter.ipaddress} .*? Mask: (#{ipregex})}x,
-                :munge => nil,
-            }
-        when 'SunOS'
-            ops = {
-                :ifconfig => '/usr/sbin/ifconfig -a',
-                :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s (\w{8})}x,
-                :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
-            }
-        when 'FreeBSD','NetBSD','OpenBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
-            ops = {
-                :ifconfig => '/sbin/ifconfig -a',
-                :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s 0x(\w{8})}x,
-                :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
-            }
-        end
-
-        %x{#{ops[:ifconfig]}}.split(/\n/).collect do |line|
-            matches = line.match(ops[:regex])
-            if !matches.nil?
-                if ops[:munge].nil?
-                    netmask = matches[1]
-                else
-                    netmask = ops[:munge].call(matches[1])
-                end
-            end
-        end
-        netmask
+    ops = nil
+    case Facter.value(:kernel)
+    when 'Linux'
+      ops = {
+        :ifconfig => '/sbin/ifconfig',
+        :regex => %r{\s+ inet\saddr: #{Facter.ipaddress} .*? Mask: (#{ipregex})}x,
+        :munge => nil,
+      }
+    when 'SunOS'
+      ops = {
+        :ifconfig => '/usr/sbin/ifconfig -a',
+        :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s (\w{8})}x,
+        :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
+      }
+    when 'FreeBSD','NetBSD','OpenBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
+      ops = {
+        :ifconfig => '/sbin/ifconfig -a',
+        :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s 0x(\w{8})}x,
+        :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
+      }
     end
+
+    %x{#{ops[:ifconfig]}}.split(/\n/).collect do |line|
+      matches = line.match(ops[:regex])
+      if !matches.nil?
+        if ops[:munge].nil?
+          netmask = matches[1]
+        else
+          netmask = ops[:munge].call(matches[1])
+        end
+      end
+    end
+    netmask
+  end
 end

--- a/lib/facter/util/plist.rb
+++ b/lib/facter/util/plist.rb
@@ -18,7 +18,7 @@ require 'facter/util/plist/generator'
 require 'facter/util/plist/parser'
 
 module Plist
-    VERSION = '3.0.0'
+  VERSION = '3.0.0'
 end
 
 # $Id: plist.rb 1781 2006-10-16 01:01:35Z luke $

--- a/lib/facter/util/plist/generator.rb
+++ b/lib/facter/util/plist/generator.rb
@@ -1,228 +1,228 @@
 #--###########################################################
-# Copyright 2006, Ben Bleything <ben@bleything.net> and      #
-# Patrick May <patrick@hexane.org>                           #
-#                                                            #
-# Distributed under the MIT license.                         #
+# Copyright 2006, Ben Bleything <ben@bleything.net> and    #
+# Patrick May <patrick@hexane.org>               #
+#                              #
+# Distributed under the MIT license.             #
 ##############################################################
 #++
 # See Plist::Emit.
 module Plist
-    # === Create a plist
-    # You can dump an object to a plist in one of two ways:
-    #
-    # * <tt>Plist::Emit.dump(obj)</tt>
-    # * <tt>obj.to_plist</tt>
-    #   * This requires that you mixin the <tt>Plist::Emit</tt> module, which is already done for +Array+ and +Hash+.
-    #
-    # The following Ruby classes are converted into native plist types:
-    #   Array, Bignum, Date, DateTime, Fixnum, Float, Hash, Integer, String, Symbol, Time, true, false
-    # * +Array+ and +Hash+ are both recursive; their elements will be converted into plist nodes inside the <array> and <dict> containers (respectively).
-    # * +IO+ (and its descendants) and +StringIO+ objects are read from and their contents placed in a <data> element.
-    # * User classes may implement +to_plist_node+ to dictate how they should be serialized; otherwise the object will be passed to <tt>Marshal.dump</tt> and the result placed in a <data> element.
-    #
-    # For detailed usage instructions, refer to USAGE[link:files/docs/USAGE.html] and the methods documented below.
-    module Emit
-        # Helper method for injecting into classes.  Calls <tt>Plist::Emit.dump</tt> with +self+.
-        def to_plist(envelope = true)
-            return Plist::Emit.dump(self, envelope)
-        end
-
-        # Helper method for injecting into classes.  Calls <tt>Plist::Emit.save_plist</tt> with +self+.
-        def save_plist(filename)
-            Plist::Emit.save_plist(self, filename)
-        end
-
-        # The following Ruby classes are converted into native plist types:
-        #   Array, Bignum, Date, DateTime, Fixnum, Float, Hash, Integer, String, Symbol, Time
-        #
-        # Write us (via RubyForge) if you think another class can be coerced safely into one of the expected plist classes.
-        #
-        # +IO+ and +StringIO+ objects are encoded and placed in <data> elements; other objects are <tt>Marshal.dump</tt>'ed unless they implement +to_plist_node+.
-        #
-        # The +envelope+ parameters dictates whether or not the resultant plist fragment is wrapped in the normal XML/plist header and footer.  Set it to false if you only want the fragment.
-        def self.dump(obj, envelope = true)
-            output = plist_node(obj)
-
-            output = wrap(output) if envelope
-
-            return output
-        end
-
-        # Writes the serialized object's plist to the specified filename.
-        def self.save_plist(obj, filename)
-            File.open(filename, 'wb') do |f|
-                f.write(obj.to_plist)
-            end
-        end
-
-        private
-        def self.plist_node(element)
-            output = ''
-
-            if element.respond_to? :to_plist_node
-                output << element.to_plist_node
-            else
-                case element
-                when Array
-                    if element.empty?
-                        output << "<array/>\n"
-                    else
-                        output << tag('array') {
-                            element.collect {|e| plist_node(e)}
-                        }
-                    end
-                when Hash
-                    if element.empty?
-                        output << "<dict/>\n"
-                    else
-                        inner_tags = []
-
-                        element.keys.sort.each do |k|
-                            v = element[k]
-                            inner_tags << tag('key', CGI::escapeHTML(k.to_s))
-                            inner_tags << plist_node(v)
-                        end
-
-                        output << tag('dict') {
-                            inner_tags
-                        }
-                    end
-                when true, false
-                    output << "<#{element}/>\n"
-                when Time
-                    output << tag('date', element.utc.strftime('%Y-%m-%dT%H:%M:%SZ'))
-                when Date # also catches DateTime
-                    output << tag('date', element.strftime('%Y-%m-%dT%H:%M:%SZ'))
-                when String, Symbol, Fixnum, Bignum, Integer, Float
-                    output << tag(element_type(element), CGI::escapeHTML(element.to_s))
-                when IO, StringIO
-                    element.rewind
-                    contents = element.read
-                    # note that apple plists are wrapped at a different length then
-                    # what ruby's base64 wraps by default.
-                    # I used #encode64 instead of #b64encode (which allows a length arg)
-                    # because b64encode is b0rked and ignores the length arg.
-                    data = "\n"
-                    Base64::encode64(contents).gsub(/\s+/, '').scan(/.{1,68}/o) { data << $& << "\n" }
-                    output << tag('data', data)
-                else
-                    output << comment( 'The <data> element below contains a Ruby object which has been serialized with Marshal.dump.' )
-                    data = "\n"
-                    Base64::encode64(Marshal.dump(element)).gsub(/\s+/, '').scan(/.{1,68}/o) { data << $& << "\n" }
-                    output << tag('data', data )
-                end
-            end
-
-            return output
-        end
-
-        def self.comment(content)
-            return "<!-- #{content} -->\n"
-        end
-
-        def self.tag(type, contents = '', &block)
-            out = nil
-
-            if block_given?
-                out = IndentedString.new
-                out << "<#{type}>"
-                out.raise_indent
-
-                out << block.call
-
-                out.lower_indent
-                out << "</#{type}>"
-            else
-                out = "<#{type}>#{contents.to_s}</#{type}>\n"
-            end
-
-            return out.to_s
-        end
-
-        def self.wrap(contents)
-            output = ''
-
-            output << '<?xml version="1.0" encoding="UTF-8"?>' + "\n"
-            output << '<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' + "\n"
-            output << '<plist version="1.0">' + "\n"
-
-            output << contents
-
-            output << '</plist>' + "\n"
-
-            return output
-        end
-
-        def self.element_type(item)
-            return case item
-                   when String, Symbol;          'string'
-                   when Fixnum, Bignum, Integer; 'integer'
-                   when Float;                   'real'
-                   else
-                       raise "Don't know about this data type... something must be wrong!"
-                   end
-        end
-
-        private
-
-        class IndentedString #:nodoc:
-            attr_accessor :indent_string
-
-            @@indent_level = 0
-
-            def initialize(str = "\t")
-                @indent_string = str
-                @contents = ''
-            end
-
-            def to_s
-                return @contents
-            end
-
-            def raise_indent
-                @@indent_level += 1
-            end
-
-            def lower_indent
-                @@indent_level -= 1 if @@indent_level > 0
-            end
-
-            def <<(val)
-                if val.is_a? Array
-                    val.each do |f|
-                        self << f
-                    end
-                else
-                    # if it's already indented, don't bother indenting further
-                    unless val =~ /\A#{@indent_string}/
-                        indent = @indent_string * @@indent_level
-
-                        @contents << val.gsub(/^/, indent)
-                    else
-                        @contents << val
-                    end
-
-                    # it already has a newline, don't add another
-                    @contents << "\n" unless val =~ /\n$/
-                end
-            end
-        end
+  # === Create a plist
+  # You can dump an object to a plist in one of two ways:
+  #
+  # * <tt>Plist::Emit.dump(obj)</tt>
+  # * <tt>obj.to_plist</tt>
+  #   * This requires that you mixin the <tt>Plist::Emit</tt> module, which is already done for +Array+ and +Hash+.
+  #
+  # The following Ruby classes are converted into native plist types:
+  #   Array, Bignum, Date, DateTime, Fixnum, Float, Hash, Integer, String, Symbol, Time, true, false
+  # * +Array+ and +Hash+ are both recursive; their elements will be converted into plist nodes inside the <array> and <dict> containers (respectively).
+  # * +IO+ (and its descendants) and +StringIO+ objects are read from and their contents placed in a <data> element.
+  # * User classes may implement +to_plist_node+ to dictate how they should be serialized; otherwise the object will be passed to <tt>Marshal.dump</tt> and the result placed in a <data> element.
+  #
+  # For detailed usage instructions, refer to USAGE[link:files/docs/USAGE.html] and the methods documented below.
+  module Emit
+    # Helper method for injecting into classes.  Calls <tt>Plist::Emit.dump</tt> with +self+.
+    def to_plist(envelope = true)
+      return Plist::Emit.dump(self, envelope)
     end
+
+    # Helper method for injecting into classes.  Calls <tt>Plist::Emit.save_plist</tt> with +self+.
+    def save_plist(filename)
+      Plist::Emit.save_plist(self, filename)
+    end
+
+    # The following Ruby classes are converted into native plist types:
+    #   Array, Bignum, Date, DateTime, Fixnum, Float, Hash, Integer, String, Symbol, Time
+    #
+    # Write us (via RubyForge) if you think another class can be coerced safely into one of the expected plist classes.
+    #
+    # +IO+ and +StringIO+ objects are encoded and placed in <data> elements; other objects are <tt>Marshal.dump</tt>'ed unless they implement +to_plist_node+.
+    #
+    # The +envelope+ parameters dictates whether or not the resultant plist fragment is wrapped in the normal XML/plist header and footer.  Set it to false if you only want the fragment.
+    def self.dump(obj, envelope = true)
+      output = plist_node(obj)
+
+      output = wrap(output) if envelope
+
+      return output
+    end
+
+    # Writes the serialized object's plist to the specified filename.
+    def self.save_plist(obj, filename)
+      File.open(filename, 'wb') do |f|
+        f.write(obj.to_plist)
+      end
+    end
+
+    private
+    def self.plist_node(element)
+      output = ''
+
+      if element.respond_to? :to_plist_node
+        output << element.to_plist_node
+      else
+        case element
+        when Array
+          if element.empty?
+            output << "<array/>\n"
+          else
+            output << tag('array') {
+              element.collect {|e| plist_node(e)}
+            }
+          end
+        when Hash
+          if element.empty?
+            output << "<dict/>\n"
+          else
+            inner_tags = []
+
+            element.keys.sort.each do |k|
+              v = element[k]
+              inner_tags << tag('key', CGI::escapeHTML(k.to_s))
+              inner_tags << plist_node(v)
+            end
+
+            output << tag('dict') {
+              inner_tags
+            }
+          end
+        when true, false
+          output << "<#{element}/>\n"
+        when Time
+          output << tag('date', element.utc.strftime('%Y-%m-%dT%H:%M:%SZ'))
+        when Date # also catches DateTime
+          output << tag('date', element.strftime('%Y-%m-%dT%H:%M:%SZ'))
+        when String, Symbol, Fixnum, Bignum, Integer, Float
+          output << tag(element_type(element), CGI::escapeHTML(element.to_s))
+        when IO, StringIO
+          element.rewind
+          contents = element.read
+          # note that apple plists are wrapped at a different length then
+          # what ruby's base64 wraps by default.
+          # I used #encode64 instead of #b64encode (which allows a length arg)
+          # because b64encode is b0rked and ignores the length arg.
+          data = "\n"
+          Base64::encode64(contents).gsub(/\s+/, '').scan(/.{1,68}/o) { data << $& << "\n" }
+          output << tag('data', data)
+        else
+          output << comment( 'The <data> element below contains a Ruby object which has been serialized with Marshal.dump.' )
+          data = "\n"
+          Base64::encode64(Marshal.dump(element)).gsub(/\s+/, '').scan(/.{1,68}/o) { data << $& << "\n" }
+          output << tag('data', data )
+        end
+      end
+
+      return output
+    end
+
+    def self.comment(content)
+      return "<!-- #{content} -->\n"
+    end
+
+    def self.tag(type, contents = '', &block)
+      out = nil
+
+      if block_given?
+        out = IndentedString.new
+        out << "<#{type}>"
+        out.raise_indent
+
+        out << block.call
+
+        out.lower_indent
+        out << "</#{type}>"
+      else
+        out = "<#{type}>#{contents.to_s}</#{type}>\n"
+      end
+
+      return out.to_s
+    end
+
+    def self.wrap(contents)
+      output = ''
+
+      output << '<?xml version="1.0" encoding="UTF-8"?>' + "\n"
+      output << '<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' + "\n"
+      output << '<plist version="1.0">' + "\n"
+
+      output << contents
+
+      output << '</plist>' + "\n"
+
+      return output
+    end
+
+    def self.element_type(item)
+      return case item
+      when String, Symbol;      'string'
+      when Fixnum, Bignum, Integer; 'integer'
+      when Float;           'real'
+      else
+        raise "Don't know about this data type... something must be wrong!"
+      end
+    end
+
+    private
+
+    class IndentedString #:nodoc:
+      attr_accessor :indent_string
+
+      @@indent_level = 0
+
+      def initialize(str = "\t")
+        @indent_string = str
+        @contents = ''
+      end
+
+      def to_s
+        return @contents
+      end
+
+      def raise_indent
+        @@indent_level += 1
+      end
+
+      def lower_indent
+        @@indent_level -= 1 if @@indent_level > 0
+      end
+
+      def <<(val)
+        if val.is_a? Array
+          val.each do |f|
+            self << f
+          end
+        else
+          # if it's already indented, don't bother indenting further
+          unless val =~ /\A#{@indent_string}/
+            indent = @indent_string * @@indent_level
+
+            @contents << val.gsub(/^/, indent)
+          else
+            @contents << val
+          end
+
+          # it already has a newline, don't add another
+          @contents << "\n" unless val =~ /\n$/
+        end
+      end
+    end
+  end
 end
 
 # we need to add this so sorting hash keys works properly
 class Symbol #:nodoc:
-    def <=> (other)
-        self.to_s <=> other.to_s
-    end
+  def <=> (other)
+    self.to_s <=> other.to_s
+  end
 end
 
 class Array #:nodoc:
-    include Plist::Emit
+  include Plist::Emit
 end
 
 class Hash #:nodoc:
-    include Plist::Emit
+  include Plist::Emit
 end
 
 # $Id: generator.rb 1781 2006-10-16 01:01:35Z luke $

--- a/lib/facter/util/plist/parser.rb
+++ b/lib/facter/util/plist/parser.rb
@@ -1,8 +1,8 @@
 #--###########################################################
-# Copyright 2006, Ben Bleything <ben@bleything.net> and      #
-# Patrick May <patrick@hexane.org>                           #
-#                                                            #
-# Distributed under the MIT license.                         #
+# Copyright 2006, Ben Bleything <ben@bleything.net> and    #
+# Patrick May <patrick@hexane.org>               #
+#                              #
+# Distributed under the MIT license.             #
 ##############################################################
 #++
 # Plist parses Mac OS X xml property list files into ruby data structures.
@@ -21,206 +21,206 @@ module Plist
 # If you encounter such an error, or if you have a Date element which
 # can't be parsed into a Time object, please send your plist file to
 # plist@hexane.org so that I can implement the proper support.
-    def Plist::parse_xml( filename_or_xml )
-        listener = Listener.new
-        #parser = REXML::Parsers::StreamParser.new(File.new(filename), listener)
-        parser = StreamParser.new(filename_or_xml, listener)
-        parser.parse
-        listener.result
+  def Plist::parse_xml( filename_or_xml )
+    listener = Listener.new
+    #parser = REXML::Parsers::StreamParser.new(File.new(filename), listener)
+    parser = StreamParser.new(filename_or_xml, listener)
+    parser.parse
+    listener.result
+  end
+
+  class Listener
+    #include REXML::StreamListener
+
+    attr_accessor :result, :open
+
+    def initialize
+      @result = nil
+      @open   = Array.new
     end
 
-    class Listener
-        #include REXML::StreamListener
 
-        attr_accessor :result, :open
-
-        def initialize
-            @result = nil
-            @open   = Array.new
-        end
-
-
-        def tag_start(name, attributes)
-            @open.push PTag::mappings[name].new
-        end
-
-        def text( contents )
-            @open.last.text = contents if @open.last
-        end
-
-        def tag_end(name)
-            last = @open.pop
-            if @open.empty?
-                @result = last.to_ruby
-            else
-                @open.last.children.push last
-            end
-        end
+    def tag_start(name, attributes)
+      @open.push PTag::mappings[name].new
     end
 
-    class StreamParser
-        def initialize( filename_or_xml, listener )
-            @filename_or_xml = filename_or_xml
-            @listener = listener
-        end
-
-        TEXT            = /([^<]+)/
-        XMLDECL_PATTERN = /<\?xml\s+(.*?)\?>*/um
-        DOCTYPE_PATTERN = /\s*<!DOCTYPE\s+(.*?)(\[|>)/um
-        COMMENT_START   = /\A<!--/u
-        COMMENT_END     = /.*?-->/um
-
-        def parse
-            plist_tags = PTag::mappings.keys.join('|')
-            start_tag  = /<(#{plist_tags})([^>]*)>/i
-            end_tag    = /<\/(#{plist_tags})[^>]*>/i
-
-            require 'strscan'
-
-            contents = (
-                if (File.exists? @filename_or_xml)
-                    File.open(@filename_or_xml) {|f| f.read}
-                else
-                    @filename_or_xml
-                end
-            )
-
-            @scanner = StringScanner.new( contents )
-            until @scanner.eos?
-                if @scanner.scan(COMMENT_START)
-                    @scanner.scan(COMMENT_END)
-                elsif @scanner.scan(XMLDECL_PATTERN)
-                elsif @scanner.scan(DOCTYPE_PATTERN)
-                elsif @scanner.scan(start_tag)
-                    @listener.tag_start(@scanner[1], nil)
-                    if (@scanner[2] =~ /\/$/)
-                        @listener.tag_end(@scanner[1])
-                    end
-                elsif @scanner.scan(TEXT)
-                    @listener.text(@scanner[1])
-                elsif @scanner.scan(end_tag)
-                    @listener.tag_end(@scanner[1])
-                else
-                    raise "Unimplemented element"
-                end
-            end
-        end
+    def text( contents )
+      @open.last.text = contents if @open.last
     end
 
-    class PTag
-        @@mappings = { }
-        def PTag::mappings
-            @@mappings
-        end
+    def tag_end(name)
+      last = @open.pop
+      if @open.empty?
+        @result = last.to_ruby
+      else
+        @open.last.children.push last
+      end
+    end
+  end
 
-        def PTag::inherited( sub_class )
-            key = sub_class.to_s.downcase
-            key.gsub!(/^plist::/, '' )
-            key.gsub!(/^p/, '')  unless key == "plist"
-
-            @@mappings[key] = sub_class
-        end
-
-        attr_accessor :text, :children
-        def initialize
-            @children = Array.new
-        end
-
-        def to_ruby
-            raise "Unimplemented: " + self.class.to_s + "#to_ruby on #{self.inspect}"
-        end
+  class StreamParser
+    def initialize( filename_or_xml, listener )
+      @filename_or_xml = filename_or_xml
+      @listener = listener
     end
 
-    class PList < PTag
-        def to_ruby
-            children.first.to_ruby if children.first
+    TEXT      = /([^<]+)/
+    XMLDECL_PATTERN = /<\?xml\s+(.*?)\?>*/um
+    DOCTYPE_PATTERN = /\s*<!DOCTYPE\s+(.*?)(\[|>)/um
+    COMMENT_START   = /\A<!--/u
+    COMMENT_END   = /.*?-->/um
+
+    def parse
+      plist_tags = PTag::mappings.keys.join('|')
+      start_tag  = /<(#{plist_tags})([^>]*)>/i
+      end_tag  = /<\/(#{plist_tags})[^>]*>/i
+
+      require 'strscan'
+
+      contents = (
+        if (File.exists? @filename_or_xml)
+          File.open(@filename_or_xml) {|f| f.read}
+        else
+          @filename_or_xml
         end
+      )
+
+      @scanner = StringScanner.new( contents )
+      until @scanner.eos?
+        if @scanner.scan(COMMENT_START)
+          @scanner.scan(COMMENT_END)
+        elsif @scanner.scan(XMLDECL_PATTERN)
+        elsif @scanner.scan(DOCTYPE_PATTERN)
+        elsif @scanner.scan(start_tag)
+          @listener.tag_start(@scanner[1], nil)
+          if (@scanner[2] =~ /\/$/)
+            @listener.tag_end(@scanner[1])
+          end
+        elsif @scanner.scan(TEXT)
+          @listener.text(@scanner[1])
+        elsif @scanner.scan(end_tag)
+          @listener.tag_end(@scanner[1])
+        else
+          raise "Unimplemented element"
+        end
+      end
+    end
+  end
+
+  class PTag
+    @@mappings = { }
+    def PTag::mappings
+      @@mappings
     end
 
-    class PDict < PTag
-        def to_ruby
-            dict = Hash.new
-            key = nil
+    def PTag::inherited( sub_class )
+      key = sub_class.to_s.downcase
+      key.gsub!(/^plist::/, '' )
+      key.gsub!(/^p/, '')  unless key == "plist"
 
-            children.each do |c|
-                if key.nil?
-                    key = c.to_ruby
-                else
-                    dict[key] = c.to_ruby
-                    key = nil
-                end
-            end
-
-            dict
-        end
+      @@mappings[key] = sub_class
     end
 
-    class PKey < PTag
-        def to_ruby
-            CGI::unescapeHTML(text || '')
-        end
+    attr_accessor :text, :children
+    def initialize
+      @children = Array.new
     end
 
-    class PString < PTag
-        def to_ruby
-            CGI::unescapeHTML(text || '')
-        end
+    def to_ruby
+      raise "Unimplemented: " + self.class.to_s + "#to_ruby on #{self.inspect}"
     end
+  end
 
-    class PArray < PTag
-        def to_ruby
-            children.collect do |c|
-                c.to_ruby
-            end
-        end
+  class PList < PTag
+    def to_ruby
+      children.first.to_ruby if children.first
     end
+  end
 
-    class PInteger < PTag
-        def to_ruby
-            text.to_i
+  class PDict < PTag
+    def to_ruby
+      dict = Hash.new
+      key = nil
+
+      children.each do |c|
+        if key.nil?
+          key = c.to_ruby
+        else
+          dict[key] = c.to_ruby
+          key = nil
         end
-    end
+      end
 
-    class PTrue < PTag
-        def to_ruby
-            true
-        end
+      dict
     end
+  end
 
-    class PFalse < PTag
-        def to_ruby
-            false
-        end
+  class PKey < PTag
+    def to_ruby
+      CGI::unescapeHTML(text || '')
     end
+  end
 
-    class PReal < PTag
-        def to_ruby
-            text.to_f
-        end
+  class PString < PTag
+    def to_ruby
+      CGI::unescapeHTML(text || '')
     end
+  end
 
-    require 'date'
-    class PDate < PTag
-        def to_ruby
-            DateTime.parse(text)
-        end
+  class PArray < PTag
+    def to_ruby
+      children.collect do |c|
+        c.to_ruby
+      end
     end
+  end
 
-    require 'base64'
-    class PData < PTag
-        def to_ruby
-            data = Base64.decode64(text.gsub(/\s+/, ''))
-
-            begin
-                return Marshal.load(data)
-            rescue Exception => e
-                io = StringIO.new
-                io.write data
-                io.rewind
-                return io
-            end
-        end
+  class PInteger < PTag
+    def to_ruby
+      text.to_i
     end
+  end
+
+  class PTrue < PTag
+    def to_ruby
+      true
+    end
+  end
+
+  class PFalse < PTag
+    def to_ruby
+      false
+    end
+  end
+
+  class PReal < PTag
+    def to_ruby
+      text.to_f
+    end
+  end
+
+  require 'date'
+  class PDate < PTag
+    def to_ruby
+      DateTime.parse(text)
+    end
+  end
+
+  require 'base64'
+  class PData < PTag
+    def to_ruby
+      data = Base64.decode64(text.gsub(/\s+/, ''))
+
+      begin
+        return Marshal.load(data)
+      rescue Exception => e
+        io = StringIO.new
+        io.write data
+        io.rewind
+        return io
+      end
+    end
+  end
 end
 
 # $Id: parser.rb 1781 2006-10-16 01:01:35Z luke $

--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -26,7 +26,7 @@ module Facter::Util::Processor
         Thread::exclusive do
           File.readlines(cpuinfo).each do |l|
             if l =~ /processor\s+:\s+(\d+)/
-              processor_num = $1.to_i	
+              processor_num = $1.to_i
             elsif l =~ /cpu\s+:\s+(.*)\s*$/
               processor_list[processor_num] = $1 unless processor_num == -1
               processor_num = -1

--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -9,179 +9,179 @@ require 'facter/util/config'
 require 'timeout'
 
 class Facter::Util::Resolution
-    attr_accessor :interpreter, :code, :name, :timeout
+  attr_accessor :interpreter, :code, :name, :timeout
 
-    INTERPRETER = Facter::Util::Config.is_windows? ? "cmd.exe" : "/bin/sh"
+  INTERPRETER = Facter::Util::Config.is_windows? ? "cmd.exe" : "/bin/sh"
 
-    def self.have_which
-        if ! defined?(@have_which) or @have_which.nil?
-            if Facter.value(:kernel) == 'windows'
-                @have_which = false
-            else
-                %x{which which >/dev/null 2>&1}
-                @have_which = ($? == 0)
-            end
-        end
-        @have_which
+  def self.have_which
+    if ! defined?(@have_which) or @have_which.nil?
+      if Facter.value(:kernel) == 'windows'
+        @have_which = false
+      else
+        %x{which which >/dev/null 2>&1}
+        @have_which = ($? == 0)
+      end
     end
+    @have_which
+  end
 
-    # Execute a program and return the output of that program.
+  # Execute a program and return the output of that program.
+  #
+  # Returns nil if the program can't be found, or if there is a problem
+  # executing the code.
+  #
+  def self.exec(code, interpreter = nil)
+    Facter.warnonce "The interpreter parameter to 'exec' is deprecated and will be removed in a future version." if interpreter
+
+    # Try to guess whether the specified code can be executed by looking at the
+    # first word. If it cannot be found on the PATH defer on resolving the fact
+    # by returning nil.
+    # This only fails on shell built-ins, most of which are masked by stuff in 
+    # /bin or of dubious value anyways. In the worst case, "sh -c 'builtin'" can
+    # be used to work around this limitation
     #
-    # Returns nil if the program can't be found, or if there is a problem
-    # executing the code.
-    #
-    def self.exec(code, interpreter = nil)
-        Facter.warnonce "The interpreter parameter to 'exec' is deprecated and will be removed in a future version." if interpreter
+    # Windows' %x{} throws Errno::ENOENT when the command is not found, so we 
+    # can skip the check there. This is good, since builtins cannot be found 
+    # elsewhere.
+    if have_which and !Facter::Util::Config.is_windows?
+      path = nil
+      binary = code.split.first
+      if code =~ /^\//
+        path = binary
+      else
+        path = %x{which #{binary} 2>/dev/null}.chomp
+        # we don't have the binary necessary
+        return nil if path == "" or path.match(/Command not found\./)
+      end
 
-        # Try to guess whether the specified code can be executed by looking at the
-        # first word. If it cannot be found on the PATH defer on resolving the fact
-        # by returning nil.
-        # This only fails on shell built-ins, most of which are masked by stuff in 
-        # /bin or of dubious value anyways. In the worst case, "sh -c 'builtin'" can
-        # be used to work around this limitation
-        #
-        # Windows' %x{} throws Errno::ENOENT when the command is not found, so we 
-        # can skip the check there. This is good, since builtins cannot be found 
-        # elsewhere.
-        if have_which and !Facter::Util::Config.is_windows?
-            path = nil
-            binary = code.split.first
-            if code =~ /^\//
-                path = binary
-            else
-                path = %x{which #{binary} 2>/dev/null}.chomp
-                # we don't have the binary necessary
-                return nil if path == "" or path.match(/Command not found\./)
-            end
+      return nil unless FileTest.exists?(path)
+    end
 
-            return nil unless FileTest.exists?(path)
-        end
+    out = nil
 
-        out = nil
+    begin
+      out = %x{#{code}}.chomp
+    rescue Errno::ENOENT => detail
+      # command not found on Windows
+      return nil
+    rescue => detail
+      $stderr.puts detail
+      return nil
+    end
 
-        begin
-            out = %x{#{code}}.chomp
-        rescue Errno::ENOENT => detail
-            # command not found on Windows
-            return nil
-        rescue => detail
-            $stderr.puts detail
-            return nil
-        end
+    if out == ""
+      return nil
+    else
+      return out
+    end
+  end
 
-        if out == ""
-            return nil
+  # Add a new confine to the resolution mechanism.
+  def confine(confines)
+    confines.each do |fact, values|
+      @confines.push Facter::Util::Confine.new(fact, *values)
+    end
+  end
+
+  def has_weight(weight)
+    @weight = weight
+  end
+
+  # Create a new resolution mechanism.
+  def initialize(name)
+    @name = name
+    @confines = []
+    @value = nil
+    @timeout = 0
+    @weight = nil
+  end
+
+  # Return the importance of this resolution.
+  def weight
+    if @weight
+      @weight
+    else
+      @confines.length
+    end
+  end
+
+  # We need this as a getter for 'timeout', because some versions
+  # of ruby seem to already have a 'timeout' method and we can't
+  # seem to override the instance methods, somehow.
+  def limit
+    @timeout
+  end
+
+  # Set our code for returning a value.
+  def setcode(string = nil, interp = nil, &block)
+    Facter.warnonce "The interpreter parameter to 'setcode' is deprecated and will be removed in a future version." if interp
+    if string
+      @code = string
+      @interpreter = interp || INTERPRETER
+    else
+      unless block_given?
+        raise ArgumentError, "You must pass either code or a block"
+      end
+      @code = block
+    end
+  end
+
+  def interpreter
+    Facter.warnonce "The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version."
+    @interpreter
+  end
+
+  def interpreter=(interp)
+    Facter.warnonce "The 'Facter::Util::Resolution.interpreter=' method is deprecated and will be removed in a future version."
+    @interpreter = interp
+  end
+
+  # Is this resolution mechanism suitable on the system in question?
+  def suitable?
+    unless defined? @suitable
+      @suitable = ! @confines.detect { |confine| ! confine.true? }
+    end
+
+    return @suitable
+  end
+
+  def to_s
+    return self.value()
+  end
+
+  # How we get a value for our resolution mechanism.
+  def value
+    result = nil
+    return result if @code == nil
+
+    starttime = Time.now.to_f
+
+    begin
+      Timeout.timeout(limit) do
+        if @code.is_a?(Proc)
+          result = @code.call()
         else
-            return out
+          result = Facter::Util::Resolution.exec(@code)
         end
+      end
+    rescue Timeout::Error => detail
+      warn "Timed out seeking value for %s" % self.name
+
+      # This call avoids zombies -- basically, create a thread that will
+      # dezombify all of the child processes that we're ignoring because
+      # of the timeout.
+      Thread.new { Process.waitall }
+      return nil
+    rescue => details
+      warn "Could not retrieve %s: %s" % [self.name, details]
+      return nil
     end
 
-    # Add a new confine to the resolution mechanism.
-    def confine(confines)
-        confines.each do |fact, values|
-            @confines.push Facter::Util::Confine.new(fact, *values)
-        end
-    end
+    finishtime = Time.now.to_f
+    ms = (finishtime - starttime) * 1000
+    Facter.show_time "#{self.name}: #{"%.2f" % ms}ms"
 
-    def has_weight(weight)
-        @weight = weight
-    end
-
-    # Create a new resolution mechanism.
-    def initialize(name)
-        @name = name
-        @confines = []
-        @value = nil
-        @timeout = 0
-        @weight = nil
-    end
-
-    # Return the importance of this resolution.
-    def weight
-        if @weight
-            @weight
-        else
-            @confines.length
-        end
-    end
-
-    # We need this as a getter for 'timeout', because some versions
-    # of ruby seem to already have a 'timeout' method and we can't
-    # seem to override the instance methods, somehow.
-    def limit
-        @timeout
-    end
-
-    # Set our code for returning a value.
-    def setcode(string = nil, interp = nil, &block)
-        Facter.warnonce "The interpreter parameter to 'setcode' is deprecated and will be removed in a future version." if interp
-        if string
-            @code = string
-            @interpreter = interp || INTERPRETER
-        else
-            unless block_given?
-                raise ArgumentError, "You must pass either code or a block"
-            end
-            @code = block
-        end
-    end
-
-    def interpreter
-      Facter.warnonce "The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version."
-      @interpreter
-    end
-
-    def interpreter=(interp)
-      Facter.warnonce "The 'Facter::Util::Resolution.interpreter=' method is deprecated and will be removed in a future version."
-      @interpreter = interp
-    end
-
-    # Is this resolution mechanism suitable on the system in question?
-    def suitable?
-        unless defined? @suitable
-            @suitable = ! @confines.detect { |confine| ! confine.true? }
-        end
-
-        return @suitable
-    end
-
-    def to_s
-        return self.value()
-    end
-
-    # How we get a value for our resolution mechanism.
-    def value
-        result = nil
-        return result if @code == nil
-
-        starttime = Time.now.to_f
-
-        begin
-            Timeout.timeout(limit) do
-                if @code.is_a?(Proc)
-                    result = @code.call()
-                else
-                    result = Facter::Util::Resolution.exec(@code)
-                end
-            end
-        rescue Timeout::Error => detail
-            warn "Timed out seeking value for %s" % self.name
-
-            # This call avoids zombies -- basically, create a thread that will
-            # dezombify all of the child processes that we're ignoring because
-            # of the timeout.
-            Thread.new { Process.waitall }
-            return nil
-        rescue => details
-            warn "Could not retrieve %s: %s" % [self.name, details]
-            return nil
-        end
-
-        finishtime = Time.now.to_f
-        ms = (finishtime - starttime) * 1000
-        Facter.show_time "#{self.name}: #{"%.2f" % ms}ms"
-
-        return nil if result == ""
-        return result
-    end
+    return nil if result == ""
+    return result
+  end
 end

--- a/lib/facter/util/uptime.rb
+++ b/lib/facter/util/uptime.rb
@@ -3,63 +3,63 @@ require 'time'
 # A module to gather uptime facts
 #
 module Facter::Util::Uptime
-    def self.get_uptime_seconds_unix
-        uptime_proc_uptime or uptime_sysctl or uptime_kstat or uptime_who_dash_b
+  def self.get_uptime_seconds_unix
+    uptime_proc_uptime or uptime_sysctl or uptime_kstat or uptime_who_dash_b
+  end
+
+  def self.get_uptime_seconds_win
+    require 'facter/util/wmi'
+
+    last_boot = ""
+    Facter::Util::WMI.execquery("select * from Win32_OperatingSystem").each do |x|
+      last_boot = x.LastBootupTime
     end
+    self.compute_uptime(Time.parse(last_boot.split('.').first))
+  end
 
-    def self.get_uptime_seconds_win
-      require 'facter/util/wmi'
+  private
 
-      last_boot = ""
-      Facter::Util::WMI.execquery("select * from Win32_OperatingSystem").each do |x|
-        last_boot = x.LastBootupTime
-      end
-      self.compute_uptime(Time.parse(last_boot.split('.').first))
+  def self.uptime_proc_uptime
+    if output = Facter::Util::Resolution.exec("/bin/cat #{uptime_file} 2>/dev/null")
+      output.chomp.split(" ").first.to_i
     end
+  end
 
-    private
-
-    def self.uptime_proc_uptime
-        if output = Facter::Util::Resolution.exec("/bin/cat #{uptime_file} 2>/dev/null")
-            output.chomp.split(" ").first.to_i
-        end
+  def self.uptime_sysctl
+    if output = Facter::Util::Resolution.exec("#{uptime_sysctl_cmd} 2>/dev/null")
+      compute_uptime(Time.at(output.unpack('L').first))
     end
+  end
 
-    def self.uptime_sysctl
-        if output = Facter::Util::Resolution.exec("#{uptime_sysctl_cmd} 2>/dev/null")
-            compute_uptime(Time.at(output.unpack('L').first))
-        end
+  def self.uptime_kstat
+    if output = Facter::Util::Resolution.exec("#{uptime_kstat_cmd} 2>/dev/null")
+      compute_uptime(Time.at(output.chomp.split(/\s/).last.to_i))
     end
+  end
 
-    def self.uptime_kstat
-        if output = Facter::Util::Resolution.exec("#{uptime_kstat_cmd} 2>/dev/null")
-            compute_uptime(Time.at(output.chomp.split(/\s/).last.to_i))
-        end
+  def self.uptime_who_dash_b
+    if output = Facter::Util::Resolution.exec("#{uptime_who_cmd} 2>/dev/null")
+      compute_uptime(Time.parse(output))
     end
+  end
 
-    def self.uptime_who_dash_b
-        if output = Facter::Util::Resolution.exec("#{uptime_who_cmd} 2>/dev/null")
-            compute_uptime(Time.parse(output))
-        end
-    end
+  def self.compute_uptime(time)
+    (Time.now - time).to_i
+  end
 
-    def self.compute_uptime(time)
-        (Time.now - time).to_i
-    end
+  def self.uptime_file
+    "/proc/uptime"
+  end
 
-    def self.uptime_file
-        "/proc/uptime"
-    end
+  def self.uptime_sysctl_cmd
+    'sysctl -b kern.boottime'
+  end
 
-    def self.uptime_sysctl_cmd
-        'sysctl -b kern.boottime'
-    end
+  def self.uptime_kstat_cmd
+    'kstat -p unix:::boot_time'
+  end
 
-    def self.uptime_kstat_cmd
-        'kstat -p unix:::boot_time'
-    end
-
-    def self.uptime_who_cmd
-        'who -b'
-    end
+  def self.uptime_who_cmd
+    'who -b'
+  end
 end

--- a/lib/facter/util/values.rb
+++ b/lib/facter/util/values.rb
@@ -1,14 +1,14 @@
 # A util module for facter containing helper methods
 module Facter
-    module Util
-        module Values
-            module_function
+  module Util
+    module Values
+      module_function
 
-            def convert(value)
-                value = value.to_s if value.is_a?(Symbol)
-                value = value.downcase if value.is_a?(String)
-                value
-            end    
-        end
+      def convert(value)
+        value = value.to_s if value.is_a?(Symbol)
+        value = value.downcase if value.is_a?(String)
+        value
+      end  
     end
+  end
 end

--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -1,86 +1,86 @@
 module Facter::Util::Virtual
-    def self.openvz?
-        FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
+  def self.openvz?
+    FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
+  end
+
+  # So one can either have #6728 work on OpenVZ or Cloudlinux. Whoo.
+  def self.openvz_type
+    return false unless self.openvz?
+    return false unless FileTest.exists?( '/proc/self/status' )
+
+    envid = Facter::Util::Resolution.exec( 'grep "envID" /proc/self/status' )
+    if envid =~ /^envID:\s+0$/i
+    return 'openvzhn'
+    elsif envid =~ /^envID:\s+(\d+)$/i
+    return 'openvzve'
     end
+  end
 
-    # So one can either have #6728 work on OpenVZ or Cloudlinux. Whoo.
-    def self.openvz_type
-      return false unless self.openvz?
-      return false unless FileTest.exists?( '/proc/self/status' )
+  # Cloudlinux uses OpenVZ to a degree, but always has an empty /proc/vz/ and
+  # has /proc/lve/list present
+  def self.openvz_cloudlinux?
+    FileTest.file?("/proc/lve/list") or Dir.glob('/proc/vz/*').empty?
+  end
 
-      envid = Facter::Util::Resolution.exec( 'grep "envID" /proc/self/status' )
-      if envid =~ /^envID:\s+0$/i
-        return 'openvzhn'
-      elsif envid =~ /^envID:\s+(\d+)$/i
-        return 'openvzve'
+  def self.zone?
+    return true if FileTest.directory?("/.SUNWnative")
+    z = Facter::Util::Resolution.exec("/sbin/zonename")
+    return false unless z
+    return z.chomp != 'global'
+  end
+
+  def self.vserver?
+    return false unless FileTest.exists?("/proc/self/status")
+    txt = File.read("/proc/self/status")
+    return true if txt =~ /^(s_context|VxID):[[:blank:]]*[0-9]/
+    return false
+  end
+
+  def self.vserver_type
+    if self.vserver?
+      if FileTest.exists?("/proc/virtual")
+        "vserver_host"
+      else
+        "vserver"
       end
     end
+  end
 
-    # Cloudlinux uses OpenVZ to a degree, but always has an empty /proc/vz/ and
-    # has /proc/lve/list present
-    def self.openvz_cloudlinux?
-      FileTest.file?("/proc/lve/list") or Dir.glob('/proc/vz/*').empty?
+  def self.xen?
+    ["/proc/sys/xen", "/sys/bus/xen", "/proc/xen" ].detect do |f|
+      FileTest.exists?(f)
     end
+  end
 
-    def self.zone?
-        return true if FileTest.directory?("/.SUNWnative")
-        z = Facter::Util::Resolution.exec("/sbin/zonename")
-        return false unless z
-        return z.chomp != 'global'
-    end
+  def self.kvm?
+     txt = if FileTest.exists?("/proc/cpuinfo")
+       File.read("/proc/cpuinfo")
+     elsif Facter.value(:kernel)=="FreeBSD"
+       Facter::Util::Resolution.exec("/sbin/sysctl -n hw.model")
+     end
+     (txt =~ /QEMU Virtual CPU/) ? true : false
+  end
 
-    def self.vserver?
-        return false unless FileTest.exists?("/proc/self/status")
-        txt = File.read("/proc/self/status")
-        return true if txt =~ /^(s_context|VxID):[[:blank:]]*[0-9]/
-        return false
-    end
+  def self.kvm_type
+    # TODO Tell the difference between kvm and qemu
+    # Can't work out a way to do this at the moment that doesn't
+    # require a special binary
+    "kvm"
+  end
 
-    def self.vserver_type
-        if self.vserver?
-            if FileTest.exists?("/proc/virtual")
-                "vserver_host"
-            else
-                "vserver"
-            end
-        end
+  def self.jail?
+    path = case Facter.value(:kernel)
+      when "FreeBSD" then "/sbin"
+      when "GNU/kFreeBSD" then "/bin"
     end
+    Facter::Util::Resolution.exec("#{path}/sysctl -n security.jail.jailed") == "1"
+  end
 
-    def self.xen?
-        ["/proc/sys/xen", "/sys/bus/xen", "/proc/xen" ].detect do |f|
-            FileTest.exists?(f)
-        end
-    end
-
-    def self.kvm?
-       txt = if FileTest.exists?("/proc/cpuinfo")
-           File.read("/proc/cpuinfo")
-       elsif Facter.value(:kernel)=="FreeBSD"
-           Facter::Util::Resolution.exec("/sbin/sysctl -n hw.model")
-       end
-       (txt =~ /QEMU Virtual CPU/) ? true : false
-    end
-
-    def self.kvm_type
-      # TODO Tell the difference between kvm and qemu
-      # Can't work out a way to do this at the moment that doesn't
-      # require a special binary
-      "kvm"
-    end
-
-    def self.jail?
-        path = case Facter.value(:kernel)
-            when "FreeBSD" then "/sbin"
-            when "GNU/kFreeBSD" then "/bin"
-        end
-        Facter::Util::Resolution.exec("#{path}/sysctl -n security.jail.jailed") == "1"
-    end
-
-    def self.hpvm?
-        Facter::Util::Resolution.exec("/usr/bin/getconf MACHINE_MODEL").chomp =~ /Virtual Machine/
-    end
+  def self.hpvm?
+    Facter::Util::Resolution.exec("/usr/bin/getconf MACHINE_MODEL").chomp =~ /Virtual Machine/
+  end
 
    def self.zlinux?
-        "zlinux"
+    "zlinux"
    end
 end

--- a/lib/facter/util/vlans.rb
+++ b/lib/facter/util/vlans.rb
@@ -1,24 +1,24 @@
 # A module to gather vlan facts
 #
 module Facter::Util::Vlans
-    def self.get_vlan_config
-        output = ""
-            if File.exists?('/proc/net/vlan/config') and File.readable?('/proc/net/vlan/config')
-                output = File.open('/proc/net/vlan/config').read
-            end
-        output
-    end
+  def self.get_vlan_config
+    output = ""
+      if File.exists?('/proc/net/vlan/config') and File.readable?('/proc/net/vlan/config')
+        output = File.open('/proc/net/vlan/config').read
+      end
+    output
+  end
 
-    def self.get_vlans
-        vlans = Array.new
-        if self.get_vlan_config
-            self.get_vlan_config.each_line do |line|
-                if line =~ /^([0-9A-Za-z]+)\.([0-9]+) /
-                    vlans.insert(-1, $~[2]) if $~[2]
-                end
-            end
+  def self.get_vlans
+    vlans = Array.new
+    if self.get_vlan_config
+      self.get_vlan_config.each_line do |line|
+        if line =~ /^([0-9A-Za-z]+)\.([0-9]+) /
+          vlans.insert(-1, $~[2]) if $~[2]
         end
-
-        vlans.join(',')
+      end
     end
+
+    vlans.join(',')
+  end
 end

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -10,8 +10,8 @@
 #   display.
 #
 #   On Linux, BSD, Solaris and HPUX:
-#     Much of the logic here is obscured behind util/virtual.rb, which rather
-#     than document here, which would encourage drift, just refer to it.
+#   Much of the logic here is obscured behind util/virtual.rb, which rather
+#   than document here, which would encourage drift, just refer to it.
 #   The Xen tests in here rely on /sys and /proc, and check for the presence and
 #   contents of files in there.
 #   If after all the other tests, it's still seen as physical, then it tries to
@@ -27,120 +27,120 @@
 require 'facter/util/virtual'
 
 Facter.add("virtual") do
-    confine :kernel => "Darwin"
+  confine :kernel => "Darwin"
 
-    setcode do
-        require 'facter/util/macosx'
-        result = "physical"
-        output = Facter::Util::Macosx.profiler_data("SPDisplaysDataType")
-        if output.is_a?(Hash)
-            result = "parallels" if output["spdisplays_vendor-id"] =~ /0x1ab8/
-            result = "parallels" if output["spdisplays_vendor"] =~ /[Pp]arallels/
-            result = "vmware" if output["spdisplays_vendor-id"] =~ /0x15ad/
-            result = "vmware" if output["spdisplays_vendor"] =~ /VM[wW]are/
-            result = "virtualbox" if output["spdisplays_vendor-id"] =~ /0x80ee/
-        end
-        result
+  setcode do
+    require 'facter/util/macosx'
+    result = "physical"
+    output = Facter::Util::Macosx.profiler_data("SPDisplaysDataType")
+    if output.is_a?(Hash)
+      result = "parallels" if output["spdisplays_vendor-id"] =~ /0x1ab8/
+      result = "parallels" if output["spdisplays_vendor"] =~ /[Pp]arallels/
+      result = "vmware" if output["spdisplays_vendor-id"] =~ /0x15ad/
+      result = "vmware" if output["spdisplays_vendor"] =~ /VM[wW]are/
+      result = "virtualbox" if output["spdisplays_vendor-id"] =~ /0x80ee/
     end
+    result
+  end
 end
 
 
 Facter.add("virtual") do
-    confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX GNU/kFreeBSD}
+  confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX GNU/kFreeBSD}
 
-    result = "physical"
+  result = "physical"
 
-    setcode do
+  setcode do
 
-        if Facter.value(:operatingsystem) == "Solaris" and Facter::Util::Virtual.zone?
-            result = "zone"
-        end
-
-        if Facter.value(:kernel)=="HP-UX"
-            result = "hpvm" if Facter::Util::Virtual.hpvm?
-        end
-
-        if Facter.value(:architecture)=="s390x"
-            result = "zlinux" if Facter::Util::Virtual.zlinux?
-        end
-
-        if Facter::Util::Virtual.openvz?
-            result = Facter::Util::Virtual.openvz_type()
-        end
-
-        if Facter::Util::Virtual.vserver?
-            result = Facter::Util::Virtual.vserver_type()
-        end
-
-        if Facter::Util::Virtual.xen?
-            if FileTest.exists?("/proc/xen/xsd_kva")
-                result = "xen0"
-            elsif FileTest.exists?("/proc/xen/capabilities")
-                result = "xenu"
-            end
-        end
-
-        if Facter::Util::Virtual.kvm?
-            result = Facter::Util::Virtual.kvm_type()
-        end
-
-        if ["FreeBSD", "GNU/kFreeBSD"].include? Facter.value(:kernel)
-            result = "jail" if Facter::Util::Virtual.jail?
-        end
-
-        if result == "physical"
-            output = Facter::Util::Resolution.exec('lspci')
-            if not output.nil?
-                output.each_line do |p|
-                    # --- look for the vmware video card to determine if it is virtual => vmware.
-                    # ---     00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter
-                    result = "vmware" if p =~ /VM[wW]are/
-                    # --- look for virtualbox video card to determine if it is virtual => virtualbox.
-                    # ---     00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter
-                    result = "virtualbox" if p =~ /VirtualBox/
-                    # --- look for pci vendor id used by Parallels video card
-                    # ---   01:00.0 VGA compatible controller: Unknown device 1ab8:4005
-                    result = "parallels" if p =~ /1ab8:|[Pp]arallels/
-                    # --- look for pci vendor id used by Xen HVM device
-                    # ---   00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)
-                    result = "xenhvm" if p =~ /XenSource/
-                    # --- look for Hyper-V video card
-                    # ---   00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA
-                    result = "hyperv" if p =~ /Microsoft Corporation Hyper-V/
-                end
-            else
-                output = Facter::Util::Resolution.exec('dmidecode')
-                if not output.nil?
-                    output.each_line do |pd|
-                        result = "parallels" if pd =~ /Parallels/
-                        result = "vmware" if pd =~ /VMware/
-                        result = "virtualbox" if pd =~ /VirtualBox/
-                        result = "xenhvm" if pd =~ /HVM domU/
-                        result = "hyperv" if pd =~ /Product Name: Virtual Machine/
-                    end
-                elsif Facter.value(:kernel) == 'SunOS'
-                    res = Facter::Util::Resolution.new('prtdiag')
-                    res.timeout = 6
-                    res.setcode('prtdiag')
-                    output = res.value
-                    if not output.nil?
-                        output.each_line do |pd|
-                            result = "parallels" if pd =~ /Parallels/
-                            result = "vmware" if pd =~ /VMware/
-                            result = "virtualbox" if pd =~ /VirtualBox/
-                            result = "xenhvm" if pd =~ /HVM domU/
-                        end
-                    end
-                end
-            end
-            
-            if output = Facter::Util::Resolution.exec("vmware -v")
-                result = output.sub(/(\S+)\s+(\S+).*/) { | text | "#{$1}_#{$2}"}.downcase
-            end
-        end
-
-        result
+    if Facter.value(:operatingsystem) == "Solaris" and Facter::Util::Virtual.zone?
+      result = "zone"
     end
+
+    if Facter.value(:kernel)=="HP-UX"
+      result = "hpvm" if Facter::Util::Virtual.hpvm?
+    end
+
+    if Facter.value(:architecture)=="s390x"
+      result = "zlinux" if Facter::Util::Virtual.zlinux?
+    end
+
+    if Facter::Util::Virtual.openvz?
+      result = Facter::Util::Virtual.openvz_type()
+    end
+
+    if Facter::Util::Virtual.vserver?
+      result = Facter::Util::Virtual.vserver_type()
+    end
+
+    if Facter::Util::Virtual.xen?
+      if FileTest.exists?("/proc/xen/xsd_kva")
+        result = "xen0"
+      elsif FileTest.exists?("/proc/xen/capabilities")
+        result = "xenu"
+      end
+    end
+
+    if Facter::Util::Virtual.kvm?
+      result = Facter::Util::Virtual.kvm_type()
+    end
+
+    if ["FreeBSD", "GNU/kFreeBSD"].include? Facter.value(:kernel)
+      result = "jail" if Facter::Util::Virtual.jail?
+    end
+
+    if result == "physical"
+      output = Facter::Util::Resolution.exec('lspci')
+      if not output.nil?
+        output.each_line do |p|
+          # --- look for the vmware video card to determine if it is virtual => vmware.
+          # ---   00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter
+          result = "vmware" if p =~ /VM[wW]are/
+          # --- look for virtualbox video card to determine if it is virtual => virtualbox.
+          # ---   00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter
+          result = "virtualbox" if p =~ /VirtualBox/
+          # --- look for pci vendor id used by Parallels video card
+          # ---   01:00.0 VGA compatible controller: Unknown device 1ab8:4005
+          result = "parallels" if p =~ /1ab8:|[Pp]arallels/
+          # --- look for pci vendor id used by Xen HVM device
+          # ---   00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)
+          result = "xenhvm" if p =~ /XenSource/
+          # --- look for Hyper-V video card
+          # ---   00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA
+          result = "hyperv" if p =~ /Microsoft Corporation Hyper-V/
+        end
+      else
+        output = Facter::Util::Resolution.exec('dmidecode')
+        if not output.nil?
+          output.each_line do |pd|
+            result = "parallels" if pd =~ /Parallels/
+            result = "vmware" if pd =~ /VMware/
+            result = "virtualbox" if pd =~ /VirtualBox/
+            result = "xenhvm" if pd =~ /HVM domU/
+            result = "hyperv" if pd =~ /Product Name: Virtual Machine/
+          end
+        elsif Facter.value(:kernel) == 'SunOS'
+          res = Facter::Util::Resolution.new('prtdiag')
+          res.timeout = 6
+          res.setcode('prtdiag')
+          output = res.value
+          if not output.nil?
+            output.each_line do |pd|
+              result = "parallels" if pd =~ /Parallels/
+              result = "vmware" if pd =~ /VMware/
+              result = "virtualbox" if pd =~ /VirtualBox/
+              result = "xenhvm" if pd =~ /HVM domU/
+            end
+          end
+        end
+      end
+      
+      if output = Facter::Util::Resolution.exec("vmware -v")
+        result = output.sub(/(\S+)\s+(\S+).*/) { | text | "#{$1}_#{$2}"}.downcase
+      end
+    end
+
+    result
+  end
 end
 
 # Fact: is_virtual
@@ -155,15 +155,15 @@ end
 #
 
 Facter.add("is_virtual") do
-    confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD}
+  confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD}
 
-    setcode do
-        physical_types = %w{physical xen0 vmware_server vmware_workstation openvzhn}
+  setcode do
+    physical_types = %w{physical xen0 vmware_server vmware_workstation openvzhn}
 
-        if physical_types.include? Facter.value(:virtual)
-            "false"
-        else
-            "true"
-        end
+    if physical_types.include? Facter.value(:virtual)
+      "false"
+    else
+      "true"
     end
+  end
 end

--- a/lib/facter/vlans.rb
+++ b/lib/facter/vlans.rb
@@ -10,9 +10,9 @@
 
 require 'facter/util/vlans'
     
-    Facter.add("vlans") do
-        confine :kernel => :linux
-        setcode do
-            Facter::Util::Vlans.get_vlans
-        end
-    end
+Facter.add("vlans") do
+  confine :kernel => :linux
+  setcode do
+    Facter::Util::Vlans.get_vlans
+  end
+end

--- a/spec/integration/facter_spec.rb
+++ b/spec/integration/facter_spec.rb
@@ -3,25 +3,25 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Facter do
-    before do
-        Facter.reset
-    end
+  before do
+    Facter.reset
+  end
 
-    after do
-        Facter.reset
-    end
+  after do
+    Facter.reset
+  end
 
-    it "should create a new collection if one does not exist" do
-        Facter.reset
-        coll = mock('coll')
-        Facter::Util::Collection.stubs(:new).returns coll
-        Facter.collection.should equal(coll)
-        Facter.reset
-    end
+  it "should create a new collection if one does not exist" do
+    Facter.reset
+    coll = mock('coll')
+    Facter::Util::Collection.stubs(:new).returns coll
+    Facter.collection.should equal(coll)
+    Facter.reset
+  end
 
-    it "should remove the collection when reset" do
-        old = Facter.collection
-        Facter.reset
-        Facter.collection.should_not equal(old)
-    end
+  it "should remove the collection when reset" do
+    old = Facter.collection
+    Facter.reset
+    Facter.collection.should_not equal(old)
+  end
 end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -42,7 +42,7 @@ describe "Memory facts" do
         swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
 
         swapusage =~ /\(encrypted\)/
-	Facter.fact(:swapencrypted).value.should == true
+        Facter.fact(:swapencrypted).value.should == true
     end
 
     describe "on OpenBSD" do

--- a/spec/unit/util/uptime_spec.rb
+++ b/spec/unit/util/uptime_spec.rb
@@ -28,10 +28,10 @@ describe Facter::Util::Uptime do
 
       it "should use 'sysctl kern.boottime'" do
         if [1].pack("L") == [1].pack("V") # Determine endianness
-	  sysctl_output_filename = 'sysctl_kern_boottime_little_endian'
-	else
-	  sysctl_output_filename = 'sysctl_kern_boottime_big_endian'
-	end
+          sysctl_output_filename = 'sysctl_kern_boottime_little_endian'
+        else
+          sysctl_output_filename = 'sysctl_kern_boottime_big_endian'
+        end
         sysctl_output_file = File.join(SPECDIR, 'fixtures', 'uptime', sysctl_output_filename) # Aug 01 14:13:47 -0700 2010
         Facter::Util::Uptime.stubs(:uptime_sysctl_cmd).returns("cat \"#{sysctl_output_file}\"")
         Time.stubs(:now).returns Time.parse("Aug 01 15:13:47 -0700 2010") # one hour later

--- a/tasks/rake/changlog.rake
+++ b/tasks/rake/changlog.rake
@@ -1,15 +1,15 @@
 desc "Create a ChangeLog based on git commits."
 task :changelog do
-    begin
-         gitc = %x{which git-changelog}
-    rescue 
-        puts "This task needs the git-changelog binary - http://github.com/ReinH/git-changelog"
-    end
+  begin
+     gitc = %x{which git-changelog}
+  rescue 
+    puts "This task needs the git-changelog binary - http://github.com/ReinH/git-changelog"
+  end
 
-    CHANGELOG_DIR = "#{Dir.pwd}"
-    mkdir(CHANGELOG_DIR) unless File.directory?(CHANGELOG_DIR)
-    change_body = `git-changelog --limit=99999`
-    File.open(File.join(CHANGELOG_DIR, "CHANGELOG"), 'w') do |f|
-        f << change_body
-    end
+  CHANGELOG_DIR = "#{Dir.pwd}"
+  mkdir(CHANGELOG_DIR) unless File.directory?(CHANGELOG_DIR)
+  change_body = `git-changelog --limit=99999`
+  File.open(File.join(CHANGELOG_DIR, "CHANGELOG"), 'w') do |f|
+    f << change_body
+  end
 end

--- a/tasks/rake/ci.rake
+++ b/tasks/rake/ci.rake
@@ -1,14 +1,14 @@
 desc "Prep CI RSpec tests"
 task :ci_prep do
-    require 'rubygems'
-    begin
-        gem 'ci_reporter'
-        require 'ci/reporter/rake/rspec'
-        require 'ci/reporter/rake/test_unit'
-        ENV['CI_REPORTS'] = 'results'
-    rescue LoadError
-       puts 'Missing ci_reporter gem. You must have the ci_reporter gem installed to run the CI spec tests'
-    end 
+  require 'rubygems'
+  begin
+    gem 'ci_reporter'
+    require 'ci/reporter/rake/rspec'
+    require 'ci/reporter/rake/test_unit'
+    ENV['CI_REPORTS'] = 'results'
+  rescue LoadError
+     puts 'Missing ci_reporter gem. You must have the ci_reporter gem installed to run the CI spec tests'
+  end 
 end
 
 desc "Run the CI RSpec tests"

--- a/tasks/rake/mail_patches.rake
+++ b/tasks/rake/mail_patches.rake
@@ -1,48 +1,48 @@
 desc "Send patch information to the puppet-dev list"
 task :mail_patches do
-    if Dir.glob("00*.patch").length > 0
-        raise "Patches already exist matching '00*.patch'; clean up first"
+  if Dir.glob("00*.patch").length > 0
+    raise "Patches already exist matching '00*.patch'; clean up first"
+  end
+
+  unless %x{git status} =~ /On branch (.+)/
+    raise "Could not get branch from 'git status'"
+  end
+  branch = $1
+
+  unless branch =~ %r{^([^\/]+)/([^\/]+)/([^\/]+)$}
+    raise "Branch name does not follow <type>/<parent>/<name> model; cannot autodetect parent branch"
+  end
+
+  type, parent, name = $1, $2, $3
+
+  # Create all of the patches
+  sh "git format-patch -C -M -s -n --subject-prefix='PATCH/facter' #{parent}..HEAD"
+
+  # Add info to the patches
+  additional_info = "Local-branch: #{branch}\n"
+  files = Dir.glob("00*.patch")
+  files.each do |file|
+    contents = File.read(file)
+    contents.sub!(/^---\n/, "---\n#{additional_info}")
+    File.open(file, 'w') do |file_handle|
+      file_handle.print contents
     end
+  end
 
-    unless %x{git status} =~ /On branch (.+)/
-        raise "Could not get branch from 'git status'"
-    end
-    branch = $1
+  # And then mail them out.
 
-    unless branch =~ %r{^([^\/]+)/([^\/]+)/([^\/]+)$}
-        raise "Branch name does not follow <type>/<parent>/<name> model; cannot autodetect parent branch"
-    end
+  # If we've got more than one patch, add --compose
+  if files.length > 1
+    compose = "--compose"
+    subject = %Q{--subject "#{type} #{name} against #{parent}"}
+  else
+    compose = ""
+    subject = ""
+  end
 
-    type, parent, name = $1, $2, $3
+  # Now send the mail.
+  sh "git send-email #{compose} #{subject} --no-signed-off-by-cc --suppress-from --to puppet-dev@googlegroups.com 00*.patch"
 
-    # Create all of the patches
-    sh "git format-patch -C -M -s -n --subject-prefix='PATCH/facter' #{parent}..HEAD"
-
-    # Add info to the patches
-    additional_info = "Local-branch: #{branch}\n"
-    files = Dir.glob("00*.patch")
-    files.each do |file|
-        contents = File.read(file)
-        contents.sub!(/^---\n/, "---\n#{additional_info}")
-        File.open(file, 'w') do |file_handle|
-            file_handle.print contents
-        end
-    end
-
-    # And then mail them out.
-
-    # If we've got more than one patch, add --compose
-    if files.length > 1
-        compose = "--compose"
-        subject = %Q{--subject "#{type} #{name} against #{parent}"}
-    else
-        compose = ""
-        subject = ""
-    end
-
-    # Now send the mail.
-    sh "git send-email #{compose} #{subject} --no-signed-off-by-cc --suppress-from --to puppet-dev@googlegroups.com 00*.patch"
-
-    # Finally, clean up the patches
-    sh "rm 00*.patch"
+  # Finally, clean up the patches
+  sh "rm 00*.patch"
 end

--- a/tasks/rake/metrics.rake
+++ b/tasks/rake/metrics.rake
@@ -1,6 +1,6 @@
 begin
-    require 'metric_fu'
+  require 'metric_fu'
 rescue LoadError
-    # Metric-fu not installed
-    # http://metric-fu.rubyforge.org/
+  # Metric-fu not installed
+  # http://metric-fu.rubyforge.org/
 end

--- a/tasks/rake/sign.rake
+++ b/tasks/rake/sign.rake
@@ -1,14 +1,14 @@
 desc "Sign the package with the Puppet Labs release key"
 task :sign_packages do
 
-version = Facter::FACTERVERSION
+  version = Facter::FACTERVERSION
 
-# Sign package
+  # Sign package
 
-sh "gpg --homedir $HOME/pl_release_key --detach-sign --output pkg/facter-#{version}.tar.gz.sign --armor pkg/facter-#{version}.tar.gz"
+  sh "gpg --homedir $HOME/pl_release_key --detach-sign --output pkg/facter-#{version}.tar.gz.sign --armor pkg/facter-#{version}.tar.gz"
 
-# Sign gem
+  # Sign gem
 
-sh "gpg --homedir $HOME/pl_release_key --detach-sign --output pkg/facter-#{version}.gem.sign --armor pkg/facter-#{version}.gem"
+  sh "gpg --homedir $HOME/pl_release_key --detach-sign --output pkg/facter-#{version}.gem.sign --armor pkg/facter-#{version}.gem"
 
 end


### PR DESCRIPTION
(#9555) Change all cases of tabs and 4 space indentation to 2 space indentation.

Since 2 space indentation seems to be Puppets (and the ruby communities)
standard this patch converts all incorrect indentation to 2 spaces.

The fact that we were mixing the indentation was causing people to mix them
within files - sometimes using 4 space, sometimes 2 space. This single change
makes it consistent across all the code.
