### PR TITLE
Feature #12790: Raise an exception if fact recursion is detected

### DIFF
--- a/lib/facter/util/fact.rb
+++ b/lib/facter/util/fact.rb
@@ -103,16 +103,7 @@ class Facter::Util::Fact
 
   # Lock our searching process, so we never ge stuck in recursion.
   def searching
-    if searching?
-      Facter.debug "Caught recursion on %s" % @name
-
-      # return a cached value if we've got it
-      if @value
-        return @value
-      else
-        return nil
-      end
-    end
+    raise RuntimeError, "Caught recursion on #{@name}" if searching?
 
     # If we've gotten this far, we're not already searching, so go ahead and do so.
     @searching = true


### PR DESCRIPTION
Facter can already detect if fact dependencies will end up in a loop.
Recursions can lead to strange errors because facter will return nil (or
an already cached value) for the fact value.

The change now changes the behaviour upon recursion detection: Dont
print a debug message but throw an error. This way a recursion is a
lot easier to detect so we can actually fix it.

examples for recursions:
http://projects.puppetlabs.com/issues/11511
http://projects.puppetlabs.com/issues/12831
