### PR TITLE
(#9555) Spec tests: Change all cases of tabs and 4 space indentation to 2

### DIFF
--- a/spec/unit/architecture_spec.rb
+++ b/spec/unit/architecture_spec.rb
@@ -6,49 +6,49 @@ require 'facter'
 
 describe "Architecture fact" do
 
-    it "should default to the hardware model" do
-        Facter.fact(:hardwaremodel).stubs(:value).returns("NonSpecialCasedHW")
+  it "should default to the hardware model" do
+    Facter.fact(:hardwaremodel).stubs(:value).returns("NonSpecialCasedHW")
 
-        Facter.fact(:architecture).value.should == "NonSpecialCasedHW"
+    Facter.fact(:architecture).value.should == "NonSpecialCasedHW"
+  end
+
+  os_archs = Hash.new
+  os_archs = {
+    ["Debian","x86_64"] => "amd64",
+    ["Gentoo","x86_64"] => "amd64",
+    ["GNU/kFreeBSD","x86_64"] => "amd64",
+    ["Ubuntu","x86_64"] => "amd64",
+    ["Gentoo","i386"] => "x86",
+    ["Gentoo","i486"] => "x86",
+    ["Gentoo","i586"] => "x86",
+    ["Gentoo","i686"] => "x86",
+    ["Gentoo","pentium"] => "x86",
+  }
+  generic_archs = Hash.new
+  generic_archs = {
+    "i386" => "i386",
+    "i486" => "i386",
+    "i586" => "i386",
+    "i686" => "i386",
+    "pentium" => "i386",
+  }
+  
+  os_archs.each do |pair, result|
+    it "should be #{result} if os is #{pair[0]} and hardwaremodel is #{pair[1]}" do
+     Facter.fact(:operatingsystem).stubs(:value).returns(pair[0])
+     Facter.fact(:hardwaremodel).stubs(:value).returns(pair[1])
+
+     Facter.fact(:architecture).value.should == result
     end
+  end
 
-    os_archs = Hash.new
-    os_archs = {
-	["Debian","x86_64"] => "amd64",
-	["Gentoo","x86_64"] => "amd64",
-	["GNU/kFreeBSD","x86_64"] => "amd64",
-	["Ubuntu","x86_64"] => "amd64",
-	["Gentoo","i386"] => "x86",
-	["Gentoo","i486"] => "x86",
-	["Gentoo","i586"] => "x86",
-	["Gentoo","i686"] => "x86",
-	["Gentoo","pentium"] => "x86",
-    }
-    generic_archs = Hash.new
-    generic_archs = {
-	"i386" => "i386",
-	"i486" => "i386",
-	"i586" => "i386",
-	"i686" => "i386",
-	"pentium" => "i386",
-    }
-    
-    os_archs.each do |pair, result|
-	it "should be #{result} if os is #{pair[0]} and hardwaremodel is #{pair[1]}" do
-	 Facter.fact(:operatingsystem).stubs(:value).returns(pair[0])
-	 Facter.fact(:hardwaremodel).stubs(:value).returns(pair[1])
+  generic_archs.each do |hw, result|
+    it "should be #{result} if hardwaremodel is #{hw}" do
+     Facter.fact(:hardwaremodel).stubs(:value).returns(hw)
+     Facter.fact(:operatingsystem).stubs(:value).returns("NonSpecialCasedOS")
 
-	 Facter.fact(:architecture).value.should == result
-	end
+     Facter.fact(:architecture).value.should == result
     end
-
-    generic_archs.each do |hw, result|
-	it "should be #{result} if hardwaremodel is #{hw}" do
-	 Facter.fact(:hardwaremodel).stubs(:value).returns(hw)
-	 Facter.fact(:operatingsystem).stubs(:value).returns("NonSpecialCasedOS")
-
-	 Facter.fact(:architecture).value.should == result
-	end
-    end
+  end
 
 end

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -4,268 +4,268 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Facter do
 
-    it "should have a version" do
-        Facter.version.should =~ /^[0-9]+(\.[0-9]+)*$/
+  it "should have a version" do
+    Facter.version.should =~ /^[0-9]+(\.[0-9]+)*$/
+  end
+
+  it "should have a method for returning its collection" do
+    Facter.should respond_to(:collection)
+  end
+
+  it "should cache the collection" do
+    Facter.collection.should equal(Facter.collection)
+  end
+
+  it "should delegate the :flush method to the collection" do
+    Facter.collection.expects(:flush)
+    Facter.flush
+  end
+
+  it "should delegate the :fact method to the collection" do
+    Facter.collection.expects(:fact)
+    Facter.fact
+  end
+
+  it "should delegate the :list method to the collection" do
+    Facter.collection.expects(:list)
+    Facter.list
+  end
+
+  it "should load all facts when listing" do
+    Facter.collection.expects(:load_all)
+    Facter.collection.stubs(:list)
+    Facter.list
+  end
+
+  it "should delegate the :to_hash method to the collection" do
+    Facter.collection.expects(:to_hash)
+    Facter.to_hash
+  end
+
+  it "should load all facts when calling :to_hash" do
+    Facter.collection.expects(:load_all)
+    Facter.collection.stubs(:to_hash)
+    Facter.to_hash
+  end
+
+  it "should delegate the :value method to the collection" do
+    Facter.collection.expects(:value)
+    Facter.value
+  end
+
+  it "should delegate the :each method to the collection" do
+    Facter.collection.expects(:each)
+    Facter.each
+  end
+
+  it "should load all facts when calling :each" do
+    Facter.collection.expects(:load_all)
+    Facter.collection.stubs(:each)
+    Facter.each
+  end
+
+  it "should yield to the block when using :each" do
+    Facter.collection.stubs(:load_all)
+    Facter.collection.stubs(:each).yields "foo"
+    result = []
+    Facter.each { |f| result << f }
+    result.should == %w{foo}
+  end
+
+  describe "when provided code as a string" do
+    it "should execute the code in the shell" do
+      Facter.add("shell_testing") do
+        setcode "echo yup"
+      end
+
+      Facter["shell_testing"].value.should == "yup"
+    end
+  end
+
+  describe "when asked for a fact as an undefined Facter class method" do
+    describe "and the collection is already initialized" do
+      it "should return the fact's value" do
+        Facter.collection
+        Facter.ipaddress.should == Facter['ipaddress'].value
+      end
     end
 
-    it "should have a method for returning its collection" do
-        Facter.should respond_to(:collection)
+    describe "and the collection has been just reset" do
+      it "should return the fact's value" do
+        Facter.reset
+        Facter.ipaddress.should == Facter['ipaddress'].value
+      end
+    end
+  end
+
+  describe "when passed code as a block" do
+    it "should execute the provided block" do
+      Facter.add("block_testing") { setcode { "foo" } }
+
+      Facter["block_testing"].value.should == "foo"
+    end
+  end
+
+  describe Facter[:hostname] do
+    it "should have its ldapname set to 'cn'" do
+      Facter[:hostname].ldapname.should == "cn"
+    end
+  end
+
+  describe Facter[:ipaddress] do
+    it "should have its ldapname set to 'iphostnumber'" do
+      Facter[:ipaddress].ldapname.should == "iphostnumber"
+    end
+  end
+
+  # #33 Make sure we only get one mac address
+  it "should only return one mac address" do
+    Facter.value(:macaddress).should_not be_include(" ")
+  end
+
+  it "should have a method for registering directories to search" do
+    Facter.should respond_to(:search)
+  end
+
+  it "should have a method for returning the registered search directories" do
+    Facter.should respond_to(:search_path)
+  end
+
+  it "should have a method to query debugging mode" do
+    Facter.should respond_to(:debugging?)
+  end
+
+  it "should have a method to query timing mode" do
+    Facter.should respond_to(:timing?)
+  end
+
+  it "should have a method to show timing information" do
+    Facter.should respond_to(:show_time)
+  end
+
+  it "should have a method to warn" do
+    Facter.should respond_to(:warn)
+  end
+
+  describe "when warning" do
+    it "should warn if debugging is enabled" do
+      Facter.debugging(true)
+      Kernel.stubs(:warn)
+      Kernel.expects(:warn).with('foo')
+      Facter.warn('foo')
     end
 
-    it "should cache the collection" do
-        Facter.collection.should equal(Facter.collection)
+    it "should not warn if debugging is enabled but nil is passed" do
+      Facter.debugging(true)
+      Kernel.stubs(:warn)
+      Kernel.expects(:warn).never
+      Facter.warn(nil)
     end
 
-    it "should delegate the :flush method to the collection" do
-        Facter.collection.expects(:flush)
-        Facter.flush
+    it "should not warn if debugging is enabled but an empyt string is passed" do
+      Facter.debugging(true)
+      Kernel.stubs(:warn)
+      Kernel.expects(:warn).never
+      Facter.warn('')
     end
 
-    it "should delegate the :fact method to the collection" do
-        Facter.collection.expects(:fact)
-        Facter.fact
+    it "should not warn if debugging is disabled" do
+      Facter.debugging(false)
+      Kernel.stubs(:warn)
+      Kernel.expects(:warn).never
+      Facter.warn('foo')
     end
 
-    it "should delegate the :list method to the collection" do
-        Facter.collection.expects(:list)
-        Facter.list
+    it "should warn for any given element for an array if debugging is enabled" do
+      Facter.debugging(true)
+      Kernel.stubs(:warn)
+      Kernel.expects(:warn).with('foo')
+      Kernel.expects(:warn).with('bar')
+      Facter.warn( ['foo','bar'])
+    end
+  end
+
+  describe "when warning once" do
+    it "should only warn once" do
+      Kernel.stubs(:warnonce)
+      Kernel.expects(:warn).with('foo').once
+      Facter.warnonce('foo')
+      Facter.warnonce('foo')
     end
 
-    it "should load all facts when listing" do
-        Facter.collection.expects(:load_all)
-        Facter.collection.stubs(:list)
-        Facter.list
+    it "should not warnonce if nil is passed" do
+      Kernel.stubs(:warn)
+      Kernel.expects(:warnonce).never
+      Facter.warnonce(nil)
     end
 
-    it "should delegate the :to_hash method to the collection" do
-        Facter.collection.expects(:to_hash)
-        Facter.to_hash
+    it "should not warnonce if an empty string is passed" do
+      Kernel.stubs(:warn)
+      Kernel.expects(:warnonce).never
+      Facter.warnonce('')
+    end
+  end
+
+  describe "when setting debugging mode" do
+    it "should have debugging enabled using 1" do
+      Facter.debugging(1)
+      Facter.should be_debugging
+    end
+    it "should have debugging enabled using true" do
+      Facter.debugging(true)
+      Facter.should be_debugging
+    end
+    it "should have debugging enabled using any string except off" do
+      Facter.debugging('aaaaa')
+      Facter.should be_debugging
+    end
+    it "should have debugging disabled using 0" do
+      Facter.debugging(0)
+      Facter.should_not be_debugging
+    end
+    it "should have debugging disabled using false" do
+      Facter.debugging(false)
+      Facter.should_not be_debugging
+    end
+    it "should have debugging disabled using the string 'off'" do
+      Facter.debugging('off')
+      Facter.should_not be_debugging
+    end
+  end
+
+  describe "when setting timing mode" do
+    it "should have timing enabled using 1" do
+      Facter.timing(1)
+      Facter.should be_timing
+    end
+    it "should have timing enabled using true" do
+      Facter.timing(true)
+      Facter.should be_timing
+    end
+    it "should have timing disabled using 0" do
+      Facter.timing(0)
+      Facter.should_not be_timing
+    end
+    it "should have timing disabled using false" do
+      Facter.timing(false)
+      Facter.should_not be_timing
+    end
+  end
+
+  describe "when registering directories to search" do
+    after { Facter.instance_variable_set("@search_path", []) }
+
+    it "should allow registration of a directory" do
+      Facter.search "/my/dir"
     end
 
-    it "should load all facts when calling :to_hash" do
-        Facter.collection.expects(:load_all)
-        Facter.collection.stubs(:to_hash)
-        Facter.to_hash
+    it "should allow registration of multiple directories" do
+      Facter.search "/my/dir", "/other/dir"
     end
 
-    it "should delegate the :value method to the collection" do
-        Facter.collection.expects(:value)
-        Facter.value
+    it "should return all registered directories when asked" do
+      Facter.search "/my/dir", "/other/dir"
+      Facter.search_path.should == %w{/my/dir /other/dir}
     end
-
-    it "should delegate the :each method to the collection" do
-        Facter.collection.expects(:each)
-        Facter.each
-    end
-
-    it "should load all facts when calling :each" do
-        Facter.collection.expects(:load_all)
-        Facter.collection.stubs(:each)
-        Facter.each
-    end
-
-    it "should yield to the block when using :each" do
-        Facter.collection.stubs(:load_all)
-        Facter.collection.stubs(:each).yields "foo"
-        result = []
-        Facter.each { |f| result << f }
-        result.should == %w{foo}
-    end
-
-    describe "when provided code as a string" do
-        it "should execute the code in the shell" do
-            Facter.add("shell_testing") do
-                setcode "echo yup"
-            end
-
-            Facter["shell_testing"].value.should == "yup"
-        end
-    end
-
-    describe "when asked for a fact as an undefined Facter class method" do
-        describe "and the collection is already initialized" do
-            it "should return the fact's value" do
-                Facter.collection
-                Facter.ipaddress.should == Facter['ipaddress'].value
-            end
-        end
-
-        describe "and the collection has been just reset" do
-            it "should return the fact's value" do
-                Facter.reset
-                Facter.ipaddress.should == Facter['ipaddress'].value
-            end
-        end
-    end
-
-    describe "when passed code as a block" do
-        it "should execute the provided block" do
-            Facter.add("block_testing") { setcode { "foo" } }
-
-            Facter["block_testing"].value.should == "foo"
-        end
-    end
-
-    describe Facter[:hostname] do
-        it "should have its ldapname set to 'cn'" do
-            Facter[:hostname].ldapname.should == "cn"
-        end
-    end
-
-    describe Facter[:ipaddress] do
-        it "should have its ldapname set to 'iphostnumber'" do
-            Facter[:ipaddress].ldapname.should == "iphostnumber"
-        end
-    end
-
-    # #33 Make sure we only get one mac address
-    it "should only return one mac address" do
-        Facter.value(:macaddress).should_not be_include(" ")
-    end
-
-    it "should have a method for registering directories to search" do
-        Facter.should respond_to(:search)
-    end
-
-    it "should have a method for returning the registered search directories" do
-        Facter.should respond_to(:search_path)
-    end
-
-    it "should have a method to query debugging mode" do
-        Facter.should respond_to(:debugging?)
-    end
-
-    it "should have a method to query timing mode" do
-        Facter.should respond_to(:timing?)
-    end
-
-    it "should have a method to show timing information" do
-        Facter.should respond_to(:show_time)
-    end
-
-    it "should have a method to warn" do
-        Facter.should respond_to(:warn)
-    end
-
-    describe "when warning" do
-        it "should warn if debugging is enabled" do
-          Facter.debugging(true)
-          Kernel.stubs(:warn)
-          Kernel.expects(:warn).with('foo')
-          Facter.warn('foo')
-        end
-
-        it "should not warn if debugging is enabled but nil is passed" do
-          Facter.debugging(true)
-          Kernel.stubs(:warn)
-          Kernel.expects(:warn).never
-          Facter.warn(nil)
-        end
-
-        it "should not warn if debugging is enabled but an empyt string is passed" do
-          Facter.debugging(true)
-          Kernel.stubs(:warn)
-          Kernel.expects(:warn).never
-          Facter.warn('')
-        end
-
-        it "should not warn if debugging is disabled" do
-          Facter.debugging(false)
-          Kernel.stubs(:warn)
-          Kernel.expects(:warn).never
-          Facter.warn('foo')
-        end
-
-        it "should warn for any given element for an array if debugging is enabled" do
-          Facter.debugging(true)
-          Kernel.stubs(:warn)
-          Kernel.expects(:warn).with('foo')
-          Kernel.expects(:warn).with('bar')
-          Facter.warn( ['foo','bar'])
-        end
-    end
-
-    describe "when warning once" do
-        it "should only warn once" do
-          Kernel.stubs(:warnonce)
-          Kernel.expects(:warn).with('foo').once
-          Facter.warnonce('foo')
-          Facter.warnonce('foo')
-        end
-
-        it "should not warnonce if nil is passed" do
-          Kernel.stubs(:warn)
-          Kernel.expects(:warnonce).never
-          Facter.warnonce(nil)
-        end
-
-        it "should not warnonce if an empty string is passed" do
-          Kernel.stubs(:warn)
-          Kernel.expects(:warnonce).never
-          Facter.warnonce('')
-        end
-    end
-
-    describe "when setting debugging mode" do
-        it "should have debugging enabled using 1" do
-            Facter.debugging(1)
-            Facter.should be_debugging
-        end
-        it "should have debugging enabled using true" do
-            Facter.debugging(true)
-            Facter.should be_debugging
-        end
-        it "should have debugging enabled using any string except off" do
-            Facter.debugging('aaaaa')
-            Facter.should be_debugging
-        end
-        it "should have debugging disabled using 0" do
-            Facter.debugging(0)
-            Facter.should_not be_debugging
-        end
-        it "should have debugging disabled using false" do
-            Facter.debugging(false)
-            Facter.should_not be_debugging
-        end
-        it "should have debugging disabled using the string 'off'" do
-            Facter.debugging('off')
-            Facter.should_not be_debugging
-        end
-    end
-
-    describe "when setting timing mode" do
-        it "should have timing enabled using 1" do
-            Facter.timing(1)
-            Facter.should be_timing
-        end
-        it "should have timing enabled using true" do
-            Facter.timing(true)
-            Facter.should be_timing
-        end
-        it "should have timing disabled using 0" do
-            Facter.timing(0)
-            Facter.should_not be_timing
-        end
-        it "should have timing disabled using false" do
-            Facter.timing(false)
-            Facter.should_not be_timing
-        end
-    end
-
-    describe "when registering directories to search" do
-        after { Facter.instance_variable_set("@search_path", []) }
-
-        it "should allow registration of a directory" do
-            Facter.search "/my/dir"
-        end
-
-        it "should allow registration of multiple directories" do
-            Facter.search "/my/dir", "/other/dir"
-        end
-
-        it "should return all registered directories when asked" do
-            Facter.search "/my/dir", "/other/dir"
-            Facter.search_path.should == %w{/my/dir /other/dir}
-        end
-    end
+  end
 end

--- a/spec/unit/id_spec.rb
+++ b/spec/unit/id_spec.rb
@@ -4,25 +4,25 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "id fact" do
 
-    kernel = [ 'Linux', 'Darwin', 'windows', 'FreeBSD', 'OpenBSD', 'NetBSD', 'AIX', 'HP-UX' ]
+  kernel = [ 'Linux', 'Darwin', 'windows', 'FreeBSD', 'OpenBSD', 'NetBSD', 'AIX', 'HP-UX' ]
 
-    kernel.each do |k|
-        describe "with kernel reported as #{k}" do
-            it "should return the current user" do
-                Facter.fact(:kernel).stubs(:value).returns(k)
-                Facter::Util::Config.stubs(:is_windows?).returns(k == 'windows')
-                Facter::Util::Resolution.expects(:exec).once.with('whoami').returns 'bar'
+  kernel.each do |k|
+    describe "with kernel reported as #{k}" do
+      it "should return the current user" do
+        Facter.fact(:kernel).stubs(:value).returns(k)
+        Facter::Util::Config.stubs(:is_windows?).returns(k == 'windows')
+        Facter::Util::Resolution.expects(:exec).once.with('whoami').returns 'bar'
 
-                Facter.fact(:id).value.should == 'bar'
-            end
-        end
+        Facter.fact(:id).value.should == 'bar'
+      end
     end
+  end
 
-    it "should return the current user on Solaris" do
-       Facter::Util::Config.stubs(:is_windows?).returns(false)
-       Facter::Util::Resolution.stubs(:exec).with('uname -s').returns('SunOS')
-       Facter::Util::Resolution.expects(:exec).once.with('/usr/xpg4/bin/id -un').returns 'bar'
+  it "should return the current user on Solaris" do
+     Facter::Util::Config.stubs(:is_windows?).returns(false)
+     Facter::Util::Resolution.stubs(:exec).with('uname -s').returns('SunOS')
+     Facter::Util::Resolution.expects(:exec).once.with('/usr/xpg4/bin/id -un').returns 'bar'
 
-       Facter.fact(:id).value.should == 'bar'
-    end
+     Facter.fact(:id).value.should == 'bar'
+  end
 end

--- a/spec/unit/interfaces_spec.rb
+++ b/spec/unit/interfaces_spec.rb
@@ -6,13 +6,13 @@ require 'facter'
 require 'facter/util/ip'
 
 describe "Per Interface IP facts" do
-    it "should replace the ':' in an interface list with '_'" do
-        # So we look supported
-        Facter.fact(:kernel).stubs(:value).returns("SunOS")
+  it "should replace the ':' in an interface list with '_'" do
+    # So we look supported
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
 
-        Facter::Util::IP.stubs(:get_interfaces).returns %w{eth0:1 eth1:2}
-        Facter.fact(:interfaces).value.should == %{eth0_1,eth1_2}
-    end
+    Facter::Util::IP.stubs(:get_interfaces).returns %w{eth0:1 eth1:2}
+    Facter.fact(:interfaces).value.should == %{eth0_1,eth1_2}
+  end
 
   it "should replace non-alphanumerics in an interface list with '_'" do
     Facter.fact(:kernel).stubs(:value).returns("windows")

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -5,146 +5,146 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 require 'facter'
 
 describe "Memory facts" do
-    before do
-        # We need these facts loaded, but they belong to a file with a
-        # different name, so load the file explicitly.
-        Facter.collection.loader.load(:memory)
+  before do
+    # We need these facts loaded, but they belong to a file with a
+    # different name, so load the file explicitly.
+    Facter.collection.loader.load(:memory)
+  end
+
+  after do
+    Facter.clear
+  end
+
+  it "should return the current swap size" do
+
+    Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
+    swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
+
+    if swapusage =~ /total = (\S+).*/
+      Facter.fact(:swapfree).value.should == $1
+    end
+  end
+
+  it "should return the current swap free" do
+    Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
+    swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
+
+    if swapusage =~ /free = (\S+).*/
+      Facter.fact(:swapfree).value.should == $1
+    end
+  end
+
+  it "should return whether swap is encrypted" do
+    Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
+    swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
+
+    swapusage =~ /\(encrypted\)/
+    Facter.fact(:swapencrypted).value.should == true
+  end
+
+  describe "on OpenBSD" do
+    before :each do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
+
+      swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
+      Facter::Util::Resolution.stubs(:exec).with('swapctl -s').returns(swapusage)
+
+      vmstat = <<EOS
+ procs  memory     page          disks  traps      cpu
+ r b w  avm   fre  flt  re  pi  po  fr  sr cd0 sd0  int   sys   cs us sy id
+ 0 0 0  11048  181028   39   0   0   0   0   0   0   1  3  90   17  0  0 100
+EOS
+      Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(vmstat)
+
+      Facter::Util::Resolution.stubs(:exec).with("sysctl hw.physmem | cut -d'=' -f2").returns('267321344')
+
+      Facter.collection.loader.load(:memory)
     end
 
-    after do
-        Facter.clear
-    end
-
-    it "should return the current swap size" do
-
-        Facter.fact(:kernel).stubs(:value).returns("Darwin")
-        Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
-        swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
-
-        if swapusage =~ /total = (\S+).*/
-            Facter.fact(:swapfree).value.should == $1
-        end
+    after :each do
+      Facter.clear
     end
 
     it "should return the current swap free" do
-        Facter.fact(:kernel).stubs(:value).returns("Darwin")
-        Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
-        swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
-
-        if swapusage =~ /free = (\S+).*/
-            Facter.fact(:swapfree).value.should == $1
-        end
+      Facter.fact(:swapfree).value.should == "144.87 MB"
     end
 
-    it "should return whether swap is encrypted" do
-        Facter.fact(:kernel).stubs(:value).returns("Darwin")
-        Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)")
-        swapusage = "vm.swapusage: total = 64.00M  used = 0.00M  free = 64.00M  (encrypted)"
-
-        swapusage =~ /\(encrypted\)/
-        Facter.fact(:swapencrypted).value.should == true
+    it "should return the current swap size" do
+      Facter.fact(:swapsize).value.should == "144.87 MB"
     end
 
-    describe "on OpenBSD" do
-        before :each do
-            Facter.clear
-            Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
-
-            swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
-            Facter::Util::Resolution.stubs(:exec).with('swapctl -s').returns(swapusage)
-
-            vmstat = <<EOS
- procs    memory       page                    disks    traps          cpu
- r b w    avm     fre  flt  re  pi  po  fr  sr cd0 sd0  int   sys   cs us sy id
- 0 0 0  11048  181028   39   0   0   0   0   0   0   1    3    90   17  0  0 100
-EOS
-            Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(vmstat)
-
-            Facter::Util::Resolution.stubs(:exec).with("sysctl hw.physmem | cut -d'=' -f2").returns('267321344')
-
-            Facter.collection.loader.load(:memory)
-        end
-
-        after :each do
-            Facter.clear
-        end
-
-        it "should return the current swap free" do
-            Facter.fact(:swapfree).value.should == "144.87 MB"
-        end
-
-        it "should return the current swap size" do
-            Facter.fact(:swapsize).value.should == "144.87 MB"
-        end
-
-        it "should return the current memorysize" do
-            Facter.fact(:memorytotal).value.should == "254.94 MB"
-        end
+    it "should return the current memorysize" do
+      Facter.fact(:memorytotal).value.should == "254.94 MB"
     end
+  end
 
-    describe "on DragonFly BSD" do
-        before :each do
-            Facter.clear
-            Facter.fact(:kernel).stubs(:value).returns("dragonfly")
+  describe "on DragonFly BSD" do
+    before :each do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns("dragonfly")
 
-            swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
-            Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n hw.pagesize').returns("4096")
-            Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_size').returns("128461")
-            Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_anon_use').returns("2635")
-            Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_cache_use').returns("0")
+      swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n hw.pagesize').returns("4096")
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_size').returns("128461")
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_anon_use').returns("2635")
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_cache_use').returns("0")
 
-            vmstat = <<EOS
- procs      memory      page                    disks     faults      cpu
- r b w     avm    fre  flt  re  pi  po  fr  sr da0 sg1   in   sy  cs us sy id
+      vmstat = <<EOS
+ procs    memory    page          disks   faults    cpu
+ r b w   avm  fre  flt  re  pi  po  fr  sr da0 sg1   in   sy  cs us sy id
  0 0 0   33152  13940 1902120 2198 53119 11642 6544597 5460994   0   0 6148243 7087927 3484264  0  1 9
 EOS
-            Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(vmstat)
+      Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(vmstat)
 
-            Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.physmem").returns('248512512')
+      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.physmem").returns('248512512')
 
-            Facter.collection.loader.load(:memory)
-        end
-
-        after :each do
-            Facter.clear
-        end
-
-        it "should return the current swap free" do
-            Facter.fact(:swapfree).value.should == "491.51 MB"
-        end
-
-        it "should return the current swap size" do
-            Facter.fact(:swapsize).value.should == "501.80 MB"
-        end
-
-        it "should return the current memorysize" do
-            Facter.fact(:memorytotal).value.should == "237.00 MB"
-        end
+      Facter.collection.loader.load(:memory)
     end
 
-    describe "on Windows" do
-        before :each do
-             Facter.clear
-             Facter.fact(:kernel).stubs(:value).returns("windows")
-             Facter.collection.loader.load(:memory)
-
-             require 'facter/util/wmi'
-        end
-
-        it "should return free memory" do
-             os = stubs 'os'
-             os.stubs(:FreePhysicalMemory).returns("3415624")
-             Facter::Util::WMI.stubs(:execquery).returns([os])
-
-             Facter.fact(:MemoryFree).value.should == '3.26 GB'
-        end
-
-        it "should return total memory" do
-             computer = stubs 'computer'
-             computer.stubs(:TotalPhysicalMemory).returns("4193837056")
-             Facter::Util::WMI.stubs(:execquery).returns([computer])
-
-             Facter.fact(:MemoryTotal).value.should == '3.91 GB'
-        end
+    after :each do
+      Facter.clear
     end
+
+    it "should return the current swap free" do
+      Facter.fact(:swapfree).value.should == "491.51 MB"
+    end
+
+    it "should return the current swap size" do
+      Facter.fact(:swapsize).value.should == "501.80 MB"
+    end
+
+    it "should return the current memorysize" do
+      Facter.fact(:memorytotal).value.should == "237.00 MB"
+    end
+  end
+
+  describe "on Windows" do
+    before :each do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns("windows")
+      Facter.collection.loader.load(:memory)
+
+      require 'facter/util/wmi'
+    end
+
+    it "should return free memory" do
+      os = stubs 'os'
+      os.stubs(:FreePhysicalMemory).returns("3415624")
+      Facter::Util::WMI.stubs(:execquery).returns([os])
+
+      Facter.fact(:MemoryFree).value.should == '3.26 GB'
+    end
+
+    it "should return total memory" do
+      computer = stubs 'computer'
+      computer.stubs(:TotalPhysicalMemory).returns("4193837056")
+      Facter::Util::WMI.stubs(:execquery).returns([computer])
+
+      Facter.fact(:MemoryTotal).value.should == '3.91 GB'
+    end
+  end
 end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -6,78 +6,78 @@ require 'facter'
 
 describe "Operating System fact" do
 
-    before do
-        Facter.clear
-    end
+  before do
+    Facter.clear
+  end
 
-    after do
-        Facter.clear
-    end
+  after do
+    Facter.clear
+  end
 
-    it "should default to the kernel name" do
-        Facter.fact(:kernel).stubs(:value).returns("Nutmeg")
+  it "should default to the kernel name" do
+    Facter.fact(:kernel).stubs(:value).returns("Nutmeg")
 
-        Facter.fact(:operatingsystem).value.should == "Nutmeg"
-    end
+    Facter.fact(:operatingsystem).value.should == "Nutmeg"
+  end
 
-    it "should be Solaris for SunOS" do
-         Facter.fact(:kernel).stubs(:value).returns("SunOS")
+  it "should be Solaris for SunOS" do
+     Facter.fact(:kernel).stubs(:value).returns("SunOS")
 
-         Facter.fact(:operatingsystem).value.should == "Solaris"
-    end
+     Facter.fact(:operatingsystem).value.should == "Solaris"
+  end
 
-    it "should be ESXi for VMkernel" do
-         Facter.fact(:kernel).stubs(:value).returns("VMkernel")
+  it "should be ESXi for VMkernel" do
+     Facter.fact(:kernel).stubs(:value).returns("VMkernel")
 
-         Facter.fact(:operatingsystem).value.should == "ESXi"
-    end
+     Facter.fact(:operatingsystem).value.should == "ESXi"
+  end
 
-    it "should identify Oracle VM as OVS" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.stubs(:value).with(:lsbdistid).returns(nil)
-        FileTest.stubs(:exists?).returns false
+  it "should identify Oracle VM as OVS" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.stubs(:value).with(:lsbdistid).returns(nil)
+    FileTest.stubs(:exists?).returns false
 
-        FileTest.expects(:exists?).with("/etc/ovs-release").returns true
-        FileTest.expects(:exists?).with("/etc/enterprise-release").returns true
+    FileTest.expects(:exists?).with("/etc/ovs-release").returns true
+    FileTest.expects(:exists?).with("/etc/enterprise-release").returns true
 
-        Facter.fact(:operatingsystem).value.should == "OVS"
-    end
+    Facter.fact(:operatingsystem).value.should == "OVS"
+  end
    
-    it "should identify VMWare ESX" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.stubs(:value).with(:lsbdistid).returns(nil)
-        FileTest.stubs(:exists?).returns false
+  it "should identify VMWare ESX" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.stubs(:value).with(:lsbdistid).returns(nil)
+    FileTest.stubs(:exists?).returns false
 
-        FileTest.expects(:exists?).with("/etc/vmware-release").returns true
+    FileTest.expects(:exists?).with("/etc/vmware-release").returns true
 
-        Facter.fact(:operatingsystem).value.should == "VMWareESX"
-    end
+    Facter.fact(:operatingsystem).value.should == "VMWareESX"
+  end
 
-    it "should identify Alpine Linux" do
-      Facter.fact(:kernel).stubs(:value).returns("Linux")
-      
-      FileTest.stubs(:exists?).returns false
-      
-      FileTest.expects(:exists?).with("/etc/alpine-release").returns true
+  it "should identify Alpine Linux" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    
+    FileTest.stubs(:exists?).returns false
+    
+    FileTest.expects(:exists?).with("/etc/alpine-release").returns true
 
-      Facter.fact(:operatingsystem).value.should == "Alpine"
-    end
+    Facter.fact(:operatingsystem).value.should == "Alpine"
+  end
 
-    it "should identify Scientific Linux" do
-      Facter.fact(:kernel).stubs(:value).returns("Linux")
-      FileTest.stubs(:exists?).returns false
+  it "should identify Scientific Linux" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    FileTest.stubs(:exists?).returns false
 
-      FileTest.expects(:exists?).with("/etc/redhat-release").returns true
-      File.expects(:read).with("/etc/redhat-release").returns("Scientific Linux SLC 5.7 (Boron)")
-      Facter.fact(:operatingsystem).value.should == "Scientific"
-    end
+    FileTest.expects(:exists?).with("/etc/redhat-release").returns true
+    File.expects(:read).with("/etc/redhat-release").returns("Scientific Linux SLC 5.7 (Boron)")
+    Facter.fact(:operatingsystem).value.should == "Scientific"
+  end
 
-    it "should differentiate between Scientific Linux CERN and Scientific Linux" do
-      Facter.fact(:kernel).stubs(:value).returns("Linux")
-      FileTest.stubs(:exists?).returns false
+  it "should differentiate between Scientific Linux CERN and Scientific Linux" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    FileTest.stubs(:exists?).returns false
 
-      FileTest.expects(:exists?).with("/etc/redhat-release").returns true
-      File.expects(:read).with("/etc/redhat-release").returns("Scientific Linux CERN SLC 5.7 (Boron)")
-      Facter.fact(:operatingsystem).value.should == "SLC"
-    end
+    FileTest.expects(:exists?).with("/etc/redhat-release").returns true
+    File.expects(:read).with("/etc/redhat-release").returns("Scientific Linux CERN SLC 5.7 (Boron)")
+    Facter.fact(:operatingsystem).value.should == "SLC"
+  end
 end

--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -6,55 +6,55 @@ require 'facter'
 
 describe "Operating System Release fact" do
 
-    before do
-        Facter.clear
-    end
+  before do
+    Facter.clear
+  end
 
-    after do
-        Facter.clear
-    end
+  after do
+    Facter.clear
+  end
 
-    test_cases = {
-        "CentOS"      => "/etc/redhat-release",
-        "RedHat"      => "/etc/redhat-release",
-        "Scientific"  => "/etc/redhat-release",
-        "Fedora"      => "/etc/fedora-release",
-        "MeeGo"       => "/etc/meego-release",
-        "OEL"         => "/etc/enterprise-release",
-        "oel"         => "/etc/enterprise-release",
-        "OVS"         => "/etc/ovs-release",
-        "ovs"         => "/etc/ovs-release",
-        "OracleLinux" => "/etc/oracle-release",
-    }
+  test_cases = {
+    "CentOS"    => "/etc/redhat-release",
+    "RedHat"    => "/etc/redhat-release",
+    "Scientific"  => "/etc/redhat-release",
+    "Fedora"    => "/etc/fedora-release",
+    "MeeGo"     => "/etc/meego-release",
+    "OEL"     => "/etc/enterprise-release",
+    "oel"     => "/etc/enterprise-release",
+    "OVS"     => "/etc/ovs-release",
+    "ovs"     => "/etc/ovs-release",
+    "OracleLinux" => "/etc/oracle-release",
+  }
 
-    test_cases.each do |system, file|
-        describe "with operatingsystem reported as #{system.inspect}" do
-            it "should read the #{file.inspect} file" do
-                Facter.fact(:operatingsystem).stubs(:value).returns(system)
+  test_cases.each do |system, file|
+    describe "with operatingsystem reported as #{system.inspect}" do
+      it "should read the #{file.inspect} file" do
+        Facter.fact(:operatingsystem).stubs(:value).returns(system)
 
-                File.expects(:open).with(file, "r").at_least(1)
-
-                Facter.fact(:operatingsystemrelease).value
-            end
-        end
-    end
-
-    it "for VMWareESX it should run the vmware -v command" do
-        Facter.fact(:kernel).stubs(:value).returns("VMkernel")
-        Facter.fact(:kernelrelease).stubs(:value).returns("4.1.0")
-        Facter.fact(:operatingsystem).stubs(:value).returns("VMwareESX")
-
-        Facter::Util::Resolution.stubs(:exec).with('vmware -v').returns('foo')
+        File.expects(:open).with(file, "r").at_least(1)
 
         Facter.fact(:operatingsystemrelease).value
+      end
     end
+  end
 
-    it "for Alpine it should use the contents of /etc/alpine-release" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:operatingsystem).stubs(:value).returns("Alpine")
+  it "for VMWareESX it should run the vmware -v command" do
+    Facter.fact(:kernel).stubs(:value).returns("VMkernel")
+    Facter.fact(:kernelrelease).stubs(:value).returns("4.1.0")
+    Facter.fact(:operatingsystem).stubs(:value).returns("VMwareESX")
 
-        File.expects(:read).with("/etc/alpine-release").returns("foo")
+    Facter::Util::Resolution.stubs(:exec).with('vmware -v').returns('foo')
 
-        Facter.fact(:operatingsystemrelease).value.should == "foo"
-    end
+    Facter.fact(:operatingsystemrelease).value
+  end
+
+  it "for Alpine it should use the contents of /etc/alpine-release" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:operatingsystem).stubs(:value).returns("Alpine")
+
+    File.expects(:read).with("/etc/alpine-release").returns("foo")
+
+    Facter.fact(:operatingsystemrelease).value.should == "foo"
+  end
 end

--- a/spec/unit/selinux_spec.rb
+++ b/spec/unit/selinux_spec.rb
@@ -7,84 +7,84 @@ require 'facter'
 describe "SELinux facts" do
 
 
-    after do
-        Facter.clear
-    end
+  after do
+    Facter.clear
+  end
 
-    it "should return true if SELinux enabled" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
+  it "should return true if SELinux enabled" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
 
-        FileTest.stubs(:exists?).returns false
-        File.stubs(:read).with("/proc/self/attr/current").returns("notkernel")
+    FileTest.stubs(:exists?).returns false
+    File.stubs(:read).with("/proc/self/attr/current").returns("notkernel")
 
-        FileTest.expects(:exists?).with("/selinux/enforce").returns true
-        FileTest.expects(:exists?).with("/proc/self/attr/current").returns true
-        File.expects(:read).with("/proc/self/attr/current").returns("kernel")
+    FileTest.expects(:exists?).with("/selinux/enforce").returns true
+    FileTest.expects(:exists?).with("/proc/self/attr/current").returns true
+    File.expects(:read).with("/proc/self/attr/current").returns("kernel")
 
-        Facter.fact(:selinux).value.should == "true"
-    end
+    Facter.fact(:selinux).value.should == "true"
+  end
 
-    it "should return true if SELinux policy enabled" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
+  it "should return true if SELinux policy enabled" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
 
-       FileTest.stubs(:exists?).returns false
-       File.stubs(:read).with("/selinux/enforce").returns("0")
+    FileTest.stubs(:exists?).returns false
+    File.stubs(:read).with("/selinux/enforce").returns("0")
 
-       FileTest.expects(:exists?).with("/selinux/enforce").returns true
-       File.expects(:read).with("/selinux/enforce").returns("1")
+    FileTest.expects(:exists?).with("/selinux/enforce").returns true
+    File.expects(:read).with("/selinux/enforce").returns("1")
 
-       Facter.fact(:selinux_enforced).value.should == "true"
-    end
+    Facter.fact(:selinux_enforced).value.should == "true"
+  end
 
-    it "should return an SELinux policy version" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
-       FileTest.stubs(:exists?).with("/proc/self/mountinfo").returns false
+  it "should return an SELinux policy version" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
+    FileTest.stubs(:exists?).with("/proc/self/mountinfo").returns false
 
-       File.stubs(:read).with("/selinux/policyvers").returns("")
+    File.stubs(:read).with("/selinux/policyvers").returns("")
 
-       File.expects(:read).with("/selinux/policyvers").returns("1")
+    File.expects(:read).with("/selinux/policyvers").returns("1")
 
-       Facter.fact(:selinux_policyversion).value.should == "1"
-    end
+    Facter.fact(:selinux_policyversion).value.should == "1"
+  end
 
-    it "should return the SELinux current mode" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
+  it "should return the SELinux current mode" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
 
-       sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
-       selinux_sestatus = File.read(sample_output_file)
+    sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
+    selinux_sestatus = File.read(sample_output_file)
 
-       Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
+    Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
 
-       Facter.fact(:selinux_current_mode).value.should == "permissive"
-    end
+    Facter.fact(:selinux_current_mode).value.should == "permissive"
+  end
 
-    it "should return the SELinux mode from the configuration file" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
+  it "should return the SELinux mode from the configuration file" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
 
-       sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
-       selinux_sestatus = File.read(sample_output_file)
+    sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
+    selinux_sestatus = File.read(sample_output_file)
 
-       Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
+    Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
 
-       Facter.fact(:selinux_config_mode).value.should == "permissive"
-    end
+    Facter.fact(:selinux_config_mode).value.should == "permissive"
+  end
 
-    it "should return the SELinux configuration file policy" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
+  it "should return the SELinux configuration file policy" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
 
-       sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
-       selinux_sestatus = File.read(sample_output_file)
+    sample_output_file = File.dirname(__FILE__) + '/data/selinux_sestatus'
+    selinux_sestatus = File.read(sample_output_file)
 
-       Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
+    Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/sestatus').returns(selinux_sestatus)
 
-       Facter.fact(:selinux_config_policy).value.should == "targeted"
-    end
+    Facter.fact(:selinux_config_policy).value.should == "targeted"
+  end
 
-    it "should ensure legacy selinux_mode facts returns same value as selinux_config_policy fact" do
-       Facter.fact(:selinux).stubs(:value).returns("true")
+  it "should ensure legacy selinux_mode facts returns same value as selinux_config_policy fact" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
 
-       Facter.fact(:selinux_config_policy).stubs(:value).returns("targeted")
+    Facter.fact(:selinux_config_policy).stubs(:value).returns("targeted")
 
-       Facter.fact(:selinux_mode).value.should == "targeted"
-    end
+    Facter.fact(:selinux_mode).value.should == "targeted"
+  end
 end

--- a/spec/unit/util/collection_spec.rb
+++ b/spec/unit/util/collection_spec.rb
@@ -5,251 +5,251 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/collection'
 
 describe Facter::Util::Collection do
-    it "should have a method for adding facts" do
-        Facter::Util::Collection.new.should respond_to(:add)
+  it "should have a method for adding facts" do
+    Facter::Util::Collection.new.should respond_to(:add)
+  end
+
+  it "should have a method for returning a loader" do
+    Facter::Util::Collection.new.should respond_to(:loader)
+  end
+
+  it "should use an instance of the Loader class as its loader" do
+    Facter::Util::Collection.new.loader.should be_instance_of(Facter::Util::Loader)
+  end
+
+  it "should cache its loader" do
+    coll = Facter::Util::Collection.new
+    coll.loader.should equal(coll.loader)
+  end
+
+  it "should have a method for loading all facts" do
+    Facter::Util::Collection.new.should respond_to(:load_all)
+  end
+
+  it "should delegate its load_all method to its loader" do
+    coll = Facter::Util::Collection.new
+    coll.loader.expects(:load_all)
+    coll.load_all
+  end
+
+  describe "when adding facts" do
+    before do
+      @coll = Facter::Util::Collection.new
     end
 
-    it "should have a method for returning a loader" do
-        Facter::Util::Collection.new.should respond_to(:loader)
+    it "should create a new fact if no fact with the same name already exists" do
+      fact = mock 'fact'
+      Facter::Util::Fact.expects(:new).with { |name, *args| name == :myname }.returns fact
+
+      @coll.add(:myname)
     end
 
-    it "should use an instance of the Loader class as its loader" do
-        Facter::Util::Collection.new.loader.should be_instance_of(Facter::Util::Loader)
+    it "should accept options" do
+      @coll.add(:myname, :ldapname => "whatever") { }
     end
 
-    it "should cache its loader" do
-        coll = Facter::Util::Collection.new
-        coll.loader.should equal(coll.loader)
+    it "should set any appropriate options on the fact instances" do
+      # Use a real fact instance, because we're using respond_to?
+      fact = Facter::Util::Fact.new(:myname)
+      fact.expects(:ldapname=).with("testing")
+      Facter::Util::Fact.expects(:new).with(:myname).returns fact
+
+      @coll.add(:myname, :ldapname => "testing")
     end
 
-    it "should have a method for loading all facts" do
-        Facter::Util::Collection.new.should respond_to(:load_all)
+    it "should set appropriate options on the resolution instance" do
+      fact = Facter::Util::Fact.new(:myname)
+      Facter::Util::Fact.expects(:new).with(:myname).returns fact
+
+      resolve = Facter::Util::Resolution.new(:myname) {}
+      fact.expects(:add).returns resolve
+
+      @coll.add(:myname, :timeout => "myval") {}
     end
 
-    it "should delegate its load_all method to its loader" do
-        coll = Facter::Util::Collection.new
-        coll.loader.expects(:load_all)
-        coll.load_all
+    it "should not pass fact-specific options to resolutions" do
+      fact = Facter::Util::Fact.new(:myname)
+      Facter::Util::Fact.expects(:new).with(:myname).returns fact
+
+      resolve = Facter::Util::Resolution.new(:myname) {}
+      fact.expects(:add).returns resolve
+
+      fact.expects(:ldapname=).with("foo")
+      resolve.expects(:timeout=).with("myval")
+
+      @coll.add(:myname, :timeout => "myval", :ldapname => "foo") {}
     end
 
-    describe "when adding facts" do
-        before do
-            @coll = Facter::Util::Collection.new
-        end
-
-        it "should create a new fact if no fact with the same name already exists" do
-            fact = mock 'fact'
-            Facter::Util::Fact.expects(:new).with { |name, *args| name == :myname }.returns fact
-
-            @coll.add(:myname)
-        end
-
-        it "should accept options" do
-            @coll.add(:myname, :ldapname => "whatever") { }
-        end
-
-        it "should set any appropriate options on the fact instances" do
-            # Use a real fact instance, because we're using respond_to?
-            fact = Facter::Util::Fact.new(:myname)
-            fact.expects(:ldapname=).with("testing")
-            Facter::Util::Fact.expects(:new).with(:myname).returns fact
-
-            @coll.add(:myname, :ldapname => "testing")
-        end
-
-        it "should set appropriate options on the resolution instance" do
-            fact = Facter::Util::Fact.new(:myname)
-            Facter::Util::Fact.expects(:new).with(:myname).returns fact
-
-            resolve = Facter::Util::Resolution.new(:myname) {}
-            fact.expects(:add).returns resolve
-
-            @coll.add(:myname, :timeout => "myval") {}
-        end
-
-        it "should not pass fact-specific options to resolutions" do
-            fact = Facter::Util::Fact.new(:myname)
-            Facter::Util::Fact.expects(:new).with(:myname).returns fact
-
-            resolve = Facter::Util::Resolution.new(:myname) {}
-            fact.expects(:add).returns resolve
-
-            fact.expects(:ldapname=).with("foo")
-            resolve.expects(:timeout=).with("myval")
-
-            @coll.add(:myname, :timeout => "myval", :ldapname => "foo") {}
-        end
-
-        it "should fail if invalid options are provided" do
-            lambda { @coll.add(:myname, :foo => :bar) }.should raise_error(ArgumentError)
-        end
-
-        describe "and a block is provided" do
-            it "should use the block to add a resolution to the fact" do
-                fact = mock 'fact'
-                Facter::Util::Fact.expects(:new).returns fact
-
-                fact.expects(:add)
-
-                @coll.add(:myname) {}
-            end
-        end
+    it "should fail if invalid options are provided" do
+      lambda { @coll.add(:myname, :foo => :bar) }.should raise_error(ArgumentError)
     end
 
-    it "should have a method for retrieving facts by name" do
-        Facter::Util::Collection.new.should respond_to(:fact)
+    describe "and a block is provided" do
+      it "should use the block to add a resolution to the fact" do
+        fact = mock 'fact'
+        Facter::Util::Fact.expects(:new).returns fact
+
+        fact.expects(:add)
+
+        @coll.add(:myname) {}
+      end
+    end
+  end
+
+  it "should have a method for retrieving facts by name" do
+    Facter::Util::Collection.new.should respond_to(:fact)
+  end
+
+  describe "when retrieving facts" do
+    before do
+      @coll = Facter::Util::Collection.new
+
+      @fact = @coll.add("YayNess")
     end
 
-    describe "when retrieving facts" do
-        before do
-            @coll = Facter::Util::Collection.new
-
-            @fact = @coll.add("YayNess")
-        end
-
-        it "should return the fact instance specified by the name" do
-            @coll.fact("YayNess").should equal(@fact)
-        end
-
-        it "should be case-insensitive" do
-            @coll.fact("yayness").should equal(@fact)
-        end
-
-        it "should treat strings and symbols equivalently" do
-            @coll.fact(:yayness).should equal(@fact)
-        end
-
-        it "should use its loader to try to load the fact if no fact can be found" do
-            @coll.loader.expects(:load).with(:testing)
-            @coll.fact("testing")
-        end
-
-        it "should return nil if it cannot find or load the fact" do
-            @coll.loader.expects(:load).with(:testing)
-            @coll.fact("testing").should be_nil
-        end
+    it "should return the fact instance specified by the name" do
+      @coll.fact("YayNess").should equal(@fact)
     end
 
-    it "should have a method for returning a fact's value" do
-        Facter::Util::Collection.new.should respond_to(:value)
+    it "should be case-insensitive" do
+      @coll.fact("yayness").should equal(@fact)
     end
 
-    describe "when returning a fact's value" do
-        before do
-            @coll = Facter::Util::Collection.new
-            @fact = @coll.add("YayNess")
-
-            @fact.stubs(:value).returns "result"
-        end
-
-        it "should use the 'fact' method to retrieve the fact" do
-            @coll.expects(:fact).with(:yayness).returns @fact
-            @coll.value(:yayness)
-        end
-
-        it "should return the result of calling :value on the fact" do
-            @fact.expects(:value).returns "result"
-
-            @coll.value("YayNess").should == "result"
-        end
-
-        it "should be case-insensitive" do
-            @coll.value("yayness").should_not be_nil
-        end
-
-        it "should treat strings and symbols equivalently" do
-            @coll.value(:yayness).should_not be_nil
-        end
+    it "should treat strings and symbols equivalently" do
+      @coll.fact(:yayness).should equal(@fact)
     end
 
-    it "should return the fact's value when the array index method is used" do
-        @coll = Facter::Util::Collection.new
-        @coll.expects(:value).with("myfact").returns "foo"
-        @coll["myfact"].should == "foo"
+    it "should use its loader to try to load the fact if no fact can be found" do
+      @coll.loader.expects(:load).with(:testing)
+      @coll.fact("testing")
     end
 
-    it "should have a method for flushing all facts" do
-        @coll = Facter::Util::Collection.new
-        @fact = @coll.add("YayNess")
+    it "should return nil if it cannot find or load the fact" do
+      @coll.loader.expects(:load).with(:testing)
+      @coll.fact("testing").should be_nil
+    end
+  end
 
-        @fact.expects(:flush)
+  it "should have a method for returning a fact's value" do
+    Facter::Util::Collection.new.should respond_to(:value)
+  end
 
-        @coll.flush
+  describe "when returning a fact's value" do
+    before do
+      @coll = Facter::Util::Collection.new
+      @fact = @coll.add("YayNess")
+
+      @fact.stubs(:value).returns "result"
     end
 
-    it "should have a method that returns all fact names" do
-        @coll = Facter::Util::Collection.new
-        @coll.add(:one)
-        @coll.add(:two)
-
-        @coll.list.sort { |a,b| a.to_s <=> b.to_s }.should == [:one, :two]
+    it "should use the 'fact' method to retrieve the fact" do
+      @coll.expects(:fact).with(:yayness).returns @fact
+      @coll.value(:yayness)
     end
 
-    it "should have a method for returning a hash of fact values" do
-        Facter::Util::Collection.new.should respond_to(:to_hash)
+    it "should return the result of calling :value on the fact" do
+      @fact.expects(:value).returns "result"
+
+      @coll.value("YayNess").should == "result"
     end
 
-    describe "when returning a hash of values" do
-        before do
-            @coll = Facter::Util::Collection.new
-            @fact = @coll.add(:one)
-            @fact.stubs(:value).returns "me"
-        end
-
-        it "should return a hash of fact names and values with the fact names as strings" do
-            @coll.to_hash.should == {"one" => "me"}
-        end
-
-        it "should not include facts that did not return a value" do
-            f = @coll.add(:two)
-            f.stubs(:value).returns nil
-            @coll.to_hash.should_not be_include(:two)
-        end
+    it "should be case-insensitive" do
+      @coll.value("yayness").should_not be_nil
     end
 
-    it "should have a method for iterating over all facts" do
-        Facter::Util::Collection.new.should respond_to(:each)
+    it "should treat strings and symbols equivalently" do
+      @coll.value(:yayness).should_not be_nil
+    end
+  end
+
+  it "should return the fact's value when the array index method is used" do
+    @coll = Facter::Util::Collection.new
+    @coll.expects(:value).with("myfact").returns "foo"
+    @coll["myfact"].should == "foo"
+  end
+
+  it "should have a method for flushing all facts" do
+    @coll = Facter::Util::Collection.new
+    @fact = @coll.add("YayNess")
+
+    @fact.expects(:flush)
+
+    @coll.flush
+  end
+
+  it "should have a method that returns all fact names" do
+    @coll = Facter::Util::Collection.new
+    @coll.add(:one)
+    @coll.add(:two)
+
+    @coll.list.sort { |a,b| a.to_s <=> b.to_s }.should == [:one, :two]
+  end
+
+  it "should have a method for returning a hash of fact values" do
+    Facter::Util::Collection.new.should respond_to(:to_hash)
+  end
+
+  describe "when returning a hash of values" do
+    before do
+      @coll = Facter::Util::Collection.new
+      @fact = @coll.add(:one)
+      @fact.stubs(:value).returns "me"
     end
 
-    it "should include Enumerable" do
-        Facter::Util::Collection.ancestors.should be_include(Enumerable)
+    it "should return a hash of fact names and values with the fact names as strings" do
+      @coll.to_hash.should == {"one" => "me"}
     end
 
-    describe "when iterating over facts" do
-        before do
-            @coll = Facter::Util::Collection.new
-            @one = @coll.add(:one)
-            @two = @coll.add(:two)
-        end
-
-        it "should yield each fact name and the fact value" do
-            @one.stubs(:value).returns "ONE"
-            @two.stubs(:value).returns "TWO"
-            facts = {}
-            @coll.each do |fact, value|
-                facts[fact] = value
-            end
-            facts.should == {"one" => "ONE", "two" => "TWO"}
-        end
-
-        it "should convert the fact name to a string" do
-            @one.stubs(:value).returns "ONE"
-            @two.stubs(:value).returns "TWO"
-            facts = {}
-            @coll.each do |fact, value|
-                fact.should be_instance_of(String)
-            end
-        end
-
-        it "should only yield facts that have values" do
-            @one.stubs(:value).returns "ONE"
-            @two.stubs(:value).returns nil
-            facts = {}
-            @coll.each do |fact, value|
-                facts[fact] = value
-            end
-
-            facts.should_not be_include("two")
-        end
+    it "should not include facts that did not return a value" do
+      f = @coll.add(:two)
+      f.stubs(:value).returns nil
+      @coll.to_hash.should_not be_include(:two)
     end
+  end
+
+  it "should have a method for iterating over all facts" do
+    Facter::Util::Collection.new.should respond_to(:each)
+  end
+
+  it "should include Enumerable" do
+    Facter::Util::Collection.ancestors.should be_include(Enumerable)
+  end
+
+  describe "when iterating over facts" do
+    before do
+      @coll = Facter::Util::Collection.new
+      @one = @coll.add(:one)
+      @two = @coll.add(:two)
+    end
+
+    it "should yield each fact name and the fact value" do
+      @one.stubs(:value).returns "ONE"
+      @two.stubs(:value).returns "TWO"
+      facts = {}
+      @coll.each do |fact, value|
+        facts[fact] = value
+      end
+      facts.should == {"one" => "ONE", "two" => "TWO"}
+    end
+
+    it "should convert the fact name to a string" do
+      @one.stubs(:value).returns "ONE"
+      @two.stubs(:value).returns "TWO"
+      facts = {}
+      @coll.each do |fact, value|
+        fact.should be_instance_of(String)
+      end
+    end
+
+    it "should only yield facts that have values" do
+      @one.stubs(:value).returns "ONE"
+      @two.stubs(:value).returns nil
+      facts = {}
+      @coll.each do |fact, value|
+        facts[fact] = value
+      end
+
+      facts.should_not be_include("two")
+    end
+  end
 end

--- a/spec/unit/util/confine_spec.rb
+++ b/spec/unit/util/confine_spec.rb
@@ -8,133 +8,133 @@ require 'facter/util/values'
 include Facter::Util::Values
 
 describe Facter::Util::Confine do
-    it "should require a fact name" do
-        Facter::Util::Confine.new("yay", true).fact.should == "yay"
+  it "should require a fact name" do
+    Facter::Util::Confine.new("yay", true).fact.should == "yay"
+  end
+
+  it "should accept a value specified individually" do
+    Facter::Util::Confine.new("yay", "test").values.should == ["test"]
+  end
+
+  it "should accept multiple values specified at once" do
+    Facter::Util::Confine.new("yay", "test", "other").values.should == ["test", "other"]
+  end
+
+  it "should fail if no fact name is provided" do
+    lambda { Facter::Util::Confine.new(nil, :test) }.should raise_error(ArgumentError)
+  end
+
+  it "should fail if no values were provided" do
+    lambda { Facter::Util::Confine.new("yay") }.should raise_error(ArgumentError)
+  end
+
+  it "should have a method for testing whether it matches" do
+    Facter::Util::Confine.new("yay", :test).should respond_to(:true?)
+  end
+
+  describe "when evaluating" do
+    before do
+      @confine = Facter::Util::Confine.new("yay", "one", "two", "Four", :xy, true, 1, [3,4])
+      @fact = mock 'fact'
+      Facter.stubs(:[]).returns @fact
     end
 
-    it "should accept a value specified individually" do
-        Facter::Util::Confine.new("yay", "test").values.should == ["test"]
+    it "should return false if the fact does not exist" do
+      Facter.expects(:[]).with("yay").returns nil
+
+      @confine.true?.should be_false
     end
 
-    it "should accept multiple values specified at once" do
-        Facter::Util::Confine.new("yay", "test", "other").values.should == ["test", "other"]
+    it "should use the returned fact to get the value" do
+      Facter.expects(:[]).with("yay").returns @fact
+
+      @fact.expects(:value).returns nil
+
+      @confine.true?
     end
 
-    it "should fail if no fact name is provided" do
-        lambda { Facter::Util::Confine.new(nil, :test) }.should raise_error(ArgumentError)
+    it "should return false if the fact has no value" do
+      @fact.stubs(:value).returns nil
+
+      @confine.true?.should be_false
     end
 
-    it "should fail if no values were provided" do
-        lambda { Facter::Util::Confine.new("yay") }.should raise_error(ArgumentError)
+    it "should return true if any of the provided values matches the fact's value" do
+      @fact.stubs(:value).returns "two"
+
+      @confine.true?.should be_true
     end
 
-    it "should have a method for testing whether it matches" do
-        Facter::Util::Confine.new("yay", :test).should respond_to(:true?)
+    it "should return true if any of the provided symbol values matches the fact's value" do
+      @fact.stubs(:value).returns :xy
+
+      @confine.true?.should be_true
     end
 
-    describe "when evaluating" do
-        before do
-            @confine = Facter::Util::Confine.new("yay", "one", "two", "Four", :xy, true, 1, [3,4])
-            @fact = mock 'fact'
-            Facter.stubs(:[]).returns @fact
-        end
+    it "should return true if any of the provided integer values matches the fact's value" do
+      @fact.stubs(:value).returns 1
 
-        it "should return false if the fact does not exist" do
-            Facter.expects(:[]).with("yay").returns nil
-
-            @confine.true?.should be_false
-        end
-
-        it "should use the returned fact to get the value" do
-            Facter.expects(:[]).with("yay").returns @fact
-
-            @fact.expects(:value).returns nil
-
-            @confine.true?
-        end
-
-        it "should return false if the fact has no value" do
-            @fact.stubs(:value).returns nil
-
-            @confine.true?.should be_false
-        end
-
-        it "should return true if any of the provided values matches the fact's value" do
-            @fact.stubs(:value).returns "two"
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided symbol values matches the fact's value" do
-            @fact.stubs(:value).returns :xy
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided integer values matches the fact's value" do
-            @fact.stubs(:value).returns 1
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided boolan values matches the fact's value" do
-            @fact.stubs(:value).returns true
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided array values matches the fact's value" do
-            @fact.stubs(:value).returns [3,4]
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided symbol values matches the fact's string value" do
-            @fact.stubs(:value).returns :one
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided string values matches case-insensitive the fact's value" do
-            @fact.stubs(:value).returns "four"
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided symbol values matches case-insensitive the fact's string value" do
-            @fact.stubs(:value).returns :four
-
-            @confine.true?.should be_true
-        end
-
-        it "should return true if any of the provided symbol values matches the fact's string value" do
-            @fact.stubs(:value).returns :Xy
-
-            @confine.true?.should be_true
-        end
-
-        it "should return false if none of the provided values matches the fact's value" do
-            @fact.stubs(:value).returns "three"
-
-            @confine.true?.should be_false
-        end
-
-        it "should return false if none of the provided integer values matches the fact's value" do
-            @fact.stubs(:value).returns 2
-
-            @confine.true?.should be_false
-        end
-
-        it "should return false if none of the provided boolan values matches the fact's value" do
-            @fact.stubs(:value).returns false
-
-            @confine.true?.should be_false
-        end
-
-        it "should return false if none of the provided array values matches the fact's value" do
-            @fact.stubs(:value).returns [1,2]
-
-            @confine.true?.should be_false
-        end
+      @confine.true?.should be_true
     end
+
+    it "should return true if any of the provided boolan values matches the fact's value" do
+      @fact.stubs(:value).returns true
+
+      @confine.true?.should be_true
+    end
+
+    it "should return true if any of the provided array values matches the fact's value" do
+      @fact.stubs(:value).returns [3,4]
+
+      @confine.true?.should be_true
+    end
+
+    it "should return true if any of the provided symbol values matches the fact's string value" do
+      @fact.stubs(:value).returns :one
+
+      @confine.true?.should be_true
+    end
+
+    it "should return true if any of the provided string values matches case-insensitive the fact's value" do
+      @fact.stubs(:value).returns "four"
+
+      @confine.true?.should be_true
+    end
+
+    it "should return true if any of the provided symbol values matches case-insensitive the fact's string value" do
+      @fact.stubs(:value).returns :four
+
+      @confine.true?.should be_true
+    end
+
+    it "should return true if any of the provided symbol values matches the fact's string value" do
+      @fact.stubs(:value).returns :Xy
+
+      @confine.true?.should be_true
+    end
+
+    it "should return false if none of the provided values matches the fact's value" do
+      @fact.stubs(:value).returns "three"
+
+      @confine.true?.should be_false
+    end
+
+    it "should return false if none of the provided integer values matches the fact's value" do
+      @fact.stubs(:value).returns 2
+
+      @confine.true?.should be_false
+    end
+
+    it "should return false if none of the provided boolan values matches the fact's value" do
+      @fact.stubs(:value).returns false
+
+      @confine.true?.should be_false
+    end
+
+    it "should return false if none of the provided array values matches the fact's value" do
+      @fact.stubs(:value).returns [1,2]
+
+      @confine.true?.should be_false
+    end
+  end
 end

--- a/spec/unit/util/fact_spec.rb
+++ b/spec/unit/util/fact_spec.rb
@@ -5,125 +5,125 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/fact'
 
 describe Facter::Util::Fact do
-    it "should require a name" do
-        lambda { Facter::Util::Fact.new }.should raise_error(ArgumentError)
+  it "should require a name" do
+    lambda { Facter::Util::Fact.new }.should raise_error(ArgumentError)
+  end
+
+  it "should always downcase the name and convert it to a symbol" do
+    Facter::Util::Fact.new("YayNess").name.should == :yayness
+  end
+
+  it "should default to its name converted to a string as its ldapname" do
+    Facter::Util::Fact.new("YayNess").ldapname.should == "yayness"
+  end
+
+  it "should allow specifying the ldap name at initialization" do
+    Facter::Util::Fact.new("YayNess", :ldapname => "fooness").ldapname.should == "fooness"
+  end
+
+  it "should fail if an unknown option is provided" do
+    lambda { Facter::Util::Fact.new('yay', :foo => :bar) }.should raise_error(ArgumentError)
+  end
+
+  it "should have a method for adding resolution mechanisms" do
+    Facter::Util::Fact.new("yay").should respond_to(:add)
+  end
+
+  describe "when adding resolution mechanisms" do
+    before do
+      @fact = Facter::Util::Fact.new("yay")
+
+      @resolution = mock 'resolution'
+      @resolution.stub_everything
+
     end
 
-    it "should always downcase the name and convert it to a symbol" do
-        Facter::Util::Fact.new("YayNess").name.should == :yayness
+    it "should fail if no block is given" do
+      lambda { @fact.add }.should raise_error(ArgumentError)
     end
 
-    it "should default to its name converted to a string as its ldapname" do
-        Facter::Util::Fact.new("YayNess").ldapname.should == "yayness"
+    it "should create a new resolution instance" do
+      Facter::Util::Resolution.expects(:new).returns @resolution
+
+      @fact.add { }
     end
 
-    it "should allow specifying the ldap name at initialization" do
-        Facter::Util::Fact.new("YayNess", :ldapname => "fooness").ldapname.should == "fooness"
+    it "should instance_eval the passed block on the new resolution" do
+      @resolution.expects(:instance_eval)
+
+      Facter::Util::Resolution.stubs(:new).returns @resolution
+
+      @fact.add { }
     end
 
-    it "should fail if an unknown option is provided" do
-        lambda { Facter::Util::Fact.new('yay', :foo => :bar) }.should raise_error(ArgumentError)
+    it "should re-sort the resolutions by weight, so the most restricted resolutions are first" do
+      r1 = stub 'r1', :weight => 1
+      r2 = stub 'r2', :weight => 2
+      r3 = stub 'r3', :weight => 0
+      Facter::Util::Resolution.expects(:new).times(3).returns(r1).returns(r2).returns(r3)
+      @fact.add { }
+      @fact.add { }
+      @fact.add { }
+
+      @fact.instance_variable_get("@resolves").should == [r2, r1, r3]
+    end
+  end
+
+  it "should be able to return a value" do
+    Facter::Util::Fact.new("yay").should respond_to(:value)
+  end
+
+  describe "when returning a value" do
+    before do
+      @fact = Facter::Util::Fact.new("yay")
     end
 
-    it "should have a method for adding resolution mechanisms" do
-        Facter::Util::Fact.new("yay").should respond_to(:add)
+    it "should return nil if there are no resolutions" do
+      Facter::Util::Fact.new("yay").value.should be_nil
     end
 
-    describe "when adding resolution mechanisms" do
-        before do
-            @fact = Facter::Util::Fact.new("yay")
+    it "should return the first value returned by a resolution" do
+      r1 = stub 'r1', :weight => 2, :value => nil, :suitable? => true
+      r2 = stub 'r2', :weight => 1, :value => "yay", :suitable? => true
+      r3 = stub 'r3', :weight => 0, :value => "foo", :suitable? => true
+      Facter::Util::Resolution.expects(:new).times(3).returns(r1).returns(r2).returns(r3)
+      @fact.add { }
+      @fact.add { }
+      @fact.add { }
 
-            @resolution = mock 'resolution'
-            @resolution.stub_everything
-
-        end
-
-        it "should fail if no block is given" do
-            lambda { @fact.add }.should raise_error(ArgumentError)
-        end
-
-        it "should create a new resolution instance" do
-            Facter::Util::Resolution.expects(:new).returns @resolution
-
-            @fact.add { }
-        end
-
-        it "should instance_eval the passed block on the new resolution" do
-            @resolution.expects(:instance_eval)
-
-            Facter::Util::Resolution.stubs(:new).returns @resolution
-
-            @fact.add { }
-        end
-
-        it "should re-sort the resolutions by weight, so the most restricted resolutions are first" do
-            r1 = stub 'r1', :weight => 1
-            r2 = stub 'r2', :weight => 2
-            r3 = stub 'r3', :weight => 0
-            Facter::Util::Resolution.expects(:new).times(3).returns(r1).returns(r2).returns(r3)
-            @fact.add { }
-            @fact.add { }
-            @fact.add { }
-
-            @fact.instance_variable_get("@resolves").should == [r2, r1, r3]
-        end
+      @fact.value.should == "yay"
     end
 
-    it "should be able to return a value" do
-        Facter::Util::Fact.new("yay").should respond_to(:value)
+    it "should short-cut returning the value once one is found" do
+      r1 = stub 'r1', :weight => 2, :value => "foo", :suitable? => true
+      r2 = stub 'r2', :weight => 1, :suitable? => true # would fail if 'value' were asked for
+      Facter::Util::Resolution.expects(:new).times(2).returns(r1).returns(r2)
+      @fact.add { }
+      @fact.add { }
+
+      @fact.value
     end
 
-    describe "when returning a value" do
-        before do
-            @fact = Facter::Util::Fact.new("yay")
-        end
+    it "should skip unsuitable resolutions" do
+      r1 = stub 'r1', :weight => 2, :suitable? => false # would fail if 'value' were asked for'
+      r2 = stub 'r2', :weight => 1, :value => "yay", :suitable? => true
+      Facter::Util::Resolution.expects(:new).times(2).returns(r1).returns(r2)
+      @fact.add { }
+      @fact.add { }
 
-        it "should return nil if there are no resolutions" do
-            Facter::Util::Fact.new("yay").value.should be_nil
-        end
-
-        it "should return the first value returned by a resolution" do
-            r1 = stub 'r1', :weight => 2, :value => nil, :suitable? => true
-            r2 = stub 'r2', :weight => 1, :value => "yay", :suitable? => true
-            r3 = stub 'r3', :weight => 0, :value => "foo", :suitable? => true
-            Facter::Util::Resolution.expects(:new).times(3).returns(r1).returns(r2).returns(r3)
-            @fact.add { }
-            @fact.add { }
-            @fact.add { }
-
-            @fact.value.should == "yay"
-        end
-
-        it "should short-cut returning the value once one is found" do
-            r1 = stub 'r1', :weight => 2, :value => "foo", :suitable? => true
-            r2 = stub 'r2', :weight => 1, :suitable? => true # would fail if 'value' were asked for
-            Facter::Util::Resolution.expects(:new).times(2).returns(r1).returns(r2)
-            @fact.add { }
-            @fact.add { }
-
-            @fact.value
-        end
-
-        it "should skip unsuitable resolutions" do
-            r1 = stub 'r1', :weight => 2, :suitable? => false # would fail if 'value' were asked for'
-            r2 = stub 'r2', :weight => 1, :value => "yay", :suitable? => true
-            Facter::Util::Resolution.expects(:new).times(2).returns(r1).returns(r2)
-            @fact.add { }
-            @fact.add { }
-
-            @fact.value.should == "yay"
-        end
-
-        it "should return nil if the value is the empty string" do
-            r1 = stub 'r1', :suitable? => true, :value => ""
-            Facter::Util::Resolution.expects(:new).returns r1
-            @fact.add { }
-
-            @fact.value.should be_nil
-        end
+      @fact.value.should == "yay"
     end
 
-    it "should have a method for flushing the cached fact" do
-        Facter::Util::Fact.new(:foo).should respond_to(:flush)
+    it "should return nil if the value is the empty string" do
+      r1 = stub 'r1', :suitable? => true, :value => ""
+      Facter::Util::Resolution.expects(:new).returns r1
+      @fact.add { }
+
+      @fact.value.should be_nil
     end
+  end
+
+  it "should have a method for flushing the cached fact" do
+    Facter::Util::Fact.new(:foo).should respond_to(:flush)
+  end
 end

--- a/spec/unit/util/ip_spec.rb
+++ b/spec/unit/util/ip_spec.rb
@@ -5,295 +5,295 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/ip'
 
 describe Facter::Util::IP do
+  before :each do
+    Facter::Util::Config.stubs(:is_windows?).returns(false)
+  end
+
+  [:freebsd, :linux, :netbsd, :openbsd, :sunos, :darwin, :"hp-ux", :"gnu/kfreebsd", :windows].each do |platform|
+    it "should be supported on #{platform}" do
+      Facter::Util::Config.stubs(:is_windows?).returns(platform == :windows)
+      Facter::Util::IP.supported_platforms.should be_include(platform)
+    end
+  end
+
+  it "should return a list of interfaces" do
+    Facter::Util::IP.should respond_to(:get_interfaces)
+  end
+
+  it "should return an empty list of interfaces on an unknown kernel" do
+    Facter.stubs(:value).returns("UnknownKernel")
+    Facter::Util::IP.get_interfaces().should == []
+  end
+
+  it "should return a list with a single interface and the loopback interface on Linux with a single interface" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/linux_ifconfig_all_with_single_interface'
+    linux_ifconfig = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(linux_ifconfig)
+    Facter::Util::IP.get_interfaces().should == ["eth0", "lo"]
+  end
+
+  it "should return a list two interfaces on Darwin with two interfaces" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/darwin_ifconfig_all_with_multiple_interfaces'
+    darwin_ifconfig = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(darwin_ifconfig)
+    Facter::Util::IP.get_interfaces().should == ["lo0", "en0"]
+  end
+
+  it "should return a list two interfaces on Solaris with two interfaces multiply reporting" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/solaris_ifconfig_all_with_multiple_interfaces'
+    solaris_ifconfig = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(solaris_ifconfig)
+    Facter::Util::IP.get_interfaces().should == ["lo0", "e1000g0"]
+  end
+
+  it "should return a list three interfaces on HP-UX with three interfaces multiply reporting" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/hpux_netstat_all_interfaces'
+    hpux_netstat = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(hpux_netstat)
+    Facter::Util::IP.get_interfaces().should == ["lan1", "lan0", "lo0"]
+  end
+
+  it "should return a list of six interfaces on a GNU/kFreeBSD with six interfaces" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/debian_kfreebsd_ifconfig'
+    kfreebsd_ifconfig = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(kfreebsd_ifconfig)
+    Facter::Util::IP.get_interfaces().should == ["em0", "em1", "bge0", "bge1", "lo0", "vlan0"]
+  end
+
+  it "should return a list of only connected interfaces on Windows" do
+    Facter.fact(:kernel).stubs(:value).returns("windows")
+    sample_output_file = File.dirname(__FILE__) + '/../data/windows_netsh_all_interfaces'
+    windows_netsh = File.read(sample_output_file)
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(windows_netsh)
+    Facter::Util::IP.get_interfaces().should == ["Loopback Pseudo-Interface 1", "Local Area Connection", "Teredo Tunneling Pseudo-Interface"]
+  end
+
+  it "should return a value for a specific interface" do
+    Facter::Util::IP.should respond_to(:get_interface_value)
+  end
+
+  it "should not return interface information for unsupported platforms" do
+    Facter.stubs(:value).with(:kernel).returns("bleah")
+    Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == []
+  end
+
+  it "should return ipaddress information for Solaris" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
+    solaris_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("SunOS")
+
+    Facter::Util::IP.get_interface_value("e1000g0", "ipaddress").should == "172.16.15.138"
+  end
+
+  it "should return netmask information for Solaris" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
+    solaris_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("SunOS")
+
+    Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == "255.255.255.0"
+  end
+
+  it "should return calculated network information for Solaris" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
+    solaris_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.stubs(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("SunOS")
+
+    Facter::Util::IP.get_network_value("e1000g0").should == "172.16.15.0"
+  end
+
+  it "should return ipaddress information for HP-UX" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
+    hpux_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("HP-UX")
+
+    Facter::Util::IP.get_interface_value("lan0", "ipaddress").should == "168.24.80.71"
+  end
+
+  it "should return macaddress information for HP-UX" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
+    hpux_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("HP-UX")
+
+    Facter::Util::IP.get_interface_value("lan0", "macaddress").should == "00:13:21:BD:9C:B7"
+  end
+
+  it "should return macaddress with leading zeros stripped off for GNU/kFreeBSD" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/debian_kfreebsd_ifconfig"
+    kfreebsd_ifconfig = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("em0").returns(kfreebsd_ifconfig)
+    Facter.stubs(:value).with(:kernel).returns("GNU/kFreeBSD")
+
+    Facter::Util::IP.get_interface_value("em0", "macaddress").should == "0:11:a:59:67:90"
+  end
+
+  it "should return netmask information for HP-UX" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
+    hpux_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("HP-UX")
+
+    Facter::Util::IP.get_interface_value("lan0", "netmask").should == "255.255.255.0"
+  end
+
+  it "should return calculated network information for HP-UX" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
+    hpux_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.stubs(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("HP-UX")
+
+    Facter::Util::IP.get_network_value("lan0").should == "168.24.80.0"
+  end
+
+  it "should return interface information for FreeBSD supported via an alias" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/6.0-STABLE_FreeBSD_ifconfig"
+    ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("fxp0").returns(ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("FreeBSD")
+
+    Facter::Util::IP.get_interface_value("fxp0", "macaddress").should == "00:0e:0c:68:67:7c"
+  end
+
+  it "should return macaddress information for OS X" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/Mac_OS_X_10.5.5_ifconfig"
+    ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("en1").returns(ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Darwin")
+
+    Facter::Util::IP.get_interface_value("en1", "macaddress").should == "00:1b:63:ae:02:66"
+  end
+
+  it "should return all interfaces correctly on OS X" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/Mac_OS_X_10.5.5_ifconfig"
+    ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_all_interface_output).returns(ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Darwin")
+
+    Facter::Util::IP.get_interfaces().should == ["lo0", "gif0", "stf0", "en0", "fw0", "en1", "vmnet8", "vmnet1"]
+  end
+
+  it "should return a human readable netmask on Solaris" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
+    solaris_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("SunOS")
+
+    Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == "255.255.255.0"
+  end
+
+  it "should return a human readable netmask on HP-UX" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
+    hpux_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("HP-UX")
+
+    Facter::Util::IP.get_interface_value("lan0", "netmask").should == "255.255.255.0"
+  end
+
+  it "should return a human readable netmask on Darwin" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/darwin_ifconfig_single_interface"
+
+    darwin_ifconfig_interface = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("en1").returns(darwin_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Darwin")
+
+    Facter::Util::IP.get_interface_value("en1", "netmask").should == "255.255.255.0"
+  end
+
+  it "should return a human readable netmask on GNU/kFreeBSD" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/debian_kfreebsd_ifconfig"
+
+    kfreebsd_ifconfig = File.read(sample_output_file)
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("em1").returns(kfreebsd_ifconfig)
+    Facter.stubs(:value).with(:kernel).returns("GNU/kFreeBSD")
+
+    Facter::Util::IP.get_interface_value("em1", "netmask").should == "255.255.255.0"
+  end
+
+  it "should not get bonding master on interface aliases" do
+    Facter.stubs(:value).with(:kernel).returns("Linux")
+
+    Facter::Util::IP.get_bonding_master("eth0:1").should be_nil
+  end
+
+  [:freebsd, :netbsd, :openbsd, :sunos, :darwin, :"hp-ux"].each do |platform|
+    it "should require conversion from hex on #{platform}" do
+      Facter::Util::IP.convert_from_hex?(platform).should == true
+    end
+  end
+
+  [:windows].each do |platform|
+    it "should not require conversion from hex on #{platform}" do
+      Facter::Util::IP.convert_from_hex?(platform).should be_false
+    end
+  end
+
+  it "should return an arp address on Linux" do
+    Facter.stubs(:value).with(:kernel).returns("Linux")
+
+    Facter::Util::IP.expects(:get_arp_value).with("eth0").returns("00:00:0c:9f:f0:04")
+    Facter::Util::IP.get_arp_value("eth0").should == "00:00:0c:9f:f0:04"
+  end
+
+  describe "on Windows" do
     before :each do
-        Facter::Util::Config.stubs(:is_windows?).returns(false)
+      Facter.stubs(:value).with(:kernel).returns("windows")
     end
 
-    [:freebsd, :linux, :netbsd, :openbsd, :sunos, :darwin, :"hp-ux", :"gnu/kfreebsd", :windows].each do |platform|
-        it "should be supported on #{platform}" do
-            Facter::Util::Config.stubs(:is_windows?).returns(platform == :windows)
-            Facter::Util::IP.supported_platforms.should be_include(platform)
-        end
+    it "should return ipaddress information" do
+      sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
+      windows_netsh = File.read(sample_output_file)
+
+      Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Local Area Connection", "ipaddress").returns(windows_netsh)
+
+      Facter::Util::IP.get_interface_value("Local Area Connection", "ipaddress").should == "172.16.138.216"
     end
 
-    it "should return a list of interfaces" do
-        Facter::Util::IP.should respond_to(:get_interfaces)
+    it "should return a human readable netmask" do
+      sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
+      windows_netsh = File.read(sample_output_file)
+
+      Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Local Area Connection", "netmask").returns(windows_netsh)
+
+      Facter::Util::IP.get_interface_value("Local Area Connection", "netmask").should == "255.255.255.0"
     end
 
-    it "should return an empty list of interfaces on an unknown kernel" do
-        Facter.stubs(:value).returns("UnknownKernel")
-        Facter::Util::IP.get_interfaces().should == []
+    it "should return network information" do
+      sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
+      windows_netsh = File.read(sample_output_file)
+
+      Facter::Util::IP.stubs(:get_output_for_interface_and_label).with("Local Area Connection", "ipaddress").returns(windows_netsh)
+      Facter::Util::IP.stubs(:get_output_for_interface_and_label).with("Local Area Connection", "netmask").returns(windows_netsh)
+
+      Facter::Util::IP.get_network_value("Local Area Connection").should == "172.16.138.0"
     end
 
-    it "should return a list with a single interface and the loopback interface on Linux with a single interface" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/linux_ifconfig_all_with_single_interface'
-        linux_ifconfig = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(linux_ifconfig)
-        Facter::Util::IP.get_interfaces().should == ["eth0", "lo"]
+    it "should return ipaddress6 information" do
+      sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface6"
+      windows_netsh = File.read(sample_output_file)
+
+      Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Teredo Tunneling Pseudo-Interface", "ipaddress6").returns(windows_netsh)
+
+      Facter::Util::IP.get_interface_value("Teredo Tunneling Pseudo-Interface", "ipaddress6").should == "2001:0:4137:9e76:2087:77a:53ef:7527"
     end
-
-    it "should return a list two interfaces on Darwin with two interfaces" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/darwin_ifconfig_all_with_multiple_interfaces'
-        darwin_ifconfig = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(darwin_ifconfig)
-        Facter::Util::IP.get_interfaces().should == ["lo0", "en0"]
-    end
-
-    it "should return a list two interfaces on Solaris with two interfaces multiply reporting" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/solaris_ifconfig_all_with_multiple_interfaces'
-        solaris_ifconfig = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(solaris_ifconfig)
-        Facter::Util::IP.get_interfaces().should == ["lo0", "e1000g0"]
-    end
-
-    it "should return a list three interfaces on HP-UX with three interfaces multiply reporting" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/hpux_netstat_all_interfaces'
-        hpux_netstat = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(hpux_netstat)
-        Facter::Util::IP.get_interfaces().should == ["lan1", "lan0", "lo0"]
-    end
-
-    it "should return a list of six interfaces on a GNU/kFreeBSD with six interfaces" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/debian_kfreebsd_ifconfig'
-        kfreebsd_ifconfig = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(kfreebsd_ifconfig)
-        Facter::Util::IP.get_interfaces().should == ["em0", "em1", "bge0", "bge1", "lo0", "vlan0"]
-    end
-
-    it "should return a list of only connected interfaces on Windows" do
-        Facter.fact(:kernel).stubs(:value).returns("windows")
-        sample_output_file = File.dirname(__FILE__) + '/../data/windows_netsh_all_interfaces'
-        windows_netsh = File.read(sample_output_file)
-        Facter::Util::IP.stubs(:get_all_interface_output).returns(windows_netsh)
-        Facter::Util::IP.get_interfaces().should == ["Loopback Pseudo-Interface 1", "Local Area Connection", "Teredo Tunneling Pseudo-Interface"]
-    end
-
-    it "should return a value for a specific interface" do
-        Facter::Util::IP.should respond_to(:get_interface_value)
-    end
-
-    it "should not return interface information for unsupported platforms" do
-        Facter.stubs(:value).with(:kernel).returns("bleah")
-        Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == []
-    end
-
-    it "should return ipaddress information for Solaris" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
-        solaris_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("SunOS")
-
-        Facter::Util::IP.get_interface_value("e1000g0", "ipaddress").should == "172.16.15.138"
-    end
-
-    it "should return netmask information for Solaris" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
-        solaris_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("SunOS")
-
-        Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == "255.255.255.0"
-    end
-
-    it "should return calculated network information for Solaris" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
-        solaris_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.stubs(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("SunOS")
-
-        Facter::Util::IP.get_network_value("e1000g0").should == "172.16.15.0"
-    end
-
-    it "should return ipaddress information for HP-UX" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
-        hpux_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("HP-UX")
-
-        Facter::Util::IP.get_interface_value("lan0", "ipaddress").should == "168.24.80.71"
-    end
-
-    it "should return macaddress information for HP-UX" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
-        hpux_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("HP-UX")
-
-        Facter::Util::IP.get_interface_value("lan0", "macaddress").should == "00:13:21:BD:9C:B7"
-    end
-
-    it "should return macaddress with leading zeros stripped off for GNU/kFreeBSD" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/debian_kfreebsd_ifconfig"
-        kfreebsd_ifconfig = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("em0").returns(kfreebsd_ifconfig)
-        Facter.stubs(:value).with(:kernel).returns("GNU/kFreeBSD")
-
-        Facter::Util::IP.get_interface_value("em0", "macaddress").should == "0:11:a:59:67:90"
-    end
-
-    it "should return netmask information for HP-UX" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
-        hpux_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("HP-UX")
-
-        Facter::Util::IP.get_interface_value("lan0", "netmask").should == "255.255.255.0"
-    end
-
-    it "should return calculated network information for HP-UX" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
-        hpux_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.stubs(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("HP-UX")
-
-        Facter::Util::IP.get_network_value("lan0").should == "168.24.80.0"
-    end
-
-    it "should return interface information for FreeBSD supported via an alias" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/6.0-STABLE_FreeBSD_ifconfig"
-        ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("fxp0").returns(ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("FreeBSD")
-
-        Facter::Util::IP.get_interface_value("fxp0", "macaddress").should == "00:0e:0c:68:67:7c"
-    end
-
-    it "should return macaddress information for OS X" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/Mac_OS_X_10.5.5_ifconfig"
-        ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("en1").returns(ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("Darwin")
-
-        Facter::Util::IP.get_interface_value("en1", "macaddress").should == "00:1b:63:ae:02:66"
-    end
-
-    it "should return all interfaces correctly on OS X" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/Mac_OS_X_10.5.5_ifconfig"
-        ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_all_interface_output).returns(ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("Darwin")
-
-        Facter::Util::IP.get_interfaces().should == ["lo0", "gif0", "stf0", "en0", "fw0", "en1", "vmnet8", "vmnet1"]
-    end
-
-    it "should return a human readable netmask on Solaris" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/solaris_ifconfig_single_interface"
-        solaris_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("SunOS")
-
-        Facter::Util::IP.get_interface_value("e1000g0", "netmask").should == "255.255.255.0"
-    end
-
-    it "should return a human readable netmask on HP-UX" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/hpux_ifconfig_single_interface"
-        hpux_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("lan0").returns(hpux_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("HP-UX")
-
-        Facter::Util::IP.get_interface_value("lan0", "netmask").should == "255.255.255.0"
-    end
-
-    it "should return a human readable netmask on Darwin" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/darwin_ifconfig_single_interface"
-
-        darwin_ifconfig_interface = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("en1").returns(darwin_ifconfig_interface)
-        Facter.stubs(:value).with(:kernel).returns("Darwin")
-
-        Facter::Util::IP.get_interface_value("en1", "netmask").should == "255.255.255.0"
-    end
-
-    it "should return a human readable netmask on GNU/kFreeBSD" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/debian_kfreebsd_ifconfig"
-
-        kfreebsd_ifconfig = File.read(sample_output_file)
-
-        Facter::Util::IP.expects(:get_single_interface_output).with("em1").returns(kfreebsd_ifconfig)
-        Facter.stubs(:value).with(:kernel).returns("GNU/kFreeBSD")
-
-        Facter::Util::IP.get_interface_value("em1", "netmask").should == "255.255.255.0"
-    end
-
-    it "should not get bonding master on interface aliases" do
-        Facter.stubs(:value).with(:kernel).returns("Linux")
-
-        Facter::Util::IP.get_bonding_master("eth0:1").should be_nil
-    end
-
-    [:freebsd, :netbsd, :openbsd, :sunos, :darwin, :"hp-ux"].each do |platform|
-        it "should require conversion from hex on #{platform}" do
-            Facter::Util::IP.convert_from_hex?(platform).should == true
-        end
-    end
-
-    [:windows].each do |platform|
-        it "should not require conversion from hex on #{platform}" do
-            Facter::Util::IP.convert_from_hex?(platform).should be_false
-        end
-    end
-
-    it "should return an arp address on Linux" do
-        Facter.stubs(:value).with(:kernel).returns("Linux")
-
-        Facter::Util::IP.expects(:get_arp_value).with("eth0").returns("00:00:0c:9f:f0:04")
-        Facter::Util::IP.get_arp_value("eth0").should == "00:00:0c:9f:f0:04"
-    end
-
-    describe "on Windows" do
-        before :each do
-            Facter.stubs(:value).with(:kernel).returns("windows")
-        end
-
-        it "should return ipaddress information" do
-            sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
-            windows_netsh = File.read(sample_output_file)
-
-            Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Local Area Connection", "ipaddress").returns(windows_netsh)
-
-            Facter::Util::IP.get_interface_value("Local Area Connection", "ipaddress").should == "172.16.138.216"
-        end
-
-        it "should return a human readable netmask" do
-            sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
-            windows_netsh = File.read(sample_output_file)
-
-            Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Local Area Connection", "netmask").returns(windows_netsh)
-
-            Facter::Util::IP.get_interface_value("Local Area Connection", "netmask").should == "255.255.255.0"
-        end
-
-        it "should return network information" do
-            sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface"
-            windows_netsh = File.read(sample_output_file)
-
-            Facter::Util::IP.stubs(:get_output_for_interface_and_label).with("Local Area Connection", "ipaddress").returns(windows_netsh)
-            Facter::Util::IP.stubs(:get_output_for_interface_and_label).with("Local Area Connection", "netmask").returns(windows_netsh)
-
-            Facter::Util::IP.get_network_value("Local Area Connection").should == "172.16.138.0"
-        end
-
-        it "should return ipaddress6 information" do
-            sample_output_file = File.dirname(__FILE__) + "/../data/windows_netsh_single_interface6"
-            windows_netsh = File.read(sample_output_file)
-
-            Facter::Util::IP.expects(:get_output_for_interface_and_label).with("Teredo Tunneling Pseudo-Interface", "ipaddress6").returns(windows_netsh)
-
-            Facter::Util::IP.get_interface_value("Teredo Tunneling Pseudo-Interface", "ipaddress6").should == "2001:0:4137:9e76:2087:77a:53ef:7527"
-        end
-    end
+  end
 end

--- a/spec/unit/util/loader_spec.rb
+++ b/spec/unit/util/loader_spec.rb
@@ -19,273 +19,273 @@ end
 
 
 describe Facter::Util::Loader do
-    before :each do
-        Facter::Util::Loader.any_instance.unstub(:load_all)
+  before :each do
+    Facter::Util::Loader.any_instance.unstub(:load_all)
+  end
+
+  def with_env(values)
+    old = {}
+    values.each do |var, value|
+      if old_val = ENV[var]
+        old[var] = old_val
+      end
+      ENV[var] = value
+    end
+    yield
+    values.each do |var, value|
+      if old.include?(var)
+        ENV[var] = old[var]
+      else
+        ENV.delete(var)
+      end
+    end
+  end
+
+  it "should have a method for loading individual facts by name" do
+    Facter::Util::Loader.new.should respond_to(:load)
+  end
+
+  it "should have a method for loading all facts" do
+    Facter::Util::Loader.new.should respond_to(:load_all)
+  end
+
+  it "should have a method for returning directories containing facts" do
+    Facter::Util::Loader.new.should respond_to(:search_path)
+  end
+
+  describe "when determining the search path" do
+    before do
+      @loader = Facter::Util::Loader.new
+      @settings = mock 'settings'
+      @settings.stubs(:value).returns "/eh"
     end
 
-    def with_env(values)
-        old = {}
-        values.each do |var, value|
-            if old_val = ENV[var]
-                old[var] = old_val
-            end
-            ENV[var] = value
-        end
-        yield
-        values.each do |var, value|
-            if old.include?(var)
-                ENV[var] = old[var]
-            else
-                ENV.delete(var)
-            end
-        end
+    it "should include the facter subdirectory of all paths in ruby LOAD_PATH" do
+      dirs = $LOAD_PATH.collect { |d| File.join(d, "facter") }
+      paths = @loader.search_path
+
+      dirs.each do |dir|
+        paths.should be_include(dir)
+      end
     end
 
-    it "should have a method for loading individual facts by name" do
-        Facter::Util::Loader.new.should respond_to(:load)
+    it "should include all search paths registered with Facter" do
+      Facter.expects(:search_path).returns %w{/one /two}
+      paths = @loader.search_path
+      paths.should be_include("/one")
+      paths.should be_include("/two")
     end
 
-    it "should have a method for loading all facts" do
-        Facter::Util::Loader.new.should respond_to(:load_all)
+    describe "and the FACTERLIB environment variable is set" do
+      it "should include all paths in FACTERLIB" do
+        with_env "FACTERLIB" => "/one/path:/two/path" do
+          paths = @loader.search_path
+          %w{/one/path /two/path}.each do |dir|
+            paths.should be_include(dir)
+          end
+        end
+      end
+    end
+  end
+
+  describe "when loading facts" do
+    before do
+      @loader = Facter::Util::Loader.new
+      @loader.stubs(:search_path).returns []
     end
 
-    it "should have a method for returning directories containing facts" do
-        Facter::Util::Loader.new.should respond_to(:search_path)
-    end
+    it "should load values from the matching environment variable if one is present" do
+      Facter.expects(:add).with("testing")
 
-    describe "when determining the search path" do
-        before do
-            @loader = Facter::Util::Loader.new
-            @settings = mock 'settings'
-            @settings.stubs(:value).returns "/eh"
-        end
-
-        it "should include the facter subdirectory of all paths in ruby LOAD_PATH" do
-            dirs = $LOAD_PATH.collect { |d| File.join(d, "facter") }
-            paths = @loader.search_path
-
-            dirs.each do |dir|
-                paths.should be_include(dir)
-            end
-        end
-
-        it "should include all search paths registered with Facter" do
-            Facter.expects(:search_path).returns %w{/one /two}
-            paths = @loader.search_path
-            paths.should be_include("/one")
-            paths.should be_include("/two")
-        end
-
-        describe "and the FACTERLIB environment variable is set" do
-            it "should include all paths in FACTERLIB" do
-                with_env "FACTERLIB" => "/one/path:/two/path" do
-                    paths = @loader.search_path
-                    %w{/one/path /two/path}.each do |dir|
-                        paths.should be_include(dir)
-                    end
-                end
-            end
-        end
-    end
-
-    describe "when loading facts" do
-        before do
-            @loader = Facter::Util::Loader.new
-            @loader.stubs(:search_path).returns []
-        end
-
-        it "should load values from the matching environment variable if one is present" do
-            Facter.expects(:add).with("testing")
-
-            with_env "facter_testing" => "yayness" do
-                @loader.load(:testing)
-            end
-        end
-
-        it "should load any files in the search path with names matching the fact name" do
-            @loader.expects(:search_path).returns %w{/one/dir /two/dir}
-            FileTest.stubs(:exist?).returns false
-            FileTest.expects(:exist?).with("/one/dir/testing.rb").returns true
-            FileTest.expects(:exist?).with("/two/dir/testing.rb").returns true
-
-            Kernel.expects(:load).with("/one/dir/testing.rb")
-            Kernel.expects(:load).with("/two/dir/testing.rb")
-
-            @loader.load(:testing)
-        end
-
-      it 'should load any ruby files in directories matching the fact name in the search path in sorted order regardless of the order returned by Dir.entries' do
-        @loader = TestLoader.new
-
-        @loader.stubs(:search_path).returns %w{/one/dir}
-        FileTest.stubs(:exist?).returns false
-        FileTest.stubs(:directory?).with("/one/dir/testing").returns true
-        @loader.stubs(:search_path).returns %w{/one/dir}
-
-        Dir.stubs(:entries).with("/one/dir/testing").returns %w{foo.rb bar.rb}
-        %w{/one/dir/testing/foo.rb /one/dir/testing/bar.rb}.each do |f|
-          File.stubs(:directory?).with(f).returns false
-          Kernel.stubs(:load).with(f)
-        end
-
+      with_env "facter_testing" => "yayness" do
         @loader.load(:testing)
-        @loader.loaded_files.should == %w{/one/dir/testing/bar.rb /one/dir/testing/foo.rb}
       end
-
-        it "should load any ruby files in directories matching the fact name in the search path" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-            FileTest.stubs(:exist?).returns false
-            FileTest.expects(:directory?).with("/one/dir/testing").returns true
-
-            Dir.expects(:entries).with("/one/dir/testing").returns %w{two.rb}
-
-            Kernel.expects(:load).with("/one/dir/testing/two.rb")
-
-            @loader.load(:testing)
-        end
-
-        it "should not load files that don't end in '.rb'" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-            FileTest.stubs(:exist?).returns false
-            FileTest.expects(:directory?).with("/one/dir/testing").returns true
-
-            Dir.expects(:entries).with("/one/dir/testing").returns %w{one}
-
-            Kernel.expects(:load).never
-
-            @loader.load(:testing)
-        end
     end
 
-    describe "when loading all facts" do
-        before do
-            @loader = Facter::Util::Loader.new
-            @loader.stubs(:search_path).returns []
+    it "should load any files in the search path with names matching the fact name" do
+      @loader.expects(:search_path).returns %w{/one/dir /two/dir}
+      FileTest.stubs(:exist?).returns false
+      FileTest.expects(:exist?).with("/one/dir/testing.rb").returns true
+      FileTest.expects(:exist?).with("/two/dir/testing.rb").returns true
 
-            FileTest.stubs(:directory?).returns true
-        end
+      Kernel.expects(:load).with("/one/dir/testing.rb")
+      Kernel.expects(:load).with("/two/dir/testing.rb")
 
-        it "should skip directories that do not exist" do
-            @loader.expects(:search_path).returns %w{/one/dir}
+      @loader.load(:testing)
+    end
 
-            FileTest.expects(:directory?).with("/one/dir").returns false
+    it 'should load any ruby files in directories matching the fact name in the search path in sorted order regardless of the order returned by Dir.entries' do
+    @loader = TestLoader.new
 
-            Dir.expects(:entries).with("/one/dir").never
+    @loader.stubs(:search_path).returns %w{/one/dir}
+    FileTest.stubs(:exist?).returns false
+    FileTest.stubs(:directory?).with("/one/dir/testing").returns true
+    @loader.stubs(:search_path).returns %w{/one/dir}
 
-            @loader.load_all
-        end
+    Dir.stubs(:entries).with("/one/dir/testing").returns %w{foo.rb bar.rb}
+    %w{/one/dir/testing/foo.rb /one/dir/testing/bar.rb}.each do |f|
+      File.stubs(:directory?).with(f).returns false
+      Kernel.stubs(:load).with(f)
+    end
 
-        it "should load all files in all search paths" do
-            @loader.expects(:search_path).returns %w{/one/dir /two/dir}
+    @loader.load(:testing)
+    @loader.loaded_files.should == %w{/one/dir/testing/bar.rb /one/dir/testing/foo.rb}
+    end
 
-            Dir.expects(:entries).with("/one/dir").returns %w{a.rb b.rb}
-            Dir.expects(:entries).with("/two/dir").returns %w{c.rb d.rb}
+    it "should load any ruby files in directories matching the fact name in the search path" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+      FileTest.stubs(:exist?).returns false
+      FileTest.expects(:directory?).with("/one/dir/testing").returns true
 
-            %w{/one/dir/a.rb /one/dir/b.rb /two/dir/c.rb /two/dir/d.rb}.each { |f| Kernel.expects(:load).with(f) }
+      Dir.expects(:entries).with("/one/dir/testing").returns %w{two.rb}
 
-            @loader.load_all
-        end
+      Kernel.expects(:load).with("/one/dir/testing/two.rb")
 
-        it "should load all files in all subdirectories in all search paths" do
-            @loader.expects(:search_path).returns %w{/one/dir /two/dir}
+      @loader.load(:testing)
+    end
 
-            Dir.expects(:entries).with("/one/dir").returns %w{a}
-            Dir.expects(:entries).with("/two/dir").returns %w{b}
+    it "should not load files that don't end in '.rb'" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+      FileTest.stubs(:exist?).returns false
+      FileTest.expects(:directory?).with("/one/dir/testing").returns true
 
-            %w{/one/dir/a /two/dir/b}.each { |f| File.expects(:directory?).with(f).returns true }
+      Dir.expects(:entries).with("/one/dir/testing").returns %w{one}
 
-            Dir.expects(:entries).with("/one/dir/a").returns %w{c.rb}
-            Dir.expects(:entries).with("/two/dir/b").returns %w{d.rb}
+      Kernel.expects(:load).never
 
-            %w{/one/dir/a/c.rb /two/dir/b/d.rb}.each { |f| Kernel.expects(:load).with(f) }
+      @loader.load(:testing)
+    end
+  end
 
-            @loader.load_all
-        end
+  describe "when loading all facts" do
+    before do
+      @loader = Facter::Util::Loader.new
+      @loader.stubs(:search_path).returns []
 
-      it 'should load all files in sorted order for any given directory regardless of the order returned by Dir.entries' do
-        @loader = TestLoader.new
+      FileTest.stubs(:directory?).returns true
+    end
 
-        @loader.stubs(:search_path).returns %w{/one/dir}
-        Dir.stubs(:entries).with("/one/dir").returns %w{foo.rb bar.rb}
+    it "should skip directories that do not exist" do
+      @loader.expects(:search_path).returns %w{/one/dir}
 
-        %w{/one/dir}.each { |f| File.stubs(:directory?).with(f).returns true }
+      FileTest.expects(:directory?).with("/one/dir").returns false
 
-        %w{/one/dir/foo.rb /one/dir/bar.rb}.each do |f|
-          File.stubs(:directory?).with(f).returns false
-          Kernel.expects(:load).with(f)
-        end
+      Dir.expects(:entries).with("/one/dir").never
 
+      @loader.load_all
+    end
+
+    it "should load all files in all search paths" do
+      @loader.expects(:search_path).returns %w{/one/dir /two/dir}
+
+      Dir.expects(:entries).with("/one/dir").returns %w{a.rb b.rb}
+      Dir.expects(:entries).with("/two/dir").returns %w{c.rb d.rb}
+
+      %w{/one/dir/a.rb /one/dir/b.rb /two/dir/c.rb /two/dir/d.rb}.each { |f| Kernel.expects(:load).with(f) }
+
+      @loader.load_all
+    end
+
+    it "should load all files in all subdirectories in all search paths" do
+      @loader.expects(:search_path).returns %w{/one/dir /two/dir}
+
+      Dir.expects(:entries).with("/one/dir").returns %w{a}
+      Dir.expects(:entries).with("/two/dir").returns %w{b}
+
+      %w{/one/dir/a /two/dir/b}.each { |f| File.expects(:directory?).with(f).returns true }
+
+      Dir.expects(:entries).with("/one/dir/a").returns %w{c.rb}
+      Dir.expects(:entries).with("/two/dir/b").returns %w{d.rb}
+
+      %w{/one/dir/a/c.rb /two/dir/b/d.rb}.each { |f| Kernel.expects(:load).with(f) }
+
+      @loader.load_all
+    end
+
+    it 'should load all files in sorted order for any given directory regardless of the order returned by Dir.entries' do
+    @loader = TestLoader.new
+
+    @loader.stubs(:search_path).returns %w{/one/dir}
+    Dir.stubs(:entries).with("/one/dir").returns %w{foo.rb bar.rb}
+
+    %w{/one/dir}.each { |f| File.stubs(:directory?).with(f).returns true }
+
+    %w{/one/dir/foo.rb /one/dir/bar.rb}.each do |f|
+      File.stubs(:directory?).with(f).returns false
+      Kernel.expects(:load).with(f)
+    end
+
+    @loader.load_all
+
+    @loader.loaded_files.should == %w{/one/dir/bar.rb /one/dir/foo.rb}
+    end
+
+    it "should not load files in the util subdirectory" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+
+      Dir.expects(:entries).with("/one/dir").returns %w{util}
+
+      File.expects(:directory?).with("/one/dir/util").returns true
+
+      Dir.expects(:entries).with("/one/dir/util").never
+
+      @loader.load_all
+    end
+
+    it "should not load files in a lib subdirectory" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+
+      Dir.expects(:entries).with("/one/dir").returns %w{lib}
+
+      File.expects(:directory?).with("/one/dir/lib").returns true
+
+      Dir.expects(:entries).with("/one/dir/lib").never
+
+      @loader.load_all
+    end
+
+    it "should not load files in '.' or '..'" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+
+      Dir.expects(:entries).with("/one/dir").returns %w{. ..}
+
+      File.expects(:entries).with("/one/dir/.").never
+      File.expects(:entries).with("/one/dir/..").never
+
+      @loader.load_all
+    end
+
+    it "should not raise an exception when a file is unloadable" do
+      @loader.expects(:search_path).returns %w{/one/dir}
+      Dir.expects(:entries).with("/one/dir").returns %w{a.rb}
+
+      Kernel.expects(:load).with("/one/dir/a.rb").raises(LoadError)
+      @loader.expects(:warn)
+
+      lambda { @loader.load_all }.should_not raise_error
+    end
+
+    it "should load all facts from the environment" do
+      Facter.expects(:add).with('one')
+      Facter.expects(:add).with('two')
+
+      with_env "facter_one" => "yayness", "facter_two" => "boo" do
         @loader.load_all
-
-        @loader.loaded_files.should == %w{/one/dir/bar.rb /one/dir/foo.rb}
       end
-
-        it "should not load files in the util subdirectory" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-
-            Dir.expects(:entries).with("/one/dir").returns %w{util}
-
-            File.expects(:directory?).with("/one/dir/util").returns true
-
-            Dir.expects(:entries).with("/one/dir/util").never
-
-            @loader.load_all
-        end
-
-        it "should not load files in a lib subdirectory" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-
-            Dir.expects(:entries).with("/one/dir").returns %w{lib}
-
-            File.expects(:directory?).with("/one/dir/lib").returns true
-
-            Dir.expects(:entries).with("/one/dir/lib").never
-
-            @loader.load_all
-        end
-
-        it "should not load files in '.' or '..'" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-
-            Dir.expects(:entries).with("/one/dir").returns %w{. ..}
-
-            File.expects(:entries).with("/one/dir/.").never
-            File.expects(:entries).with("/one/dir/..").never
-
-            @loader.load_all
-        end
-
-        it "should not raise an exception when a file is unloadable" do
-            @loader.expects(:search_path).returns %w{/one/dir}
-            Dir.expects(:entries).with("/one/dir").returns %w{a.rb}
-
-            Kernel.expects(:load).with("/one/dir/a.rb").raises(LoadError)
-            @loader.expects(:warn)
-
-            lambda { @loader.load_all }.should_not raise_error
-        end
-
-        it "should load all facts from the environment" do
-            Facter.expects(:add).with('one')
-            Facter.expects(:add).with('two')
-
-            with_env "facter_one" => "yayness", "facter_two" => "boo" do
-                @loader.load_all
-            end
-        end
-
-        it "should only load all facts one time" do
-            @loader.expects(:load_env).once
-            @loader.load_all
-            @loader.load_all
-        end
     end
 
-    it "should load facts on the facter search path only once" do
-        facterlibdir = File.expand_path(File.dirname(__FILE__) + '../../../fixtures/unit/util/loader')
-        with_env 'FACTERLIB' => facterlibdir do
-            Facter::Util::Loader.new.load_all
-            Facter.value(:nosuchfact).should be_nil
-        end
+    it "should only load all facts one time" do
+      @loader.expects(:load_env).once
+      @loader.load_all
+      @loader.load_all
     end
+  end
+
+  it "should load facts on the facter search path only once" do
+    facterlibdir = File.expand_path(File.dirname(__FILE__) + '../../../fixtures/unit/util/loader')
+    with_env 'FACTERLIB' => facterlibdir do
+      Facter::Util::Loader.new.load_all
+      Facter.value(:nosuchfact).should be_nil
+    end
+  end
 end

--- a/spec/unit/util/macosx_spec.rb
+++ b/spec/unit/util/macosx_spec.rb
@@ -5,77 +5,77 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/macosx'
 
 describe Facter::Util::Macosx do
-    it "should be able to retrieve profiler data as xml for a given data field" do
-        Facter::Util::Resolution.expects(:exec).with("/usr/sbin/system_profiler -xml foo").returns "yay"
-        Facter::Util::Macosx.profiler_xml("foo").should == "yay"
+  it "should be able to retrieve profiler data as xml for a given data field" do
+    Facter::Util::Resolution.expects(:exec).with("/usr/sbin/system_profiler -xml foo").returns "yay"
+    Facter::Util::Macosx.profiler_xml("foo").should == "yay"
+  end
+
+  it "should use PList to convert xml to data structures" do
+    Plist.expects(:parse_xml).with("foo").returns "bar"
+
+    Facter::Util::Macosx.intern_xml("foo").should == "bar"
+  end
+
+  describe "when collecting profiler data" do
+    it "should return the first value in the '_items' hash in the first value of the results of the system_profiler data, with the '_name' field removed, if the profiler returns data" do
+      @result = [
+        '_items' => [
+          {'_name' => "foo", "yay" => "bar"}
+        ]
+      ]
+      Facter::Util::Macosx.expects(:profiler_xml).with("foo").returns "eh"
+      Facter::Util::Macosx.expects(:intern_xml).with("eh").returns @result
+      Facter::Util::Macosx.profiler_data("foo").should == {"yay" => "bar"}
     end
 
-    it "should use PList to convert xml to data structures" do
-        Plist.expects(:parse_xml).with("foo").returns "bar"
-
-        Facter::Util::Macosx.intern_xml("foo").should == "bar"
+    it "should return nil if an exception is thrown during parsing of xml" do
+      Facter::Util::Macosx.expects(:profiler_xml).with("foo").returns "eh"
+      Facter::Util::Macosx.expects(:intern_xml).with("eh").raises "boo!"
+      Facter::Util::Macosx.profiler_data("foo").should be_nil
     end
+  end
 
-    describe "when collecting profiler data" do
-        it "should return the first value in the '_items' hash in the first value of the results of the system_profiler data, with the '_name' field removed, if the profiler returns data" do
-            @result = [
-                '_items' => [
-                    {'_name' => "foo", "yay" => "bar"}
-                ]
-            ]
-            Facter::Util::Macosx.expects(:profiler_xml).with("foo").returns "eh"
-            Facter::Util::Macosx.expects(:intern_xml).with("eh").returns @result
-            Facter::Util::Macosx.profiler_data("foo").should == {"yay" => "bar"}
-        end
+  it "should return the profiler data for 'SPHardwareDataType' as the hardware information" do
+    Facter::Util::Macosx.expects(:profiler_data).with("SPHardwareDataType").returns "eh"
+    Facter::Util::Macosx.hardware_overview.should == "eh"
+  end
 
-        it "should return nil if an exception is thrown during parsing of xml" do
-            Facter::Util::Macosx.expects(:profiler_xml).with("foo").returns "eh"
-            Facter::Util::Macosx.expects(:intern_xml).with("eh").raises "boo!"
-            Facter::Util::Macosx.profiler_data("foo").should be_nil
-        end
-    end
-
-    it "should return the profiler data for 'SPHardwareDataType' as the hardware information" do
-        Facter::Util::Macosx.expects(:profiler_data).with("SPHardwareDataType").returns "eh"
-        Facter::Util::Macosx.hardware_overview.should == "eh"
-    end
-
-    it "should return the profiler data for 'SPSoftwareDataType' as the os information" do
-        Facter::Util::Macosx.expects(:profiler_data).with("SPSoftwareDataType").returns "eh"
-        Facter::Util::Macosx.os_overview.should == "eh"
+  it "should return the profiler data for 'SPSoftwareDataType' as the os information" do
+    Facter::Util::Macosx.expects(:profiler_data).with("SPSoftwareDataType").returns "eh"
+    Facter::Util::Macosx.os_overview.should == "eh"
+  end
+  
+  describe "when working out software version" do
+    
+    before do
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productName").returns "Mac OS X"
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -buildVersion").returns "9J62"
     end
     
-    describe "when working out software version" do
-        
-        before do
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productName").returns "Mac OS X"
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -buildVersion").returns "9J62"
-        end
-        
-        it "should have called sw_vers three times when determining software version" do
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "10.5.7"
-            Facter::Util::Macosx.sw_vers
-        end
-    
-        it "should return a hash with the correct keys when determining software version" do
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "10.5.7"
-            Facter::Util::Macosx.sw_vers.keys.sort.should == ["macosx_productName",
-                                                              "macosx_buildVersion",
-                                                              "macosx_productversion_minor",
-                                                              "macosx_productversion_major",
-                                                              "macosx_productVersion"].sort
-        end
-    
-        it "should split a product version of 'x.y.z' into separate hash entries correctly" do
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "1.2.3"
-            sw_vers = Facter::Util::Macosx.sw_vers
-            sw_vers["macosx_productversion_major"].should == "1.2"
-            sw_vers["macosx_productversion_minor"].should == "3"
-        end
-    
-        it "should treat a product version of 'x.y' as 'x.y.0" do
-            Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "2.3"
-            Facter::Util::Macosx.sw_vers["macosx_productversion_minor"].should == "0"
-        end
+    it "should have called sw_vers three times when determining software version" do
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "10.5.7"
+      Facter::Util::Macosx.sw_vers
     end
+  
+    it "should return a hash with the correct keys when determining software version" do
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "10.5.7"
+      Facter::Util::Macosx.sw_vers.keys.sort.should == ["macosx_productName",
+                                                        "macosx_buildVersion",
+                                                        "macosx_productversion_minor",
+                                                        "macosx_productversion_major",
+                                                        "macosx_productVersion"].sort
+    end
+  
+    it "should split a product version of 'x.y.z' into separate hash entries correctly" do
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "1.2.3"
+      sw_vers = Facter::Util::Macosx.sw_vers
+      sw_vers["macosx_productversion_major"].should == "1.2"
+      sw_vers["macosx_productversion_minor"].should == "3"
+    end
+  
+    it "should treat a product version of 'x.y' as 'x.y.0" do
+      Facter::Util::Resolution.expects(:exec).with("/usr/bin/sw_vers -productVersion").returns "2.3"
+      Facter::Util::Macosx.sw_vers["macosx_productversion_minor"].should == "0"
+    end
+  end
 end

--- a/spec/unit/util/manufacturer_spec.rb
+++ b/spec/unit/util/manufacturer_spec.rb
@@ -3,52 +3,52 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/manufacturer'
 
 describe Facter::Manufacturer do
-    before :each do
-        Facter.clear
-    end
+  before :each do
+    Facter.clear
+  end
 
-    it "should return the system DMI table" do
-        Facter::Manufacturer.should respond_to(:get_dmi_table)
-    end
+  it "should return the system DMI table" do
+    Facter::Manufacturer.should respond_to(:get_dmi_table)
+  end
 
-    it "should return nil on non-supported operating systems" do
-        Facter.stubs(:value).with(:kernel).returns("SomeThing")
-        Facter::Manufacturer.get_dmi_table().should be_nil
-    end
+  it "should return nil on non-supported operating systems" do
+    Facter.stubs(:value).with(:kernel).returns("SomeThing")
+    Facter::Manufacturer.get_dmi_table().should be_nil
+  end
 
-    it "should parse prtdiag output" do
-        Facter::Util::Resolution.stubs(:exec).returns("System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server")
-        Facter::Manufacturer.prtdiag_sparc_find_system_info()
-        Facter.value(:manufacturer).should == "Sun Microsystems"
-        Facter.value(:productname).should == "Sun SPARC Enterprise M3000 Server"
-    end
+  it "should parse prtdiag output" do
+    Facter::Util::Resolution.stubs(:exec).returns("System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server")
+    Facter::Manufacturer.prtdiag_sparc_find_system_info()
+    Facter.value(:manufacturer).should == "Sun Microsystems"
+    Facter.value(:productname).should == "Sun SPARC Enterprise M3000 Server"
+  end
 
-    it "should strip white space on dmi output with spaces" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/linux_dmidecode_with_spaces"
-        dmidecode_output = File.new(sample_output_file).read()
-        Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
+  it "should strip white space on dmi output with spaces" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/linux_dmidecode_with_spaces"
+    dmidecode_output = File.new(sample_output_file).read()
+    Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
 
-        query = { '[Ss]ystem [Ii]nformation' => [ { 'Product(?: Name)?:' => 'productname' } ] }
+    query = { '[Ss]ystem [Ii]nformation' => [ { 'Product(?: Name)?:' => 'productname' } ] }
 
-        Facter::Manufacturer.dmi_find_system_info(query)
-        Facter.value(:productname).should == "MS-6754"
-    end
+    Facter::Manufacturer.dmi_find_system_info(query)
+    Facter.value(:productname).should == "MS-6754"
+  end
 
-    it "should handle output from smbios when run under sunos" do
-        sample_output_file = File.dirname(__FILE__) + "/../data/opensolaris_smbios"
-        smbios_output = File.new(sample_output_file).read()
-        Facter::Manufacturer.expects(:get_dmi_table).returns(smbios_output)
-        Facter.fact(:kernel).stubs(:value).returns("SunOS")
+  it "should handle output from smbios when run under sunos" do
+    sample_output_file = File.dirname(__FILE__) + "/../data/opensolaris_smbios"
+    smbios_output = File.new(sample_output_file).read()
+    Facter::Manufacturer.expects(:get_dmi_table).returns(smbios_output)
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
 
-        query = { 'BIOS information' => [ { 'Release Date:' => 'reldate' } ] }
+    query = { 'BIOS information' => [ { 'Release Date:' => 'reldate' } ] }
 
-        Facter::Manufacturer.dmi_find_system_info(query)
-        Facter.value(:reldate).should == "12/01/2006"
-    end
+    Facter::Manufacturer.dmi_find_system_info(query)
+    Facter.value(:reldate).should == "12/01/2006"
+  end
 
-    it "should not split on dmi keys containing the string Handle" do
-        dmidecode_output = <<-eos
+  it "should not split on dmi keys containing the string Handle" do
+    dmidecode_output = <<-eos
 Handle 0x1000, DMI type 16, 15 bytes
 Physical Memory Array
         Location: System Board Or Motherboard
@@ -61,16 +61,16 @@ Physical Memory Array
 Handle 0x001F
         DMI type 127, 4 bytes.
         End Of Table
-        eos
-        Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        query = { 'Physical Memory Array' => [ { 'Number Of Devices:' => 'ramslots'}]}
-        Facter::Manufacturer.dmi_find_system_info(query)
-        Facter.value(:ramslots).should == "123"
-    end
+    eos
+    Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    query = { 'Physical Memory Array' => [ { 'Number Of Devices:' => 'ramslots'}]}
+    Facter::Manufacturer.dmi_find_system_info(query)
+    Facter.value(:ramslots).should == "123"
+  end
 
-    it "should match the key in the defined section and not the first one found" do
-        dmidecode_output = <<-eos
+  it "should match the key in the defined section and not the first one found" do
+    dmidecode_output = <<-eos
 Handle 0x000C, DMI type 7, 19 bytes
 Cache Information
         Socket Designation: Internal L2 Cache
@@ -99,55 +99,55 @@ Physical Memory Array
 Handle 0x001F
         DMI type 127, 4 bytes.
         End Of Table
-        eos
-        Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        query = { 'Physical Memory Array' => [ { 'Location:' => 'ramlocation'}]}
-        Facter::Manufacturer.dmi_find_system_info(query)
-        Facter.value(:ramlocation).should == "System Board Or Motherboard"
-    end
+    eos
+    Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    query = { 'Physical Memory Array' => [ { 'Location:' => 'ramlocation'}]}
+    Facter::Manufacturer.dmi_find_system_info(query)
+    Facter.value(:ramlocation).should == "System Board Or Motherboard"
+  end
 
-    def find_product_name(os)
-        output_file = case os
-            when "FreeBSD" then File.dirname(__FILE__) + "/../data/freebsd_dmidecode"
-            when "SunOS" then File.dirname(__FILE__) + "/../data/opensolaris_smbios"
-            end
+  def find_product_name(os)
+    output_file = case os
+      when "FreeBSD" then File.dirname(__FILE__) + "/../data/freebsd_dmidecode"
+      when "SunOS" then File.dirname(__FILE__) + "/../data/opensolaris_smbios"
+      end
 
-        output = File.new(output_file).read()
-        query = { '[Ss]ystem [Ii]nformation' => [ { 'Product(?: Name)?:' => "product_name_#{os}" } ] }
+    output = File.new(output_file).read()
+    query = { '[Ss]ystem [Ii]nformation' => [ { 'Product(?: Name)?:' => "product_name_#{os}" } ] }
 
-        Facter.fact(:kernel).stubs(:value).returns(os)
-        Facter::Manufacturer.expects(:get_dmi_table).returns(output)
+    Facter.fact(:kernel).stubs(:value).returns(os)
+    Facter::Manufacturer.expects(:get_dmi_table).returns(output)
 
-        Facter::Manufacturer.dmi_find_system_info(query)
+    Facter::Manufacturer.dmi_find_system_info(query)
 
-        return Facter.value("product_name_#{os}")
-    end
+    return Facter.value("product_name_#{os}")
+  end
 
-    it "should return the same result with smbios than with dmidecode" do
-        find_product_name("FreeBSD").should_not == nil
-        find_product_name("FreeBSD").should == find_product_name("SunOS")
-    end
+  it "should return the same result with smbios than with dmidecode" do
+    find_product_name("FreeBSD").should_not == nil
+    find_product_name("FreeBSD").should == find_product_name("SunOS")
+  end
 
-    it "should find information on Windows" do
-        Facter.fact(:kernel).stubs(:value).returns("windows")
-        require 'facter/util/wmi'
+  it "should find information on Windows" do
+    Facter.fact(:kernel).stubs(:value).returns("windows")
+    require 'facter/util/wmi'
 
-        bios = stubs 'bios'
-        bios.stubs(:Manufacturer).returns("Phoenix Technologies LTD")
-        bios.stubs(:Serialnumber).returns("56 4d 40 2b 4d 81 94 d6-e6 c5 56 a4 56 0c 9e 9f")
+    bios = stubs 'bios'
+    bios.stubs(:Manufacturer).returns("Phoenix Technologies LTD")
+    bios.stubs(:Serialnumber).returns("56 4d 40 2b 4d 81 94 d6-e6 c5 56 a4 56 0c 9e 9f")
 
-        product = stubs 'product'
-        product.stubs(:Name).returns("VMware Virtual Platform")
+    product = stubs 'product'
+    product.stubs(:Name).returns("VMware Virtual Platform")
 
-        wmi = stubs 'wmi'
-        wmi.stubs(:ExecQuery).with("select * from Win32_Bios").returns([bios])
-        wmi.stubs(:ExecQuery).with("select * from Win32_Bios").returns([bios])
-        wmi.stubs(:ExecQuery).with("select * from Win32_ComputerSystemProduct").returns([product])
+    wmi = stubs 'wmi'
+    wmi.stubs(:ExecQuery).with("select * from Win32_Bios").returns([bios])
+    wmi.stubs(:ExecQuery).with("select * from Win32_Bios").returns([bios])
+    wmi.stubs(:ExecQuery).with("select * from Win32_ComputerSystemProduct").returns([product])
 
-        Facter::Util::WMI.stubs(:connect).returns(wmi)
-        Facter.value(:manufacturer).should == "Phoenix Technologies LTD"
-        Facter.value(:serialnumber).should == "56 4d 40 2b 4d 81 94 d6-e6 c5 56 a4 56 0c 9e 9f"
-        Facter.value(:productname).should == "VMware Virtual Platform"
-    end
+    Facter::Util::WMI.stubs(:connect).returns(wmi)
+    Facter.value(:manufacturer).should == "Phoenix Technologies LTD"
+    Facter.value(:serialnumber).should == "56 4d 40 2b 4d 81 94 d6-e6 c5 56 a4 56 0c 9e 9f"
+    Facter.value(:productname).should == "VMware Virtual Platform"
+  end
 end

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -5,295 +5,295 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/resolution'
 
 describe Facter::Util::Resolution do
-    it "should require a name" do
-        lambda { Facter::Util::Resolution.new }.should raise_error(ArgumentError)
+  it "should require a name" do
+    lambda { Facter::Util::Resolution.new }.should raise_error(ArgumentError)
+  end
+
+  it "should have a name" do
+    Facter::Util::Resolution.new("yay").name.should == "yay"
+  end
+
+  it "should have a method for setting the weight" do
+    Facter::Util::Resolution.new("yay").should respond_to(:has_weight)
+  end
+
+  it "should have a method for setting the code" do
+    Facter::Util::Resolution.new("yay").should respond_to(:setcode)
+  end
+
+  it "should support a timeout value" do
+    Facter::Util::Resolution.new("yay").should respond_to(:timeout=)
+  end
+
+  it "should default to a timeout of 0 seconds" do
+    Facter::Util::Resolution.new("yay").limit.should == 0
+  end
+
+  it "should default to nil for code" do
+    Facter::Util::Resolution.new("yay").code.should be_nil
+  end
+
+  it "should default to nil for interpreter" do
+    Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version.")
+    Facter::Util::Resolution.new("yay").interpreter.should be_nil
+  end
+
+  it "should provide a 'limit' method that returns the timeout" do
+    res = Facter::Util::Resolution.new("yay")
+    res.timeout = "testing"
+    res.limit.should == "testing"
+  end
+
+  describe "when setting the code" do
+    before do
+      Facter.stubs(:warnonce)
+      @resolve = Facter::Util::Resolution.new("yay")
     end
 
-    it "should have a name" do
-        Facter::Util::Resolution.new("yay").name.should == "yay"
+    it "should deprecate the interpreter argument to 'setcode'" do
+      Facter.expects(:warnonce).with("The interpreter parameter to 'setcode' is deprecated and will be removed in a future version.")
+      @resolve.setcode "foo", "bar"
+      @resolve.interpreter.should == "bar"
     end
 
-    it "should have a method for setting the weight" do
-      Facter::Util::Resolution.new("yay").should respond_to(:has_weight)
+    it "should deprecate the interpreter= method" do
+      Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter=' method is deprecated and will be removed in a future version.")
+      @resolve.interpreter = "baz"
+      @resolve.interpreter.should == "baz"
     end
 
-    it "should have a method for setting the code" do
-        Facter::Util::Resolution.new("yay").should respond_to(:setcode)
+    it "should deprecate the interpreter method" do
+      Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version.")
+      @resolve.interpreter
     end
 
-    it "should support a timeout value" do
-        Facter::Util::Resolution.new("yay").should respond_to(:timeout=)
+    it "should set the code to any provided string" do
+      @resolve.setcode "foo"
+      @resolve.code.should == "foo"
     end
 
-    it "should default to a timeout of 0 seconds" do
-        Facter::Util::Resolution.new("yay").limit.should == 0
+    it "should set the code to any provided block" do
+      block = lambda { }
+      @resolve.setcode(&block)
+      @resolve.code.should equal(block)
     end
 
-    it "should default to nil for code" do
-        Facter::Util::Resolution.new("yay").code.should be_nil
+    it "should prefer the string over a block" do
+      @resolve.setcode("foo") { }
+      @resolve.code.should == "foo"
     end
 
-    it "should default to nil for interpreter" do
-        Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version.")
-        Facter::Util::Resolution.new("yay").interpreter.should be_nil
+    it "should fail if neither a string nor block has been provided" do
+      lambda { @resolve.setcode }.should raise_error(ArgumentError)
+    end
+  end
+
+  it "should be able to return a value" do
+    Facter::Util::Resolution.new("yay").should respond_to(:value)
+  end
+
+  describe "when returning the value" do
+    before do
+      @resolve = Facter::Util::Resolution.new("yay")
     end
 
-    it "should provide a 'limit' method that returns the timeout" do
-        res = Facter::Util::Resolution.new("yay")
-        res.timeout = "testing"
-        res.limit.should == "testing"
+    describe "and setcode has not been called" do
+      it "should return nil" do
+        Facter::Util::Resolution.expects(:exec).with(nil, nil).never
+        @resolve.value.should be_nil
+      end
     end
 
-    describe "when setting the code" do
+    describe "and the code is a string" do
+      describe "on windows" do
         before do
-            Facter.stubs(:warnonce)
-            @resolve = Facter::Util::Resolution.new("yay")
+          Facter::Util::Resolution::WINDOWS = true
         end
 
-        it "should deprecate the interpreter argument to 'setcode'" do
-            Facter.expects(:warnonce).with("The interpreter parameter to 'setcode' is deprecated and will be removed in a future version.")
-            @resolve.setcode "foo", "bar"
-            @resolve.interpreter.should == "bar"
+        it "should return the result of executing the code" do
+          @resolve.setcode "/bin/foo"
+          Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns "yup"
+
+          @resolve.value.should == "yup"
         end
 
-        it "should deprecate the interpreter= method" do
-            Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter=' method is deprecated and will be removed in a future version.")
-            @resolve.interpreter = "baz"
-            @resolve.interpreter.should == "baz"
+        it "should return nil if the value is an empty string" do
+          @resolve.setcode "/bin/foo"
+          Facter::Util::Resolution.expects(:exec).once.returns ""
+          @resolve.value.should be_nil
         end
+      end
 
-        it "should deprecate the interpreter method" do
-            Facter.expects(:warnonce).with("The 'Facter::Util::Resolution.interpreter' method is deprecated and will be removed in a future version.")
-            @resolve.interpreter
-        end
-
-        it "should set the code to any provided string" do
-            @resolve.setcode "foo"
-            @resolve.code.should == "foo"
-        end
-
-        it "should set the code to any provided block" do
-            block = lambda { }
-            @resolve.setcode(&block)
-            @resolve.code.should equal(block)
-        end
-
-        it "should prefer the string over a block" do
-            @resolve.setcode("foo") { }
-            @resolve.code.should == "foo"
-        end
-
-        it "should fail if neither a string nor block has been provided" do
-            lambda { @resolve.setcode }.should raise_error(ArgumentError)
-        end
-    end
-
-    it "should be able to return a value" do
-        Facter::Util::Resolution.new("yay").should respond_to(:value)
-    end
-
-    describe "when returning the value" do
+      describe "on non-windows systems" do
         before do
-            @resolve = Facter::Util::Resolution.new("yay")
+          Facter::Util::Resolution::WINDOWS = false
         end
 
-        describe "and setcode has not been called" do
-            it "should return nil" do
-                Facter::Util::Resolution.expects(:exec).with(nil, nil).never
-                @resolve.value.should be_nil
-            end
+        it "should return the result of executing the code" do
+          @resolve.setcode "/bin/foo"
+          Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns "yup"
+
+          @resolve.value.should == "yup"
         end
 
-        describe "and the code is a string" do
-            describe "on windows" do
-                before do
-                    Facter::Util::Resolution::WINDOWS = true
-                end
-
-                it "should return the result of executing the code" do
-                    @resolve.setcode "/bin/foo"
-                    Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns "yup"
-
-                    @resolve.value.should == "yup"
-                end
-
-                it "should return nil if the value is an empty string" do
-                    @resolve.setcode "/bin/foo"
-                    Facter::Util::Resolution.expects(:exec).once.returns ""
-                    @resolve.value.should be_nil
-                end
-            end
-
-            describe "on non-windows systems" do
-                before do
-                    Facter::Util::Resolution::WINDOWS = false
-                end
-
-                it "should return the result of executing the code" do
-                    @resolve.setcode "/bin/foo"
-                    Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns "yup"
-
-                    @resolve.value.should == "yup"
-                end
-
-                it "should return nil if the value is an empty string" do
-                    @resolve.setcode "/bin/foo"
-                    Facter::Util::Resolution.expects(:exec).once.returns ""
-                    @resolve.value.should be_nil
-                end
-            end
+        it "should return nil if the value is an empty string" do
+          @resolve.setcode "/bin/foo"
+          Facter::Util::Resolution.expects(:exec).once.returns ""
+          @resolve.value.should be_nil
         end
-
-        describe "and the code is a block" do
-            it "should warn but not fail if the code fails" do
-                @resolve.setcode { raise "feh" }
-                @resolve.expects(:warn)
-                @resolve.value.should be_nil
-            end
-
-            it "should return the value returned by the block" do
-                @resolve.setcode { "yayness" }
-                @resolve.value.should == "yayness"
-            end
-
-            it "should return nil if the value is an empty string" do
-                @resolve.setcode { "" }
-                @resolve.value.should be_nil
-            end
-
-            it "should return nil if the value is an empty block" do
-                @resolve.setcode { "" }
-                @resolve.value.should be_nil
-            end
-
-            it "should use its limit method to determine the timeout, to avoid conflict when a 'timeout' method exists for some other reason" do
-                @resolve.expects(:timeout).never
-                @resolve.expects(:limit).returns "foo"
-                Timeout.expects(:timeout).with("foo")
-
-                @resolve.setcode { sleep 2; "raise This is a test"}
-                @resolve.value
-            end
-
-            it "should timeout after the provided timeout" do
-                @resolve.expects(:warn)
-                @resolve.timeout = 0.1
-                @resolve.setcode { sleep 2; raise "This is a test" }
-                Thread.expects(:new).yields
-
-                @resolve.value.should be_nil
-            end
-
-            it "should waitall to avoid zombies if the timeout is exceeded" do
-                @resolve.stubs(:warn)
-                @resolve.timeout = 0.1
-                @resolve.setcode { sleep 2; raise "This is a test" }
-
-                Thread.expects(:new).yields
-                Process.expects(:waitall)
-
-                @resolve.value
-            end
-        end
+      end
     end
 
-    it "should return its value when converted to a string" do
-        @resolve = Facter::Util::Resolution.new("yay")
-        @resolve.expects(:value).returns "myval"
-        @resolve.to_s.should == "myval"
+    describe "and the code is a block" do
+      it "should warn but not fail if the code fails" do
+        @resolve.setcode { raise "feh" }
+        @resolve.expects(:warn)
+        @resolve.value.should be_nil
+      end
+
+      it "should return the value returned by the block" do
+        @resolve.setcode { "yayness" }
+        @resolve.value.should == "yayness"
+      end
+
+      it "should return nil if the value is an empty string" do
+        @resolve.setcode { "" }
+        @resolve.value.should be_nil
+      end
+
+      it "should return nil if the value is an empty block" do
+        @resolve.setcode { "" }
+        @resolve.value.should be_nil
+      end
+
+      it "should use its limit method to determine the timeout, to avoid conflict when a 'timeout' method exists for some other reason" do
+        @resolve.expects(:timeout).never
+        @resolve.expects(:limit).returns "foo"
+        Timeout.expects(:timeout).with("foo")
+
+        @resolve.setcode { sleep 2; "raise This is a test"}
+        @resolve.value
+      end
+
+      it "should timeout after the provided timeout" do
+        @resolve.expects(:warn)
+        @resolve.timeout = 0.1
+        @resolve.setcode { sleep 2; raise "This is a test" }
+        Thread.expects(:new).yields
+
+        @resolve.value.should be_nil
+      end
+
+      it "should waitall to avoid zombies if the timeout is exceeded" do
+        @resolve.stubs(:warn)
+        @resolve.timeout = 0.1
+        @resolve.setcode { sleep 2; raise "This is a test" }
+
+        Thread.expects(:new).yields
+        Process.expects(:waitall)
+
+        @resolve.value
+      end
+    end
+  end
+
+  it "should return its value when converted to a string" do
+    @resolve = Facter::Util::Resolution.new("yay")
+    @resolve.expects(:value).returns "myval"
+    @resolve.to_s.should == "myval"
+  end
+
+  it "should allow the adding of confines" do
+    Facter::Util::Resolution.new("yay").should respond_to(:confine)
+  end
+
+  it "should provide a method for returning the number of confines" do
+    @resolve = Facter::Util::Resolution.new("yay")
+    @resolve.confine "one" => "foo", "two" => "fee"
+    @resolve.weight.should == 2
+  end
+
+  it "should return 0 confines when no confines have been added" do
+    Facter::Util::Resolution.new("yay").weight.should == 0
+  end
+
+  it "should provide a way to set the weight" do
+    @resolve = Facter::Util::Resolution.new("yay")
+    @resolve.has_weight(45)
+    @resolve.weight.should == 45
+  end
+
+  it "should allow the weight to override the number of confines" do
+    @resolve = Facter::Util::Resolution.new("yay")
+    @resolve.confine "one" => "foo", "two" => "fee"
+    @resolve.weight.should == 2
+    @resolve.has_weight(45)
+    @resolve.weight.should == 45
+  end
+
+  it "should have a method for determining if it is suitable" do
+    Facter::Util::Resolution.new("yay").should respond_to(:suitable?)
+  end
+
+  describe "when adding confines" do
+    before do
+      @resolve = Facter::Util::Resolution.new("yay")
     end
 
-    it "should allow the adding of confines" do
-        Facter::Util::Resolution.new("yay").should respond_to(:confine)
+    it "should accept a hash of fact names and values" do
+      lambda { @resolve.confine :one => "two" }.should_not raise_error
     end
 
-    it "should provide a method for returning the number of confines" do
-        @resolve = Facter::Util::Resolution.new("yay")
-        @resolve.confine "one" => "foo", "two" => "fee"
-        @resolve.weight.should == 2
+    it "should create a Util::Confine instance for every argument in the provided hash" do
+      Facter::Util::Confine.expects(:new).with("one", "foo")
+      Facter::Util::Confine.expects(:new).with("two", "fee")
+
+      @resolve.confine "one" => "foo", "two" => "fee"
     end
 
-    it "should return 0 confines when no confines have been added" do
-        Facter::Util::Resolution.new("yay").weight.should == 0
+  end
+
+  describe "when determining suitability" do
+    before do
+      @resolve = Facter::Util::Resolution.new("yay")
     end
 
-    it "should provide a way to set the weight" do
-        @resolve = Facter::Util::Resolution.new("yay")
-        @resolve.has_weight(45)
-        @resolve.weight.should == 45
+    it "should always be suitable if no confines have been added" do
+      @resolve.should be_suitable
     end
 
-    it "should allow the weight to override the number of confines" do
-        @resolve = Facter::Util::Resolution.new("yay")
-        @resolve.confine "one" => "foo", "two" => "fee"
-        @resolve.weight.should == 2
-        @resolve.has_weight(45)
-        @resolve.weight.should == 45
+    it "should be unsuitable if any provided confines return false" do
+      confine1 = mock 'confine1', :true? => true
+      confine2 = mock 'confine2', :true? => false
+      Facter::Util::Confine.expects(:new).times(2).returns(confine1).then.returns(confine2)
+      @resolve.confine :one => :two, :three => :four
+
+      @resolve.should_not be_suitable
     end
 
-    it "should have a method for determining if it is suitable" do
-        Facter::Util::Resolution.new("yay").should respond_to(:suitable?)
+    it "should be suitable if all provided confines return true" do
+      confine1 = mock 'confine1', :true? => true
+      confine2 = mock 'confine2', :true? => true
+      Facter::Util::Confine.expects(:new).times(2).returns(confine1).then.returns(confine2)
+      @resolve.confine :one => :two, :three => :four
+
+      @resolve.should be_suitable
+    end
+  end
+
+  it "should have a class method for executing code" do
+    Facter::Util::Resolution.should respond_to(:exec)
+  end
+
+  # It's not possible, AFAICT, to mock %x{}, so I can't really test this bit.
+  describe "when executing code" do
+    it "should deprecate the interpreter parameter" do
+      Facter.expects(:warnonce).with("The interpreter parameter to 'exec' is deprecated and will be removed in a future version.")
+      Facter::Util::Resolution.exec("/something", "/bin/perl")
     end
 
-    describe "when adding confines" do
-        before do
-            @resolve = Facter::Util::Resolution.new("yay")
-        end
-
-        it "should accept a hash of fact names and values" do
-            lambda { @resolve.confine :one => "two" }.should_not raise_error
-        end
-
-        it "should create a Util::Confine instance for every argument in the provided hash" do
-            Facter::Util::Confine.expects(:new).with("one", "foo")
-            Facter::Util::Confine.expects(:new).with("two", "fee")
-
-            @resolve.confine "one" => "foo", "two" => "fee"
-        end
-
+    it "should execute the binary" do
+      Facter::Util::Resolution.exec("echo foo").should == "foo"
     end
-
-    describe "when determining suitability" do
-        before do
-            @resolve = Facter::Util::Resolution.new("yay")
-        end
-
-        it "should always be suitable if no confines have been added" do
-            @resolve.should be_suitable
-        end
-
-        it "should be unsuitable if any provided confines return false" do
-            confine1 = mock 'confine1', :true? => true
-            confine2 = mock 'confine2', :true? => false
-            Facter::Util::Confine.expects(:new).times(2).returns(confine1).then.returns(confine2)
-            @resolve.confine :one => :two, :three => :four
-
-            @resolve.should_not be_suitable
-        end
-
-        it "should be suitable if all provided confines return true" do
-            confine1 = mock 'confine1', :true? => true
-            confine2 = mock 'confine2', :true? => true
-            Facter::Util::Confine.expects(:new).times(2).returns(confine1).then.returns(confine2)
-            @resolve.confine :one => :two, :three => :four
-
-            @resolve.should be_suitable
-        end
-    end
-
-    it "should have a class method for executing code" do
-        Facter::Util::Resolution.should respond_to(:exec)
-    end
-
-    # It's not possible, AFAICT, to mock %x{}, so I can't really test this bit.
-    describe "when executing code" do
-        it "should deprecate the interpreter parameter" do
-            Facter.expects(:warnonce).with("The interpreter parameter to 'exec' is deprecated and will be removed in a future version.")
-            Facter::Util::Resolution.exec("/something", "/bin/perl")
-        end
-
-        it "should execute the binary" do
-            Facter::Util::Resolution.exec("echo foo").should == "foo"
-        end
-    end
+  end
 end

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -4,172 +4,172 @@ require 'facter/util/virtual'
 
 describe Facter::Util::Virtual do
 
-    after do
-        Facter.clear
-    end
-    it "should detect openvz" do
-        FileTest.stubs(:directory?).with("/proc/vz").returns(true)
-        Dir.stubs(:glob).with("/proc/vz/*").returns(['vzquota'])
-        Facter::Util::Virtual.should be_openvz
-    end
+  after do
+    Facter.clear
+  end
+  it "should detect openvz" do
+    FileTest.stubs(:directory?).with("/proc/vz").returns(true)
+    Dir.stubs(:glob).with("/proc/vz/*").returns(['vzquota'])
+    Facter::Util::Virtual.should be_openvz
+  end
 
-    it "should not detect openvz when /proc/lve/list is present" do
-        FileTest.stubs(:file?).with("/proc/lve/list").returns(true)
-        Facter::Util::Virtual.should_not be_openvz
-    end
+  it "should not detect openvz when /proc/lve/list is present" do
+    FileTest.stubs(:file?).with("/proc/lve/list").returns(true)
+    Facter::Util::Virtual.should_not be_openvz
+  end
 
-    it "should not detect openvz when /proc/vz/ is empty" do
-        FileTest.stubs(:file?).with("/proc/lve/list").returns(false)
-        FileTest.stubs(:directory?).with("/proc/vz").returns(true)
-        Dir.stubs(:glob).with("/proc/vz/*").returns([])
-        Facter::Util::Virtual.should_not be_openvz
-    end
+  it "should not detect openvz when /proc/vz/ is empty" do
+    FileTest.stubs(:file?).with("/proc/lve/list").returns(false)
+    FileTest.stubs(:directory?).with("/proc/vz").returns(true)
+    Dir.stubs(:glob).with("/proc/vz/*").returns([])
+    Facter::Util::Virtual.should_not be_openvz
+  end
 
-    it "should identify openvzhn when /proc/self/status has envID of 0" do
-        Facter::Util::Virtual.stubs(:openvz?).returns(true)
+  it "should identify openvzhn when /proc/self/status has envID of 0" do
+    Facter::Util::Virtual.stubs(:openvz?).returns(true)
+    FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
+    Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  0")
+    Facter::Util::Virtual.openvz_type().should == "openvzhn"
+  end
+
+  it "should identify openvzve when /proc/self/status has envID of 0" do
+    Facter::Util::Virtual.stubs(:openvz?).returns(true)
+    FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
+    Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  666")
+    Facter::Util::Virtual.openvz_type().should == "openvzve"
+  end
+
+  it "should not attempt to identify openvz when /proc/self/status has no envID" do
+    Facter::Util::Virtual.stubs(:openvz?).returns(true)
+    FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
+    Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("")
+    Facter::Util::Virtual.openvz_type().should be_nil
+  end
+
+  it "should identify Solaris zones when non-global zone" do
+    Facter::Util::Resolution.stubs(:exec).with("/sbin/zonename").returns("somezone")
+    Facter::Util::Virtual.should be_zone
+  end
+
+  it "should not identify Solaris zones when global zone" do
+    Facter::Util::Resolution.stubs(:exec).with("/sbin/zonename").returns("global")
+    Facter::Util::Virtual.should_not be_zone
+  end
+
+  it "should not detect vserver if no self status" do
+    FileTest.stubs(:exists?).with("/proc/self/status").returns(false)
+    Facter::Util::Virtual.should_not be_vserver
+  end
+
+  it "should detect vserver when vxid present in process status" do
+    FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
+    File.stubs(:read).with("/proc/self/status").returns("VxID: 42\n")
+    Facter::Util::Virtual.should be_vserver
+  end
+
+  it "should detect vserver when s_context present in process status" do
+    FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
+    File.stubs(:read).with("/proc/self/status").returns("s_context: 42\n")
+    Facter::Util::Virtual.should be_vserver
+  end
+
+  it "should not detect vserver when vserver flags not present in process status" do
+    FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
+    File.stubs(:read).with("/proc/self/status").returns("wibble: 42\n")
+    Facter::Util::Virtual.should_not be_vserver
+  end
+
+  fixture_path = File.join(SPECDIR, 'fixtures', 'virtual', 'proc_self_status')
+
+  test_cases = [
+    [File.join(fixture_path, 'vserver_2_1', 'guest'), true, 'vserver 2.1 guest'],
+    [File.join(fixture_path, 'vserver_2_1', 'host'),  true, 'vserver 2.1 host'],
+    [File.join(fixture_path, 'vserver_2_3', 'guest'), true, 'vserver 2.3 guest'],
+    [File.join(fixture_path, 'vserver_2_3', 'host'),  true, 'vserver 2.3 host']
+  ]
+
+  test_cases.each do |status_file, expected, description|
+    describe "with /proc/self/status from #{description}" do
+      it "should detect vserver as #{expected.inspect}" do
+        status = File.read(status_file)
         FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  0")
-        Facter::Util::Virtual.openvz_type().should == "openvzhn"
+        File.stubs(:read).with("/proc/self/status").returns(status)
+        Facter::Util::Virtual.vserver?.should == expected
+      end
     end
+  end
 
-    it "should identify openvzve when /proc/self/status has envID of 0" do
-        Facter::Util::Virtual.stubs(:openvz?).returns(true)
-        FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("envID:  666")
-        Facter::Util::Virtual.openvz_type().should == "openvzve"
-    end
+  it "should identify vserver_host when /proc/virtual exists" do
+    Facter::Util::Virtual.expects(:vserver?).returns(true)
+    FileTest.stubs(:exists?).with("/proc/virtual").returns(true)
+    Facter::Util::Virtual.vserver_type().should == "vserver_host"
+  end
 
-    it "should not attempt to identify openvz when /proc/self/status has no envID" do
-        Facter::Util::Virtual.stubs(:openvz?).returns(true)
-        FileTest.stubs(:exists?).with('/proc/self/status').returns(true)
-        Facter::Util::Resolution.stubs(:exec).with('grep "envID" /proc/self/status').returns("")
-        Facter::Util::Virtual.openvz_type().should be_nil
-    end
+  it "should identify vserver_type as vserver when /proc/virtual does not exist" do
+    Facter::Util::Virtual.expects(:vserver?).returns(true)
+    FileTest.stubs(:exists?).with("/proc/virtual").returns(false)
+    Facter::Util::Virtual.vserver_type().should == "vserver"
+  end
 
-    it "should identify Solaris zones when non-global zone" do
-        Facter::Util::Resolution.stubs(:exec).with("/sbin/zonename").returns("somezone")
-        Facter::Util::Virtual.should be_zone
-    end
+  it "should detect xen when /proc/sys/xen exists" do
+    FileTest.expects(:exists?).with("/proc/sys/xen").returns(true)
+    Facter::Util::Virtual.should be_xen
+  end
 
-    it "should not identify Solaris zones when global zone" do
-        Facter::Util::Resolution.stubs(:exec).with("/sbin/zonename").returns("global")
-        Facter::Util::Virtual.should_not be_zone
-    end
+  it "should detect xen when /sys/bus/xen exists" do
+    FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
+    FileTest.expects(:exists?).with("/sys/bus/xen").returns(true)
+    Facter::Util::Virtual.should be_xen
+  end
 
-    it "should not detect vserver if no self status" do
-        FileTest.stubs(:exists?).with("/proc/self/status").returns(false)
-        Facter::Util::Virtual.should_not be_vserver
-    end
+  it "should detect xen when /proc/xen exists" do
+    FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
+    FileTest.expects(:exists?).with("/sys/bus/xen").returns(false)
+    FileTest.expects(:exists?).with("/proc/xen").returns(true)
+    Facter::Util::Virtual.should be_xen
+  end
 
-    it "should detect vserver when vxid present in process status" do
-        FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-        File.stubs(:read).with("/proc/self/status").returns("VxID: 42\n")
-        Facter::Util::Virtual.should be_vserver
-    end
+  it "should not detect xen when no sysfs/proc xen directories exist" do
+    FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
+    FileTest.expects(:exists?).with("/sys/bus/xen").returns(false)
+    FileTest.expects(:exists?).with("/proc/xen").returns(false)
+    Facter::Util::Virtual.should_not be_xen
+  end
 
-    it "should detect vserver when s_context present in process status" do
-        FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-        File.stubs(:read).with("/proc/self/status").returns("s_context: 42\n")
-        Facter::Util::Virtual.should be_vserver
-    end
+  it "should detect kvm" do
+    FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(true)
+    File.stubs(:read).with("/proc/cpuinfo").returns("model name : QEMU Virtual CPU version 0.9.1\n")
+    Facter::Util::Virtual.should be_kvm
+  end
 
-    it "should not detect vserver when vserver flags not present in process status" do
-        FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-        File.stubs(:read).with("/proc/self/status").returns("wibble: 42\n")
-        Facter::Util::Virtual.should_not be_vserver
-    end
+  it "should detect kvm on FreeBSD" do
+    FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(false)
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n hw.model").returns("QEMU Virtual CPU version 0.12.4")
+    Facter::Util::Virtual.should be_kvm
+  end
 
-    fixture_path = File.join(SPECDIR, 'fixtures', 'virtual', 'proc_self_status')
+  it "should identify FreeBSD jail when in jail" do
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n security.jail.jailed").returns("1")
+    Facter::Util::Virtual.should be_jail
+  end
 
-    test_cases = [
-        [File.join(fixture_path, 'vserver_2_1', 'guest'), true, 'vserver 2.1 guest'],
-        [File.join(fixture_path, 'vserver_2_1', 'host'),  true, 'vserver 2.1 host'],
-        [File.join(fixture_path, 'vserver_2_3', 'guest'), true, 'vserver 2.3 guest'],
-        [File.join(fixture_path, 'vserver_2_3', 'host'),  true, 'vserver 2.3 host']
-    ]
+  it "should not identify GNU/kFreeBSD jail when not in jail" do
+    Facter.fact(:kernel).stubs(:value).returns("GNU/kFreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with("/bin/sysctl -n security.jail.jailed").returns("0")
+    Facter::Util::Virtual.should_not be_jail
+  end
 
-    test_cases.each do |status_file, expected, description|
-        describe "with /proc/self/status from #{description}" do
-            it "should detect vserver as #{expected.inspect}" do
-                status = File.read(status_file)
-                FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-                File.stubs(:read).with("/proc/self/status").returns(status)
-                Facter::Util::Virtual.vserver?.should == expected
-            end
-        end
-    end
+  it "should detect hpvm on HP-UX" do
+    Facter.fact(:kernel).stubs(:value).returns("HP-UX")
+    Facter::Util::Resolution.stubs(:exec).with("/usr/bin/getconf MACHINE_MODEL").returns('ia64 hp server Integrity Virtual Machine')
+    Facter::Util::Virtual.should be_hpvm
+  end
 
-    it "should identify vserver_host when /proc/virtual exists" do
-        Facter::Util::Virtual.expects(:vserver?).returns(true)
-        FileTest.stubs(:exists?).with("/proc/virtual").returns(true)
-        Facter::Util::Virtual.vserver_type().should == "vserver_host"
-    end
-
-    it "should identify vserver_type as vserver when /proc/virtual does not exist" do
-        Facter::Util::Virtual.expects(:vserver?).returns(true)
-        FileTest.stubs(:exists?).with("/proc/virtual").returns(false)
-        Facter::Util::Virtual.vserver_type().should == "vserver"
-    end
-
-    it "should detect xen when /proc/sys/xen exists" do
-        FileTest.expects(:exists?).with("/proc/sys/xen").returns(true)
-        Facter::Util::Virtual.should be_xen
-    end
-
-    it "should detect xen when /sys/bus/xen exists" do
-        FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
-        FileTest.expects(:exists?).with("/sys/bus/xen").returns(true)
-        Facter::Util::Virtual.should be_xen
-    end
-
-    it "should detect xen when /proc/xen exists" do
-        FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
-        FileTest.expects(:exists?).with("/sys/bus/xen").returns(false)
-        FileTest.expects(:exists?).with("/proc/xen").returns(true)
-        Facter::Util::Virtual.should be_xen
-    end
-
-    it "should not detect xen when no sysfs/proc xen directories exist" do
-        FileTest.expects(:exists?).with("/proc/sys/xen").returns(false)
-        FileTest.expects(:exists?).with("/sys/bus/xen").returns(false)
-        FileTest.expects(:exists?).with("/proc/xen").returns(false)
-        Facter::Util::Virtual.should_not be_xen
-    end
-
-    it "should detect kvm" do
-        FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(true)
-        File.stubs(:read).with("/proc/cpuinfo").returns("model name : QEMU Virtual CPU version 0.9.1\n")
-        Facter::Util::Virtual.should be_kvm
-    end
-
-    it "should detect kvm on FreeBSD" do
-        FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(false)
-        Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-        Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n hw.model").returns("QEMU Virtual CPU version 0.12.4")
-        Facter::Util::Virtual.should be_kvm
-    end
-
-    it "should identify FreeBSD jail when in jail" do
-        Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-        Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n security.jail.jailed").returns("1")
-        Facter::Util::Virtual.should be_jail
-    end
-
-    it "should not identify GNU/kFreeBSD jail when not in jail" do
-        Facter.fact(:kernel).stubs(:value).returns("GNU/kFreeBSD")
-        Facter::Util::Resolution.stubs(:exec).with("/bin/sysctl -n security.jail.jailed").returns("0")
-        Facter::Util::Virtual.should_not be_jail
-    end
-
-    it "should detect hpvm on HP-UX" do
-        Facter.fact(:kernel).stubs(:value).returns("HP-UX")
-        Facter::Util::Resolution.stubs(:exec).with("/usr/bin/getconf MACHINE_MODEL").returns('ia64 hp server Integrity Virtual Machine')
-        Facter::Util::Virtual.should be_hpvm
-    end
-
-    it "should not detect hpvm on HP-UX when not in hpvm" do
-        Facter.fact(:kernel).stubs(:value).returns("HP-UX")
-        Facter::Util::Resolution.stubs(:exec).with("/usr/bin/getconf MACHINE_MODEL").returns('ia64 hp server rx660')
-        Facter::Util::Virtual.should_not be_hpvm
-    end
+  it "should not detect hpvm on HP-UX when not in hpvm" do
+    Facter.fact(:kernel).stubs(:value).returns("HP-UX")
+    Facter::Util::Resolution.stubs(:exec).with("/usr/bin/getconf MACHINE_MODEL").returns('ia64 hp server rx660')
+    Facter::Util::Virtual.should_not be_hpvm
+  end
 end

--- a/spec/unit/util/vlans_spec.rb
+++ b/spec/unit/util/vlans_spec.rb
@@ -5,10 +5,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 require 'facter/util/vlans'
 
 describe Facter::Util::Vlans do
-    it "should return a list of vlans on Linux" do
-        sample_output_file = File.dirname(__FILE__) + '/../data/linux_vlan_config'
-        linux_vlanconfig = File.new(sample_output_file).read();
-        Facter::Util::Vlans.stubs(:get_vlan_config).returns(linux_vlanconfig)
-        Facter::Util::Vlans.get_vlans().should == %{400,300,200,100}
-    end
+  it "should return a list of vlans on Linux" do
+    sample_output_file = File.dirname(__FILE__) + '/../data/linux_vlan_config'
+    linux_vlanconfig = File.new(sample_output_file).read();
+    Facter::Util::Vlans.stubs(:get_vlan_config).returns(linux_vlanconfig)
+    Facter::Util::Vlans.get_vlans().should == %{400,300,200,100}
+  end
 end

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -6,302 +6,302 @@ require 'facter/util/macosx'
 
 describe "Virtual fact" do
   before do
-      Facter::Util::Virtual.stubs(:zone?).returns(false)
-      Facter::Util::Virtual.stubs(:openvz?).returns(false)
-      Facter::Util::Virtual.stubs(:vserver?).returns(false)
-      Facter::Util::Virtual.stubs(:xen?).returns(false)
-      Facter::Util::Virtual.stubs(:kvm?).returns(false)
-      Facter::Util::Virtual.stubs(:hpvm?).returns(false)
-      Facter::Util::Virtual.stubs(:zlinux?).returns(false)
+    Facter::Util::Virtual.stubs(:zone?).returns(false)
+    Facter::Util::Virtual.stubs(:openvz?).returns(false)
+    Facter::Util::Virtual.stubs(:vserver?).returns(false)
+    Facter::Util::Virtual.stubs(:xen?).returns(false)
+    Facter::Util::Virtual.stubs(:kvm?).returns(false)
+    Facter::Util::Virtual.stubs(:hpvm?).returns(false)
+    Facter::Util::Virtual.stubs(:zlinux?).returns(false)
   end
 
   it "should be zone on Solaris when a zone" do
-      Facter.fact(:kernel).stubs(:value).returns("SunOS")
-      Facter::Util::Virtual.stubs(:zone?).returns(true)
-      Facter::Util::Virtual.stubs(:vserver?).returns(false)
-      Facter::Util::Virtual.stubs(:xen?).returns(false)
-      Facter.fact(:virtual).value.should == "zone"
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    Facter::Util::Virtual.stubs(:zone?).returns(true)
+    Facter::Util::Virtual.stubs(:vserver?).returns(false)
+    Facter::Util::Virtual.stubs(:xen?).returns(false)
+    Facter.fact(:virtual).value.should == "zone"
   end
 
   it "should be jail on FreeBSD when a jail in kvm" do
-      Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Util::Virtual.stubs(:jail?).returns(true)
-      Facter::Util::Virtual.stubs(:kvm?).returns(true)
-      Facter.fact(:virtual).value.should == "jail"
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Virtual.stubs(:jail?).returns(true)
+    Facter::Util::Virtual.stubs(:kvm?).returns(true)
+    Facter.fact(:virtual).value.should == "jail"
   end
 
   it "should be hpvm on HP-UX when in HP-VM" do
-     Facter.fact(:kernel).stubs(:value).returns("HP-UX")
-     Facter::Util::Virtual.stubs(:hpvm?).returns(true)
-     Facter.fact(:virtual).value.should == "hpvm"
+   Facter.fact(:kernel).stubs(:value).returns("HP-UX")
+   Facter::Util::Virtual.stubs(:hpvm?).returns(true)
+   Facter.fact(:virtual).value.should == "hpvm"
   end
 
   it "should be zlinux on s390x" do
-     Facter.fact(:kernel).stubs(:value).returns("Linux")
-     Facter.fact(:architecture).stubs(:value).returns("s390x")
-     Facter::Util::Virtual.stubs(:zlinux?).returns(true)
-     Facter.fact(:virtual).value.should == "zlinux"
+   Facter.fact(:kernel).stubs(:value).returns("Linux")
+   Facter.fact(:architecture).stubs(:value).returns("s390x")
+   Facter::Util::Virtual.stubs(:zlinux?).returns(true)
+   Facter.fact(:virtual).value.should == "zlinux"
   end
 
   describe "on Darwin" do
-      it "should be parallels with Parallels vendor id" do
-          Facter.fact(:kernel).stubs(:value).returns("Darwin")
-          Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor-id" => "0x1ab8" })
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor id" do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor-id" => "0x1ab8" })
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be parallels with Parallels vendor name" do
-          Facter.fact(:kernel).stubs(:value).returns("Darwin")
-          Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor" => "Parallels" })
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor name" do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor" => "Parallels" })
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be vmware with VMWare vendor id" do
-          Facter.fact(:kernel).stubs(:value).returns("Darwin")
-          Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor-id" => "0x15ad" })
-          Facter.fact(:virtual).value.should == "vmware"
-      end
+    it "should be vmware with VMWare vendor id" do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor-id" => "0x15ad" })
+      Facter.fact(:virtual).value.should == "vmware"
+    end
 
-      it "should be vmware with VMWare vendor name" do
-          Facter.fact(:kernel).stubs(:value).returns("Darwin")
-          Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor" => "VMWare" })
-          Facter.fact(:virtual).value.should == "vmware"
-      end
+    it "should be vmware with VMWare vendor name" do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+      Facter::Util::Macosx.stubs(:profiler_data).returns({ "spdisplays_vendor" => "VMWare" })
+      Facter.fact(:virtual).value.should == "vmware"
+    end
   end
 
   describe "on Linux" do
 
-      before do
-        Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
-        Facter.fact(:operatingsystem).stubs(:value).returns(true)
-        # Ensure the tests don't fail on Xen
-        FileTest.stubs(:exists?).with("/proc/sys/xen").returns false
-        FileTest.stubs(:exists?).with("/sys/bus/xen").returns false
-        FileTest.stubs(:exists?).with("/proc/xen").returns false
-        Facter.fact(:architecture).stubs(:value).returns(true)
-      end
+    before do
+    Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
+    Facter.fact(:operatingsystem).stubs(:value).returns(true)
+    # Ensure the tests don't fail on Xen
+    FileTest.stubs(:exists?).with("/proc/sys/xen").returns false
+    FileTest.stubs(:exists?).with("/sys/bus/xen").returns false
+    FileTest.stubs(:exists?).with("/proc/xen").returns false
+    Facter.fact(:architecture).stubs(:value).returns(true)
+    end
 
-      it "should be parallels with Parallels vendor id from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Unknown device 1ab8:4005")
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor id from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Unknown device 1ab8:4005")
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be parallels with Parallels vendor name from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Parallels Display Adapter")
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor name from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Parallels Display Adapter")
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be vmware with VMware vendor name from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter")
-          Facter.fact(:virtual).value.should == "vmware"
-      end
+    it "should be vmware with VMware vendor name from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter")
+      Facter.fact(:virtual).value.should == "vmware"
+    end
 
-      it "should be virtualbox with VirtualBox vendor name from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter")
-          Facter.fact(:virtual).value.should == "virtualbox"
-      end
+    it "should be virtualbox with VirtualBox vendor name from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter")
+      Facter.fact(:virtual).value.should == "virtualbox"
+    end
 
-      it "should be vmware with VMWare vendor name from dmidecode" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
-          Facter.fact(:virtual).value.should == "vmware"
-      end
+    it "should be vmware with VMWare vendor name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
+      Facter.fact(:virtual).value.should == "vmware"
+    end
 
-      it "should be xenhvm with Xen HVM vendor name from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)")
-          Facter.fact(:virtual).value.should == "xenhvm"
-      end
+    it "should be xenhvm with Xen HVM vendor name from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)")
+      Facter.fact(:virtual).value.should == "xenhvm"
+    end
 
-      it "should be xenhvm with Xen HVM vendor name from dmidecode" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Xen\nProduct Name: HVM domU")
-          Facter.fact(:virtual).value.should == "xenhvm"
-      end
+    it "should be xenhvm with Xen HVM vendor name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Xen\nProduct Name: HVM domU")
+      Facter.fact(:virtual).value.should == "xenhvm"
+    end
 
-      it "should be parallels with Parallels vendor name from dmidecode" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device Information\nType: Video\nStatus: Disabled\nDescription: Parallels Video Adapter")
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device Information\nType: Video\nStatus: Disabled\nDescription: Parallels Video Adapter")
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be virtualbox with VirtualBox vendor name from dmidecode" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("BIOS Information\nVendor: innotek GmbH\nVersion: VirtualBox\n\nSystem Information\nManufacturer: innotek GmbH\nProduct Name: VirtualBox\nFamily: Virtual Machine")
-          Facter.fact(:virtual).value.should == "virtualbox"
-      end
+    it "should be virtualbox with VirtualBox vendor name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("BIOS Information\nVendor: innotek GmbH\nVersion: VirtualBox\n\nSystem Information\nManufacturer: innotek GmbH\nProduct Name: VirtualBox\nFamily: Virtual Machine")
+      Facter.fact(:virtual).value.should == "virtualbox"
+    end
 
-      it "should be hyperv with Microsoft vendor name from lspci" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA")
-          Facter.fact(:virtual).value.should == "hyperv"
-      end
+    it "should be hyperv with Microsoft vendor name from lspci" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA")
+      Facter.fact(:virtual).value.should == "hyperv"
+    end
 
-      it "should be hyperv with Microsoft vendor name from dmidecode" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Microsoft Corporation\nProduct Name: Virtual Machine")
-          Facter.fact(:virtual).value.should == "hyperv"
-      end
+    it "should be hyperv with Microsoft vendor name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Microsoft Corporation\nProduct Name: Virtual Machine")
+      Facter.fact(:virtual).value.should == "hyperv"
+    end
 
   end
   describe "on Solaris" do
-      before(:each) do
-          Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
-      end
+    before(:each) do
+      Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
+    end
 
-      it "should be vmware with VMWare vendor name from prtdiag" do
-          Facter.fact(:kernel).stubs(:value).returns("SunOS")
-          Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
-          Facter.fact(:virtual).value.should == "vmware"
-      end
+    it "should be vmware with VMWare vendor name from prtdiag" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
+      Facter.fact(:virtual).value.should == "vmware"
+    end
 
-      it "should be parallels with Parallels vendor name from prtdiag" do
-          Facter.fact(:kernel).stubs(:value).returns("SunOS")
-          Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: Parallels Virtual Platform")
-          Facter.fact(:virtual).value.should == "parallels"
-      end
+    it "should be parallels with Parallels vendor name from prtdiag" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: Parallels Virtual Platform")
+      Facter.fact(:virtual).value.should == "parallels"
+    end
 
-      it "should be virtualbox with VirtualBox vendor name from prtdiag" do
-          Facter.fact(:kernel).stubs(:value).returns("SunOS")
-          Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
-          Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: innotek GmbH VirtualBox")
-          Facter.fact(:virtual).value.should == "virtualbox"
-      end
+    it "should be virtualbox with VirtualBox vendor name from prtdiag" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: innotek GmbH VirtualBox")
+      Facter.fact(:virtual).value.should == "virtualbox"
+    end
 
-      it "should be xen0 with xen dom0 files in /proc" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
-          Facter.fact(:hardwaremodel).stubs(:value).returns("i386")
-          Facter::Util::Virtual.expects(:xen?).returns(true)
-          FileTest.expects(:exists?).with("/proc/xen/xsd_kva").returns(true)
-          Facter.fact(:virtual).value.should == "xen0"
-      end
-      
-      it "should be xenu with xen domU files in /proc" do
-          Facter.fact(:kernel).stubs(:value).returns("Linux")
-          Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
-          Facter.fact(:hardwaremodel).stubs(:value).returns("i386")
-          Facter::Util::Virtual.expects(:xen?).returns(true)
-          FileTest.expects(:exists?).with("/proc/xen/xsd_kva").returns(false)
-          FileTest.expects(:exists?).with("/proc/xen/capabilities").returns(true)
-          Facter.fact(:virtual).value.should == "xenu"
-      end
+    it "should be xen0 with xen dom0 files in /proc" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
+      Facter.fact(:hardwaremodel).stubs(:value).returns("i386")
+      Facter::Util::Virtual.expects(:xen?).returns(true)
+      FileTest.expects(:exists?).with("/proc/xen/xsd_kva").returns(true)
+      Facter.fact(:virtual).value.should == "xen0"
+    end
+    
+    it "should be xenu with xen domU files in /proc" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
+      Facter.fact(:hardwaremodel).stubs(:value).returns("i386")
+      Facter::Util::Virtual.expects(:xen?).returns(true)
+      FileTest.expects(:exists?).with("/proc/xen/xsd_kva").returns(false)
+      FileTest.expects(:exists?).with("/proc/xen/capabilities").returns(true)
+      Facter.fact(:virtual).value.should == "xenu"
+    end
   end
 end
 
 describe "is_virtual fact" do
 
-    it "should be virtual when running on xen" do
-       Facter.fact(:kernel).stubs(:value).returns("Linux")
-       Facter.fact(:virtual).stubs(:value).returns("xenu")
-       Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be virtual when running on xen" do
+     Facter.fact(:kernel).stubs(:value).returns("Linux")
+     Facter.fact(:virtual).stubs(:value).returns("xenu")
+     Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be false when running on xen0" do
-       Facter.fact(:kernel).stubs(:value).returns("Linux")
-       Facter.fact(:virtual).stubs(:value).returns("xen0")
-       Facter.fact(:is_virtual).value.should == "false"
-    end
+  it "should be false when running on xen0" do
+     Facter.fact(:kernel).stubs(:value).returns("Linux")
+     Facter.fact(:virtual).stubs(:value).returns("xen0")
+     Facter.fact(:is_virtual).value.should == "false"
+  end
 
-    it "should be true when running on xenhvm" do
-       Facter.fact(:kernel).stubs(:value).returns("Linux")
-       Facter.fact(:virtual).stubs(:value).returns("xenhvm")
-       Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on xenhvm" do
+     Facter.fact(:kernel).stubs(:value).returns("Linux")
+     Facter.fact(:virtual).stubs(:value).returns("xenhvm")
+     Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be false when running on physical" do
-       Facter.fact(:kernel).stubs(:value).returns("Linux")
-       Facter.fact(:virtual).stubs(:value).returns("physical")
-       Facter.fact(:is_virtual).value.should == "false"
-    end
+  it "should be false when running on physical" do
+     Facter.fact(:kernel).stubs(:value).returns("Linux")
+     Facter.fact(:virtual).stubs(:value).returns("physical")
+     Facter.fact(:is_virtual).value.should == "false"
+  end
 
-    it "should be true when running on vmware" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("vmware")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on vmware" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("vmware")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on virtualbox" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("virtualbox")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on virtualbox" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("virtualbox")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on openvzve" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("openvzve")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on openvzve" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("openvzve")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on kvm" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("kvm")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on kvm" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("kvm")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running in jail" do
-        Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-        Facter.fact(:virtual).stubs(:value).returns("jail")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running in jail" do
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter.fact(:virtual).stubs(:value).returns("jail")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running in zone" do
-        Facter.fact(:kernel).stubs(:value).returns("SunOS")
-        Facter.fact(:virtual).stubs(:value).returns("zone")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running in zone" do
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    Facter.fact(:virtual).stubs(:value).returns("zone")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on hp-vm" do
-        Facter.fact(:kernel).stubs(:value).returns("HP-UX")
-        Facter.fact(:virtual).stubs(:value).returns("hpvm")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on hp-vm" do
+    Facter.fact(:kernel).stubs(:value).returns("HP-UX")
+    Facter.fact(:virtual).stubs(:value).returns("hpvm")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on S390" do
-        Facter.fact(:architecture).stubs(:value).returns("s390x")
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("zlinux")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on S390" do
+    Facter.fact(:architecture).stubs(:value).returns("s390x")
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("zlinux")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be true when running on parallels" do
-        Facter.fact(:kernel).stubs(:value).returns("Darwin")
-        Facter.fact(:virtual).stubs(:value).returns("parallels")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on parallels" do
+    Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    Facter.fact(:virtual).stubs(:value).returns("parallels")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 
-    it "should be false on vmware_server" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("vmware_server")
-        Facter.fact(:is_virtual).value.should == "false"
-    end
+  it "should be false on vmware_server" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("vmware_server")
+    Facter.fact(:is_virtual).value.should == "false"
+  end
 
-    it "should be false on openvz host nodes" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("openvzhn")
-        Facter.fact(:is_virtual).value.should == "false"
-    end
+  it "should be false on openvz host nodes" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("openvzhn")
+    Facter.fact(:is_virtual).value.should == "false"
+  end
 
-    it "should be true when running on hyperv" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.fact(:virtual).stubs(:value).returns("hyperv")
-        Facter.fact(:is_virtual).value.should == "true"
-    end
+  it "should be true when running on hyperv" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("hyperv")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
 end


### PR DESCRIPTION
(#9555) Spec tests: Change all cases of tabs and 4 space indentation to 2 space indentation.

Since 2 space indentation seems to be Puppets (and the ruby communities)
standard this patch converts all incorrect indentation to 2 spaces.

The fact that we were mixing the indentation was causing people to mix them
within files - sometimes using 4 space, sometimes 2 space. This single change
makes it consistent across all the code.

This commit fixes any whitespace cleanups for the spec tests missed in the last commit.