### PR TITLE
(#11041) Add dmidecode as a requirement for rpm

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -21,6 +21,7 @@ BuildArch: noarch
 
 Requires: ruby >= 1.8.1
 Requires: which
+Requires: dmidecode
 %if %has_ruby_abi
 Requires: ruby(abi) = 1.8
 %endif


### PR DESCRIPTION
We were implicitly relying on dmidecode to determine certain facts
without being certain that it was installed.  This change to the rpm
spec file will ensure we have dmidecode pulled in by rpm/yum as a
dependency and thus causing the correct functionality on facter.

Note this change only impacts EL based systems.  The debian packaging is
handled in another repository.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
