### PR TITLE
Ticket/1.6.x/14674 stub architecture

### DIFF
--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -16,6 +16,8 @@ describe "Processor facts" do
     def load(procs)
       require 'facter/util/wmi'
       Facter::Util::WMI.stubs(:execquery).with("select * from Win32_Processor").returns(procs)
+      # This is to workaround #14674
+      Facter.fact(:architecture).stubs(:value).returns("x64")
 
       # processor facts belong to a file with a different name,
       # so load the file explicitly (after stubbing kernel),


### PR DESCRIPTION
Previously the Windows specific tests were failing when run on Linux
(but not Mac or Windows), because the processor fact always runs Linux,
Aix, and Solaris specific commands, causing the architecture fact to be
loaded, which loads the hardwaremodel, which was recently changed to use
WMI to retrieve the processor architecture instead of using RbConfig.

This commit just stubs the architecture fact until the processor fact
can be fixed to conditionally execute those commands based on the
current kernel fact.
