### PR TITLE
Revert "Remove libexec from file list as its only in 2.x"

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -7,7 +7,7 @@ summary: 'Facter, a system inventory tool'
 description: 'You can prove anything with facts!'
 version_file: 'lib/facter/version.rb'
 # files and gem_files are space separated lists
-files: '[A-Z]* acceptance bin documentation etc ext install.rb lib man spec'
+files: '[A-Z]* acceptance bin documentation etc ext install.rb lib libexec man spec'
 gem_files: '[A-Z]* install.rb bin etc ext lib spec'
 gem_require_path: 'lib'
 gem_test_files: 'spec/**/*'


### PR DESCRIPTION
The commit this reverts is a small packaging change that
is only applicable to facter 1.6.x and does not apply to
2.x. It was carried up with the last merge-up.

This reverts commit e0454dfee13975aba498f2851abe6e0eb2627406.
