### PR TITLE
(maint) Fix requirement for FileUtils as operatingsystem_spec needs it n...

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'rubygems'
 require 'mocha'
 require 'rspec'
 require 'facter'
+require 'fileutils'
 
 # load any monkey-patches
 Dir["#{dir}/monkey_patches/*.rb"].map { |file| require file }


### PR DESCRIPTION
...ow

Fix #9789 introduced the use of FileUtils however there was no require line.
Since later versions of rspec (2.6+) it has been requiring it, but this breaks
on older rspec revisions. This patch adds it to rspec_helper so we can avoid
hitting this again on tests, even individual ones.
