### PR TITLE
(#10251) Creating RC tarballs should be handled by rake.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ require 'rake/packagetask'
 require 'rake/gempackagetask'
 
 module Facter
-  FACTERVERSION = File.read('lib/facter.rb')[/FACTERVERSION *= *'(.*)'/,1] or fail "Couldn't find FACTERVERSION"
+  FACTERVERSION = `git describe`.strip
 end
 
 FILES = FileList[


### PR DESCRIPTION
Previously generating tarballs for rc's required a lot of manual
intervention.  This fix corrects the versioning scheme so that
everything is handled automatically via the rake task.
