### PR TITLE
(#14667) Add external cache for facts

### DIFF
--- a/bin/external_cache.sh
+++ b/bin/external_cache.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+set -e
 
 CACHE_DIR="/var/lib/facter"
-CACHE="${CACHE_DIR}/facts.cache"
-TEMP_CACHE="/tmp/temp_cache"
+CACHE="${CACHE_DIR}/facts.yaml"
+TEMP_CACHE=`mktemp "${CACHE_DIR}/facts.yaml.tempXXXXXX"`
 
-mkdir -p $CACHE_DIR
-facter -y > $TEMP_CACHE
-mv $TEMP_CACHE $CACHE
+mkdir -p "$CACHE_DIR"
+facter -y -p > "$TEMP_CACHE"
+chmod 0644 "$TEMP_CACHE"
+mv "$TEMP_CACHE" "$CACHE"


### PR DESCRIPTION
Add a shell script which will send the output of Facter to
a `yaml` file, which can serve as an external cache for facts.
