### PR TITLE
(#10261) Detect x64 architecture on Windows

### DIFF
--- a/lib/facter/architecture.rb
+++ b/lib/facter/architecture.rb
@@ -25,7 +25,7 @@ Facter.add(:architecture) do
       end
     when /(i[3456]86|pentium)/
       case Facter.value(:operatingsystem)
-      when "Gentoo"
+      when "Gentoo", "windows"
         "x86"
       else
         "i386"

--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -28,7 +28,31 @@ end
 Facter.add(:hardwaremodel) do
   confine :operatingsystem => :windows
   setcode do
-    require 'rbconfig'
-    RbConfig::CONFIG['host_cpu']
+    # http://source.winehq.org/source/include/winnt.h#L568
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394373(v=vs.85).aspx
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/windows.system.processorarchitecture.aspx
+    require 'facter/util/wmi'
+    model = ""
+    Facter::Util::WMI.execquery("select Architecture, Level from Win32_Processor").each do |cpu|
+      model =
+        case cpu.Architecture
+        when 11: 'neutral'        # PROCESSOR_ARCHITECTURE_NEUTRAL
+        when 10: 'i686'           # PROCESSOR_ARCHITECTURE_IA32_ON_WIN64
+        when 9: 'x64'             # PROCESSOR_ARCHITECTURE_AMD64
+        when 8: 'msil'            # PROCESSOR_ARCHITECTURE_MSIL
+        when 7: 'alpha64'         # PROCESSOR_ARCHITECTURE_ALPHA64
+        when 6: 'ia64'            # PROCESSOR_ARCHITECTURE_IA64
+        when 5: 'arm'             # PROCESSOR_ARCHITECTURE_ARM
+        when 4: 'shx'             # PROCESSOR_ARCHITECTURE_SHX
+        when 3: 'powerpc'         # PROCESSOR_ARCHITECTURE_PPC
+        when 2: 'alpha'           # PROCESSOR_ARCHITECTURE_ALPHA
+        when 1: 'mips'            # PROCESSOR_ARCHITECTURE_MIPS
+        when 0: "i#{cpu.Level}86" # PROCESSOR_ARCHITECTURE_INTEL
+        else 'unknown'            # PROCESSOR_ARCHITECTURE_UNKNOWN
+        end
+      break
+    end
+
+    model
   end
 end

--- a/spec/unit/architecture_spec.rb
+++ b/spec/unit/architecture_spec.rb
@@ -21,6 +21,8 @@ describe "Architecture fact" do
     ["Gentoo","i586"] => "x86",
     ["Gentoo","i686"] => "x86",
     ["Gentoo","pentium"] => "x86",
+    ["windows","i386"] => "x86",
+    ["windows","x64"] => "x64",
   }
   generic_archs = Hash.new
   generic_archs = {

--- a/spec/unit/hardwaremodel_spec.rb
+++ b/spec/unit/hardwaremodel_spec.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'facter'
+
+describe "Hardwaremodel fact" do
+  it "should match uname -m by default" do
+    Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    Facter::Util::Resolution.stubs(:exec).with("uname -m").returns("Inky")
+
+    Facter.fact(:hardwaremodel).value.should == "Inky"
+  end
+
+  describe "on Windows" do
+    require 'facter/util/wmi'
+    before :each do
+      Facter.fact(:kernel).stubs(:value).returns("windows")
+    end
+
+    it "should detect i686" do
+      cpu = mock('cpu', :Architecture => 0, :Level => 6)
+      Facter::Util::WMI.expects(:execquery).returns([cpu])
+
+      Facter.fact(:hardwaremodel).value.should == "i686"
+    end
+
+    it "should detect x64" do
+      cpu = mock('cpu', :Architecture => 9)
+      Facter::Util::WMI.expects(:execquery).returns([cpu])
+
+      Facter.fact(:hardwaremodel).value.should == "x64"
+    end
+  end
+end


### PR DESCRIPTION
Previously, the hardwaremodel fact was using

```
RbConfig::CONFIG['host_cpu']
```

for Windows, but this returns i686 on a 64-bit OS, which is incorrect. And
this caused the architecture fact to be reported as i386, which is also
wrong.

This commit updates the hardwaremodel fact on Windows to return the
appropriate cpu model, e.g. x64, i686, etc. Based on that, the
architecture fact will either be x86 or x64, and can be used to install
architecture-specific packages, e.g. splunk-4.2.4-110225-x64-release.msi.
