### PR TITLE
(Maint) Fix Facter version to be 2.0.0-rc4

### DIFF
--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,6 +1,6 @@
 module Facter
   if not defined? FACTERVERSION then
-    FACTERVERSION = '1.6.11'
+    FACTERVERSION = '2.0.0-rc4'
   end
 
   def self.version


### PR DESCRIPTION
During the merge-up from 1.6.x I accidentally set the Facter version to
be 1.6.11 in the 2.x branch.  This is a problem because Puppet 3.x
currently requires Facter 2.x and fails hard if the version is
mis-reported.

This patch fixes the problem by setting the hard-coded version of
Facter.version to be 2.0.0-rc4 which is the last known explicitly set
version in the 2.x branch.
