### PR TITLE
(#14582) Fix noise in LSB facts

### DIFF
--- a/lib/facter/lsbdistcodename.rb
+++ b/lib/facter/lsbdistcodename.rb
@@ -13,6 +13,6 @@
 Facter.add(:lsbdistcodename) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]
   setcode do
-    Facter::Util::Resolution.exec('lsb_release -c -s')
+    Facter::Util::Resolution.exec('lsb_release -c -s 2>/dev/null')
   end
 end

--- a/lib/facter/lsbdistdescription.rb
+++ b/lib/facter/lsbdistdescription.rb
@@ -13,7 +13,7 @@
 Facter.add(:lsbdistdescription) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]
   setcode do
-    if output = Facter::Util::Resolution.exec('lsb_release -d -s')
+    if output = Facter::Util::Resolution.exec('lsb_release -d -s 2>/dev/null')
       # the output may be quoted (at least it is on gentoo)
       output.sub(/^"(.*)"$/,'\1')
     end

--- a/lib/facter/lsbdistid.rb
+++ b/lib/facter/lsbdistid.rb
@@ -13,6 +13,6 @@
 Facter.add(:lsbdistid) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]
   setcode do
-    Facter::Util::Resolution.exec('lsb_release -i -s')
+    Facter::Util::Resolution.exec('lsb_release -i -s 2>/dev/null')
   end
 end

--- a/lib/facter/lsbdistrelease.rb
+++ b/lib/facter/lsbdistrelease.rb
@@ -13,6 +13,6 @@
 Facter.add(:lsbdistrelease) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]
   setcode do
-    Facter::Util::Resolution.exec('lsb_release -r -s')
+    Facter::Util::Resolution.exec('lsb_release -r -s 2>/dev/null')
   end
 end

--- a/lib/facter/lsbrelease.rb
+++ b/lib/facter/lsbrelease.rb
@@ -13,6 +13,6 @@
 Facter.add(:lsbrelease) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]
   setcode do
-    Facter::Util::Resolution.exec('lsb_release -v -s')
+    Facter::Util::Resolution.exec('lsb_release -v -s 2>/dev/null')
   end
 end

--- a/spec/unit/lsbdistcodename_spec.rb
+++ b/spec/unit/lsbdistcodename_spec.rb
@@ -10,13 +10,13 @@ describe "lsbdistcodename fact" do
         Facter.fact(:kernel).stubs(:value).returns kernel
       end
 
-      it "should return the codename through lsb_release -c -s" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -c -s').returns 'n/a'
+      it "should return the codename through lsb_release -c -s 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -c -s 2>/dev/null').returns 'n/a'
         Facter.fact(:lsbdistcodename).value.should == 'n/a'
       end
 
       it "should return nil if lsb_release is not installed" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -c -s').returns nil
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -c -s 2>/dev/null').returns nil
         Facter.fact(:lsbdistcodename).value.should be_nil
       end
     end

--- a/spec/unit/lsbdistdescription_spec.rb
+++ b/spec/unit/lsbdistdescription_spec.rb
@@ -10,13 +10,13 @@ describe "lsbdistdescription fact" do
         Facter.fact(:kernel).stubs(:value).returns kernel
       end
 
-      it "should return the description through lsb_release -d -s" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -d -s').returns '"Gentoo Base System release 2.1"'
+      it "should return the description through lsb_release -d -s 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -d -s 2>/dev/null').returns '"Gentoo Base System release 2.1"'
         Facter.fact(:lsbdistdescription).value.should == 'Gentoo Base System release 2.1'
       end
 
       it "should return nil if lsb_release is not installed" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -d -s').returns nil
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -d -s 2>/dev/null').returns nil
         Facter.fact(:lsbdistdescription).value.should be_nil
       end
     end

--- a/spec/unit/lsbdistid_spec.rb
+++ b/spec/unit/lsbdistid_spec.rb
@@ -10,13 +10,13 @@ describe "lsbdistid fact" do
         Facter.fact(:kernel).stubs(:value).returns kernel
       end
 
-      it "should return the id through lsb_release -i -s" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -i -s').returns 'Gentoo'
+      it "should return the id through lsb_release -i -s 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -i -s 2>/dev/null').returns 'Gentoo'
         Facter.fact(:lsbdistid).value.should == 'Gentoo'
       end
 
-      it "should return nil if lsb_release is not installed" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -i -s').returns nil
+      it "should return nil if lsb_release is not installed 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -i -s 2>/dev/null').returns nil
         Facter.fact(:lsbdistid).value.should be_nil
       end
     end

--- a/spec/unit/lsbdistrelease_spec.rb
+++ b/spec/unit/lsbdistrelease_spec.rb
@@ -10,13 +10,13 @@ describe "lsbdistrelease fact" do
         Facter.fact(:kernel).stubs(:value).returns kernel
       end
 
-      it "should return the release through lsb_release -r -s" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -r -s').returns '2.1'
+      it "should return the release through lsb_release -r -s 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -r -s 2>/dev/null').returns '2.1'
         Facter.fact(:lsbdistrelease).value.should == '2.1'
       end
 
       it "should return nil if lsb_release is not installed" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -r -s').returns nil
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -r -s 2>/dev/null').returns nil
         Facter.fact(:lsbdistrelease).value.should be_nil
       end
     end

--- a/spec/unit/lsbrelease_spec.rb
+++ b/spec/unit/lsbrelease_spec.rb
@@ -10,13 +10,13 @@ describe "lsbrelease fact" do
         Facter.fact(:kernel).stubs(:value).returns kernel
       end
 
-      it "should return the release through lsb_release -v -s" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -v -s').returns 'n/a'
+      it "should return the release through lsb_release -v -s 2>/dev/null" do
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -v -s 2>/dev/null').returns 'n/a'
         Facter.fact(:lsbrelease).value.should == 'n/a'
       end
 
       it "should return nil if lsb_release is not installed" do
-        Facter::Util::Resolution.stubs(:exec).with('lsb_release -v -s').returns nil
+        Facter::Util::Resolution.stubs(:exec).with('lsb_release -v -s 2>/dev/null').returns nil
         Facter.fact(:lsbrelease).value.should be_nil
       end
     end


### PR DESCRIPTION
Redirect LSB fact's stderr to /dev/null to prevent excess noise.
