### PR TITLE
(#15049) Return only one selinuxfs path as string from mountinfo

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -15,15 +15,16 @@ sestatus_cmd = '/usr/sbin/sestatus'
 # This supports the fact that the selinux mount point is not always in the
 # same location -- the selinux mount point is operating system specific.
 def selinux_mount_point
-  if FileTest.exists?('/proc/self/mountinfo')
-    File.open('/proc/self/mountinfo') do |f|
+  path = "/selinux"
+  if FileTest.exists?('/proc/self/mounts')
+    File.open('/proc/self/mounts') do |f|
       f.grep(/selinuxfs/) do |line|
-        line.split[4]
+        path = line.split[1]
+        break
       end
     end
-  else
-    "/selinux"
   end
+  path
 end
 
 Facter.add("selinux") do


### PR DESCRIPTION
The block that parses /proc/self/mountinfo to find a selinuxfs filesystem would
return results as an array.  On Ruby 1.8, interpolating this into a string for
File.exists? when one result was returned worked, while on Ruby 1.9 it
interpolated as ["/sys/fs/selinux"]/enforce so later failed.

This changes the block to return the single result string rather than an array.
This also fixes #11531 where multiple selinuxfs filesystems could be mounted,
as it returns only the first mountpoint.
