### PR TITLE
(#11663) add FreeBSD support to blockdevice fact(s)

### DIFF
--- a/lib/facter/blockdevices.rb
+++ b/lib/facter/blockdevices.rb
@@ -118,6 +118,8 @@ if Facter.value(:kernel) == 'FreeBSD'
     Facter.add("blockdevice_#{device}_model".to_sym) do
       if device =~ /ad/
         setcode { Facter::Util::Resolution.exec("/sbin/atacontrol list | /usr/bin/awk -F '<|>' '/#{device}/ { print $2 }'") }
+      elsif device =~ /mfi/
+        setcode { "MFI Local Disk" }
       else
         setcode { Facter::Util::Resolution.exec("/sbin/camcontrol inquiry #{device} -D | /usr/bin/awk -F '<|>' '{ print $2}'" ) }
       end


### PR DESCRIPTION
This adds blockdevice,  size, and model, similar to the Linux supported facts for FreeBSD (tested on 8 and 9).
