### PR TITLE
Fix three failing tests.

### DIFF
--- a/spec/unit/util/directory_loader_spec.rb
+++ b/spec/unit/util/directory_loader_spec.rb
@@ -22,14 +22,14 @@ describe Facter::Util::DirectoryLoader do
   it "raises an error when the directory does not exist" do
     missing_dir = "missing"
     File.stubs(:directory?).with(missing_dir).returns(false)
-    expect { Facter::Util::DirectoryLoader.loader_for(missing_dir) }.should raise_error Facter::Util::DirectoryLoader::NoSuchDirectoryError
+    expect { Facter::Util::DirectoryLoader.loader_for(missing_dir) }.to raise_error Facter::Util::DirectoryLoader::NoSuchDirectoryError
   end
 
   it "should do nothing bad when dir doesn't exist" do
     fakepath = "/foobar/path"
     my_loader = Facter::Util::DirectoryLoader.new(fakepath)
     FileTest.exists?(my_loader.directory).should be_false
-    expect { my_loader.load(collection) }.should_not raise_error
+    expect { my_loader.load(collection) }.to_not raise_error
    end
 
   describe "when loading facts from disk" do

--- a/spec/unit/util/macosx_spec.rb
+++ b/spec/unit/util/macosx_spec.rb
@@ -42,7 +42,7 @@ describe Facter::Util::Macosx do
   end
 
   it 'should fail when trying to read invalid XML' do
-    expect { Facter::Util::Macosx.intern_xml('<bad}|%-->xml<--->') }.should \
+    expect { Facter::Util::Macosx.intern_xml('<bad}|%-->xml<--->') }.to \
       raise_error(RuntimeError, /A plist file could not be properly read by Facter::Util::CFPropertyList/)
   end
 


### PR DESCRIPTION
In one of the more recent versions of rspec they changed calls from
expect{} to be .to and .to_not instead of should/should_not.  This
fixes the three failure tests I see every time I run the tests.  This
was driving me crazy.
