### PR TITLE
(#6617) Deprecate DESTDIR environment variable for installer

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -258,20 +258,7 @@ def prepare_installation
     mandir = Config::CONFIG['mandir']
   end
 
-  # To be deprecated once people move over to using --destdir option
-  if (destdir = ENV['DESTDIR'])
-    warn "DESTDIR is deprecated. Use --destdir instead."
-    bindir = join(destdir, bindir)
-    sbindir = join(destdir, sbindir)
-    mandir = join(destdir, mandir)
-    sitelibdir = join(destdir, sitelibdir)
-
-    FileUtils.makedirs(bindir)
-    FileUtils.makedirs(sbindir)
-    FileUtils.makedirs(mandir)
-    FileUtils.makedirs(sitelibdir)
-    # This is the new way forward
-  elsif (destdir = InstallOptions.destdir)
+  if (destdir = InstallOptions.destdir)
     bindir = join(destdir, bindir)
     sbindir = join(destdir, sbindir)
     mandir = join(destdir, mandir)


### PR DESCRIPTION
The DESTDIR environment variable has been deprecated since release 1.5.1. This
commit finally removes it completely.

Instead, one should use --destdir as a switch on the command line.
