### PR TITLE
Ticket/1.6.x/14332 ubuntu stubbing

### DIFF
--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -37,6 +37,9 @@ describe "Operating System fact" do
   describe "on Linux" do
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
+
+      # Always stub lsbdistid by default, so tests work on Ubuntu
+      Facter.stubs(:value).with(:lsbdistid).returns(nil)
     end
 
     {
@@ -69,7 +72,7 @@ describe "Operating System fact" do
       it "on Ubuntu should use the lsbdistid fact" do
         FileUtils.stubs(:exists?).with("/etc/debian_version").returns true
 
-        Facter.fact(:lsbdistid).expects(:value).returns("Ubuntu")
+        Facter.stubs(:value).with(:lsbdistid).returns("Ubuntu")
         Facter.fact(:operatingsystem).value.should == "Ubuntu"
       end
 


### PR DESCRIPTION
The tests for facter fail on Ubuntu because lsbdistid is not correctly stubbed.
This patch fixes that small mistake by stubbing lsbdistid for all Linux tests,
except where the test is really about testing for Ubuntu.
