### PR TITLE
(maint) Update debian/rules to use new --ruby flag

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -7,5 +7,4 @@ LIBDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["vendordir"]')
 BINDIR=$(shell /usr/bin/ruby -rrbconfig -e 'puts RbConfig::CONFIG["bindir"]')
 
 binary-install/facter::
-	 /usr/bin/ruby install.rb --sitelibdir=$(LIBDIR) --destdir=$(CURDIR)/debian/$(cdbs_curpkg) --quick
-	 cp -p $(CURDIR)/bin/facter $(CURDIR)/debian/$(cdbs_curpkg)/$(BINDIR)
+	 /usr/bin/ruby install.rb --sitelibdir=$(LIBDIR) --bindir=$(BINDIR) --ruby=/usr/bin/ruby --destdir=$(CURDIR)/debian/$(cdbs_curpkg) --quick


### PR DESCRIPTION
This updates the install.rb call in debian/rules to use the new --ruby flag and
sets the ruby binary location to /usr/bin/ruby, as is the standard on
debian/ubuntu installations. This is preferred to using env ruby as is in the
facter binary because that depends on the users' path, and might not bring in
the expected ruby.
