### PR TITLE
Ticket/1.6.x/8279 ec2 join facts with comma

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -23,9 +23,8 @@ def metadata(id = "")
     if key[-1..-1] != '/'
       value = open("http://169.254.169.254/2008-02-01/meta-data/#{key}").read.
         split("\n")
-      value = value.size>1 ? value : value.first
       symbol = "ec2_#{key.gsub(/\-|\//, '_')}".to_sym
-      Facter.add(symbol) { setcode { value } }
+      Facter.add(symbol) { setcode { value.join(',') } }
     else
       metadata(key)
     end


### PR DESCRIPTION
ec2 facts were being concatenated, which made array data harder to use.
Switched to comma delimited data.

Thanks to Hunter Haugen hunter@puppetlabs.com for this patch.
