### PR TITLE
Try to get VirtualBox info without dmidecode

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -61,6 +61,13 @@ module Facter::Util::Virtual
      (txt =~ /QEMU Virtual CPU/) ? true : false
   end
 
+  def self.virtualbox?
+    txt = if FileTest.exists?("/sys/devices/virtual/dmi/id/product_name")
+            File.read("/sys/devices/virtual/dmi/id/product_name")
+          end
+    (txt =~ /VirtualBox/) ? true : false
+  end
+
   def self.kvm_type
     # TODO Tell the difference between kvm and qemu
     # Can't work out a way to do this at the moment that doesn't

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -80,6 +80,10 @@ Facter.add("virtual") do
       end
     end
 
+    if Facter::Util::Virtual.virtualbox?
+      result = "virtualbox"
+    end
+
     if Facter::Util::Virtual.kvm?
       result = Facter::Util::Virtual.kvm_type()
     end


### PR DESCRIPTION
I found that the virtual fact said "physical" on my virtualbox machine because I had a minimal install.
This fix reads from /sys/devices/virtual/dmi/id/product_name and gets the value VirtualBox.

I'm sure it works on several other hypervisors but virtualbox is all I have to test on so I'm leaving it at that.
