### PR TITLE
(#11640) Added support for new OpenStack MAC addresses

### DIFF
--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -26,10 +26,11 @@ module Facter::Util::EC2
       !!(Facter.value(:macaddress) =~ %r{^[dD]0:0[dD]:})
     end
 
-    # Test if this host has a mac address used by OpenStack, which 
-    # normally starts with 02:16:3E
+    # Test if this host has a mac address used by OpenStack, which
+    # normally starts with FA:16:3E (older versions of OpenStack
+    # may generate mac addresses starting with 02:16:3E)
     def has_openstack_mac?
-      !!(Facter.value(:macaddress) =~ %r{^02:16:3[eE]})
+      !!(Facter.value(:macaddress) =~ %r{^(02|[fF][aA]):16:3[eE]})
     end
 
     # Test if the host has an arp entry in its cache that matches the EC2 arp,

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -83,6 +83,22 @@ describe Facter::Util::EC2 do
       Facter::Util::EC2.has_openstack_mac?.should == true
     end
 
+    it "should return true when the mac is a newer openstack mac" do
+      # https://github.com/openstack/nova/commit/b684d651f540fc512ced58acd5ae2ef4d55a885c#nova/utils.py
+      Facter.expects(:value).with(:macaddress).\
+        at_least_once.returns("fa:16:3e:54:89:fd")
+
+      Facter::Util::EC2.has_openstack_mac?.should == true
+    end
+
+    it "should return true when the mac is a newer openstack mac and returned in upper case" do
+      # https://github.com/openstack/nova/commit/b684d651f540fc512ced58acd5ae2ef4d55a885c#nova/utils.py
+      Facter.expects(:value).with(:macaddress).\
+        at_least_once.returns("FA:16:3E:54:89:FD")
+
+      Facter::Util::EC2.has_openstack_mac?.should == true
+    end
+
     it "should return false when the mac is not a openstack one" do
       Facter.expects(:value).with(:macaddress).\
         at_least_once.returns("0c:1d:a0:bc:aa:02")


### PR DESCRIPTION
OpenStack changed the MAC address prefix they use to address an issues with libvirt

OpenStack bug: https://bugs.launchpad.net/nova/+bug/921838
