### PR TITLE
Show point releases for Ubuntu LTS releases

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -56,7 +56,7 @@ Facter.add(:operatingsystemrelease) do
   confine :operatingsystem => %w{Ubuntu}
   setcode do
     release = Facter::Util::Resolution.exec('cat /etc/issue')
-    if release =~ /Ubuntu (\d+.\d+)/
+    if release =~ /Ubuntu (\d+.\d+\.{0,1}\d+)/
       $1
     end
   end


### PR DESCRIPTION
Ubuntu LTS Releases can have point releases.
This is important to know, because sometimes
things are changing in between point releases.

This is true for Ubuntu and for RHEL systems.
But the point release is shown as Minor Version
in operatingsystemrelease facter for RHEL.
This fixes it for Ubuntu.

(And no, the i.e. 10.04.3 is not covered by Ubuntus lsb_release implementation)
