### PR TITLE
Faster MAC address load on Linux via sysfs

### DIFF
--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -10,6 +10,19 @@
 require 'facter/util/macaddress'
 
 Facter.add(:macaddress) do
+  confine :kernel => 'Linux'
+  has_weight  10                # about an order of magnitude faster
+  setcode do
+    begin
+      Dir.glob('/sys/class/net/*').reject {|x| x[-3..-1] == '/lo' }.first
+      path and File.read(path + '/address')
+    rescue Exception
+      nil
+    end
+  end
+end
+
+Facter.add(:macaddress) do
   confine :kernel => %w{SunOS Linux GNU/kFreeBSD}
   setcode do
     ether = []


### PR DESCRIPTION
When sysfs is available we can work out the MAC address of the primary
interface much faster than shelling out to ifconfig delivers.

This is about an order of magnitude faster on my machine, being 0.12ms vs
1.5ms when using the external process.

Signed-off-by: Daniel Pittman daniel@puppetlabs.com
