### PR TITLE
(#12864) Windows: get primary DNS from registry

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -52,12 +52,17 @@ end
 Facter.add(:domain) do
   confine :kernel => :windows
   setcode do
-    require 'facter/util/wmi'
+    require 'facter/util/registry'
     domain = ""
-    Facter::Util::WMI.execquery("select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True").each { |nic|
-      domain = nic.DNSDomain
-      break
-    }
+    regvalue = Facter::Util::Registry.hklm_read('SYSTEM\CurrentControlSet\Services\Tcpip\Parameters', 'Domain')
+    domain = regvalue if regvalue
+    if domain == ""
+      require 'facter/util/wmi'
+      Facter::Util::WMI.execquery("select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True").each { |nic|
+        domain = nic.DNSDomain
+        break
+      }
+    end
     domain
   end
 end

--- a/lib/facter/util/registry.rb
+++ b/lib/facter/util/registry.rb
@@ -1,0 +1,9 @@
+module Facter::Util::Registry
+  class << self
+    def hklm_read(key, value)
+      require 'win32/registry'
+      reg = Win32::Registry::HKEY_LOCAL_MACHINE.open(key)
+      reg[value]
+    end
+  end
+end

--- a/spec/unit/util/registry_spec.rb
+++ b/spec/unit/util/registry_spec.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env rspec
+require 'spec_helper'
+require 'facter/operatingsystem'
+require 'facter/util/registry'
+
+describe Facter::Util::Registry do
+  describe "hklm_read", :if => Facter::Util::Config.is_windows? do
+    before(:all) do
+      require 'win32/registry'
+    end
+    describe "valid params" do
+      [ {:key => "valid_key", :value => "valid_value",  :expected => "valid"},
+        {:key => "valid_key", :value => "",             :expected => "valid"},
+        {:key => "valid_key", :value => nil,            :expected => "invalid"},
+        {:key => "",          :value => "valid_value",  :expected => "valid"},
+        {:key => "",          :value => "",             :expected => "valid"},
+        {:key => "",          :value => nil,            :expected => "invalid"},
+        {:key => nil,         :value => "valid_value",  :expected => "invalid"},
+        {:key => nil,         :value => "",             :expected => "invalid"},
+        {:key => nil,         :value => nil,            :expected => "invalid"}
+      ].each do |scenario|
+        describe "with key #{scenario[:key] || "nil"} and value #{scenario[:value] || "nil"}" do
+          let :fake_registry_key do
+            fake = {}
+            fake[scenario[:value]] = scenario[:expected]
+            fake
+          end
+          it "should return #{scenario[:expected]} value" do
+            Win32::Registry::HKEY_LOCAL_MACHINE.stubs(:open).with(scenario[:key]).returns(fake_registry_key)
+
+            Facter::Util::Registry.hklm_read(scenario[:key], scenario[:value]).should == scenario[:expected]
+          end
+        end
+      end
+    end
+    
+    describe "invalid params" do
+      [ {:key => "valid_key",   :value => "invalid_value"},
+        {:key => "valid_key",   :value => ""},
+        {:key => "valid_key",   :value => nil},
+      ].each do |scenario|
+        describe "with valid key and value #{scenario[:value] || "nil"}" do
+          let :fake_registry_key do
+            {}
+          end
+          it "should raise an error" do
+            Win32::Registry::HKEY_LOCAL_MACHINE.stubs(:open).with(scenario[:key]).returns(fake_registry_key)
+
+            Facter::Util::Registry.hklm_read(scenario[:key], scenario[:value]).should raise_error
+          end
+        end
+      end
+      [ {:key => "invalid_key", :value => "valid_value"},
+        {:key => "invalid_key", :value => ""},
+        {:key => "invalid_key", :value => nil},
+        {:key => "",            :value => "valid_value"},
+        {:key => "",            :value => ""},
+        {:key => "",            :value => nil},
+        {:key => nil,           :value => "valid_value"},
+        {:key => nil,           :value => ""},
+        {:key => nil,           :value => nil}
+      ].each do |scenario|
+        describe "with invalid key #{scenario[:key] || "nil"} and value #{scenario[:value] || "nil"}" do
+          it "should raise an error" do
+            Win32::Registry::HKEY_LOCAL_MACHINE.stubs(:open).with(scenario[:key]).raises(Win32::Registry::Error, 2)
+            expect do
+              Facter::Util::Registry.hklm_read(scenario[:key], scenario[:value])
+            end.to raise_error Win32::Registry::Error
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Windows does not expose the host's primary DNS suffix via WMI, only the
registry. This commit adds a registry helper class and will retrieve the
primary DNS suffix from the registry. In the case the primary DNS suffix
does not exist or is empty, the domain fact will fall back to using WMI
for any connection-specific DNS suffix.

Rebased against master. See Pull Request #192 for greater discussion.
