### PR TITLE
Ticket/1.6.x/10490

### DIFF
--- a/lib/facter/util/macaddress.rb
+++ b/lib/facter/util/macaddress.rb
@@ -3,6 +3,7 @@
 module Facter::Util::Macaddress
 
   def self.standardize(macaddress)
+    return nil unless macaddress
     macaddress.split(":").map{|x| "0#{x}"[-2..-1]}.join(":")
   end
 

--- a/spec/fixtures/ifconfig/linux_ifconfig_no_mac
+++ b/spec/fixtures/ifconfig/linux_ifconfig_no_mac
@@ -1,0 +1,8 @@
+lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0 
+          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
+

--- a/spec/fixtures/ifconfig/linux_ifconfig_venet
+++ b/spec/fixtures/ifconfig/linux_ifconfig_venet
@@ -1,0 +1,24 @@
+lo        Link encap:Local Loopback
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+          RX packets:334 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:334 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:16700 (16.7 KB)  TX bytes:16700 (16.7 KB)
+
+venet0    Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+          inet addr:127.0.0.1  P-t-P:127.0.0.1  Bcast:0.0.0.0  Mask:255.255.255.255
+          UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1
+          RX packets:7622207 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:8183436 errors:0 dropped:1 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:2102750761 (2.1 GB)  TX bytes:2795213667 (2.7 GB)
+
+venet0:0  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+          inet addr:XXX.XXX.XXX.XX1  P-t-P:XXX.XXX.XXX.XX1  Bcast:0.0.0.0  Mask:255.255.255.255
+          UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1
+
+venet0:1  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+          inet addr:XXX.XXX.XXX.XX2  P-t-P:XXX.XXX.XXX.XX2  Bcast:0.0.0.0  Mask:255.255.255.255
+          UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -120,7 +120,9 @@ describe Facter do
 
   # #33 Make sure we only get one mac address
   it "should only return one mac address" do
-    Facter.value(:macaddress).should_not be_include(" ")
+    if macaddress = Facter.value(:macaddress)
+      macaddress.should_not be_include(" ")
+    end
   end
 
   it "should have a method for registering directories to search" do

--- a/spec/unit/macaddress_spec.rb
+++ b/spec/unit/macaddress_spec.rb
@@ -18,21 +18,45 @@ describe "macaddress fact" do
     Facter::Util::Config.stubs(:is_windows?).returns(false)
   end
 
-  it "should return macaddress information for Linux" do
-    Facter.fact(:kernel).stubs(:value).returns("Linux")
-    Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
-    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
-      returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces'))
+  describe "when run on Linux" do
+    before :each do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
+    end
 
-    Facter.value(:macaddress).should == "00:12:3f:be:22:01"
+    it "should return the macaddress of the first interface" do
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
+        returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces'))
+
+      Facter.value(:macaddress).should == "00:12:3f:be:22:01"
+    end
+
+    it "should return nil when no macaddress can be found" do
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
+        returns(ifconfig_fixture('linux_ifconfig_no_mac'))
+
+      proc { Facter.value(:macaddress) }.should_not raise_error
+      Facter.value(:macaddress).should be_nil
+    end
+
+    # some interfaces dont have a real mac addresses (like venet inside a container)
+    it "should return nil when no interface has a real macaddress" do
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
+        returns(ifconfig_fixture('linux_ifconfig_venet'))
+
+      proc { Facter.value(:macaddress) }.should_not raise_error
+      Facter.value(:macaddress).should be_nil
+    end
   end
 
-  it "should return macaddress information for BSD" do
-    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig').
-      returns(ifconfig_fixture('bsd_ifconfig_all_with_multiple_interfaces'))
+  describe "when run on BSD" do
+    it "should return macaddress information" do
+      Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig').
+        returns(ifconfig_fixture('bsd_ifconfig_all_with_multiple_interfaces'))
 
-    Facter.value(:macaddress).should == "00:0b:db:93:09:67"
+      Facter.value(:macaddress).should == "00:0b:db:93:09:67"
+    end
   end
 
 end

--- a/spec/unit/util/macaddress_spec.rb
+++ b/spec/unit/util/macaddress_spec.rb
@@ -8,9 +8,14 @@ describe "standardized MAC address" do
   it "should have zeroes added if missing" do
     Facter::Util::Macaddress::standardize("0:ab:cd:e:12:3").should == "00:ab:cd:0e:12:03"
   end
-  
+
   it "should be identical if each octet already has two digits" do
     Facter::Util::Macaddress::standardize("00:ab:cd:0e:12:03").should == "00:ab:cd:0e:12:03"
+  end
+
+  it "should be nil if input is nil" do
+    proc { result = Facter::Util::Macaddress.standardize(nil) }.should_not raise_error
+    Facter::Util::Macaddress.standardize(nil).should be_nil
   end
 end
 


### PR DESCRIPTION
If we do not find a macaddress when running ifconfig -a (case is
described in #10490 and is reproduceable if you deconfigure all
interfaces despite lo0) we get the error:

```
Could not retrieve macaddress: private method split' called for
nil:NilClass
```

Return nil as a macaddress if no macaddress can be found. The same
behaviour is already used for macaddresses on windows.
