### PR TITLE
Ticket/10395 fix manufacturer test on windows

### DIFF
--- a/spec/unit/util/manufacturer_spec.rb
+++ b/spec/unit/util/manufacturer_spec.rb
@@ -31,6 +31,9 @@ describe Facter::Manufacturer do
   end
 
   it "should not set manufacturer or productname if prtdiag output is nil" do
+    # Stub kernel so we don't have windows fall through to its own mechanism
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+
     Facter::Util::Resolution.stubs(:exec).returns(nil)
     Facter::Manufacturer.prtdiag_sparc_find_system_info()
     Facter.value(:manufacturer).should be_nil


### PR DESCRIPTION
Commit b2a66a97eb518c5d6207353c18ce6056e9715995 brought in changes to
test for prtdiag returning nothing.

Because the fact returns nothing though, on windows the tests fall back
to use Windows own mechanism for detection therefore causing the test
assertion to fail. It should be nil, but instead its return a real
manufacturer value.

To stop it from falling back to the windows mechanism, I'm simply moching
the kernel fact to be 'SunOS' instead.
