### PR TITLE
(#6682) Add Solaris ldom facts and update virtual detection.

### DIFF
--- a/lib/facter/ldom.rb
+++ b/lib/facter/ldom.rb
@@ -1,0 +1,46 @@
+if Facter.value(:kernel) == 'SunOS'
+  virtinfo = Facter::Util::Resolution.exec('virtinfo -ap')
+
+  # Convert virtinfo parseable output format to array of arrays.
+  # DOMAINROLE|impl=LDoms|control=true|io=true|service=true|root=true
+  # DOMAINNAME|name=primary
+  # DOMAINUUID|uuid=8e0d6ec5-cd55-e57f-ae9f-b4cc050999a4
+  # DOMAINCONTROL|name=san-t2k-6
+  # DOMAINCHASSIS|serialno=0704RB0280
+  #
+  # For keys containing multiple value such as domain role:
+  # ldom_{key}_{subkey} = value
+  # Otherwise the fact will simply be:
+  # ldom_{key} = value
+  unless virtinfo.nil?
+    virt_array = virtinfo.split("\n").select{|l| l =~ /^DOMAIN/ }.collect{|l| l.split('|')}
+    virt_array.each do |x|
+      key = x[0]
+      value = x[1..x.size]
+
+      if value.size == 1
+        Facter.add("ldom_#{key.downcase}") do
+          setcode { value.first.split('=')[1] }
+        end
+      else
+        value.each do |y|
+          k = y.split('=')[0]
+          v = y.split('=')[1]
+          Facter.add("ldom_#{key.downcase}_#{k.downcase}") do
+            setcode { v }
+          end
+        end
+      end
+    end
+
+    # When ldom domainrole control = false, the system is a guest, so we mark it
+    # as a virtual system:
+    Facter.add("virtual") do
+      confine :ldom_domainrole_control => 'false'
+      has_weight 10
+      setcode do
+        Facter.value(:ldom_domainrole_impl)
+      end
+    end
+  end
+end

--- a/spec/fixtures/ldom/ldom_v1
+++ b/spec/fixtures/ldom/ldom_v1
@@ -1,0 +1,6 @@
+VERSION 1.0
+DOMAINROLE|impl=LDoms|control=false|io=true|service=true|root=true
+DOMAINNAME|name=primary
+DOMAINUUID|uuid=8e0d6ec5-cd55-e57f-ae9f-b4cc050999a4
+DOMAINCONTROL|name=san-t2k-6
+DOMAINCHASSIS|serialno=0704RB0280

--- a/spec/unit/ldom_spec.rb
+++ b/spec/unit/ldom_spec.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+
+def ldom_fixtures(filename)
+  File.read(fixtures('ldom', filename))
+end
+
+describe "ldom fact" do
+  before do
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+  end
+
+  describe "when running on ldom hardware" do
+    before :each do
+      # For virtinfo documentation:
+      # http://docs.oracle.com/cd/E23824_01/html/821-1462/virtinfo-1m.html
+      Facter::Util::Resolution.stubs(:exec).with("virtinfo -ap").returns(ldom_fixtures('ldom_v1'))
+      Facter.collection.loader.load(:ldom)
+    end
+
+    it "should return correct impl on version 1.0" do
+      Facter.fact(:ldom_domainrole_impl).value.should == "LDoms"
+    end
+
+    it "should return correct control on version 1.0" do
+      Facter.fact(:ldom_domainrole_control).value.should == "false"
+    end
+
+    it "should return correct io on version 1.0" do
+      Facter.fact(:ldom_domainrole_io).value.should == "true"
+    end
+
+    it "should return correct service on version 1.0" do
+      Facter.fact(:ldom_domainrole_service).value.should == "true"
+    end
+
+    it "should return correct root on version 1.0" do
+      Facter.fact(:ldom_domainrole_root).value.should == "true"
+    end
+
+    it "should return correct domain name on version 1.0" do
+      Facter.fact(:ldom_domainname).value.should == "primary"
+    end
+
+    it "should return correct uuid on version 1.0" do
+      Facter.fact(:ldom_domainuuid).value.should == "8e0d6ec5-cd55-e57f-ae9f-b4cc050999a4"
+    end
+
+    it "should return correct ldomcontrol on version 1.0" do
+      Facter.fact(:ldom_domaincontrol).value.should == "san-t2k-6"
+    end
+
+    it "should return correct serial on version 1.0" do
+      Facter.fact(:ldom_domainchassis).value.should == "0704RB0280"
+    end
+
+    it "should return correct virtual on version 1.0" do
+      Facter.fact(:virtual).value.should == "LDoms"
+    end
+  end
+
+  describe "when running on non ldom hardware" do
+    before :each do
+      Facter::Util::Resolution.stubs(:exec).with("virtinfo -ap").returns(nil)
+      Facter.collection.loader.load(:ldom)
+    end
+
+    it "should return correct virtual" do
+      Facter.fact(:ldom_domainrole_impl).should == nil
+    end
+  end
+end


### PR DESCRIPTION
Support Solaris LDOM detection via virtinfo command.
