### PR TITLE
(#1424) Adds zone facts for solaris.

### DIFF
--- a/lib/facter/zones.rb
+++ b/lib/facter/zones.rb
@@ -1,0 +1,26 @@
+# Fact: zones#
+#
+# Purpose:
+#   Return the list of zones on the system and add one zones_ fact
+#   for each zone with its state e.g. running, incomplete or installed.
+#
+# Resolution:
+#   Uses 'usr/sbin/zoneadm list -cp' to get the list of zones in separate parsable
+#   lines with delimeter being ':' which is used to split the line string and get
+#   the zone details.
+#
+# Caveats:
+#   We dont support below s10 where zones are not available.
+
+Facter.add("zones") do
+  confine :kernel => :sunos
+  fmt = [:id, :name, :status, :path, :uuid, :brand, :iptype]
+  l = Facter::Util::Resolution.exec('/usr/sbin/zoneadm list -cp').split("\n").collect{|l|l.split(':')}.each do |val|
+      fmt.each_index do |i|
+        Facter.add "zone_%s_%s" % [val[1], fmt[i]] do
+          setcode { val[i] }
+        end
+      end
+  end
+  setcode { l.length }
+end

--- a/spec/unit/zonename_spec.rb
+++ b/spec/unit/zonename_spec.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env rspec
 
 require 'spec_helper'
 require 'facter'

--- a/spec/unit/zones_spec.rb
+++ b/spec/unit/zones_spec.rb
@@ -1,0 +1,55 @@
+#!usr/bin/env rspec
+
+require 'spec_helper'
+
+describe "on Solaris" do
+  before do
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    zone_list = <<-EOF
+0:global:running:/::native:shared
+-:local:configured:/::native:shared
+-:zoneA:stopped:/::native:shared
+    EOF
+    Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/zoneadm list -cp').returns(zone_list)
+    Facter.collection.internal_loader.load(:zones)
+  end
+
+  describe "number of zones" do
+    it "should output number of zones" do
+      Facter.fact(:zones).value.should == 3
+    end
+  end
+
+  describe "zone specific values" do
+    it "Fact#zone_<z>_status" do
+      {'global' => 'running', 'local' => 'configured', 'zoneA' => 'stopped'}.each do |key, val|
+        Facter.value("zone_%s_status" % key).should == val
+      end
+    end
+
+    it "Fact#zone_<z>_id" do
+      {'global' => '0', 'local' => '-', 'zoneA' => '-'}.each do |key, val|
+        Facter.value("zone_%s_id" % key).should == val
+      end
+    end
+
+    it "Fact#zone_<z>_path" do
+      {'global' => '/', 'local' => '/', 'zoneA' => '/'}.each do |key, val|
+        Facter.value("zone_%s_path" % key).should == val
+      end
+    end
+
+    it "Fact#zone_<z>_brand" do
+      {'global' => 'native', 'local' => 'native', 'zoneA' => 'native'}.each do |key, val|
+        Facter.value("zone_%s_brand" % key).should == val
+      end
+    end
+
+    it "Fact#zone_<z>_iptype" do
+      {'global' => 'shared', 'local' => 'shared', 'zoneA' => 'shared'}.each do |key, val|
+        Facter.value("zone_%s_iptype" % key).should == val
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Added facts for zones in solaris and test data file in fixtures.
The facts added are `id, name, status, path, uuid, brand, iptype`

Based on original request [167](https://github.com/puppetlabs/facter/pull/167)
