### PR TITLE
Ticket/1.6.x/11559 rbconfig deprecation

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -1,4 +1,4 @@
-%{!?ruby_sitelibdir: %define ruby_sitelibdir %(ruby -rrbconfig -e 'puts Config::CONFIG["sitelibdir"]')}
+%{!?ruby_sitelibdir: %define ruby_sitelibdir %(ruby -rrbconfig -e 'puts Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG["sitelibdir"]'
 
 %define has_ruby_abi 0%{?fedora} || 0%{?rhel} >= 5
 %define has_ruby_noarch %has_ruby_abi

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -20,6 +20,7 @@ module Facter
 
   require 'facter/util/fact'
   require 'facter/util/collection'
+  require 'facter/util/monkey_patches'
 
   include Comparable
   include Enumerable

--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -29,6 +29,6 @@ Facter.add(:hardwaremodel) do
   confine :operatingsystem => :windows
   setcode do
     require 'rbconfig'
-    Config::CONFIG['host_cpu']
+    RbConfig::CONFIG['host_cpu']
   end
 end

--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -1,9 +1,9 @@
+require 'rbconfig'
+
 # A module to return config related data
 #
 module Facter::Util::Config
-  require 'rbconfig'
-
   def self.is_windows?
-    Config::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
+    RbConfig::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
   end
 end

--- a/lib/facter/util/monkey_patches.rb
+++ b/lib/facter/util/monkey_patches.rb
@@ -1,0 +1,7 @@
+# This provides an alias for RbConfig to Config for versions of Ruby older then
+# version 1.8.5. This allows us to use RbConfig in place of the older Config in
+# our code and still be compatible with at least Ruby 1.8.1.
+require 'rbconfig'
+unless defined? ::RbConfig
+  ::RbConfig = ::Config
+end

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+require 'facter/util/config'
+
+describe Facter::Util::Config do
+  describe "is_windows? function" do
+    it "should detect windows if RbConfig returns a windows OS" do
+      host_os = ["mswin","win32","dos","mingw","cygwin"]
+      host_os.each do |h|
+        RbConfig::CONFIG.expects(:[]).with('host_os').returns(h)
+        Facter::Util::Config.is_windows?.should be_true
+      end
+    end
+
+    it "should not detect windows if RbConfig returns a non-windows OS" do
+      host_os = ["darwin","linux"]
+      host_os.each do |h|
+        RbConfig::CONFIG.expects(:[]).with('host_os').returns(h)
+        Facter::Util::Config.is_windows?.should be_false
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Ruby 1.9.3 we started to see warning messages about the deprecated usage of
the class 'Config' as apposed to 'RbConfig'. This patch switches all our code
to 'RbConfig' instead.

Now the constant RbConfig was aliased to Config going back to Ruby 1.8.5, but
for pre-1.8.5 ruby this was not done. To support our Ruby 1.8.1 user base
(due to RHEL 4 predominantly) this provides a monkey patch util library which
provides the same alias (conditionally) but for older rubies instead.

This methodology is seen as less intrusive and less maintainance going forward
then to create conditionals everywhere, or a facter-only backwards compatible
alternative to RbConfig. And since its the similar methodology adopted by Ruby
core (more or less) it should be a monkey patch with low surprises.

I've also added testing around the facter/util/config.rb library.

Thanks to James Turnbull james@lovedthanlost.net for the original code for
this patch.
