### PR TITLE
(16468) creates a fact for every Puppet config setting

### DIFF
--- a/lib/facter/puppet_config.rb
+++ b/lib/facter/puppet_config.rb
@@ -1,0 +1,10 @@
+require 'facter'
+require 'puppet/face'
+
+Puppet.settings.each do |key, val|
+  Facter.add("puppet_config_#{key}") do
+    setcode do
+      val.value
+    end
+  end
+end


### PR DESCRIPTION
This creates a fact prepended with 'puppet_config_' for every Puppet
configuration setting.

This is useful for templating, as well as conditional logic based on
these settings.

*\* Craig Dunn authored this with me.
