### PR TITLE
(maint) remove redundant arch detection

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -44,8 +44,6 @@ Facter.add(:operatingsystem) do
       else
         "OEL"
       end
-    elsif FileTest.exists?("/etc/arch-release")
-      "Arch"
     elsif FileTest.exists?("/etc/vmware-release")
       "VMWareESX"
     elsif FileTest.exists?("/etc/redhat-release")


### PR DESCRIPTION
The operatingsystem fact had logic to test for the existence of
/etc/arch-release twice. Removed the dead branch of code.
