### PR TITLE
Ticket #10238 - Add support for identifying block devices

### DIFF
--- a/lib/facter/blockdevices.rb
+++ b/lib/facter/blockdevices.rb
@@ -1,0 +1,105 @@
+# Fact: blockdevice_<devicename>_size
+#
+# Purpose:
+#   Return the size of a block device in bytes
+#
+# Resolution:
+#   Parse the contents of /sys/block/<device>/size to receive the size (multiplying by 512 to correct for blocks-to-bytes)
+#
+# Caveats:
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#
+
+# Fact: blockdevice_<devicename>_vendor
+#
+# Purpose:
+#   Return the vendor name of block devices attached to the system
+#
+# Resolution:
+#   Parse the contents of /sys/block/<device>/device/vendor to retrieve the vendor for a device
+#
+# Caveats:
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#
+
+# Fact: blockdevice_<devicename>_model
+#
+# Purpose:
+#   Return the model name of block devices attached to the system
+#
+# Resolution:
+#   Parse the contents of /sys/block/<device>/device/model to retrieve the model name/number for a device
+#
+# Caveats:
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#
+
+
+# Fact: blockdevices
+#
+# Purpose:
+#   Return a comma seperated list of block devices
+#
+# Resolution:
+#   Retrieve the block devices that were identified and iterated over in the creation of the blockdevice_ facts
+#
+# Caveats:
+#   Block devices must have been identified using sysfs information
+#
+
+# Author: Jason Gill <jasongill@gmail.com>
+
+require 'facter'
+
+# Only Linux 2.6+ kernels support sysfs which is required to easily get device details
+if Facter.value(:kernel) == 'Linux'
+
+  sysfs_block_directory = '/sys/block/'
+
+  blockdevices = []
+
+  # This should prevent any non-2.6 kernels or odd machines without sysfs support from being investigated further  
+  if File.exist?(sysfs_block_directory)
+
+    # Iterate over each file in the /sys/block/ directory and skip ones that do not have a device subdirectory  
+    Dir.entries(sysfs_block_directory).each do |device|
+      sysfs_device_directory = sysfs_block_directory + device + "/device"
+      next unless File.exist?(sysfs_device_directory)
+
+      # Add the device to the blockdevices list, which is returned as it's own fact later on            
+      blockdevices << device
+
+      sizefile = sysfs_block_directory + device + "/size"
+      vendorfile = sysfs_device_directory + "/vendor"
+      modelfile = sysfs_device_directory + "/model"
+
+      if File.exist?(sizefile) 
+        Facter.add("blockdevice_#{device}_size".to_sym) do
+          setcode { IO.read(sizefile).strip.to_i * 512 }
+        end
+      end
+
+      if File.exist?(vendorfile)
+        Facter.add("blockdevice_#{device}_vendor".to_sym) do
+          setcode { IO.read(vendorfile).strip }
+        end
+      end
+
+      if File.exist?(modelfile)
+        Facter.add("blockdevice_#{device}_model".to_sym) do
+          setcode { IO.read(modelfile).strip }
+        end
+      end
+
+    end
+
+  end
+
+  # Return a comma-seperated list of block devices found
+  unless blockdevices.empty?
+    Facter.add(:blockdevices) do
+      setcode { blockdevices.sort.join(',') }
+    end 
+  end
+
+end

--- a/spec/unit/blockdevices_spec.rb
+++ b/spec/unit/blockdevices_spec.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+require 'facter'
+
+describe "Block device facts" do
+
+  describe "on non-Linux OS" do
+
+    it "should not exist when kernel isn't Linux" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      Facter.fact(:blockdevices).should == nil
+    end
+
+  end
+
+  describe "on Linux" do
+
+    describe "with /sys/block/" do
+
+      describe "with valid entries" do
+        before :each do
+          Facter.fact(:kernel).stubs(:value).returns("Linux")
+          File.stubs(:exist?).with('/sys/block/').returns(true)
+
+          Dir.stubs(:entries).with("/sys/block/").returns([".", "..", "hda", "sda", "sdb"])
+
+          File.stubs(:exist?).with("/sys/block/./device").returns(false)
+          File.stubs(:exist?).with("/sys/block/../device").returns(false)
+
+          stubdevices = [
+            #device,    size,               vendor,     model
+            ["hda"],
+            ["sda",     "976773168",        "ATA",      "WDC WD5000AAKS-0"],
+            ["sdb",     "8787591168",       "DELL",     "PERC H700"]
+          ]
+
+          stubdevices.each do |device, size, vendor, model|
+            stubdir = "/sys/block/#{device}"
+            File.stubs(:exist?).with(stubdir + "/device").returns(true)
+            File.stubs(:exist?).with(stubdir + "/size").returns(size ? true : false)
+            File.stubs(:exist?).with(stubdir + "/device/model").returns(model ? true : false)
+            File.stubs(:exist?).with(stubdir + "/device/vendor").returns(vendor ? true : false)
+            IO.stubs(:read).with(stubdir + "/size").returns(size) if size
+            IO.stubs(:read).with(stubdir + "/device/vendor").returns(vendor) if vendor
+            IO.stubs(:read).with(stubdir + "/device/model").returns(model) if model
+          end
+        end
+
+        it "should report three block devices, hda, sda, and sdb, with accurate information from sda and sdb, and without invalid . or .. entries" do
+          Facter.fact(:blockdevices).value.should == "hda,sda,sdb"
+
+          # handle facts that should not exist
+          %w{ . .. hda }.each do |device|
+            Facter.fact("blockdevice_#{device}_size".to_sym).should == nil
+            Facter.fact("blockdevice_#{device}_vendor".to_sym).should == nil
+            Facter.fact("blockdevice_#{device}_model".to_sym).should == nil          
+          end
+
+          # handle facts that should exist
+          %w{ sda sdb }.each do |device|
+            Facter.fact("blockdevice_#{device}_size".to_sym).should_not == nil
+            Facter.fact("blockdevice_#{device}_vendor".to_sym).should_not == nil
+            Facter.fact("blockdevice_#{device}_model".to_sym).should_not == nil          
+          end
+
+          Facter.fact(:blockdevice_sda_model).value.should == "WDC WD5000AAKS-0"
+          Facter.fact(:blockdevice_sda_vendor).value.should == "ATA"
+          Facter.fact(:blockdevice_sda_size).value.should == 500107862016
+          
+          Facter.fact(:blockdevice_sdb_model).value.should == "PERC H700"
+          Facter.fact(:blockdevice_sdb_vendor).value.should == "DELL"
+          Facter.fact(:blockdevice_sdb_size).value.should == 4499246678016
+
+        end
+
+      end
+      describe "with invalid entries in /sys/block" do
+        before :each do
+          Facter.fact(:kernel).stubs(:value).returns("Linux")
+          File.stubs(:exist?).with('/sys/block/').returns(true)
+
+          Dir.stubs(:entries).with("/sys/block/").returns([".", "..", "xda", "ydb"])
+
+          File.stubs(:exist?).with("/sys/block/./device").returns(false)
+          File.stubs(:exist?).with("/sys/block/../device").returns(false)
+          File.stubs(:exist?).with("/sys/block/xda/device").returns(false)
+          File.stubs(:exist?).with("/sys/block/ydb/device").returns(false)
+        end
+
+        it "should not exist with invalid entries in /sys/block" do
+          Facter.fact(:blockdevices).should == nil
+        end
+      end
+    end
+    describe "without /sys/block/" do
+
+      it "should not exist without /sys/block/ on Linux" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exist?).with('/sys/block/').returns(false)
+        Facter.fact(:blockdevices).should == nil
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
This pull request is for ticket #10238 and adds a new "blockdevices" fact as well as a "blockdevice_<devicename>_size", "blockdevice_<devicename>_model", "blockdevice_<devicename>_vendor" fact for each valid block device. Includes tests as requested by Adrien Thebo, feedback is requested!
