### PR TITLE
Add `defaultroute' fact, improve `ipaddress' fact

### DIFF
--- a/lib/facter/defaultroute.rb
+++ b/lib/facter/defaultroute.rb
@@ -1,0 +1,61 @@
+require 'facter/util/ip'
+require 'facter/util/netstat'
+require 'ipaddr'
+
+# Fact: defaultroute
+#
+# Purpose: Return the default route for a host.
+#
+# Resolution:
+#   Runs netstat, and returns the gateway associated with the destination
+#   "default" or "0.0.0.0".
+#
+# Caveats:
+#
+
+Facter.add(:defaultroute) do
+  confine :kernel => Facter::Util::NetStat.supported_platforms
+  setcode do
+    Facter::Util::NetStat.get_route_value('default', 'gw') ||
+    Facter::Util::NetStat.get_route_value('0.0.0.0', 'gw')
+  end
+end
+
+# Fact: defaultroute_interface
+#
+# Purpose: Return the interface uses for the host's default route.
+#
+# Resolution:
+#   Runs netstat, and returns the interface associated with the route for the
+#   destination "default" or "0.0.0.0".
+#
+#   If the default route listing only includes the gateway and not the
+#   interface (as is the case on Solaris), return the first interface whose
+#   network range includes the default gateway.
+#
+# Caveats:
+#
+
+Facter.add(:defaultroute_interface) do
+  confine :kernel => Facter::Util::NetStat.supported_platforms
+  setcode do
+    Facter::Util::NetStat.get_route_value('default', 'iface') ||
+    Facter::Util::NetStat.get_route_value('0.0.0.0', 'iface')
+  end
+end
+
+Facter.add(:defaultroute_interface) do
+  confine :kernel => Facter::Util::IP.supported_platforms
+  setcode do
+    return nil unless defaultroute = Facter.value(:defaultroute)
+    gw = IPAddr.new(defaultroute)
+
+    Facter::Util::IP.get_interfaces.collect { |i| Facter::Util::IP.alphafy(i) }.
+    detect do |i| 
+      range = Facter.value('network_' + i) +
+              '/' +
+              Facter.value('netmask_' + i)
+      IPAddr.new(range).include?(gw)
+    end
+  end
+end

--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -3,6 +3,9 @@
 # Purpose: Return the main IP address for a host.
 #
 # Resolution:
+#   As a first resort, if the interface for the default route could be
+#   determined (cf. defaultroute.rb), return its IP address.
+#
 #   On the Unixes does an ifconfig, and returns the first non 127.0.0.0/8
 #   subnetted IP it finds.
 #   On Windows, it attempts to use the socket library and resolve the machine's
@@ -21,6 +24,17 @@
 #   The ifconfig parsing purely takes the first IP address it finds without any
 #   checking this is a useful IP address.
 #
+
+Facter.add(:ipaddress) do
+  setcode do
+    interface = Facter.value(:defaultroute_interface)
+    if interface.nil?
+      nil
+    else
+      Facter.value('ipaddress_' + interface)
+    end
+  end
+end
 
 Facter.add(:ipaddress) do
   confine :kernel => :linux

--- a/lib/facter/util/netstat.rb
+++ b/lib/facter/util/netstat.rb
@@ -1,0 +1,69 @@
+module Facter::Util::NetStat
+  COLUMN_MAP = {
+    :bsd     => {
+      :aliases => [:sunos, :freebsd, :netbsd, :darwin],
+      :dest    => 0,
+      :gw      => 1,
+      :iface   => 5
+    },
+    :linux   => {
+      :dest   => 0,
+      :gw     => 1,
+      :iface  => 7
+    },
+    :openbsd => {
+      :dest   => 0,
+      :gw     => 1,
+      :iface  => 6
+    }
+  }
+
+  def self.supported_platforms
+    COLUMN_MAP.inject([]) do |result, tmp|
+      key, map = tmp
+      if map[:aliases]
+        result += map[:aliases]
+      else
+        result << key
+      end
+      result
+    end
+  end
+
+  def self.get_ipv4_output
+    output = ""
+    case Facter.value(:kernel)
+    when 'SunOS', 'FreeBSD', 'NetBSD', 'OpenBSD'
+      output = %x{/usr/bin/netstat -rn -f inet}
+    when 'Darwin' 
+      output = %x{/usr/sbin/netstat -rn -f inet}
+    when 'Linux'
+      output = %x{/bin/netstat -rn -A inet}
+    end
+    output
+  end
+
+  def self.get_route_value(route, label)
+    tmp1 = []
+
+    kernel = Facter.value(:kernel).downcase.to_sym
+
+    # If it's not directly in the map or aliased in the map, then we don't know how to deal with it.
+    unless map = COLUMN_MAP[kernel] || COLUMN_MAP.values.find { |tmp| tmp[:aliases] and tmp[:aliases].include?(kernel) }
+      return nil
+    end
+
+    c1 = map[:dest]
+    c2 = map[label.to_sym]
+
+    get_ipv4_output.to_a.collect { |s| s.split}.each { |a|
+      if a[c1] == route
+        tmp1 << a[c2]
+      end
+    }
+
+    if tmp1
+      return tmp1.shift
+    end
+  end
+end


### PR DESCRIPTION
Parse netstat output to determine the default route and its associated network
interface. Using this information, we can determine the "real" IP address of a
multi-homed host more accurately.
