### PR TITLE
(#15306) Read /proc/self/status in binary mode

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -31,7 +31,7 @@ module Facter::Util::Virtual
 
   def self.vserver?
     return false unless FileTest.exists?("/proc/self/status")
-    txt = File.read("/proc/self/status")
+    txt = File.open("/proc/self/status", "rb").read
     return true if txt =~ /^(s_context|VxID):[[:blank:]]*[0-9]/
     return false
   end

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'facter/util/virtual'
+require 'stringio'
 
 describe Facter::Util::Virtual do
 
@@ -64,19 +65,19 @@ describe Facter::Util::Virtual do
 
   it "should detect vserver when vxid present in process status" do
     FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-    File.stubs(:read).with("/proc/self/status").returns("VxID: 42\n")
+    File.stubs(:open).with("/proc/self/status", "rb").returns(StringIO.new("VxID: 42\n"))
     Facter::Util::Virtual.should be_vserver
   end
 
   it "should detect vserver when s_context present in process status" do
     FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-    File.stubs(:read).with("/proc/self/status").returns("s_context: 42\n")
+    File.stubs(:open).with("/proc/self/status", "rb").returns(StringIO.new("s_context: 42\n"))
     Facter::Util::Virtual.should be_vserver
   end
 
   it "should not detect vserver when vserver flags not present in process status" do
     FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-    File.stubs(:read).with("/proc/self/status").returns("wibble: 42\n")
+    File.stubs(:open).with("/proc/self/status", "rb").returns(StringIO.new("wibble: 42\n"))
     Facter::Util::Virtual.should_not be_vserver
   end
 
@@ -94,7 +95,7 @@ describe Facter::Util::Virtual do
       it "should detect vserver as #{expected.inspect}" do
         status = File.read(status_file)
         FileTest.stubs(:exists?).with("/proc/self/status").returns(true)
-        File.stubs(:read).with("/proc/self/status").returns(status)
+        File.stubs(:open).with("/proc/self/status", "rb").returns(StringIO.new(status))
         Facter::Util::Virtual.vserver?.should == expected
       end
     end


### PR DESCRIPTION
On at least a Joyent SmartMachine (illumos based Solaris) the file
/proc/self/status contains binary data. When read with File.read in Ruby
1.9, this is parsed as UTF-8 which fails with an exception. This patch
instead opens the file in binary mode to avoid the failure.
