### PR TITLE
Ticket/1.6.x/9599 nexenta operatingsystem

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -14,7 +14,13 @@ require 'facter/lsb'
 
 Facter.add(:operatingsystem) do
   confine :kernel => :sunos
-  setcode do "Solaris" end
+  setcode do
+    if FileTest.exists?("/etc/debian_version")
+      "Nexenta"
+    else
+      "Solaris"
+    end
+  end
 end
 
 Facter.add(:operatingsystem) do

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -22,7 +22,7 @@ Facter.add(:osfamily) do
       "Debian"
     when "SLES", "SLED", "OpenSuSE", "SuSE"
       "Suse"
-    when "Solaris"
+    when "Solaris", "Nexenta"
       "Solaris"
     else
       Facter.value("kernel")

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -15,17 +15,25 @@ describe "Operating System fact" do
 
     Facter.fact(:operatingsystem).value.should == "Nutmeg"
   end
-
-  it "should be Solaris for SunOS" do
-     Facter.fact(:kernel).stubs(:value).returns("SunOS")
-
-     Facter.fact(:operatingsystem).value.should == "Solaris"
-  end
-
   it "should be ESXi for VMkernel" do
      Facter.fact(:kernel).stubs(:value).returns("VMkernel")
 
      Facter.fact(:operatingsystem).value.should == "ESXi"
+  end
+
+  describe "on Solaris variants" do
+    before :each do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    end
+
+    it "should be Nexenta if /etc/debian_version is present" do
+      FileTest.expects(:exists?).with("/etc/debian_version").returns true
+      Facter.fact(:operatingsystem).value.should == "Nexenta"
+    end
+
+    it "should be Solaris for SunOS if no other variants match" do
+      Facter.fact(:operatingsystem).value.should == "Solaris"
+    end
   end
 
   describe "on Linux" do


### PR DESCRIPTION
Adds support for Nexenta to the operatingsystem and osfamily facts.
Since Nexenta is binary compatible with solaris, it has also been added
into the Solaris osfamily fact.

Tests and osfamily support added by Adrien Thebo adrien@puppetlabs.com
