### PR TITLE
Fix recursion on kernel fact

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -19,7 +19,7 @@ class Facter::Util::Resolution
         @have_which = false
       else
         %x{which which >/dev/null 2>&1}
-        @have_which = ($? == 0)
+        @have_which = $?.success?
       end
     end
     @have_which


### PR DESCRIPTION
We encounter a recursion if we want to detect the kernel fact for the first
time:

The kernel codeblock calls

```
Facter::Util::Resolution.exec("uname -s")
```

and Facter::Util::Resolution#exec wants to detect if we can use `which`
to get the full path of the command. But the method
Facter::Util::Resolution#have_which tries to query the kernel fact again
to check if we are on windows.

Change the check in have_which so we dont have to query the kernel fact.
