### PR TITLE
(#15687) Selinux: Test for policyvers before reading it

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -57,7 +57,11 @@ end
 Facter.add("selinux_policyversion") do
   confine :selinux => :true
   setcode do
-    File.read("#{selinux_mount_point}/policyvers")
+    result = 'unknown'
+    if FileTest.exists?("#{selinux_mount_point}/policyvers")
+      result = File.read("#{selinux_mount_point}/policyvers").chomp
+    end
+    result
   end
 end
 

--- a/spec/unit/selinux_spec.rb
+++ b/spec/unit/selinux_spec.rb
@@ -79,11 +79,18 @@ describe "SELinux facts" do
     Facter.fact(:selinux).stubs(:value).returns("true")
     FileTest.stubs(:exists?).with("/proc/self/mounts").returns false
 
-    File.stubs(:read).with("/selinux/policyvers").returns("")
-
     File.expects(:read).with("/selinux/policyvers").returns("1")
+    FileTest.expects(:exists?).with("/selinux/policyvers").returns true
 
     Facter.fact(:selinux_policyversion).value.should == "1"
+  end
+
+  it "it should return 'unknown' SELinux policy version if /selinux/policyvers doesn't exist" do
+    Facter.fact(:selinux).stubs(:value).returns("true")
+    FileTest.expects(:exists?).with("/proc/self/mounts").returns false
+    FileTest.expects(:exists?).with("/selinux/policyvers").returns false
+
+    Facter.fact(:selinux_policyversion).value.should == "unknown"
   end
 
   it "should return the SELinux current mode" do


### PR DESCRIPTION
Previously facter would read /#{selinux_mount_point}/policyvers without first
verifying it existed, which would spew stderr to the console if it did not
exist. This commit makes the default value for the fact "unknown" and only uses
a different value if policyvers exists. This also includes an updated test
which fails using the previous fact definition.
