### PR TITLE
virtual fact shows physical on KVM when copying the host CPU

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -58,7 +58,8 @@ module Facter::Util::Virtual
      elsif ["FreeBSD", "OpenBSD"].include? Facter.value(:kernel)
        Facter::Util::Resolution.exec("/sbin/sysctl -n hw.model")
      end
-     (txt =~ /QEMU Virtual CPU/) ? true : false
+     return true if txt =~ /QEMU Virtual CPU/
+     File.read("/sys/devices/virtual/dmi/id/product_name") =~ /Bochs/ rescue false
   end
 
   def self.virtualbox?

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -111,6 +111,10 @@ Facter.add("virtual") do
           # --- look for Hyper-V video card
           # ---   00:08.0 VGA compatible controller: Microsoft Corporation Hyper-V virtual VGA
           result = "hyperv" if p =~ /Microsoft Corporation Hyper-V/
+          # --- look for KVM Virtio
+          # ---  00:04.0 SCSI storage controller: Red Hat, Inc Virtio block device
+          # ---  00:07.0 RAM memory: Red Hat, Inc Virtio memory balloon
+          result = "kvm" if p =~ /Red Hat, Inc Virtio/
         end
       else
         output = Facter::Util::Resolution.exec('dmidecode')
@@ -119,6 +123,7 @@ Facter.add("virtual") do
             result = "parallels" if pd =~ /Parallels/
             result = "vmware" if pd =~ /VMware/
             result = "virtualbox" if pd =~ /VirtualBox/
+            result = "kvm" if pd =~ /Bochs/
             result = "xenhvm" if pd =~ /HVM domU/
             result = "hyperv" if pd =~ /Product Name: Virtual Machine/
           end


### PR DESCRIPTION
This patch fixes the issue by extending different outputs for
typical features only found in KVMs, such as "Bochs" vendor id
and Virtio devices in lspci.
