### PR TITLE
(#7484) Domain Fact should handle TLD

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -23,7 +23,15 @@ Facter.add(:domain) do
     # Get the domain from various sources; the order of these
     # steps is important
 
-    hostname_command = (Facter.value(:kernel) =~ /SunOS/i) ? 'hostname' : 'hostname -f' 
+    # In some OS 'hostname -f' will change the hostname to '-f' 
+    # We know that Solaris and HP-UX exhibit this behavior 
+    # On good OS, 'hostname -f' will return the FQDN which is preferable 
+    # Due to dangerous behavior of 'hostname -f' on old OS, we will explicitly opt-in 
+    # 'hostname -f' --hkenney May 9, 2012
+    hostname_command = 'hostname'
+    can_do_hostname_f = Regexp.union /Linux/i, /FreeBSD/i, /Darwin/i
+    hostname_command = 'hostname -f' if Facter.value(:kernel) =~ can_do_hostname_f
+
        
     if name = Facter::Util::Resolution.exec(hostname_command) \
       and name =~ /.*?\.(.+$)/

--- a/spec/unit/domain_spec.rb
+++ b/spec/unit/domain_spec.rb
@@ -8,6 +8,7 @@ describe "Domain name facts" do
     :solaris => {:kernel => "SunOS", :hostname_command => "hostname"},
     :darwin => {:kernel => "Darwin", :hostname_command => "hostname -f"},
     :freebsd => {:kernel => "FreeBSD", :hostname_command => "hostname -f"},
+    :hpux => {:kernel => "HP-UX", :hostname_command => "hostname"},
   }.each do |key, nested_hash|
 
     describe "on #{key}" do


### PR DESCRIPTION
The domain fact executed "hostname" on all platforms,
however the default on Linux is that "hostname" does not return FQDN.
This causes problems when the machine only has a TLD, rather than being
in a second level domain. For example, ns01.tld vs ns01.puppetlabs.com.

This patch makes 'hostname -f' to be opt-in to prevent problems 
on certain operating systems such as Solaris and HP-UX.
