### PR TITLE
Ticket/2.x/2066 make memory units in bytes

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -24,20 +24,8 @@
 # Author: Matthew Palmer <matt@solutionsfirst.com.au>
 #
 #
-require 'facter/util/memory'
 
-{   :MemorySize => "MemTotal",
-    :MemoryFree => "MemFree",
-    :SwapSize   => "SwapTotal",
-    :SwapFree   => "SwapFree"
-}.each do |fact, name|
-  Facter.add(fact) do
-    confine :kernel => [ :linux, :"gnu/kfreebsd" ]
-    setcode do
-      Facter::Memory.meminfo_number(name)
-    end
-  end
-end
+require 'facter/util/memory'
 
 [  "memorysize",
    "memoryfree",
@@ -77,6 +65,20 @@ Facter.add("memoryfree_mb") do
   setcode do
     memfree = Facter::Memory.mem_free
     "%.2f" % [memfree] if memfree
+  end
+end
+
+{   :memorysize_mb => "MemTotal",
+    :memoryfree_mb => "MemFree",
+    :swapsize_mb   => "SwapTotal",
+    :swapfree_mb   => "SwapFree"
+}.each do |fact, name|
+  Facter.add(fact) do
+    confine :kernel => [ :linux, :"gnu/kfreebsd" ]
+    meminfo = Facter::Memory.meminfo_number(name)
+    setcode do
+      "%.2f" % [meminfo]
+    end
   end
 end
 

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -94,6 +94,55 @@ VMSTAT
     end
   end
 
+  [   "linux",
+      "gnu/kfreebsd",
+  ].each do |kernel|
+
+
+    describe "on #{kernel}" do
+      before(:each) do
+        Facter.clear
+        Facter.fact(:kernel).stubs(:value).returns(kernel)
+        meminfo = <<INFO
+MemTotal:   255908 kB
+MemFree:     69936 kB
+Buffers:     15812 kB
+Cached:     115124 kB
+SwapCached:      0 kB
+Active:      92700 kB
+Inactive:    63792 kB
+SwapTotal:  524280 kB
+SwapFree:   524280 kB
+Dirty:           4 kB
+INFO
+
+        File.stubs(:readlines).with("/proc/meminfo").returns(meminfo.split("\n"))
+        
+        Facter.collection.loader.load(:memory)
+      end
+      
+      after(:each) do
+        Facter.clear
+      end
+      
+      it "should return the current memory size in MB" do
+        Facter.fact(:memorysize_mb).value.should == "249.91"
+      end
+      
+      it "should return the current memory free in MB" do
+        Facter.fact(:memoryfree_mb).value.should == "196.16"
+      end
+      
+      it "should return the current swap size in MB" do
+        Facter.fact(:swapsize_mb).value.should == "511.99"
+      end
+      
+      it "should return the current swap free in MB" do
+        Facter.fact(:swapfree_mb).value.should == "511.99"
+      end
+    end
+  end
+
   describe "on AIX" do
     before (:each) do
       Facter.clear


### PR DESCRIPTION
Make swap and memory facts in MB for Linux/kFreeBSD, as was previously
done for other platforms. Also make scaled facts depend on MB versions.
This should fix the problems encountered in the Jenkins test of the
previously-submitted code. Add tests for memory and swap facts for Linux
and kFreeBSD.
