### PR TITLE
(#7753) Added error checking when adding resolves

### DIFF
--- a/lib/facter/util/collection.rb
+++ b/lib/facter/util/collection.rb
@@ -31,9 +31,8 @@ class Facter::Util::Collection
       end
     end
 
-    if block
-      resolve = fact.add(&block)
-      # Set any resolve-appropriate options
+    if block_given? and resolve = fact.add(&block)
+      # If the resolve was actually added, set any resolve-appropriate options
       options.each do |opt, value|
         method = opt.to_s + "="
         if resolve.respond_to?(method)

--- a/lib/facter/util/fact.rb
+++ b/lib/facter/util/fact.rb
@@ -33,17 +33,22 @@ class Facter::Util::Fact
   def add(&block)
     raise ArgumentError, "You must pass a block to Fact<instance>.add" unless block_given?
 
-    resolve = Facter::Util::Resolution.new(@name)
+    begin
+      resolve = Facter::Util::Resolution.new(@name)
 
-    resolve.instance_eval(&block)
+      resolve.instance_eval(&block)
 
-    @resolves << resolve
+      @resolves << resolve
 
-    # Immediately sort the resolutions, so that we always have
-    # a sorted list for looking up values.
-    @resolves.sort! { |a, b| b.weight <=> a.weight }
+      # Immediately sort the resolutions, so that we always have
+      # a sorted list for looking up values.
+      @resolves.sort! { |a, b| b.weight <=> a.weight }
 
-    return resolve
+      resolve
+    rescue => e
+      Facter.warn "Unable to add resolve for #{@name}: #{e}"
+      nil
+    end
   end
 
   # Flush any cached values.

--- a/spec/unit/util/collection_spec.rb
+++ b/spec/unit/util/collection_spec.rb
@@ -93,6 +93,16 @@ describe Facter::Util::Collection do
 
         @coll.add(:myname) {}
       end
+
+      it "should discard resolutions that throw an exception when added" do
+        lambda {
+          @coll.add('yay') do
+            raise
+            setcode { 'yay' }
+          end
+        }.should_not raise_error
+        @coll.value('yay').should be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Added exception handling to the fact class. When adding a resolution to
a fact, if an exception was thrown outside of the setcode block, facter
would crash. Added handling so that if an exception is thrown, facter
logs the error and discards the fact.
