### PR TITLE
(#16341) return epoch to 1.6.x branch

### DIFF
--- a/ext/redhat/facter.spec.erb
+++ b/ext/redhat/facter.spec.erb
@@ -14,7 +14,7 @@ Summary: Ruby module for collecting simple facts about a host operating system
 Name: facter
 Version: %{rpmversion}
 Release: <%= @rpmrelease -%>%{?dist}
-
+Epoch: 1
 License: Apache 2.0
 Group: System Environment/Base
 URL: http://www.puppetlabs.com/puppet/related-projects/%{name}


### PR DESCRIPTION
The epoch was lost during the transition to a templated
spec file. This commit replaces it.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
