### PR TITLE
(#7038) Validate prtdiag output in manufacturer

### DIFF
--- a/lib/facter/util/manufacturer.rb
+++ b/lib/facter/util/manufacturer.rb
@@ -63,11 +63,10 @@ module Facter::Manufacturer
 
   def self.prtdiag_sparc_find_system_info()
     # Parses prtdiag for a SPARC architecture string, won't work with Solaris x86
-    output = Facter::Util::Resolution.exec('/usr/sbin/prtdiag')
+    output = Facter::Util::Resolution.exec('/usr/sbin/prtdiag 2>/dev/null')
 
     # System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server
-    sysconfig = output.split("\n")[0]
-    if sysconfig =~ /^System Configuration:\s+(.+?)\s+(sun\d+\S+)\s+(.+)/ then
+    if output and output =~ /^System Configuration:\s+(.+?)\s+(sun\d+\S+)\s+(.+)/
       Facter.add('manufacturer') do
         setcode do
           $1

--- a/spec/fixtures/unit/util/manufacturer/solaris_sunfire_v120_prtdiag
+++ b/spec/fixtures/unit/util/manufacturer/solaris_sunfire_v120_prtdiag
@@ -1,0 +1,33 @@
+System Configuration:  Sun Microsystems  sun4u Sun Fire V120 (UltraSPARC-IIe 648MHz)
+System clock frequency: 100 MHz
+Memory size: 2048 Megabytes
+
+========================= CPUs =========================
+
+                    Run   Ecache   CPU    CPU
+Brd  CPU   Module   MHz     MB    Impl.   Mask
+---  ---  -------  -----  ------  ------  ----
+ 0     0     0      648     0.5   13       3.3
+
+
+========================= IO Cards =========================
+
+     Bus#  Freq
+Brd  Type  MHz   Slot  Name                              Model
+---  ----  ----  ----  --------------------------------  ----------------------
+ 0   PCI-1  33    12   ebus                                                    
+ 0   PCI-1  33     3   pmu-pci10b9,7101                                        
+ 0   PCI-1  33     3   lomp                                                    
+ 0   PCI-1  33     7   isa                                                     
+ 0   PCI-1  33    12   network-pci108e,1101              SUNW,pci-eri          
+ 0   PCI-1  33    12   usb-pci108e,1103.1                                      
+ 0   PCI-1  33    13   ide-pci10b9,5229                                        
+ 0   PCI-1  33     5   network-pci108e,1101              SUNW,pci-eri          
+ 0   PCI-1  33     5   usb-pci108e,1103.1                                      
+ 0   PCI-2  33     8   scsi-glm                          Symbios,53C896        
+ 0   PCI-2  33     8   scsi-glm                          Symbios,53C896        
+ 0   PCI-2  33     5   network-pci108e,2bad              SUNW,pci-gem          
+
+
+No failures found in System
+===========================

--- a/spec/fixtures/unit/util/manufacturer/solaris_t5220_prtdiag
+++ b/spec/fixtures/unit/util/manufacturer/solaris_t5220_prtdiag
@@ -1,0 +1,136 @@
+System Configuration:  Sun Microsystems  sun4v SPARC Enterprise T5220
+Memory size: 32640 Megabytes
+
+================================ Virtual CPUs ================================
+
+
+CPU ID Frequency Implementation         Status
+------ --------- ---------------------- -------
+0      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+1      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+2      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+3      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+4      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+5      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+6      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+7      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+8      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+9      1165 MHz  SUNW,UltraSPARC-T2     on-line  
+10     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+11     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+12     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+13     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+14     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+15     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+16     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+17     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+18     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+19     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+20     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+21     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+22     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+23     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+24     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+25     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+26     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+27     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+28     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+29     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+30     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+31     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+32     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+33     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+34     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+35     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+36     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+37     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+38     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+39     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+40     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+41     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+42     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+43     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+44     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+45     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+46     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+47     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+48     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+49     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+50     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+51     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+52     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+53     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+54     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+55     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+56     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+57     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+58     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+59     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+60     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+61     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+62     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+63     1165 MHz  SUNW,UltraSPARC-T2     on-line  
+
+======================= Physical Memory Configuration ========================
+Segment Table:
+--------------------------------------------------------------
+Base           Segment  Interleave  Bank     Contains
+Address        Size     Factor      Size     Modules
+--------------------------------------------------------------
+0x0            32 GB    8           4 GB     MB/CMP0/BR0/CH0/D0
+                                             MB/CMP0/BR0/CH1/D0
+                                    4 GB     MB/CMP0/BR0/CH0/D1
+                                             MB/CMP0/BR0/CH1/D1
+                                    4 GB     MB/CMP0/BR1/CH0/D0
+                                             MB/CMP0/BR1/CH1/D0
+                                    4 GB     MB/CMP0/BR1/CH0/D1
+                                             MB/CMP0/BR1/CH1/D1
+                                    4 GB     MB/CMP0/BR2/CH0/D0
+                                             MB/CMP0/BR2/CH1/D0
+                                    4 GB     MB/CMP0/BR2/CH0/D1
+                                             MB/CMP0/BR2/CH1/D1
+                                    4 GB     MB/CMP0/BR3/CH0/D0
+                                             MB/CMP0/BR3/CH1/D0
+                                    4 GB     MB/CMP0/BR3/CH0/D1
+                                             MB/CMP0/BR3/CH1/D1
+
+
+================================ IO Devices ================================
+Slot +            Bus   Name +                            Model   
+Status            Type  Path                                      
+----------------------------------------------------------------------------
+MB/NET0           PCIE  network-pciex8086,105e                    
+                        /pci@0/pci@0/pci@1/pci@0/pci@2/network@0    
+MB/NET1           PCIE  network-pciex8086,105e                    
+                        /pci@0/pci@0/pci@1/pci@0/pci@2/network@0,1  
+MB/NET2           PCIE  network-pciex8086,105e                    
+                        /pci@0/pci@0/pci@1/pci@0/pci@3/network@0    
+MB/NET3           PCIE  network-pciex8086,105e                    
+                        /pci@0/pci@0/pci@1/pci@0/pci@3/network@0,1  
+MB/SASHBA         PCIE  scsi-pciex1000,58                 LSI,1068E
+                        /pci@0/pci@0/pci@2/scsi@0                   
+MB                PCIX  usb-pciclass,0c0310                       
+                        /pci@0/pci@0/pci@1/pci@0/pci@1/pci@0/usb@0  
+MB                PCIX  usb-pciclass,0c0310                       
+                        /pci@0/pci@0/pci@1/pci@0/pci@1/pci@0/usb@0,1
+MB                PCIX  usb-pciclass,0c0320                       
+                        /pci@0/pci@0/pci@1/pci@0/pci@1/pci@0/usb@0,2
+
+============================ Environmental Status ============================
+Fan sensors:
+All fan sensors are OK.
+
+Temperature sensors:
+All temperature sensors are OK.
+
+Current sensors:
+All current sensors are OK.
+
+Voltage sensors:
+All voltage sensors are OK.
+
+Voltage indicators:
+All voltage indicators are OK.
+
+============================ FRU Status ============================
+All FRUs are enabled.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@ dir = File.expand_path(File.dirname(__FILE__))
 
 SPECDIR = dir
 
+def fixture_data(file)
+  File.read(File.join(SPECDIR, "fixtures", file))
+end
+
+
 $LOAD_PATH.unshift("#{dir}/")
 $LOAD_PATH.unshift("#{dir}/../lib")
 

--- a/spec/unit/util/manufacturer_spec.rb
+++ b/spec/unit/util/manufacturer_spec.rb
@@ -16,11 +16,25 @@ describe Facter::Manufacturer do
     Facter::Manufacturer.get_dmi_table().should be_nil
   end
 
-  it "should parse prtdiag output" do
-    Facter::Util::Resolution.stubs(:exec).returns("System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server")
+  it "should parse prtdiag output on a sunfire v120" do
+    Facter::Util::Resolution.stubs(:exec).returns(fixture_data(File.join("unit", "util", "manufacturer", "solaris_sunfire_v120_prtdiag")))
     Facter::Manufacturer.prtdiag_sparc_find_system_info()
     Facter.value(:manufacturer).should == "Sun Microsystems"
-    Facter.value(:productname).should == "Sun SPARC Enterprise M3000 Server"
+    Facter.value(:productname).should == "Sun Fire V120 (UltraSPARC-IIe 648MHz)"
+  end
+
+  it "should parse prtdiag output on a t5220" do
+    Facter::Util::Resolution.stubs(:exec).returns(fixture_data(File.join("unit", "util", "manufacturer", "solaris_t5220_prtdiag")))
+    Facter::Manufacturer.prtdiag_sparc_find_system_info()
+    Facter.value(:manufacturer).should == "Sun Microsystems"
+    Facter.value(:productname).should == "SPARC Enterprise T5220"
+  end
+
+  it "should not set manufacturer or productname if prtdiag output is nil" do
+    Facter::Util::Resolution.stubs(:exec).returns(nil)
+    Facter::Manufacturer.prtdiag_sparc_find_system_info()
+    Facter.value(:manufacturer).should be_nil
+    Facter.value(:productname).should be_nil
   end
 
   it "should strip white space on dmi output with spaces" do


### PR DESCRIPTION
prtdiag cannot be run inside zones, and calling
Facter::Util::Resolution.exec on it will return nil. The manufacturer
utility was calling split() on nil, which was raising an exception.
Added validation of prtdiag output, and simplified the regex to extract
values for facts. Added more coverage for the related facts as well.
