### PR TITLE
(#3226) Strip whitespace from fact

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -10,7 +10,7 @@ require 'timeout'
 
 class Facter::Util::Resolution
   attr_accessor :interpreter, :code, :name, :timeout
-  attr_writer :value, :weight, :preserve_whitespace
+  attr_writer :value, :weight
 
   INTERPRETER = Facter::Util::Config.is_windows? ? "cmd.exe" : "/bin/sh"
 
@@ -155,6 +155,10 @@ class Facter::Util::Resolution
     @timeout
   end
 
+  def preserve_whitespace
+    @preserve_whitespace = true
+  end   
+
   # Set our code for returning a value.
   def setcode(string = nil, interp = nil, &block)
     Facter.warnonce "The interpreter parameter to 'setcode' is deprecated and will be removed in a future version." if interp
@@ -226,7 +230,7 @@ class Facter::Util::Resolution
     Facter.show_time "#{self.name}: #{"%.2f" % ms}ms"
 
     unless @preserve_whitespace
-      result = result.strip if result 
+      result.strip! if result && result.respond_to?(:strip!) 
     end
     
     return nil if result == ""

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -172,6 +172,7 @@ describe Facter::Util::Resolution do
         @resolve.setcode {'  value  '}
         @resolve.value.should == 'value' 
       end 
+
       describe "when given a string" do
         [true, false
         ].each do |windows| 
@@ -179,10 +180,8 @@ describe Facter::Util::Resolution do
             before do
               Facter::Util::Config.stubs(:is_windows?).returns(windows)
             end
-            describe "stripping whitespace" do 
-              before do
-                @resolve.preserve_whitespace = false 
-              end 
+
+            describe "stripping whitespace" do
               [{:name => 'leading', :result => '  value', :expect => 'value'},
                {:name => 'trailing', :result => 'value  ', :expect => 'value'}, 
                {:name => 'internal', :result => 'val  ue', :expect => 'val  ue'},
@@ -190,17 +189,21 @@ describe Facter::Util::Resolution do
                {:name => 'leading and internal', :result => '  val  ue', :expect => 'val  ue'}, 
                {:name => 'trailing and internal', :result => 'val  ue  ', :expect => 'val  ue'}
               ].each do |scenario|
+
                 it "should remove outer whitespace when whitespace is #{scenario[:name]}" do 
                   @resolve.setcode "/bin/foo"
                   Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns scenario[:result]
                   @resolve.value.should == scenario[:expect] 
                 end 
+
               end 
             end 
+
             describe "not stripping whitespace" do
               before do
-                @resolve.preserve_whitespace = true 
+                @resolve.preserve_whitespace 
               end 
+
               [{:name => 'leading', :result => '  value', :expect => '  value'}, 
                {:name => 'trailing', :result => 'value  ', :expect => 'value  '}, 
                {:name => 'internal', :result => 'val  ue', :expect => 'val  ue'},
@@ -208,21 +211,21 @@ describe Facter::Util::Resolution do
                {:name => 'leading and internal', :result => '  val  ue', :expect => '  val  ue'}, 
                {:name => 'trailing and internal', :result => 'val  ue  ', :expect => 'val  ue  '}
               ].each do |scenario|
+
                 it "should not remove #{scenario[:name]} whitespace" do 
                   @resolve.setcode "/bin/foo"
                   Facter::Util::Resolution.expects(:exec).once.with("/bin/foo").returns scenario[:result]
                   @resolve.value.should == scenario[:expect] 
                 end 
+
               end 
             end 
           end 
         end 
-      end 
+      end
+ 
       describe "when given a block" do
         describe "stripping whitespace" do 
-          before do
-            @resolve.preserve_whitespace = false 
-          end 
           [{:name => 'leading', :result => '  value', :expect => 'value'},
            {:name => 'trailing', :result => 'value  ', :expect => 'value'}, 
            {:name => 'internal', :result => 'val  ue', :expect => 'val  ue'},
@@ -230,31 +233,38 @@ describe Facter::Util::Resolution do
            {:name => 'leading and internal', :result => '  val  ue', :expect => 'val  ue'}, 
            {:name => 'trailing and internal', :result => 'val  ue  ', :expect => 'val  ue'}
           ].each do |scenario|
+
             it "should remove outer whitespace when whitespace is #{scenario[:name]}" do 
               @resolve.setcode {scenario[:result]}
               @resolve.value.should == scenario[:expect] 
             end
+
           end 
         end
+
         describe "not stripping whitespace" do 
           before do
-            @resolve.preserve_whitespace = true 
-          end 
+            @resolve.preserve_whitespace 
+          end
+          
           [{:name => 'leading', :result => '  value', :expect => '  value'}, 
-          {:name => 'trailing', :result => 'value  ', :expect => 'value  '}, 
-          {:name => 'internal', :result => 'val  ue', :expect => 'val  ue'},
-          {:name => 'leading and trailing', :result => '  value  ', :expect => '  value  '},  
-          {:name => 'leading and internal', :result => '  val  ue', :expect => '  val  ue'}, 
-          {:name => 'trailing and internal', :result => 'val  ue  ', :expect => 'val  ue  '}
-         ].each do |scenario|
+           {:name => 'trailing', :result => 'value  ', :expect => 'value  '}, 
+           {:name => 'internal', :result => 'val  ue', :expect => 'val  ue'},
+           {:name => 'leading and trailing', :result => '  value  ', :expect => '  value  '},  
+           {:name => 'leading and internal', :result => '  val  ue', :expect => '  val  ue'}, 
+           {:name => 'trailing and internal', :result => 'val  ue  ', :expect => 'val  ue  '}
+          ].each do |scenario|
+
             it "should not remove #{scenario[:name]} whitespace" do 
               @resolve.setcode {scenario[:result]}
               @resolve.value.should == scenario[:expect] 
             end
+
           end 
         end 
       end 
-    end 
+    end
+ 
     describe "and setcode has not been called" do
       it "should return nil" do
         Facter::Util::Resolution.expects(:exec).with(nil, nil).never


### PR DESCRIPTION
Prior to this commit, Facter was not removing trailing or leading
whitespace from facts. This change normalizes all facts by
stripping whitespace. However, since in some custom facts trailing
and leading whitespace may be essential, it is possible to opt
out of stripping the whitespace on certain facts.
