### PR TITLE
(New Feature) Added basic integration with Travis CI service

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - ree
+  - ruby-head
+branches:
+  only:
+    - master
+script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "http://rubygems.org"
+
+group :development, :test do
+  gem "rspec", "~> 2.8.0"
+  gem "mocha"
+  gem "rcov", :platform => [:mri_18]
+  gem "watchr"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    metaclass (0.0.1)
+    mocha (0.10.3)
+      metaclass (~> 0.0.1)
+    rcov (1.0.0)
+    rspec (2.8.0)
+      rspec-core (~> 2.8.0)
+      rspec-expectations (~> 2.8.0)
+      rspec-mocks (~> 2.8.0)
+    rspec-core (2.8.0)
+    rspec-expectations (2.8.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.8.0)
+    watchr (0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mocha
+  rcov
+  rspec (~> 2.8.0)
+  watchr


### PR DESCRIPTION
Added basic config for Travis CI service, including 4 basic
platforms: Ruby 1.8.7, Ruby 1.9.2, Ruby 1.9.3 and Ruby
Enterprise Edition and experimental Ruby 2.0.0dev (ruby-head).
