### PR TITLE
Ticket/1.6.x/12813 redirect lspci stderr

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -89,7 +89,7 @@ Facter.add("virtual") do
     end
 
     if result == "physical"
-      output = Facter::Util::Resolution.exec('lspci')
+      output = Facter::Util::Resolution.exec('lspci 2>/dev/null')
       if not output.nil?
         output.each_line do |p|
           # --- look for the vmware video card to determine if it is virtual => vmware.

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -81,33 +81,33 @@ describe "Virtual fact" do
     Facter.fact(:architecture).stubs(:value).returns(true)
     end
 
-    it "should be parallels with Parallels vendor id from lspci" do
+    it "should be parallels with Parallels vendor id from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Unknown device 1ab8:4005")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("01:00.0 VGA compatible controller: Unknown device 1ab8:4005")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
-    it "should be parallels with Parallels vendor name from lspci" do
+    it "should be parallels with Parallels vendor name from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("01:00.0 VGA compatible controller: Parallels Display Adapter")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("01:00.0 VGA compatible controller: Parallels Display Adapter")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
-    it "should be vmware with VMware vendor name from lspci" do
+    it "should be vmware with VMware vendor name from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("00:0f.0 VGA compatible controller: VMware Inc [VMware SVGA II] PCI Display Adapter")
       Facter.fact(:virtual).value.should == "vmware"
     end
 
-    it "should be virtualbox with VirtualBox vendor name from lspci" do
+    it "should be virtualbox with VirtualBox vendor name from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("00:02.0 VGA compatible controller: InnoTek Systemberatung GmbH VirtualBox Graphics Adapter")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
 
     it "should be vmware with VMWare vendor name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
       Facter.fact(:virtual).value.should == "vmware"
     end
@@ -131,42 +131,42 @@ describe "Virtual fact" do
       Facter.fact(:virtual).value.should == "xenu"
     end
 
-    it "should be xenhvm with Xen HVM vendor name from lspci" do
+    it "should be xenhvm with Xen HVM vendor name from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)")
       Facter.fact(:virtual).value.should == "xenhvm"
     end
 
     it "should be xenhvm with Xen HVM vendor name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Xen\nProduct Name: HVM domU")
       Facter.fact(:virtual).value.should == "xenhvm"
     end
 
     it "should be parallels with Parallels vendor name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device Information\nType: Video\nStatus: Disabled\nDescription: Parallels Video Adapter")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
     it "should be virtualbox with VirtualBox vendor name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("BIOS Information\nVendor: innotek GmbH\nVersion: VirtualBox\n\nSystem Information\nManufacturer: innotek GmbH\nProduct Name: VirtualBox\nFamily: Virtual Machine")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
 
-    it "should be hyperv with Microsoft vendor name from lspci" do
+    it "should be hyperv with Microsoft vendor name from lspci 2>/dev/null" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns("00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA")
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA")
       Facter.fact(:virtual).value.should == "hyperv"
     end
 
     it "should be hyperv with Microsoft vendor name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Microsoft Corporation\nProduct Name: Virtual Machine")
       Facter.fact(:virtual).value.should == "hyperv"
     end
@@ -180,7 +180,7 @@ describe "Virtual fact" do
     it "should be vmware with VMWare vendor name from prtdiag" do
       Facter.fact(:kernel).stubs(:value).returns("SunOS")
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
       Facter.fact(:virtual).value.should == "vmware"
@@ -189,7 +189,7 @@ describe "Virtual fact" do
     it "should be parallels with Parallels vendor name from prtdiag" do
       Facter.fact(:kernel).stubs(:value).returns("SunOS")
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: Parallels Virtual Platform")
       Facter.fact(:virtual).value.should == "parallels"
@@ -198,7 +198,7 @@ describe "Virtual fact" do
     it "should be virtualbox with VirtualBox vendor name from prtdiag" do
       Facter.fact(:kernel).stubs(:value).returns("SunOS")
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: innotek GmbH VirtualBox")
       Facter.fact(:virtual).value.should == "virtualbox"
@@ -210,7 +210,7 @@ describe "Virtual fact" do
       Facter::Util::Resolution.stubs(:exec).with("vmware -v").returns false
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('lspci').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
     end
 


### PR DESCRIPTION
On linode instances, or any instance without a working /proc/bus/pci,
the following output is produced on stderr:

```
pcilib: Cannot open /proc/bus/pci
lspci: Cannot find any working access method.
```

This is very noisy over time, and does not produce anything of value.
Redirecting it to /dev/null removes the issue.
