### PR TITLE
(#10271) Identifying 'Amazon' using '/etc/system-release'

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -84,7 +84,7 @@ Facter.add(:operatingsystem) do
       "Alpine"
     elsif FileTest.exists?("/etc/mageia-release")
       "Mageia"
-    elsif Facter.value(:lsbdistdescription) =~ /Amazon Linux/
+    elsif FileTest.exists?("/etc/system-release")
       "Amazon"
     end
   end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -45,6 +45,7 @@ describe "Operating System fact" do
       "Bluewhite64" => "/etc/bluewhite64-version",
       "Slamd64"     => "/etc/slamd64-version",
       "Slackware"   => "/etc/slackware-version",
+      "Amazon"      => "/etc/system-release",
     }.each_pair do |distribution, releasefile|
       it "should be #{distribution} if #{releasefile} exists" do
         FileTest.expects(:exists?).with(releasefile).returns true
@@ -64,10 +65,6 @@ describe "Operating System fact" do
         Facter.fact(:operatingsystem).value.should == "Ubuntu"
       end
 
-      it "on Amazon Linux should use the lsbdistdescription fact" do
-        Facter.fact(:lsbdistdescription).stubs(:value).returns "Amazon Linux"
-        Facter.fact(:operatingsystem).value.should == "Amazon"
-      end
     end
 
 


### PR DESCRIPTION
Hi,

I had some problems executing facter in my instance of Amazon Linux 2011.09 and I discovered this bug in your list of issues.

This fix I am sending worked nicely for me.

Best,

Marcus

command line results:

```
[ec2-user@ip-10-228-1-2 ~]$ cat /etc/system-release
Amazon Linux AMI release 2011.09

[ec2-user@ip-10-228-1-2 ~]$ facter | grep oper
    operatingsystem => Amazon
    operatingsystemrelease => 2.6.35.14-97.44.amzn1.x86_64
```

rspec results:

```
[ec2-user@ip-10-228-1-2 ~]$ rspec -f d spec/unit/operatingsystem_spec.rb
Operating System fact
  should default to the kernel name
  should be Solaris for SunOS
  should be ESXi for VMkernel
  on Linux
    ...
    should be Amazon if /etc/system-release exists
    ...
```
