### PR TITLE
(#13680) Distinguish "Funtoo" from "Gentoo" Linux

### DIFF
--- a/lib/facter/architecture.rb
+++ b/lib/facter/architecture.rb
@@ -5,8 +5,8 @@
 #
 # Resolution:
 #   On OpenBSD, Linux and Debian's kfreebsd, use the hardwaremodel fact.
-#   Gentoo and Debian call "x86_86" "amd64".
-#   Gentoo also calls "i386" "x86".
+#   Gentoo (and its fork Funtoo) and Debian call "x86_86" "amd64".
+#   Gentoo (and its fork Funtoo) also calls "i386" "x86".
 #
 # Caveats:
 #
@@ -18,14 +18,14 @@ Facter.add(:architecture) do
       # most linuxen use "x86_64"
     when "x86_64"
       case Facter.value(:operatingsystem)
-      when "Debian", "Gentoo", "GNU/kFreeBSD", "Ubuntu"
+      when "Debian", "Gentoo", "Funtoo", "GNU/kFreeBSD", "Ubuntu"
         "amd64"
       else
         model
       end
     when /(i[3456]86|pentium)/
       case Facter.value(:operatingsystem)
-      when "Gentoo"
+      when "Gentoo", "Funtoo"
         "x86"
       else
         "i386"

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -31,7 +31,12 @@ Facter.add(:operatingsystem) do
     elsif FileTest.exists?("/etc/debian_version")
       "Debian"
     elsif FileTest.exists?("/etc/gentoo-release")
-      "Gentoo"
+      txt = File.read("/etc/gentoo-release")
+      if txt =~ /funtoo/i
+        "Funtoo"
+      else
+        "Gentoo"
+      end
     elsif FileTest.exists?("/etc/fedora-release")
       "Fedora"
     elsif FileTest.exists?("/etc/mandriva-release")

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -22,6 +22,8 @@ Facter.add(:osfamily) do
       "Debian"
     when "SLES", "SLED", "OpenSuSE", "SuSE"
       "Suse"
+    when "Gentoo", "Funtoo"
+      "Gentoo"
     when "Solaris", "Nexenta"
       "Solaris"
     else

--- a/spec/unit/architecture_spec.rb
+++ b/spec/unit/architecture_spec.rb
@@ -14,6 +14,7 @@ describe "Architecture fact" do
   os_archs = {
     ["Debian","x86_64"] => "amd64",
     ["Gentoo","x86_64"] => "amd64",
+    ["Funtoo","x86_64"] => "amd64",
     ["GNU/kFreeBSD","x86_64"] => "amd64",
     ["Ubuntu","x86_64"] => "amd64",
     ["Gentoo","i386"] => "x86",
@@ -21,6 +22,11 @@ describe "Architecture fact" do
     ["Gentoo","i586"] => "x86",
     ["Gentoo","i686"] => "x86",
     ["Gentoo","pentium"] => "x86",
+    ["Funtoo","i386"] => "x86",
+    ["Funtoo","i486"] => "x86",
+    ["Funtoo","i586"] => "x86",
+    ["Funtoo","i686"] => "x86",
+    ["Funtoo","pentium"] => "x86",
   }
   generic_archs = Hash.new
   generic_archs = {
@@ -30,7 +36,7 @@ describe "Architecture fact" do
     "i686" => "i386",
     "pentium" => "i386",
   }
-  
+
   os_archs.each do |pair, result|
     it "should be #{result} if os is #{pair[0]} and hardwaremodel is #{pair[1]}" do
      Facter.fact(:operatingsystem).stubs(:value).returns(pair[0])

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -41,7 +41,6 @@ describe "Operating System fact" do
 
     {
       "Debian"      => "/etc/debian_version",
-      "Gentoo"      => "/etc/gentoo-release",
       "Fedora"      => "/etc/fedora-release",
       "Mandriva"    => "/etc/mandriva-release",
       "Mandrake"    => "/etc/mandrake-release",
@@ -73,6 +72,19 @@ describe "Operating System fact" do
         Facter.fact(:operatingsystem).value.should == "Ubuntu"
       end
 
+    end
+
+    # Check distributions that rely on the contents of /etc/gentoo-release
+    {
+      'Gentoo' => 'Gentoo Base System release 2.1',
+      'Funtoo' => 'Funtoo Linux - baselayout 2.1.8'
+    }.each_pair do |operatingsystem, string|
+      it "should be #{operatingsystem} based on /etc/gentoo-release contents #{string}" do
+        FileTest.expects(:exists?).with("/etc/gentoo-release").returns true
+        File.expects(:read).with("/etc/gentoo-release").returns string
+
+        Facter.fact(:operatingsystem).value.should == operatingsystem
+      end
     end
 
 

--- a/spec/unit/osfamily_spec.rb
+++ b/spec/unit/osfamily_spec.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env rspec
+
+require 'spec_helper'
+
+describe "OS Family fact" do
+
+  {
+    'Ubuntu'      => 'Debian',
+    'Debian'      => 'Debian',
+    'Funtoo'      => 'Gentoo',
+    'Gentoo'      => 'Gentoo',
+    'Fedora'      => 'RedHat',
+    'CentOS'      => 'RedHat',
+    'SLC'         => 'RedHat',
+    'Scientific'  => 'RedHat',
+    'CloudLinux'  => 'RedHat',
+    'PSBM'        => 'RedHat',
+    'Ascendos'    => 'RedHat',
+    'RedHat'      => 'RedHat',
+    'OracleLinux' => 'RedHat',
+    'OVS'         => 'RedHat',
+    'OEL'         => 'RedHat',
+    'SLES'        => 'Suse',
+    'SLED'        => 'Suse',
+    'OpenSuSE'    => 'Suse',
+    'SuSE'        => 'Suse',
+    'Nexenta'     => 'Solaris',
+    'Solaris'     => 'Solaris'
+  }.each do |os,family|
+    it "should return #{family} on operatingsystem #{os}" do
+      Facter.fact(:operatingsystem).stubs(:value).returns os
+      Facter.fact(:osfamily).value.should == family
+    end
+  end
+
+  [
+    'Mandriva',
+    'Mandrake',
+    'MeeGo',
+    'Archlinux',
+    'VMWareESX',
+    'Bluewhite64',
+    'Slamd64',
+    'Slackware',
+    'Alpine',
+    'Amazon',
+    'ESXi'
+  ].each do |os|
+    it "should return the kernel fact on operatingsystem #{os}" do
+      Facter.fact(:operatingsystem).stubs(:value).returns os
+      Facter.fact(:kernel).stubs(:value).returns 'random_kernel_fact'
+      Facter.fact(:osfamily).value.should == 'random_kernel_fact'
+    end
+  end
+end


### PR DESCRIPTION
As the ticket owner Marc Richter states:

Funtoo Linux is a Fork of Gentoo Linux from the former creator of Gentoo
Linux, Daniel Robbins. The two derivates behave mostly the same, but
they are differing more and more over time. So the package manager
portage (and it's frontend emerge) for example are behaving a little
different already. Packages are named different, versions differ, and so
on. It would be great if one could differ between Funtoo and Gentoo in
his manifests to install different package versions on Funtoo/Gentoo or
package versions or deliver different configurations.

This patch now reads the contents of `/etc/gentoo-release` to
distinguish between the two. We already do this is in a similar way with
the `/etc/redhat-release` file to distinguish between CentOS, Scientific
Linux, RHEL, etc.
