### PR TITLE
Ticket/1.6.x/11436 rename mac memorytotal fact

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -116,7 +116,7 @@ if Facter.value(:kernel) == "OpenBSD"
 
   Facter::Memory.vmstat_find_free_memory()
 
-  Facter.add("MemoryTotal") do
+  Facter.add("memorysize") do
     confine :kernel => :openbsd
     memtotal = Facter::Util::Resolution.exec("sysctl hw.physmem | cut -d'=' -f2")
     setcode do
@@ -153,7 +153,7 @@ if Facter.value(:kernel) == "Darwin"
 
   Facter::Memory.vmstat_darwin_find_free_memory()
 
-  Facter.add("MemoryTotal") do
+  Facter.add("memorysize") do
     confine :kernel => :Darwin
     memtotal = Facter::Util::Resolution.exec("sysctl hw.memsize | cut -d':' -f2")
     setcode do
@@ -220,7 +220,7 @@ if Facter.value(:kernel) == "windows"
     end
   end
 
-  Facter.add("MemoryTotal") do
+  Facter.add("memorysize") do
     confine :kernel => :windows
     setcode do
       mem = 0
@@ -254,11 +254,22 @@ Facter.add("SwapFree") do
   end
 end
 
-Facter.add("MemoryTotal") do
+Facter.add("memorysize") do
   confine :kernel => :dragonfly
   setcode do
     Facter::Memory.vmstat_find_free_memory()
     memtotal = Facter::Util::Resolution.exec("sysctl -n hw.physmem")
     Facter::Memory.scale_number(memtotal.to_f,"")
+  end
+end
+
+# http://projects.puppetlabs.com/issues/11436
+#
+# Unifying naming for the amount of physical memory in a given host.
+# This fact is DEPRECATED and will be removed in Facter 2.0 per
+# http://projects.puppetlabs.com/issues/11466
+Facter.add("MemoryTotal") do
+  setcode do
+    Facter.value("memorysize")
   end
 end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -78,7 +78,7 @@ EOS
     end
 
     it "should return the current memorysize" do
-      Facter.fact(:memorytotal).value.should == "254.94 MB"
+      Facter.fact(:memorysize).value.should == "254.94 MB"
     end
   end
 
@@ -118,7 +118,7 @@ EOS
     end
 
     it "should return the current memorysize" do
-      Facter.fact(:memorytotal).value.should == "237.00 MB"
+      Facter.fact(:memorysize).value.should == "237.00 MB"
     end
   end
 
@@ -146,5 +146,12 @@ EOS
 
       Facter.fact(:MemoryTotal).value.should == '3.91 GB'
     end
+  end
+
+  it "should use the memorysize fact for the memorytotal fact" do
+    Facter.fact("memorysize").expects(:value).once.returns "yay"
+    Facter::Util::Resolution.expects(:exec).never
+    Facter::Memory.expects(:meminfo_number).never
+    Facter.fact("memorytotal").value.should == "yay"
   end
 end


### PR DESCRIPTION
Two different names were given for the amount of physical memory in a
given node. Switched to the name of 'memorysize' for the RAM and added a
fallback fact 'memorytotal' that reverts to the memorysize.
