### PR TITLE
Avoid shell when reading the ARP table on Linux.

### DIFF
--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -37,13 +37,15 @@ module Facter::Util::EC2
     def has_ec2_arp?
       mac_address = "fe:ff:ff:ff:ff:ff"
       if Facter.value(:kernel) == 'windows'
-        arp_command = "arp -a"
         mac_address.gsub!(":","-")
+        arp_table = Facter::Util::Resolution.exec("arp -a")
+      elsif Facter.value(:kernel) == 'Linux' and File.exist?('/proc/net/arp')
+        # this is, like, an order of magnitude faster than exec
+        arp_table = File.read('/proc/net/arp')
       else
-        arp_command = "arp -an"
+        arp_table = Facter::Util::Resolution.exec("arp -an")
       end
 
-      arp_table = Facter::Util::Resolution.exec(arp_command)
       if not arp_table.nil?
         arp_table.each_line do |line|
           return true if line.downcase.include?(mac_address)


### PR DESCRIPTION
We can avoid the overhead of shelling out to read the ARP table on Linux,
since `/proc/net/arp` contains the exact set of information we want.

This is about an order of magnitude faster (0.15 rather than 1.5 ms), which
isn't all that much speed difference, but this is out of the 1.13 seconds a
complete run takes on my system - so ten hits like this is one percent of the
overall runtime.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
