### PR TITLE
Bump facter epoch to 1

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -4,7 +4,8 @@ Summary: Ruby module for collecting simple facts about a host operating system
 Name: facter
 Version: 1.6.10
 #Release: 1%{?dist}
-Release: 0.1rc1%{?dist}
+Release: 0.1rc1.2%{?dist}
+Epoch: 1
 License: Apache 2.0
 Group: System Environment/Base
 URL: http://www.puppetlabs.com/puppet/related-projects/%{name}
@@ -53,6 +54,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Jun 8 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.10-0.1rc1.2
+- Bump epoch to 1 to address errant Facter 2.0 rc release
+
 * Wed Jun 6 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.10-0.1rc1
 - Update for 1.6.10rc1
 


### PR DESCRIPTION
This commit bumps the facter epoch to 1. This
is to address the errant release of a facter 2.0rc
to the Puppet Labs yum production repository, which
may have been then installed unintentionally by its
users. The epoch bump is in tandem with equivalent
changes to Facter 1.6.9 and 2.0.0rc4. This will
ensure users who intentionally installed 1.6.10 rc/
2.0 rc keep it, while users of 1.6.9 who unintentionally
installed 2.0rc are taken back to 1.6.9.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
