### PR TITLE
Ticket/1.6.x/update redhat spec file

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -16,10 +16,11 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 Requires: ruby >= 1.8.5
 Requires: which
-# Note: dmidecode is only available on x86 and x86_64 so this package may need to move into being
-#  arch specific if people are using ppc, arm, s390 etc
+# dmidecode and pciutils are not available on all arches
+%ifarch %ix86 x86_64 ia64
 Requires: dmidecode
 Requires: pciutils
+%endif
 Requires: ruby(abi) = 1.8
 BuildRequires: ruby >= 1.8.5
 
@@ -51,7 +52,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* Mon Apr 23 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.8-1
+* Mon Apr 30 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.8-1
 - Update for 1.6.8, spec for arch-specific build, req ruby 1.8.5
 
 * Thu Feb 23 2012 Michael Stahnke <stahnma@puppetlabs.com> - 1.6.6-1


### PR DESCRIPTION
This commit updates the rpm spec file to change
the ruby dependencies to version 1.8.5. It also
removes any conditionals for ruby abi, because
we can now assume ruby abi present. The
dependency on ruby is bumped to version 1.8.5,
as we can also assume this ruby version, given
that el4 is EOL. The facter version is bumped
to 1.6.8 to reflect the latest released version.
Finally, this commit removes the manual noarch
build setting, as facter is now arch-specific
because of its dependency on dmidecode.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
