### PR TITLE
(#15585) Make ext fact regex not greedy

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -78,7 +78,7 @@ module Facter::Util::Parser
 
   class TextParser < Base
     def parse_results
-      re = /^(.+)=(.+)$/
+      re = /^(.+?)=(.+)$/
       result = {}
       content.each_line do |line|
         if match_data = re.match(line.chomp)

--- a/spec/unit/util/parser_spec.rb
+++ b/spec/unit/util/parser_spec.rb
@@ -77,6 +77,12 @@ describe Facter::Util::Parser do
       let(:data_in_txt) do "one=two\nthree=four\n" end
       it_behaves_like "txt parser"
     end
+    
+    context "extra equal sign" do
+      let(:data_in_txt) do "one=two\nthree=four=five\n" end
+      let(:data) do {"one" => "two", "three" => "four=five"} end
+      it_behaves_like "txt parser"
+    end
 
     context "extra data" do
       let(:data_in_txt) do "one=two\nfive\nthree=four\n" end


### PR DESCRIPTION
Prior to this commit an external fact value of the form fact_name = a = b would be returned as b when running
 Facter, as opposed to the correct fact_value of a = b. This commit now partitions around the first equal sign
 from fact_name=fact_value.
