### PR TITLE
(#9904) Remove windows rspec warning.

### DIFF
--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -107,7 +107,7 @@ describe Facter::Util::Resolution do
     describe "and the code is a string" do
       describe "on windows" do
         before do
-          Facter::Util::Resolution::WINDOWS = true
+          Facter::Util::Config.stubs(:is_windows?).returns(true)
         end
 
         it "should return the result of executing the code" do
@@ -126,7 +126,7 @@ describe Facter::Util::Resolution do
 
       describe "on non-windows systems" do
         before do
-          Facter::Util::Resolution::WINDOWS = false
+          Facter::Util::Config.stubs(:is_windows?).returns(false)
         end
 
         it "should return the result of executing the code" do


### PR DESCRIPTION
There was an old reference to a constant that is no longer used
in facter. This was being used to mock windows. I have changed this
now to mock the newer is_windows function in Config, thereby removing
a long standing warning message that occurs when running rspec.
