### PR TITLE
Use absolute path for $LOAD_PATH in installer

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -65,7 +65,7 @@ rescue
   $haveman = false
 end
 
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
 require 'facter'
 @operatingsystem = Facter[:operatingsystem].value
 


### PR DESCRIPTION
As of Facter 2.0, we don't load facts from relative paths in the $LOAD_PATH.
This broke the installer.
