### PR TITLE
Bug/1.6.x/12079 fix ec2 test order dependency in stubs

### DIFF
--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -11,12 +11,12 @@ describe "ec2 facts" do
   describe "when running on ec2" do
     before :each do
       # This is an ec2 instance, not a eucalyptus instance
-      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(false)
-      Facter::Util::EC2.expects(:has_openstack_mac?).at_least_once.returns(false)
-      Facter::Util::EC2.expects(:has_ec2_arp?).at_least_once.returns(true)
+      Facter::Util::EC2.stubs(:has_euca_mac?).returns(false)
+      Facter::Util::EC2.stubs(:has_openstack_mac?).returns(false)
+      Facter::Util::EC2.stubs(:has_ec2_arp?).returns(true)
 
       # Assume we can connect
-      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(true)
+      Facter::Util::EC2.stubs(:can_connect?).returns(true)
     end
 
     it "should create flat meta-data facts" do
@@ -95,12 +95,12 @@ describe "ec2 facts" do
   describe "when running on eucalyptus" do
     before :each do
       # Return false for ec2, true for eucalyptus
-      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(true)
-      Facter::Util::EC2.expects(:has_openstack_mac?).at_least_once.returns(false)
-      Facter::Util::EC2.expects(:has_ec2_arp?).never
+      Facter::Util::EC2.stubs(:has_euca_mac?).returns(true)
+      Facter::Util::EC2.stubs(:has_openstack_mac?).returns(false)
+      Facter::Util::EC2.stubs(:has_ec2_arp?).returns(false)
 
       # Assume we can connect
-      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(true)
+      Facter::Util::EC2.stubs(:can_connect?).returns(true)
     end
 
     it "should create ec2_user_data fact" do
@@ -123,12 +123,12 @@ describe "ec2 facts" do
   describe "when running on openstack" do
     before :each do
       # Return false for ec2, true for eucalyptus
-      Facter::Util::EC2.expects(:has_openstack_mac?).at_least_once.returns(true)
-      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(false)
-      Facter::Util::EC2.expects(:has_ec2_arp?).never
+      Facter::Util::EC2.stubs(:has_openstack_mac?).returns(true)
+      Facter::Util::EC2.stubs(:has_euca_mac?).returns(false)
+      Facter::Util::EC2.stubs(:has_ec2_arp?).returns(false)
 
       # Assume we can connect
-      Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(true)
+      Facter::Util::EC2.stubs(:can_connect?).returns(true)
     end
 
     it "should create ec2_user_data fact" do
@@ -151,8 +151,8 @@ describe "ec2 facts" do
   describe "when api connect test fails" do
     it "should not populate ec2_userdata" do
       # Emulate ec2 for now as it matters little to this test
-      Facter::Util::EC2.expects(:has_euca_mac?).at_least_once.returns(true)
-      Facter::Util::EC2.expects(:has_ec2_arp?).never
+      Facter::Util::EC2.stubs(:has_euca_mac?).returns(true)
+      Facter::Util::EC2.stubs(:has_ec2_arp?).never
       Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(false)
 
       # The API should never be called at this point


### PR DESCRIPTION
The submitted tests worked fine until the order they ran in was perturbed;
after that, bad expectations were shown.  This corrects that subtle failure.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
