### PR TITLE
Improve rubysitedir fact

### DIFF
--- a/lib/facter/rubysitedir.rb
+++ b/lib/facter/rubysitedir.rb
@@ -2,17 +2,11 @@
 #
 # Purpose: Returns Ruby's site library directory.
 #
-# Resolution: Works out the version to major/minor (1.8, 1.9, etc), then joins
-# that with all the $: library paths.
-#
-# Caveats:
-#
+
+require 'rbconfig'
 
 Facter.add :rubysitedir do
   setcode do
-    version = RUBY_VERSION.to_s.sub(/\.\d+$/, '')
-    $:.find do |dir|
-      dir =~ /#{File.join("site_ruby", version)}$/
-    end
+    RbConfig::CONFIG["sitelibdir"]
   end
 end


### PR DESCRIPTION
With ruby-1.9.3 -- at least on Fedora 17 -- trawling through the library
paths looking for the directory does not work.  Using RbConfig seems
more reliable and much simpler.
