### PR TITLE
Downcase arp again 1.6.x (#12666)

### DIFF
--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -46,7 +46,7 @@ module Facter::Util::EC2
       arp_table = Facter::Util::Resolution.exec(arp_command)
       if not arp_table.nil?
         arp_table.each_line do |line|
-          return true if line.include?(mac_address)
+          return true if line.downcase.include?(mac_address)
         end
       end
       return false

--- a/spec/fixtures/unit/util/ec2/centos-arp-ec2.out
+++ b/spec/fixtures/unit/util/ec2/centos-arp-ec2.out
@@ -1,0 +1,1 @@
+? (10.240.93.1) at FE:FF:FF:FF:FF:FF [ether] on eth0

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -22,6 +22,13 @@ describe Facter::Util::EC2 do
         Facter::Util::EC2.has_ec2_arp?.should == true
       end
 
+      it "should succeed if arp table contains FE:FF:FF:FF:FF:FF" do
+        ec2arp = my_fixture_read("centos-arp-ec2.out")
+        Facter::Util::Resolution.expects(:exec).with("arp -an").\
+          at_least_once.returns(ec2arp)
+        Facter::Util::EC2.has_ec2_arp?.should == true
+      end
+
       it "should fail if arp table does not contain fe:ff:ff:ff:ff:ff" do
         ec2arp = my_fixture_read("linux-arp-not-ec2.out")
         Facter::Util::Resolution.expects(:exec).with("arp -an").


### PR DESCRIPTION
Refactoring the ec2 facts lost the support for CentOS where the
hardware address in arp -an is uppercased.  Fix and add a unit
test now that there are those
