### PR TITLE
Adds fact about machine's RAID Controller

### DIFF
--- a/lib/facter/raid.rb
+++ b/lib/facter/raid.rb
@@ -17,7 +17,9 @@ if Facter.value(:kernel) == "Linux"
     Facter.add("RAIDControllerCount") do
         confine :kernel => :linux
         setcode do
-            raidcontroller_list.length.to_s
+            if raidcontroller_list.length != 0
+                raidcontroller_list.length.to_s
+            end
         end
     end
 


### PR DESCRIPTION
This adds a small fact to read out machine's raid controllers.
We use it to check RAID Controller on host and install the matching utils.
We also feed our nagios raid check with information from it.
