### PR TITLE
Ticket/1.6.x/11566 windows ec2

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -1,21 +1,5 @@
-# Original fact Tim Dysinger
-# Additional work from KurtBe
-# Additional work for Paul Nasrat
-# Additional work modelled on Ohai EC2 fact
-# Remove depedency on arp fact by Pieter Lexis
-
+require 'facter/util/ec2'
 require 'open-uri'
-require 'timeout'
-
-def can_connect?(wait_sec=2)
-  url = "http://169.254.169.254:80/"
-  Timeout::timeout(wait_sec) {open(url)}
-  return true
-  rescue Timeout::Error
-    return false
-  rescue
-    return false
-end
 
 def metadata(id = "")
   open("http://169.254.169.254/2008-02-01/meta-data/#{id||=''}").read.
@@ -40,26 +24,9 @@ def userdata()
   end
 end
 
-# Is the macaddress a eucalyptus macaddress?
-def has_euca_mac?
-  !!(Facter.value(:macaddress) =~ %r{^[dD]0:0[dD]:})
-end
+if (Facter::Util::EC2.has_euca_mac? || Facter::Util::EC2.has_ec2_arp?) &&
+  Facter::Util::EC2.can_connect?
 
-# Is there an entry in the arp table for fe:ff:ff:ff:ff:ff,
-# this is a red flag for being on amazon
-def has_ec2_arp?
-  arp_table = Facter::Util::Resolution.exec('arp -an')
-  is_amazon_arp = false
-  if not arp_table.nil?
-    arp_table.each_line do |line|
-      is_amazon_arp = true if line.include?('fe:ff:ff:ff:ff:ff')
-      break
-    end
-  end
-  is_amazon_arp
-end
-
-if (has_euca_mac? || has_ec2_arp?) && can_connect?
   metadata
   userdata
 else

--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -1,0 +1,49 @@
+require 'timeout'
+require 'open-uri'
+
+# Provide a set of utility static methods that help with resolving the EC2
+# fact.
+module Facter::Util::EC2
+  class << self
+    # Test if we can connect to the EC2 api. Return true if able to connect.
+    # On failure this function fails silently and returns false.
+    #
+    # The +wait_sec+ parameter provides you with an adjustable timeout.
+    #
+    def can_connect?(wait_sec=2)
+      url = "http://169.254.169.254:80/"
+      Timeout::timeout(wait_sec) {open(url)}
+      return true
+      rescue Timeout::Error
+        return false
+      rescue
+        return false
+    end
+
+    # Test if this host has a mac address used by Eucalyptus clouds, which
+    # normally is +d0:0d+.
+    def has_euca_mac?
+      !!(Facter.value(:macaddress) =~ %r{^[dD]0:0[dD]:})
+    end
+
+    # Test if the host has an arp entry in its cache that matches the EC2 arp,
+    # which is normally +fe:ff:ff:ff:ff:ff+.
+    def has_ec2_arp?
+      mac_address = "fe:ff:ff:ff:ff:ff"
+      if Facter.value(:kernel) == 'windows'
+        arp_command = "arp -a"
+        mac_address.gsub!(":","-")
+      else
+        arp_command = "arp -an"
+      end
+
+      arp_table = Facter::Util::Resolution.exec(arp_command)
+      if not arp_table.nil?
+        arp_table.each_line do |line|
+          return true if line.include?(mac_address)
+        end
+      end
+      return false
+    end
+  end
+end

--- a/spec/fixtures/unit/util/ec2/linux-arp-ec2.out
+++ b/spec/fixtures/unit/util/ec2/linux-arp-ec2.out
@@ -1,0 +1,1 @@
+? (10.240.93.1) at fe:ff:ff:ff:ff:ff [ether] on eth0

--- a/spec/fixtures/unit/util/ec2/linux-arp-not-ec2.out
+++ b/spec/fixtures/unit/util/ec2/linux-arp-not-ec2.out
@@ -1,0 +1,5 @@
+? (46.4.106.97) at 00:26:88:75:c1:17 [ether] on eth0
+? (10.1.2.14) at 02:00:0a:01:02:0e [ether] on virbr1
+? (10.1.2.12) at 02:00:0a:01:02:0c [ether] on virbr1
+? (10.1.2.11) at 02:00:0a:01:02:0b [ether] on virbr1
+? (10.1.2.200) at 02:00:0a:01:02:0e [ether] on virbr1

--- a/spec/fixtures/unit/util/ec2/windows-2008-arp-a-not-ec2.out
+++ b/spec/fixtures/unit/util/ec2/windows-2008-arp-a-not-ec2.out
@@ -1,0 +1,6 @@
+
+Interface: 192.168.5.4 --- 0xd
+  Internet Address      Physical Address      Type
+  192.168.5.1           c8-02-14-0c-5d-18     dynamic   
+  192.168.5.255         ff-ff-ff-ff-ff-ff     static    
+  255.255.255.255       ff-ff-ff-ff-ff-ff     static    

--- a/spec/fixtures/unit/util/ec2/windows-2008-arp-a.out
+++ b/spec/fixtures/unit/util/ec2/windows-2008-arp-a.out
@@ -1,0 +1,10 @@
+
+Interface: 10.32.123.54 --- 0xd
+  Internet Address      Physical Address      Type
+  10.32.120.163         fe-ff-ff-ff-ff-ff     dynamic   
+  10.32.122.1           fe-ff-ff-ff-ff-ff     dynamic   
+  10.32.123.255         ff-ff-ff-ff-ff-ff     static    
+  169.254.169.254       fe-ff-ff-ff-ff-ff     dynamic   
+  224.0.0.22            01-00-5e-00-00-16     static    
+  224.0.0.252           01-00-5e-00-00-fc     static    
+  255.255.255.255       ff-ff-ff-ff-ff-ff     static    

--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -1,42 +1,35 @@
 #!/usr/bin/env rspec
 
 require 'spec_helper'
+require 'facter/util/ec2'
 
 describe "ec2 facts" do
+  # This is the standard prefix for making an API call in EC2 (or fake)
+  # environments.
   let(:api_prefix) { "http://169.254.169.254" }
 
   describe "when running on ec2" do
     before :each do
-      # Return fake kernel
-      Facter.stubs(:value).with(:kernel).returns("Linux")
+      # This is an ec2 instance, not a eucalyptus instance
+      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(false)
+      Facter::Util::EC2.expects(:has_ec2_arp?).at_least_once.returns(true)
 
-      # Return something upon connecting to the root so the EC2 code continues
-      # with its evaluation.
-      Object.any_instance.expects(:open).with("#{api_prefix}:80/").\
-        at_least_once.returns("2008-02-01\nlatest")
-
-      # Return a non-eucalyptus mac address
-      Facter.expects(:value).with(:macaddress).\
-        at_least_once.returns("12:31:39:04:5A:34")
-
-      # Fake EC2 arp response
-      ec2arp = "? (10.240.93.1) at fe:ff:ff:ff:ff:ff [ether] on eth0\n"
-      Facter::Util::Resolution.expects(:exec).with("arp -an").\
-        at_least_once.returns(ec2arp)
+      # Assume we can connect
+      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(true)
     end
 
     it "should create flat meta-data facts" do
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.returns(StringIO.new("foo"))
 
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/foo").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/foo").
         at_least_once.returns(StringIO.new("bar"))
 
       # No user-data
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/user-data/").
         at_least_once.returns(StringIO.new(""))
 
       Facter.collection.loader.load(:ec2)
@@ -44,17 +37,17 @@ describe "ec2 facts" do
     end
 
     it "should create flat meta-data facts with comma seperation" do
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.returns(StringIO.new("foo"))
 
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/foo").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/foo").
         at_least_once.returns(StringIO.new("bar\nbaz"))
 
       # No user-data
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/user-data/").
         at_least_once.returns(StringIO.new(""))
 
       Facter.collection.loader.load(:ec2)
@@ -62,21 +55,21 @@ describe "ec2 facts" do
     end
 
     it "should create structured meta-data facts" do
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.returns(StringIO.new("foo/"))
 
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/foo/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/foo/").
         at_least_once.returns(StringIO.new("bar"))
 
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/foo/bar").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/foo/bar").
         at_least_once.returns(StringIO.new("baz"))
 
       # No user-data
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/user-data/").
         at_least_once.returns(StringIO.new(""))
 
       Facter.collection.loader.load(:ec2)
@@ -85,12 +78,12 @@ describe "ec2 facts" do
 
     it "should create ec2_user_data fact" do
       # No meta-data
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/meta-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.returns(StringIO.new(""))
 
-      Object.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/user-data/").
         at_least_once.returns(StringIO.new("test"))
 
       Facter.collection.loader.load(:ec2)
@@ -100,17 +93,12 @@ describe "ec2 facts" do
 
   describe "when running on eucalyptus" do
     before :each do
-      # Return fake kernel
-      Facter.stubs(:value).with(:kernel).returns("Linux")
+      # Return false for ec2, true for eucalyptus
+      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(true)
+      Facter::Util::EC2.expects(:has_ec2_arp?).never
 
-      # Return something upon connecting to the root so the EC2 code continues
-      # with its evaluation.
-      Object.any_instance.expects(:open).with("#{api_prefix}:80/").\
-        at_least_once.returns("2008-02-01\nlatest")
-
-      # Return a eucalyptus mac address
-      Facter.expects(:value).with(:macaddress).\
-        at_least_once.returns("d0:0d:1a:b0:a1:00")
+      # Assume we can connect
+      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(true)
     end
 
     it "should create ec2_user_data fact" do
@@ -123,27 +111,30 @@ describe "ec2 facts" do
         with("#{api_prefix}/2008-02-01/user-data/").\
         at_least_once.returns(StringIO.new("test"))
 
+      # Force a fact load
       Facter.collection.loader.load(:ec2)
+
       Facter.fact(:ec2_userdata).value.should == ["test"]
     end
   end
 
-  describe "when ec2 url times out" do
-    before :each do
-      # Return fake kernel
-      Facter.stubs(:value).with(:kernel).returns("Linux")
+  describe "when api connect test fails" do
+    it "should not populate ec2_userdata" do
+      # Emulate ec2 for now as it matters little to this test
+      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(true)
+      Facter::Util::EC2.expects(:has_ec2_arp?).never
+      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(false)
 
-      # Emulate a timeout when connecting by throwing an exception
-      Object.any_instance.expects(:open).with("#{api_prefix}:80/").\
-        at_least_once.raises(Timeout::Error)
+      # The API should never be called at this point
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/meta-data/").never
+      Object.any_instance.expects(:open).
+        with("#{api_prefix}/2008-02-01/user-data/").never
 
-      # Return a eucalyptus mac address
-      Facter.expects(:value).with(:macaddress).\
-        at_least_once.returns("d0:0d:1a:b0:a1:00")
-    end
+      # Force a fact load
+      Facter.collection.loader.load(:ec2)
 
-    it "should not raise exception" do
-      expect { Facter.collection.loader.load(:ec2) }.to_not raise_error
+      Facter.fact(:ec2_userdata).should == nil
     end
   end
 end

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+require 'facter/util/ec2'
+
+describe Facter::Util::EC2 do
+  # This is the standard prefix for making an API call in EC2 (or fake)
+  # environments.
+  let(:api_prefix) { "http://169.254.169.254" }
+
+  describe "is_ec2_arp? method" do
+    describe "on linux" do
+      before :each do
+        # Return fake kernel
+        Facter.stubs(:value).with(:kernel).returns("linux")
+      end
+
+      it "should succeed if arp table contains fe:ff:ff:ff:ff:ff" do
+        ec2arp = my_fixture_read("linux-arp-ec2.out")
+        Facter::Util::Resolution.expects(:exec).with("arp -an").\
+          at_least_once.returns(ec2arp)
+        Facter::Util::EC2.has_ec2_arp?.should == true
+      end
+
+      it "should fail if arp table does not contain fe:ff:ff:ff:ff:ff" do
+        ec2arp = my_fixture_read("linux-arp-not-ec2.out")
+        Facter::Util::Resolution.expects(:exec).with("arp -an").
+          at_least_once.returns(ec2arp)
+        Facter::Util::EC2.has_ec2_arp?.should == false
+      end
+    end
+
+    describe "on windows" do
+      before :each do
+        # Return fake kernel
+        Facter.stubs(:value).with(:kernel).returns("windows")
+      end
+
+      it "should succeed if arp table contains fe-ff-ff-ff-ff-ff" do
+        ec2arp = my_fixture_read("windows-2008-arp-a.out")
+        Facter::Util::Resolution.expects(:exec).with("arp -a").\
+          at_least_once.returns(ec2arp)
+        Facter::Util::EC2.has_ec2_arp?.should == true
+      end
+
+      it "should fail if arp table does not contain fe-ff-ff-ff-ff-ff" do
+        ec2arp = my_fixture_read("windows-2008-arp-a-not-ec2.out")
+        Facter::Util::Resolution.expects(:exec).with("arp -a").
+          at_least_once.returns(ec2arp)
+        Facter::Util::EC2.has_ec2_arp?.should == false
+      end
+    end
+  end
+
+  describe "is_euca_mac? method" do
+    it "should return true when the mac is a eucalyptus one" do
+      Facter.expects(:value).with(:macaddress).\
+        at_least_once.returns("d0:0d:1a:b0:a1:00")
+
+      Facter::Util::EC2.has_euca_mac?.should == true
+    end
+
+    it "should return false when the mac is not a eucalyptus one" do
+      Facter.expects(:value).with(:macaddress).\
+        at_least_once.returns("0c:1d:a0:bc:aa:02")
+
+      Facter::Util::EC2.has_euca_mac?.should == false
+    end
+  end
+
+  describe "can_connect? method" do
+    it "returns true if api responds" do
+      # Return something upon connecting to the root
+      Module.any_instance.expects(:open).with("#{api_prefix}:80/").\
+        at_least_once.returns("2008-02-01\nlatest")
+
+      Facter::Util::EC2.can_connect?.should == true
+    end
+
+    describe "when connection times out" do
+      before :each do
+        # Emulate a timeout when connecting by throwing an exception
+        Module.any_instance.expects(:open).with("#{api_prefix}:80/").\
+          at_least_once.raises(Timeout::Error)
+      end
+
+      it "should not raise exception" do
+        expect { Facter::Util::EC2.can_connect? }.to_not raise_error
+      end
+
+      it "should return false" do
+        Facter::Util::EC2.can_connect?.should == false
+      end
+    end
+
+    describe "when connection is refused" do
+      before :each do
+        # Emulate a connection refused
+        Module.any_instance.expects(:open).with("#{api_prefix}:80/").\
+          at_least_once.raises(Errno::ECONNREFUSED)
+      end
+
+      it "should not raise exception" do
+        expect { Facter::Util::EC2.can_connect? }.to_not raise_error
+      end
+
+      it "should return false" do
+        Facter::Util::EC2.can_connect?.should == false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds support for detecting ec2 on windows. This works by modifying
the linux methodology by using arp -a instead of arp -an and searching for the
mac address with a hyphen delimiter (as apposed to a quote).

I've added tests and a sample fixture which adds output from arp -a from a
windows machine.

Thanks to Feifei Jia fjia@yottaa.com for contributing the original code.
