### PR TITLE
(#14366) is_virtual/virtual should be triggered by EC2

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -1,3 +1,5 @@
+require 'facter/util/ec2'
+
 module Facter::Util::Virtual
   def self.openvz?
     FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
@@ -86,5 +88,11 @@ module Facter::Util::Virtual
 
    def self.zlinux?
     "zlinux"
+   end
+
+   def self.ec2?
+     if Facter::Util::EC2.can_connect?
+       "ec2"
+     end
    end
 end

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -92,6 +92,10 @@ Facter.add("virtual") do
       result = "jail" if Facter::Util::Virtual.jail?
     end
 
+    if Facter::Util::Virtual.ec2?
+      result = "ec2"
+    end
+
     if result == "physical"
       output = Facter::Util::Resolution.exec('lspci 2>/dev/null')
       if not output.nil?

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -13,6 +13,7 @@ describe "Virtual fact" do
     Facter::Util::Virtual.stubs(:kvm?).returns(false)
     Facter::Util::Virtual.stubs(:hpvm?).returns(false)
     Facter::Util::Virtual.stubs(:zlinux?).returns(false)
+    Facter::Util::EC2.stubs(:can_connect?).returns(false)
   end
 
   it "should be zone on Solaris when a zone" do
@@ -233,6 +234,12 @@ describe "Virtual fact" do
       Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.product 2>/dev/null').returns("HVM domU")
       Facter.fact(:virtual).value.should == "xenhvm"
     end
+
+    it "should be ec2 with EC2 can_connect?" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Util::EC2.stubs(:can_connect?).returns(true)
+      Facter.fact(:virtual).value.should == "ec2"
+    end
   end
 end
 
@@ -332,6 +339,12 @@ describe "is_virtual fact" do
   it "should be true when running on hyperv" do
     Facter.fact(:kernel).stubs(:value).returns("Linux")
     Facter.fact(:virtual).stubs(:value).returns("hyperv")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
+  
+  it "should be true when running on ec2" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter::Util::EC2.stubs(:can_connect?).returns(true)
     Facter.fact(:is_virtual).value.should == "true"
   end
 end


### PR DESCRIPTION
Uses the built-in EC2 checks that populate the ec2_\* facts to see
if we're running on EC2 and populate the is_virtual/virtual facts
appropriately.

This is my first commit, I've tried gathering the right way to do things from viewing other pull requests/commits but please let me know if anything looks off.

Thanks!
