### PR TITLE
Fix arp module for EC2

### DIFF
--- a/lib/facter/arp.rb
+++ b/lib/facter/arp.rb
@@ -5,15 +5,14 @@ Facter.add(:arp) do
   setcode do
     output = Facter::Util::Resolution.exec('arp -an')
     if not output.nil?
-      arp = ""
+      arp = []
       output.each_line do |s|
         if s =~ /^\S+\s\S+\s\S+\s(\S+)\s\S+\s\S+\s\S+$/
-          arp = $1.downcase
-          break # stops on the first match
+          arp << $1.downcase
         end
       end
     end
-    "fe:ff:ff:ff:ff:ff" == arp ? arp : nil
+    arp.contains?("fe:ff:ff:ff:ff:ff") ? "fe:ff:ff:ff:ff:ff" : nil
   end
 end
 


### PR DESCRIPTION
See http://projects.puppetlabs.com/issues/11196
- When there is more than one entry in the arp table, and the gateway isn't the first. No ec2 facts are created. This commit fixed this at the expense of more memory usage.
