### PR TITLE
Fixed #11666 - Add is_ec2 and is_euca facts

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -59,9 +59,18 @@ def has_ec2_arp?
   is_amazon_arp
 end
 
+if has_ec2_arp?
+  Facter.add(:is_ec2) { setcode { "true" } }
+elsif has_euca_mac?
+  Facter.add(:is_euca) { setcode { "true" } }
+else
+  Facter.add(:is_ec2) { setcode { "false" } }
+  Facter.add(:is_euca) { setcode { "false" } }
+end
+
 if (has_euca_mac? || has_ec2_arp?) && can_connect?
   metadata
   userdata
 else
-  Facter.debug "Not an EC2 host"
+  Facter.debug "Not an EC2 or Eucalyptus host"
 end


### PR DESCRIPTION
Sometimes you just want to know if a host is EC2 or Eucalyptus. This
adds two facts in a similar vein to the "is_virtual" fact.

The is_ec2 fact is set to true if an EC2 ARP entry is present and the
is_euca fact to true if there is a Eucalyptus MAC address.

Otherwise both default to false.
