### PR TITLE
(#9599) Generalize zone detection

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -52,7 +52,7 @@ Facter.add("virtual") do
 
   setcode do
 
-    if Facter.value(:operatingsystem) == "Solaris" and Facter::Util::Virtual.zone?
+    if Facter.value(:kernel) == "SunOS" and Facter::Util::Virtual.zone?
       result = "zone"
     end
 


### PR DESCRIPTION
All systems using the SunOS kernel can run zones, not just the solaris
operating system. Generalized this for cases like Nexenta and Open
Indiana.
