### PR TITLE
Add 'operatingsystemmajorrelease' fact on RedHat/Debian (closes #15714)

### DIFF
--- a/lib/facter/operatingsystemmajorrelease.rb
+++ b/lib/facter/operatingsystemmajorrelease.rb
@@ -1,0 +1,25 @@
+# Fact: operatingsystemmajorrelease
+#
+# Purpose: Returns the major release of the operating system.
+#
+# Resolution: splits down the operatingsystemrelease fact at decimal point for 
+#  osfamily RedHat derivatives, also Debian. 
+#
+# Caveats: The name of the fact is too long IMHO. 
+# This should be the same as lsbmajdistrelease, but on minimal systems there
+# are too many dependencies to use LSB
+# we should probably use lsbmajdistrelease if available
+
+Facter.add(:operatingsystemmajorrelease) do
+  confine :osfamily => :RedHat
+  setcode do
+    Facter.value('operatingsystemrelease').split('.').first
+  end
+end
+
+Facter.add(:operatingsystemrelease) do
+  confine :operatingsystem => "Debian"
+  setcode do
+    Facter.value('operatingsystemrelease').split('.').first
+  end
+end

--- a/spec/unit/operatingsystemmajorrelease_spec.rb
+++ b/spec/unit/operatingsystemmajorrelease_spec.rb
@@ -1,0 +1,12 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'facter'
+
+describe "OS Major Release fact" do
+    it "should be derived from operatingsystemrelease" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        Facter.fact(:operatingsystemrelease).stubs(:value).returns("6.3")
+
+        Facter.fact(:operatingsystemmajorrelease).value.should == "6"
+    end
+end


### PR DESCRIPTION
Addition of new fact based on operatingsystemrelease fact.
Whilst this information is available as the lsb majorversion
the dependencies on LSB are high (pulls in graphics and printing)
for minimal installs.

Deliberately constrained to known useful OS releases - ie it would
make no sense to return the 1st part of a Ubuntu release
