### PR TITLE
(#12077) Add pciutils RPM dependency

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -22,6 +22,7 @@ BuildArch: noarch
 Requires: ruby >= 1.8.1
 Requires: which
 Requires: dmidecode
+Requires: pciutils
 %if %has_ruby_abi
 Requires: ruby(abi) = 1.8
 %endif


### PR DESCRIPTION
This patch adds pciutils as a dependency to the redhat spec file facter/conf/redhat.  Facter uses both lspci and dmidecode to determine the virtual/is_virtual facts/detection of hypervisors, so it should also depend on the pciutils package.  Also reference RHBZ# 783749 for addition of the same to fedora, originally noted by Dominic Cleal.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
