### PR TITLE
Add build-requires of ruby-rdoc for manpage generation

### DIFF
--- a/conf/redhat/facter.spec
+++ b/conf/redhat/facter.spec
@@ -25,6 +25,7 @@ Requires: pciutils
 %endif
 Requires: ruby(abi) >= 1.8
 BuildRequires: ruby >= 1.8.5
+BuildRequires: ruby-rdoc
 
 %description
 Ruby module for collecting simple facts about a host Operating
@@ -39,7 +40,7 @@ operating system. Additional facts can be added through simple Ruby scripts
 
 %install
 rm -rf %{buildroot}
-ruby install.rb --destdir=%{buildroot} --quick --no-rdoc
+ruby install.rb --destdir=%{buildroot} --quick
 
 %clean
 rm -rf %{buildroot}
@@ -50,7 +51,7 @@ rm -rf %{buildroot}
 %{_bindir}/facter
 %{ruby_sitelibdir}/facter.rb
 %{ruby_sitelibdir}/facter
-%{_mandir}/man8/*
+%{_mandir}/man8/facter.8.gz
 %doc CHANGELOG INSTALL LICENSE README.md
 
 


### PR DESCRIPTION
Without a BuildRequires of ruby-rdoc, if we remove the --no-rdoc flag from
install.rb, the manpages will still not be generated, which will cause the
build to fail, because the %files section lists manpages. Adding a
BuildRequires of ruby-rdoc and removing the --no-rdoc flag from install.rb will
allow manpage generation for packaging.
