### PR TITLE
fix redhat spec release template variable

### DIFF
--- a/ext/redhat/facter.spec.erb
+++ b/ext/redhat/facter.spec.erb
@@ -13,7 +13,7 @@
 Summary: Ruby module for collecting simple facts about a host operating system
 Name: facter
 Version: %{rpmversion}
-Release: <%= @release -%>%{?dist}
+Release: <%= @rpmrelease -%>%{?dist}
 
 License: Apache 2.0
 Group: System Environment/Base
@@ -68,7 +68,7 @@ rm -rf %{buildroot}
 
 
 %changelog
-* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @release %>
+* <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  <%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
 
 * Wed Aug 08 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.11-2


### PR DESCRIPTION
The rpm release variable changed in the packaging repo,
this commit updates it.
