### PR TITLE
(16467) new fact for certname configuration option

### DIFF
--- a/lib/facter/certname.rb
+++ b/lib/facter/certname.rb
@@ -1,0 +1,7 @@
+require 'facter'
+require 'puppet/face'
+Facter.add("certname") do
+  setcode do
+    Puppet.settings[:certname]
+  end
+end


### PR DESCRIPTION
This commit introduce the fact, certname, which is needed now that
Puppet differentiates between fqdn and certname.

This is also needed to properly template MCollective where we want to
use certname, rather than fqdn, for the identity setting in server.cfg.
