### PR TITLE
Feature/1.6.x/12066 windows puppet facter build

### DIFF
--- a/conf/windows/stagedir/bin/facter.bat
+++ b/conf/windows/stagedir/bin/facter.bat
@@ -1,0 +1,15 @@
+@echo off
+SETLOCAL
+SET PL_BASEDIR=%~dp0..
+
+REM Avoid the nasty \..\ littering the paths.
+SET PL_BASEDIR=%PL_BASEDIR:\bin\..=%
+
+SET PUPPET_DIR=%PL_BASEDIR%\puppet
+SET FACTER_DIR=%PL_BASEDIR%\facter
+
+SET PATH=%PUPPET_DIR%\bin;%FACTER_DIR%\bin;%PL_BASEDIR%\bin;%PL_BASEDIR%\sys\ruby\bin;%PATH%
+SET RUBYLIB=%PUPPET_DIR%\lib;%FACTER_DIR%\lib;%RUBYLIB%
+SET RUBYLIB=%RUBYLIB:\=/%
+
+ruby -S -- %0 %*

--- a/install.rb
+++ b/install.rb
@@ -37,6 +37,7 @@ require 'find'
 require 'fileutils'
 require 'optparse'
 require 'ostruct'
+require 'tempfile'
 
 begin
   require 'rdoc/rdoc'
@@ -421,19 +422,15 @@ def install_binfile(from, op_file, target)
       installed_wrapper = true
     end
 
-    if not installed_wrapper
-      tmp_file2 = File.join(tmp_dir, '_tmp_wrapper')
-      cwv = <<-EOS
-@echo off
-setlocal
-set RUBY_BIN=%~dp0
-set RUBY_BIN=%RUBY_BIN:\\=/%
-"%RUBY_BIN%ruby.exe" -x "%RUBY_BIN%facter" %*
-EOS
-      File.open(tmp_file2, "w") { |cw| cw.puts cwv }
-      FileUtils.install(tmp_file2, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
-
-      File.unlink(tmp_file2)
+    if not installed_wrapper then
+      Tempfile.open([op_file, '.bat']) do |output|
+        File.open(File.join(File.dirname(__FILE__), "conf/windows/stagedir/bin/#{op_file}.bat"), 'r') do |input|
+          output.write input.read
+        end
+        # Flush the buffered writes before installing the file.
+        output.close
+        FileUtils.install(output.path, File.join(target, "#{op_file}.bat"), :mode => 0755, :verbose => true)
+      end
       installed_wrapper = true
     end
   end


### PR DESCRIPTION
Without this patch applied the default behavior of install.rb is to
write a facter.bat file using an inline string.  This is a problem
because we also need a facter.bat file for the MSI packaging rake task
in the Puppet project.

This patch address the problem by moving the `facter.bat` file out of
the inline string in install.rb to a stand alone file.

The patch also leaves the code in a better state than I found it by
replacing insecure temporary file behavior with a more secure and less
predictable Tempfile.open call.

This patch should also address all of Josh Cooper's comments at [1] in
that facter no longer automatically hard codes the `--puppet` flag.  I
removed it because Puppet may not actually be installed as Josh pointed
out.

[1] https://github.com/puppetlabs/puppet/pull/417#commitcomment-909040
