### PR TITLE
(#14469) Strip whitespace from frozen strings

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -230,7 +230,7 @@ class Facter::Util::Resolution
     Facter.show_time "#{self.name}: #{"%.2f" % ms}ms"
 
     unless @preserve_whitespace
-      result.strip! if result && result.respond_to?(:strip!) 
+      result =  result.strip if result && result.respond_to?(:strip)
     end
     
     return nil if result == ""

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -172,6 +172,13 @@ describe Facter::Util::Resolution do
         @resolve.setcode {'  value  '}
         @resolve.value.should == 'value' 
       end 
+      
+      it "should strip whitespace from frozen strings" do
+        result = '  val  ue  ' 
+        result.freeze 
+        @resolve.setcode{result}
+        @resolve.value.should == 'val  ue'
+      end 
 
       describe "when given a string" do
         [true, false


### PR DESCRIPTION
In 1.9.3, strip! did not remove whitespace from frozen strings.
Now using strip instead, this deals with frozen strings too, by
making a copy of them.
