### PR TITLE
(maint) Move solaris zone spec

### DIFF
--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -15,14 +15,6 @@ describe "Virtual fact" do
     Facter::Util::Virtual.stubs(:zlinux?).returns(false)
   end
 
-  it "should be zone on Solaris when a zone" do
-    Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    Facter::Util::Virtual.stubs(:zone?).returns(true)
-    Facter::Util::Virtual.stubs(:vserver?).returns(false)
-    Facter::Util::Virtual.stubs(:xen?).returns(false)
-    Facter.fact(:virtual).value.should == "zone"
-  end
-
   it "should be jail on FreeBSD when a jail in kvm" do
     Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
     Facter::Util::Virtual.stubs(:jail?).returns(true)
@@ -176,6 +168,15 @@ describe "Virtual fact" do
     before(:each) do
       Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
     end
+
+    it "should be zone on Solaris when a zone" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      Facter::Util::Virtual.stubs(:zone?).returns(true)
+      Facter::Util::Virtual.stubs(:vserver?).returns(false)
+      Facter::Util::Virtual.stubs(:xen?).returns(false)
+      Facter.fact(:virtual).value.should == "zone"
+    end
+
 
     it "should be vmware with VMWare vendor name from prtdiag" do
       Facter.fact(:kernel).stubs(:value).returns("SunOS")


### PR DESCRIPTION
The solaris zone spec was outside of the correct describe block, and was
not having all necessary stubs applied.
