### PR TITLE
(#15514) Add compatibility with change to operatingsystem fact

### DIFF
--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -61,7 +61,7 @@ describe "Operating System Release fact" do
 
     before :each do
       Facter.fact(:kernel).stubs(:value).returns('SunOS')
-      Facter.fact(:operatingsystem).stubs(:value).returns('Solaris')
+      Facter.fact(:osfamily).stubs(:value).returns('Solaris')
     end
 
     {


### PR DESCRIPTION
Since the operatingsystem fact can now return several different
versions of Solaris, anything that relies on operatingsystem returning
Solaris must now depend on osfamily returning Solaris.

Most of these cases have been taken care of, so far this is the
only one I have found that was missed, but it's possible there
are a few more.
