### PR TITLE
Fix #7559 - Add a flag file to check for presence of EC2

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -25,7 +25,7 @@ def userdata()
 end
 
 if (Facter::Util::EC2.has_euca_mac? || Facter::Util::EC2.has_openstack_mac? ||
-    Facter::Util::EC2.has_ec2_arp?) && Facter::Util::EC2.can_connect?
+    Facter::Util::EC2.has_ec2_arp? || Facter::Util::EC2.has_flag_file?) && Facter::Util::EC2.can_connect?
 
   metadata
   userdata

--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -32,6 +32,15 @@ module Facter::Util::EC2
       !!(Facter.value(:macaddress) =~ %r{^02:16:3[eE]})
     end
 
+    # Test to see if the EC2 flag file is present
+    def has_flag_file?
+      if Facter::Util::Config.is_windows?
+        FileTest.exist?("#{Facter::Util::Config.windows_data_dir}\\facter_ec2")
+      else
+        FileTest.exists?("/etc/facter_ec2")
+      end
+    end
+
     # Test if the host has an arp entry in its cache that matches the EC2 arp,
     # which is normally +fe:ff:ff:ff:ff:ff+.
     def has_ec2_arp?

--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -14,6 +14,7 @@ describe "ec2 facts" do
       Facter::Util::EC2.stubs(:has_euca_mac?).returns(false)
       Facter::Util::EC2.stubs(:has_openstack_mac?).returns(false)
       Facter::Util::EC2.stubs(:has_ec2_arp?).returns(true)
+      Facter::Util::EC2.stubs(:has_flag_file?).returns(true)
 
       # Assume we can connect
       Facter::Util::EC2.stubs(:can_connect?).returns(true)
@@ -98,6 +99,7 @@ describe "ec2 facts" do
       Facter::Util::EC2.stubs(:has_euca_mac?).returns(true)
       Facter::Util::EC2.stubs(:has_openstack_mac?).returns(false)
       Facter::Util::EC2.stubs(:has_ec2_arp?).returns(false)
+      Facter::Util::EC2.stubs(:has_flag_file?).returns(false)
 
       # Assume we can connect
       Facter::Util::EC2.stubs(:can_connect?).returns(true)
@@ -126,6 +128,7 @@ describe "ec2 facts" do
       Facter::Util::EC2.stubs(:has_openstack_mac?).returns(true)
       Facter::Util::EC2.stubs(:has_euca_mac?).returns(false)
       Facter::Util::EC2.stubs(:has_ec2_arp?).returns(false)
+      Facter::Util::EC2.stubs(:has_flag_file?).returns(false)
 
       # Assume we can connect
       Facter::Util::EC2.stubs(:can_connect?).returns(true)
@@ -158,6 +161,7 @@ describe "ec2 facts" do
       Facter::Util::EC2.stubs(:has_euca_mac?).returns(true)
       Facter::Util::EC2.stubs(:has_ec2_arp?).never
       Facter::Util::EC2.expects(:can_connect?).at_least_once.returns(false)
+      Facter::Util::EC2.stubs(:has_flag_file).returns(false)
 
       # The API should never be called at this point
       Object.any_instance.expects(:open).


### PR DESCRIPTION
Add a check to Facter to determine if a host is an EC2 or VPC
instance. The current checks for MAC addresses and ARP entries is
not sufficient because Amazon VPC instances do not have known MAC
addresses.

The check assumes a provisioning process or a tool like Cloud
Provisioner populates the file on the host. The check looks for
a file at /etc/facter_ec2 on Unix-like systems and·in the COMMON_APPDATA
directory on Windows systems.
