### PR TITLE
Only load rubygems in bin/facter

### DIFF
--- a/bin/facter
+++ b/bin/facter
@@ -55,6 +55,14 @@
 # Copyright (c) 2011 Puppet Labs, Inc
 # Licensed under the Apache 2.0 license
 
+# Load rubygems
+unless defined? Bundler::Setup
+  begin
+    require 'rubygems'
+  rescue LoadError
+  end
+end
+
 require 'facter/application'
 
 Facter::Application.run(ARGV)

--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -35,7 +35,6 @@ module Facter
       # Print the facts as JSON and exit
       if options[:json]
         begin
-          require 'rubygems'
           require 'json'
           puts JSON.dump(facts)
           exit(0)


### PR DESCRIPTION
We should not load rubygems when used as a library. Instead we require
rubygems when invoked from the command line.
