### PR TITLE
(#15852) Allow RC in Puppet, Facter version strings

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -27,6 +27,8 @@ module Facter
   include Comparable
   include Enumerable
 
+  FACTERVERSION = '1.6.11'
+
   # = Facter
   # Functions as a hash of 'facts' you might care about about your
   # system, such as mac address, IP address, Video card, etc.

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -3,11 +3,6 @@
 require 'spec_helper'
 
 describe Facter do
-
-  it "should have a version" do
-    Facter.version.should =~ /^[0-9]+(\.[0-9]+)*$/
-  end
-
   it "should have a method for returning its collection" do
     Facter.should respond_to(:collection)
   end


### PR DESCRIPTION
This commit is a cherry-pick of 9006e74 in facter 2.x.

Previously putting rc in the Facter version string would fail, mainly because
of a test that verified that the version only contained 3 dot separated
integers. This commit updates the Facter version to correctly use 2.0.0-rc4. It
also removes the test that verified the Facter version was a 'valid' 3 dotted
integer version.

Conflicts:
    lib/facter.rb
