### PR TITLE
Ticket/1.6.x/12170 add gem spec description

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,7 @@ spec = Gem::Specification.new do |spec|
   spec.executables = %w{facter}
   spec.version = Facter::FACTERVERSION
   spec.summary = 'Facter, a system inventory tool'
+  spec.description = 'You can prove anything with facts!'
   spec.author = 'Puppet Labs'
   spec.email = 'info@puppetlabs.com'
   spec.homepage = 'http://puppetlabs.com'


### PR DESCRIPTION
Without this patch, the gem spec file is missing a
description attribute, which causes a warning message
when generating the gem.  This patch adds a description
attribute to the spec with the facter tagline
'You can prove anything with facts!'

Signed-off-by: Moses Mendoza moses@puppetlabs.com
