### PR TITLE
(#16397) Update selinux_mount_point for 1.8.5 compatibility

### DIFF
--- a/lib/facter/util/monkey_patches.rb
+++ b/lib/facter/util/monkey_patches.rb
@@ -2,6 +2,38 @@
 # version 1.8.5. This allows us to use RbConfig in place of the older Config in
 # our code and still be compatible with at least Ruby 1.8.1.
 require 'rbconfig'
+require 'enumerator'
+
 unless defined? ::RbConfig
   ::RbConfig = ::Config
+end
+
+module Facter
+  module Util
+    module MonkeyPatches
+      module Lines
+        def lines(separator = $/)
+          if block_given?
+            self.each_line(separator) {|line| yield line }
+            return self
+          else
+            return enum_for(:each_line, separator)
+          end
+        end
+      end
+    end
+  end
+end
+
+public
+class String
+  unless method_defined? :lines
+    include Facter::Util::MonkeyPatches::Lines
+  end
+end
+
+class IO
+  unless method_defined? :lines
+    include Facter::Util::MonkeyPatches::Lines
+  end
 end

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe 'Monkey Patches' do
+  let(:subject) { "a b c d e f\ng h i j" }
+
+  context 'String' do
+    it "should respond to lines" do
+       subject.lines.to_a.should == ["a b c d e f\n", "g h i j"]
+    end
+    it "should accept a block" do
+      our_lines = []
+      subject.lines do |line| our_lines << line end
+      our_lines.should == ["a b c d e f\n", "g h i j"]
+    end
+  end
+
+  context 'IO' do
+    it "should respond to lines" do
+      our_lines = nil
+      Tempfile.open("lines") do | file |
+        file.write(subject)
+        file.flush
+        file.rewind
+        our_lines = file.lines.to_a
+      end
+      our_lines.should == ["a b c d e f\n", "g h i j"]
+    end
+    it "should accept a block" do
+      our_lines = []
+      file = Tempfile.new("lines")
+      file.write(subject)
+      file.flush
+      file.rewind
+      file.lines.each do |line| our_lines << line end
+      file.unlink
+      our_lines.should == ["a b c d e f\n", "g h i j"]
+    end
+  end
+
+end
+


### PR DESCRIPTION
The `lines` method does not exist for the String class in ruby 1.8.5, which
causes the selinux_mount_point function to print `Could not retrieve selinux:
undefined method`lines' for #String:0x2abc1ffefe88`to STDERR. This commit
replaces`lines`with an equivalent`split('\n')`, which does exist on ruby
1.8.5.
