### PR TITLE
(#15852) Allow RC in Puppet, Facter version strings

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -25,7 +25,7 @@ module Facter
   include Comparable
   include Enumerable
 
-  FACTERVERSION = '2.0.0'
+  FACTERVERSION = '2.0.0-rc4'
 
   # = Facter
   # Functions as a hash of 'facts' you might care about about your

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -3,11 +3,6 @@
 require 'spec_helper'
 
 describe Facter do
-
-  it "should have a version" do
-    Facter.version.should =~ /^[0-9]+(\.[0-9]+)*$/
-  end
-
   it "should have a method for returning its collection" do
     Facter.should respond_to(:collection)
   end


### PR DESCRIPTION
Previously putting rc in the Facter version string would fail, mainly because
of a test that verified that the version only contained 3 dot separated
integers. This commit updates the Facter version to correctly use 2.0.0-rc4. It
also updates the test that verified the Facter version was a 'valid' 3 dotted
integer version. The updated test verifies that the version string is valid
SemVer, which will also be a valid Facter version.
