### PR TITLE
Maint/1.6.x/fix hardwaremodel for ruby 1.9

### DIFF
--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -28,26 +28,29 @@ end
 Facter.add(:hardwaremodel) do
   confine :operatingsystem => :windows
   setcode do
+    # The cryptic windows cpu architecture models are documented in these places:
     # http://source.winehq.org/source/include/winnt.h#L568
     # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394373(v=vs.85).aspx
     # http://msdn.microsoft.com/en-us/library/windows/desktop/windows.system.processorarchitecture.aspx
+    # Also, arm and neutral are included because they are valid for the upcoming
+    # windows 8 release.  --jeffweiss 23 May 2012
     require 'facter/util/wmi'
     model = ""
     Facter::Util::WMI.execquery("select Architecture, Level from Win32_Processor").each do |cpu|
       model =
         case cpu.Architecture
-        when 11: 'neutral'        # PROCESSOR_ARCHITECTURE_NEUTRAL
-        when 10: 'i686'           # PROCESSOR_ARCHITECTURE_IA32_ON_WIN64
-        when 9: 'x64'             # PROCESSOR_ARCHITECTURE_AMD64
-        when 8: 'msil'            # PROCESSOR_ARCHITECTURE_MSIL
-        when 7: 'alpha64'         # PROCESSOR_ARCHITECTURE_ALPHA64
-        when 6: 'ia64'            # PROCESSOR_ARCHITECTURE_IA64
-        when 5: 'arm'             # PROCESSOR_ARCHITECTURE_ARM
-        when 4: 'shx'             # PROCESSOR_ARCHITECTURE_SHX
-        when 3: 'powerpc'         # PROCESSOR_ARCHITECTURE_PPC
-        when 2: 'alpha'           # PROCESSOR_ARCHITECTURE_ALPHA
-        when 1: 'mips'            # PROCESSOR_ARCHITECTURE_MIPS
-        when 0: "i#{cpu.Level}86" # PROCESSOR_ARCHITECTURE_INTEL
+        when 11 then 'neutral'        # PROCESSOR_ARCHITECTURE_NEUTRAL
+        when 10 then 'i686'           # PROCESSOR_ARCHITECTURE_IA32_ON_WIN64
+        when 9 then 'x64'             # PROCESSOR_ARCHITECTURE_AMD64
+        when 8 then 'msil'            # PROCESSOR_ARCHITECTURE_MSIL
+        when 7 then 'alpha64'         # PROCESSOR_ARCHITECTURE_ALPHA64
+        when 6 then 'ia64'            # PROCESSOR_ARCHITECTURE_IA64
+        when 5 then 'arm'             # PROCESSOR_ARCHITECTURE_ARM
+        when 4 then 'shx'             # PROCESSOR_ARCHITECTURE_SHX
+        when 3 then 'powerpc'         # PROCESSOR_ARCHITECTURE_PPC
+        when 2 then 'alpha'           # PROCESSOR_ARCHITECTURE_ALPHA
+        when 1 then 'mips'            # PROCESSOR_ARCHITECTURE_MIPS
+        when 0 then "i#{cpu.Level}86" # PROCESSOR_ARCHITECTURE_INTEL
         else 'unknown'            # PROCESSOR_ARCHITECTURE_UNKNOWN
         end
       break


### PR DESCRIPTION
The case statement for the windows hardware model fact was broken
because ruby 1.9 no longer supports `case x: value` syntax. If
everything is on a single line, it must be `case x then value`.
