### PR TITLE
Test facter on Travis, please

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.2
+script: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'rspec', '=2.10.0'
+gem 'mocha', '=0.11.4'
+gem 'rake'

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -13,6 +13,7 @@ describe "Virtual fact" do
     Facter::Util::Virtual.stubs(:kvm?).returns(false)
     Facter::Util::Virtual.stubs(:hpvm?).returns(false)
     Facter::Util::Virtual.stubs(:zlinux?).returns(false)
+    Facter::Util::Virtual.stubs(:virtualbox?).returns(false)
   end
 
   it "should be zone on Solaris when a zone" do


### PR DESCRIPTION
I want it to be as easy as possible to set up facter testing suite, not only on my machine, but also somewhere else, so that I can really be sure that it works independent on my machine. So here is my changeset to enable that on Travis-CI. It also fixes a bug in virtual-fact unit test, which only occures on Virtualbox Hosts.

Adds Travis-CI compatible Gemfile
Adds the travis-ci travis.yml
Also fixes testing problem on Virtualbox Testing Host where accidently all unit tests are getting virtualbox fact instead what's expected
