### PR TITLE
Parallels Server Bare Metal support for Facter (#10233)

### DIFF
--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -12,5 +12,5 @@
 
 Facter.add(:hardwareisa) do
   setcode 'uname -p'
-  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD DragonFly OEL OracleLinux OVS GNU/kFreeBSD}
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific PSBM SLC SuSE SLES Debian Ubuntu Gentoo FreeBSD OpenBSD NetBSD DragonFly OEL OracleLinux OVS GNU/kFreeBSD}
 end

--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -15,7 +15,7 @@
 require 'facter'
 
 Facter.add("lsbmajdistrelease") do
-  confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo OEL OracleLinux OVS GNU/kFreeBSD}
+  confine :operatingsystem => %w{Linux Fedora RedHat CentOS Scientific PSBM SLC SuSE SLES Debian Ubuntu Gentoo OEL OracleLinux OVS GNU/kFreeBSD}
   setcode do
     if /(\d*)\./i =~ Facter.value(:lsbdistrelease)
       result=$1

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -10,7 +10,7 @@
 require 'facter/util/macaddress'
 
 Facter.add(:macaddress) do
-  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Gentoo Ubuntu OEL OracleLinux OVS GNU/kFreeBSD}
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific PSBM SLC SuSE SLES Debian Gentoo Ubuntu OEL OracleLinux OVS GNU/kFreeBSD}
   setcode do
     ether = []
     output = Facter::Util::Resolution.exec("/sbin/ifconfig -a")

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -59,6 +59,8 @@ Facter.add(:operatingsystem) do
         "Scientific"
       elsif txt =~ /^cloudlinux/i
         "CloudLinux"
+      elsif txt =~ /^Parallels Server Bare Metal/i
+        "PSBM"
       else
         "RedHat"
       end

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -18,10 +18,10 @@
 #
 
 Facter.add(:operatingsystemrelease) do
-  confine :operatingsystem => %w{CentOS Fedora oel ovs OracleLinux RedHat MeeGo Scientific SLC CloudLinux}
+  confine :operatingsystem => %w{CentOS Fedora oel ovs OracleLinux RedHat MeeGo Scientific SLC CloudLinux PSBM}
   setcode do
     case Facter.value(:operatingsystem)
-    when "CentOS", "RedHat", "Scientific", "SLC", "CloudLinux"
+    when "CentOS", "RedHat", "Scientific", "SLC", "CloudLinux", "PSBM"
       releasefile = "/etc/redhat-release"
     when "Fedora"
       releasefile = "/etc/fedora-release"

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -16,7 +16,7 @@ Facter.add(:osfamily) do
 
   setcode do
     case Facter.value(:operatingsystem)
-    when "RedHat", "Fedora", "CentOS", "Scientific", "SLC", "CloudLinux", "OracleLinux", "OVS", "OEL"
+    when "RedHat", "Fedora", "CentOS", "Scientific", "SLC", "CloudLinux", "PSBM", "OracleLinux", "OVS", "OEL"
       "RedHat"
     when "Ubuntu", "Debian"
       "Debian"

--- a/lib/facter/uniqueid.rb
+++ b/lib/facter/uniqueid.rb
@@ -1,4 +1,4 @@
 Facter.add(:uniqueid) do
   setcode 'hostid'
-  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OracleLinux OVS GNU/kFreeBSD}
+  confine :operatingsystem => %w{Solaris Linux Fedora RedHat CentOS Scientific PSBM SLC SuSE SLES Debian Ubuntu Gentoo AIX OEL OracleLinux OVS GNU/kFreeBSD}
 end


### PR DESCRIPTION
I've created a patch so that Facter can identify Parallels Server Bare Metal servers. PSBM is a RHEL-based distro made for web hosting companies and includes virtualization built in.

This is in response to my Redmine ticket #10233
https://projects.puppetlabs.com/issues/10233
