### PR TITLE
Ticket/1.6.x/11661 ec2 rspec raises not throws

### DIFF
--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -135,7 +135,7 @@ describe "ec2 facts" do
 
       # Emulate a timeout when connecting by throwing an exception
       Object.any_instance.expects(:open).with("#{api_prefix}:80/").\
-        at_least_once.throws(Timeout::Error)
+        at_least_once.raises(Timeout::Error)
 
       # Return a eucalyptus mac address
       Facter.expects(:value).with(:macaddress).\


### PR DESCRIPTION
This patch corrects that behaviour. Also, 'throws' wasn't working on our CI
machines since we were using mocha 0.9.x.
