### PR TITLE
(#11466) Remove deprecated memorytotal fact

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -262,14 +262,3 @@ Facter.add("memorysize") do
     Facter::Memory.scale_number(memtotal.to_f,"")
   end
 end
-
-# http://projects.puppetlabs.com/issues/11436
-#
-# Unifying naming for the amount of physical memory in a given host.
-# This fact is DEPRECATED and will be removed in Facter 2.0 per
-# http://projects.puppetlabs.com/issues/11466
-Facter.add("MemoryTotal") do
-  setcode do
-    Facter.value("memorysize")
-  end
-end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -142,14 +142,7 @@ EOS
       computer.stubs(:TotalPhysicalMemory).returns("4193837056")
       Facter::Util::WMI.stubs(:execquery).returns([computer])
 
-      Facter.fact(:MemoryTotal).value.should == '3.91 GB'
+      Facter.fact(:MemorySize).value.should == '3.91 GB'
     end
-  end
-
-  it "should use the memorysize fact for the memorytotal fact" do
-    Facter.fact("memorysize").expects(:value).once.returns "yay"
-    Facter::Util::Resolution.expects(:exec).never
-    Facter::Memory.expects(:meminfo_number).never
-    Facter.fact("memorytotal").value.should == "yay"
   end
 end


### PR DESCRIPTION
The `memorytotal` fact was previously deprecated in preference to the
`memorysize` fact.  This commit now removes `memorytotal`.

This commit is a breaking change that will force any remaining
`memorytotal` fact users to switch to the preferred `memorysize` fact.
