### PR TITLE
(#14521) Fix install for vendored cfpropertylist code

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -87,7 +87,7 @@ bins  = glob(%w{bin/*})
 rdoc  = glob(%w{bin/* sbin/* lib/**/*.rb README README-library CHANGELOG TODO Install}).reject { |e| e=~ /\.(bat|cmd)$/ }
 ri  = glob(%w(bin/*.rb sbin/* lib/**/*.rb)).reject { |e| e=~ /\.(bat|cmd)$/ }
 man   = glob(%w{man/man8/*})
-libs  = glob(%w{lib/**/*.rb lib/**/*.py})
+libs  = glob(%w{lib/**/*.rb lib/**/*.py lib/**/LICENSE})
 tests = glob(%w{tests/**/*.rb})
 
 def do_bins(bins, target, strip = 's?bin/')


### PR DESCRIPTION
In Facter 2.0 we're vendoring some code for `cfpropertylist` and `install.rb` mangled the path and did not include the license. This resolves both those issues.
