### PR TITLE
Added bios information fact

### DIFF
--- a/lib/facter/manufacturer.rb
+++ b/lib/facter/manufacturer.rb
@@ -48,8 +48,9 @@ else
       { 'Serial Number:'   => 'boardserialnumber' }
     ],
     '[Bb][Ii][Oo][Ss] [Ii]nformation' => [
+      { '[Vv]endor:' => 'bios_vendor' },
       { '[Vv]ersion:' => 'bios_version' },
-      { '[Rr]elease [Dd]ate::' => 'bios_release_date' },
+      { '[Rr]elease [Dd]ate:' => 'bios_release_date' }
     ],
     '[Ss]ystem [Ii]nformation' => [
       { 'Manufacturer:'    => 'manufacturer' },


### PR DESCRIPTION
#10966

I had to rework this patch so it would apply cleanly. The former pull request can be found at https://github.com/puppetlabs/facter/pull/81.
