### PR TITLE
(#12790) Raise an exception if recursion is detected

### DIFF
--- a/lib/facter/util/fact.rb
+++ b/lib/facter/util/fact.rb
@@ -100,16 +100,7 @@ class Facter::Util::Fact
 
   # Lock our searching process, so we never ge stuck in recursion.
   def searching
-    if searching?
-      Facter.debug "Caught recursion on %s" % @name
-
-      # return a cached value if we've got it
-      if @value
-        return @value
-      else
-        return nil
-      end
-    end
+    raise RuntimeError, "Caught recursion on #{@name}" if searching?
 
     # If we've gotten this far, we're not already searching, so go ahead and do so.
     @searching = true

--- a/spec/integration/facter_spec.rb
+++ b/spec/integration/facter_spec.rb
@@ -24,4 +24,16 @@ describe Facter do
     Facter.reset
     Facter.collection.should_not equal(old)
   end
+
+  it "should raise an error if a recursion is detected" do
+    Facter.clear
+    Facter.add(:foo) do
+      confine :bar => 'some_value'
+    end
+    Facter.add(:bar) do
+      confine :foo => 'some_value'
+    end
+    lambda { Facter.value(:foo) }.should raise_error(RuntimeError, /Caught recursion on foo/)
+  end
+
 end


### PR DESCRIPTION
Facter can already detect fact dependency cycles (fact recursions).

Without this patch facter will return nil (or an already cached value)
as a factvalue when a recursion is detected. This can silently break
things. Example

```
Facter.add(:foo)
  if Facter.value(:bar) != 'baz'
    something happens here
  end
end
```

If there is now a recursion when querying the bar fact we will always
execute the following codeblock (nil != baz). This may lead to strange
and inexplicable results for the foo fact.

The fix now changes the behaviour when a recursion is detected: Do not
just print a debug message but throw an error. This way a recursion is
a lot easier to detect and we can actually fix it.
