### PR TITLE
Add detection of OmniOS to Facter

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -16,6 +16,11 @@ Facter.add(:operatingsystem) do
   setcode do
     if FileTest.exists?("/etc/debian_version")
       "Nexenta"
+    elsif FileTest.exists?("/etc/release")
+      txt = File.read("/etc/release")
+      if txt =~ /omnios/i
+        "OmniOS"
+      end
     else
       "Solaris"
     end

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -22,7 +22,7 @@ Facter.add(:osfamily) do
       "Debian"
     when "SLES", "SLED", "OpenSuSE", "SuSE"
       "Suse"
-    when "Solaris", "Nexenta"
+    when "Solaris", "Nexenta", "OmniOS"
       "Solaris"
     else
       Facter.value("kernel")


### PR DESCRIPTION
Properly detect OmniOS operatingsystem and Solaris osfamily.
