### PR TITLE
Ticket #10444 - Add motherboard identification to Facter

### DIFF
--- a/lib/facter/manufacturer.rb
+++ b/lib/facter/manufacturer.rb
@@ -42,6 +42,11 @@ elsif Facter.value(:kernel) == "windows"
   Facter::Manufacturer.win32_find_system_info(win32_keys)
 else
   query = {
+    '[Bb]ase [Bb]oard [Ii]nformation' => [
+      { 'Manufacturer:'    => 'boardmanufacturer' },
+      { 'Product(?: Name)?:' => 'boardproductname' },
+      { 'Serial Number:'   => 'boardserialnumber' }
+    ],
     '[Ss]ystem [Ii]nformation' => [
       { 'Manufacturer:'    => 'manufacturer' },
       { 'Product(?: Name)?:' => 'productname' },


### PR DESCRIPTION
This patch adds "boardmanufacturer", "boardproductname", and "boardserialnumber" facts where applicable, to supplement the information already provided by manufacturer.rb
