### PR TITLE
return vendor field and retab

### DIFF
--- a/ext/redhat/facter.spec.erb
+++ b/ext/redhat/facter.spec.erb
@@ -10,21 +10,22 @@
 %global realversion <%= @version %>
 %global rpmversion <%= @rpmversion %>
 
-Summary: Ruby module for collecting simple facts about a host operating system
-Name: facter
-Version: %{rpmversion}
-Release: <%= @rpmrelease -%>%{?dist}
-Epoch: 1
-License: ASL 2.0
-Group: System Environment/Base
-URL: http://www.puppetlabs.com/puppet/related-projects/%{name}
-# Note this URL will only be valid at official tags from Puppet Labs
-Source0: http://puppetlabs.com/downloads/%{name}/%{name}-%{realversion}.tar.gz
+Summary:        Ruby module for collecting simple facts about a host operating system
+Name:           facter
+Version:        %{rpmversion}
+Release:        <%= @rpmrelease -%>%{?dist}
+Epoch:          1
+Vendor:         %{?_host_vendor}
+License:        ASL 2.0
+Group:          System Environment/Base
+URL:            http://www.puppetlabs.com/puppet/related-projects/%{name}
+# Note this     URL will only be valid at official tags from Puppet Labs
+Source0:        http://puppetlabs.com/downloads/%{name}/%{name}-%{realversion}.tar.gz
 
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-Requires: ruby >= 1.8.5
-Requires: which
+Requires:       ruby >= 1.8.5
+Requires:       which
 # dmidecode and pciutils are not available on all arches
 %ifarch %ix86 x86_64 ia64
 Requires:       dmidecode


### PR DESCRIPTION
This commit returns the vendor field to the facter
spec, which was lost in the transition to an erb
template. It also tabs in this section for clarity.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
