### PR TITLE
(#12720) Add Solaris CPU info to 'processorN' fact.

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -5,7 +5,8 @@
 #
 # Resolution:
 #   On Linux and kFreeBSD, parse '/proc/cpuinfo' for each processor.
-#   On AIX, parse the output of 'lsdev' for it's processor section.
+#   On AIX, parse the output of 'lsdev' for its processor section.
+#   On Solaris, parse the output of 'kstat' for each processor.
 #   On OpenBSD, use 'uname -p' and the sysctl variable for 'hw.ncpu' for CPU
 #   count.
 #
@@ -81,6 +82,7 @@ end
 ## (but we need them inside the Facter.add block above for tests on processorcount to work)
 processor_list = Facter::Util::Processor.enum_cpuinfo
 processor_list_aix = Facter::Util::Processor.enum_lsdev
+processor_list_sunos = Facter::Util::Processor.enum_kstat
 
 if processor_list.length != 0
   processor_list.each_with_index do |desc, i|
@@ -95,6 +97,15 @@ elsif processor_list_aix.length != 0
   processor_list_aix.each_with_index do |desc, i|
     Facter.add("Processor#{i}") do
       confine :kernel => [ :aix ]
+      setcode do
+        desc
+      end
+    end
+  end
+elsif processor_list_sunos.length != 0
+  processor_list_sunos.each_with_index do |desc, i|
+    Facter.add("Processor#{i}") do
+      confine :kernel => [ :sunos ]
       setcode do
         desc
       end

--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -85,4 +85,23 @@ module Facter::Util::Processor
     end
     processor_list
   end
+
+  def self.enum_kstat
+    processor_num = -1
+    processor_list = []
+    Thread::exclusive do
+      kstat = Facter::Util::Resolution.exec('/usr/bin/kstat cpu_info')
+      if kstat
+        kstat.each_line do |l|
+          if l =~ /cpu_info(\d+)/
+            processor_num = $1.to_i
+          elsif l =~ /brand\s+(.*)\s*$/
+            processor_list[processor_num] = $1 unless processor_num == -1
+            processor_num = -1
+          end
+        end
+      end
+    end
+    processor_list
+  end
 end

--- a/spec/fixtures/unit/util/processor/solaris-i86pc
+++ b/spec/fixtures/unit/util/processor/solaris-i86pc
@@ -1,0 +1,28 @@
+module: cpu_info                        instance: 0     
+name:   cpu_info0                       class:    misc
+        brand                           Intel(r) Core(tm) i5 CPU       M 450  @ 2.40GHz
+        cache_id                        0
+        chip_id                         0
+        clock_MHz                       2375
+        clog_id                         0
+        core_id                         0
+        cpu_type                        i386
+        crtime                          70.899819526
+        current_clock_Hz                2374891267
+        current_cstate                  0
+        family                          6
+        fpu_type                        i387 compatible
+        implementation                  x86 (GenuineIntel family 6 model 37 step 5 clock 2375 MHz)
+        model                           37
+        ncore_per_chip                  1
+        ncpu_per_chip                   1
+        pg_id                           -1
+        pkg_core_id                     0
+        snaptime                        2279.514858392
+        state                           on-line
+        state_begin                     1329488796
+        stepping                        5
+        supported_frequencies_Hz        2374891267
+        supported_max_cstates           1
+        vendor_id                       GenuineIntel
+

--- a/spec/fixtures/unit/util/processor/solaris-sun4u
+++ b/spec/fixtures/unit/util/processor/solaris-sun4u
@@ -1,0 +1,151 @@
+module: cpu_info                        instance: 0
+name:   cpu_info0                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         0
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          92.5418505
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           1
+        snaptime                        15277456.9660361
+        state                           on-line
+        state_begin                     1314212380
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 1
+name:   cpu_info1                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         0
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3416172
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           1
+        snaptime                        15277456.9667477
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 2
+name:   cpu_info2                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         2
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3433262
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           4
+        snaptime                        15277456.9671387
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 3
+name:   cpu_info3                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         2
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3449653
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           4
+        snaptime                        15277456.9675197
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 4
+name:   cpu_info4                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         4
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3465648
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           5
+        snaptime                        15277456.9678953
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 5
+name:   cpu_info5                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         4
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3481605
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           5
+        snaptime                        15277456.968269
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 6
+name:   cpu_info6                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         6
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3497654
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           6
+        snaptime                        15277456.9686422
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000
+
+module: cpu_info                        instance: 7
+name:   cpu_info7                       class:    misc
+        brand                           SPARC64-VII
+        chip_id                         1024
+        clock_MHz                       2520
+        core_id                         6
+        cpu_fru                         hc:///component=/MBU_A
+        cpu_type                        sparcv9
+        crtime                          93.3513776
+        current_clock_Hz                2520000000
+        device_ID                       175931055444225
+        fpu_type                        sparcv9
+        implementation                  SPARC64-VII (portid 1024 impl 0x7 ver 0x91 clock 2520 MHz)
+        pg_id                           6
+        snaptime                        15277456.9690115
+        state                           on-line
+        state_begin                     1314212381
+        supported_frequencies_Hz        2520000000

--- a/spec/unit/util/processor_spec.rb
+++ b/spec/unit/util/processor_spec.rb
@@ -43,7 +43,7 @@ describe Facter::Util::Processor do
     Facter.fact(:architecture).stubs(:value).returns("amd64")
     File.stubs(:exists?).with("/proc/cpuinfo").returns(true)
     File.stubs(:readlines).with("/proc/cpuinfo").returns(cpuinfo_fixture("amd64quad"))
-    
+
     Facter::Util::Processor.enum_cpuinfo[0].should == "Quad-Core AMD Opteron(tm) Processor 2374 HE"
     Facter::Util::Processor.enum_cpuinfo[1].should == "Quad-Core AMD Opteron(tm) Processor 2374 HE"
     Facter::Util::Processor.enum_cpuinfo[2].should == "Quad-Core AMD Opteron(tm) Processor 2374 HE"
@@ -56,5 +56,28 @@ describe Facter::Util::Processor do
     Facter::Util::Resolution.stubs(:exec).with("lsattr -El proc0 -a type").returns("type PowerPC_POWER3 Processor type False")
 
     Facter::Util::Processor.enum_lsdev[0].should == "PowerPC_POWER3"
+  end
+
+  it "should get the processor description on Solaris (x86)" do
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    Facter.fact(:architecture).stubs(:value).returns("i86pc")
+    Facter::Util::Resolution.stubs(:exec).with("/usr/bin/kstat cpu_info").returns(my_fixture_read("solaris-i86pc"))
+
+    Facter::Util::Processor.enum_kstat[0].should == "Intel(r) Core(tm) i5 CPU       M 450  @ 2.40GHz"
+  end
+
+  it "should get the processor description on Solaris (SPARC64)" do
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    Facter.fact(:architecture).stubs(:value).returns("sun4u")
+    Facter::Util::Resolution.stubs(:exec).with("/usr/bin/kstat cpu_info").returns(my_fixture_read("solaris-sun4u"))
+
+    Facter::Util::Processor.enum_kstat[0].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[1].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[2].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[3].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[4].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[5].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[6].should == "SPARC64-VII"
+    Facter::Util::Processor.enum_kstat[7].should == "SPARC64-VII"
   end
 end


### PR DESCRIPTION
Add support for Solaris to the 'processorN' fact.
It parses "kstat cpu_info" to produce similar information as /proc/cpuinfo on Linux.

Rebased against 1.6.x branch and implemented suggestions from comments on https://github.com/puppetlabs/facter/pull/173.
