### PR TITLE
(#12012) Fix ENV['LANG'] spec tests on Windows

### DIFF
--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -342,16 +342,22 @@ describe Facter::Util::Resolution do
     end
 
     it "should execute the binary" do
-      Facter::Util::Resolution.exec("echo foo").should == "foo"
+      Facter::Util::Resolution.exec(
+        Facter::Util::Config.is_windows? ? 'cmd.exe /c "echo foo"' : 'echo foo'
+      ).should == "foo"
     end
 
     it "should override the LANG environment variable" do
-      Facter::Util::Resolution.exec("echo $LANG").should == "C"
+      Facter::Util::Resolution.exec(
+        Facter::Util::Config.is_windows? ? 'cmd.exe /c "echo %LANG%"' : 'echo $LANG'
+      ).should == "C"
     end
 
     it "should respect other overridden environment variables" do
       Facter::Util::Resolution.with_env( {"FOO" => "foo"} ) do
-        Facter::Util::Resolution.exec("echo $FOO").should == "foo"
+        Facter::Util::Resolution.exec(
+          Facter::Util::Config.is_windows? ? 'cmd.exe /c "echo %FOO%"' : 'echo $FOO'
+        ).should == "foo"
       end
     end
   end


### PR DESCRIPTION
Previously, the tests were failing because there isn't an `echo.exe`
on Windows.

This commit just wraps the command in a `cmd.exe` shell and expands
the variables using `%LANG%` syntax on Windows.
