### PR TITLE
Ticket/9928 rspec warning ruby 1.9.2

### DIFF
--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -207,7 +207,7 @@ describe "Processor facts" do
       File.stubs(:exists?).with('/sys/devices/system/cpu').returns(true)
       ## sysfs method is only used if cpuinfo method returned no processors
       File.stubs(:exists?).with("/proc/cpuinfo").returns(true)
-      File.stubs(:readlines).with("/proc/cpuinfo").returns("")
+      File.stubs(:readlines).with("/proc/cpuinfo").returns([])
       Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu[0-9]*").returns(%w{
         /sys/devices/system/cpu/cpu0
         /sys/devices/system/cpu/cpu1
@@ -221,7 +221,7 @@ describe "Processor facts" do
       File.stubs(:exists?).with('/sys/devices/system/cpu').returns(true)
       ## sysfs method is only used if cpuinfo method returned no processors
       File.stubs(:exists?).with("/proc/cpuinfo").returns(true)
-      File.stubs(:readlines).with("/proc/cpuinfo").returns("")
+      File.stubs(:readlines).with("/proc/cpuinfo").returns([])
       Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu[0-9]*").returns(%w{
         /sys/devices/system/cpu/cpu0
         /sys/devices/system/cpu/cpu1


### PR DESCRIPTION
(#9928) Correct readlines stubbing to return an array instead of an empty string.

We were getting warnings in Ruby-1.9.2 trying to call 'each' on a string. The
mistake here was to return an emptry string instead of an empty array for the
/proc/cpuinfo readlines call.
