### PR TITLE
Update facter debian packaging for 1.9 support

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -2,13 +2,13 @@ Source: facter
 Section: ruby
 Priority: optional
 Maintainer: Puppet Labs <info@puppetlabs.com>
-Build-Depends: cdbs, debhelper (>> 7), ruby1.8 | ruby1.9.1, libopenssl-ruby1.8 | libopenssl-ruby1.9.1
+Build-Depends: cdbs, debhelper (>> 7), ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, rdoc
 Standards-Version: 3.9.1
 Homepage: http://www.puppetlabs.com
 
 Package: facter
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby1.8 (>= 1.8.5) | ruby1.9.1, libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode, pciutils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode, pciutils
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -3,7 +3,9 @@
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/rules/buildcore.mk
 
-LIBDIR=$(shell /usr/bin/ruby1.8 -rrbconfig -e 'puts Config::CONFIG["rubylibdir"]')
+LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts Config::CONFIG["vendordir"]')
+BINDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts Config::CONFIG["bindir"]')
 
 binary-install/facter::
-	 /usr/bin/ruby1.8 install.rb --sitelibdir=$(LIBDIR) --destdir=$(CURDIR)/debian/$(cdbs_curpkg) --quick --no-rdoc
+	 /usr/bin/ruby install.rb --sitelibdir=$(LIBDIR) --destdir=$(CURDIR)/debian/$(cdbs_curpkg) --quick
+	 cp -p $(CURDIR)/bin/facter $(CURDIR)/debian/$(cdbs_curpkg)/$(BINDIR)


### PR DESCRIPTION
Because facter works on ruby 1.8 and 1.9, putting it in the vendordir instead
of the vendorlibdir or rubylibdir is preferred so that either ruby can be used
with facter. This updates the dependencies to bring in ruby instead of a
specific ruby version and also replaces ruby1.8 calls in rules with ruby calls.
