### PR TITLE
(#14467) Warn when removing relative paths

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -44,6 +44,7 @@ module Facter
   @@debug = 0
   @@timing = 0
   @@messages = {}
+  @@debug_messages = {}
 
   # module methods
 
@@ -68,6 +69,14 @@ module Facter
       puts GREEN + string + RESET
     end
   end
+
+  # Debug once.
+  def self.debugonce(msg)
+    if msg and not msg.empty? and @@debug_messages[msg].nil?
+      @@debug_messages[msg] = true
+      debug(msg) 
+    end 
+  end 
 
   def self.debugging?
     @@debug != 0

--- a/lib/facter/util/loader.rb
+++ b/lib/facter/util/loader.rb
@@ -63,7 +63,7 @@ class Facter::Util::Loader
 
     result.select do |dir|
       good = valid_search_path? dir
-      Facter.warnonce("Relative directory #{dir} removed from search path.") unless good
+      Facter.debugonce("Relative directory #{dir} removed from search path.") unless good
       good
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ RSpec.configure do |config|
     # Store any environment variables away to be restored later
     @old_env = {}
     ENV.each_key {|k| @old_env[k] = ENV[k]}
-    Kernel.stubs(:warn)
   end
 
   config.after :each do

--- a/spec/unit/util/loader_spec.rb
+++ b/spec/unit/util/loader_spec.rb
@@ -19,7 +19,6 @@ end
 describe Facter::Util::Loader do
   before :each do
     Facter::Util::Loader.any_instance.unstub(:load_all)
-    Facter.stubs(:warnonce)
   end
 
   it "should have a method for loading individual facts by name" do
@@ -116,7 +115,7 @@ describe Facter::Util::Loader do
       dirs = $LOAD_PATH.collect { |d| File.join(d, "facter") }
       @loader.stubs(:valid_search_path?).returns(false)
       dirs.each do |dir|
-        Facter.expects(:warnonce).with("Relative directory #{dir} removed from search path.").once
+        Facter.expects(:debugonce).with("Relative directory #{dir} removed from search path.").once
       end 
       paths = @loader.search_path
     end 


### PR DESCRIPTION
Due to changes made to Facter in commit
634f2f6a57b461926afcb2e07dcfe4ed659f5b0c, Facter no longer looks
for facts in relative directories for security reasons. This
change could result in users not getting all of their facts. This
commit alerts users if a relative directory has been excluded from
the search path.
