### PR TITLE
Make package task depend on tar in Rakfile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,8 @@ end
 Rake::GemPackageTask.new(spec) do |pkg|
 end
 
+task :package => :tar
+
 task :default do
   sh %{rake -T}
 end


### PR DESCRIPTION
This commit makes the built-in package task
depend on :tar to ensure the tarball is built
before the package task is called.
