### PR TITLE
Update the facter 2.0 builds for Ruby 1.9

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -22,7 +22,7 @@ Requires: which
 Requires: dmidecode
 Requires: pciutils
 %endif
-Requires: ruby(abi) = 1.8
+Requires: ruby(abi) >= 1.8
 BuildRequires: ruby >= 1.8.5
 
 %description
@@ -49,10 +49,14 @@ rm -rf %{buildroot}
 %{_bindir}/facter
 %{ruby_sitelibdir}/facter.rb
 %{ruby_sitelibdir}/facter
+%{_mandir}/man8/facter.8.gz
 %doc CHANGELOG INSTALL LICENSE README.md
 
 
 %changelog
+* Sun Jul 08 2012 Michael Stahnke <stahnma@puppetlabs.com> - 2.0.0-0.2rc4
+- Update to work on Ruby 1.9
+
 * Thu May 24 2012 Moses Mendoza <moses@puppetlabs.com> - 2.0.0-0.1rc4
 - Update for 2.0.0rc4 release
 


### PR DESCRIPTION
Facter 2.0 belongs in the Telly ecosystem with should support Ruby 1.9
as a Tier 1 platform.  This spec file change allows facter to be built
against 1.9 and run against it.

This was tested on Centos6 with Ruby 1.9 back-ported from Fedora 17.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
