### PR TITLE
Only use git describe in Rakefile if git is present

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,12 @@ FILES = FileList[
 ]
 
 def get_version
-  `git describe`.strip
+  %x{which git &> /dev/null}
+  if $?.success?
+    `git describe`.strip
+  else
+    File.read('lib/facter.rb')[/FACTERVERSION *= *'(.*)'/,1] or fail "Couldn't find FACTERVERSION"
+  end
 end
 
 # :build_environment and :tar are mostly borrowed from puppet-dashboard Rakefile


### PR DESCRIPTION
This commit modifies the get_version method of the
Rakefile to only use git describe if git is present,
and if not fall back to the old method of reading
the facter.rb file. Currently rake -T fails if git
is not present with 'command not found: git describe'.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
