### PR TITLE
(#15711) Fix misspelling of openSUSE

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -75,7 +75,7 @@ Facter.add(:operatingsystem) do
       elsif txt =~ /^SUSE LINUX Enterprise Desktop/i
         "SLED"
       elsif txt =~ /^openSUSE/i
-        "OpenSuSE"
+        "openSUSE"
       else
         "SuSE"
       end

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -62,7 +62,7 @@ Facter.add(:operatingsystemrelease) do
 end
 
 Facter.add(:operatingsystemrelease) do
-  confine :operatingsystem => %w{SLES SLED OpenSuSE}
+  confine :operatingsystem => %w{SLES SLED openSUSE}
   setcode do
     releasefile = Facter::Util::Resolution.exec('cat /etc/SuSE-release')
     if releasefile =~ /^VERSION\s*=\s*(\d+)/

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -20,7 +20,7 @@ Facter.add(:osfamily) do
       "RedHat"
     when "Ubuntu", "Debian"
       "Debian"
-    when "SLES", "SLED", "OpenSuSE", "SuSE"
+    when "SLES", "SLED", "openSUSE", "SuSE"
       "Suse"
     when "Solaris", "Nexenta"
       "Solaris"


### PR DESCRIPTION
Previously, all facts that refered to the `openSUSE` operating
system were misspelling it as `OpenSuSE`. Fix spelling in all
instances where it was wrong.

hailee@puppetlabs.com
