### PR TITLE
(#16506) Fix illegal option error from uname on hpux

### DIFF
--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -4,12 +4,17 @@
 #   Returns hardware processor type.
 #
 # Resolution:
-#   On Solaris, Linux and the BSDs simply uses the output of "uname -p"
+#   On Solaris, AIX, Linux and the BSDs simply uses the output of "uname -p"
+#   On HP-UX, "uname -m" gives us the same information.
 #
 # Caveats:
 #   Some linuxes return unknown to uname -p with relative ease.
 #
 
 Facter.add(:hardwareisa) do
-  setcode 'uname -p'
+  if Facter.value(:kernel) == 'HP-UX'
+    setcode 'uname -m'
+  else
+    setcode 'uname -p'
+  end
 end

--- a/spec/unit/hardwareisa_spec.rb
+++ b/spec/unit/hardwareisa_spec.rb
@@ -31,4 +31,11 @@ describe "Hardwareisa fact" do
 
     Facter.fact(:hardwareisa).value.should == "Clyde"
   end
+
+  it "should match uname -m on HP-UX" do
+    Facter.fact(:kernel).stubs(:value).returns("HP-UX")
+    Facter::Util::Resolution.stubs(:exec).with("uname -m").returns("Pac-Man")
+
+    Facter.fact(:hardwareisa).value.should == "Pac-Man"
+  end
 end


### PR DESCRIPTION
Without this patch applied Facter produces a misleading error message
when run on HP-UX:

```
$ facter hardwareisa
/usr/bin/uname: illegal option -- p
usage: uname [-amnrsvil] [-S nodename]
```

This patch fixes the problem by changing the command to `uname -m` when running
on the HP-UX kernel.

Original author: Alex Harvey

Reviewed-by: Jeff McCune jeff@puppetlabs.com
