### PR TITLE
(#16526) Fix physicalprocessorcount fact on Solaris

### DIFF
--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -67,6 +67,18 @@ Facter.add('physicalprocessorcount') do
   confine :kernel => :sunos
 
   setcode do
-    Facter::Util::Resolution.exec("/usr/sbin/psrinfo -p")
+    # (#16526) The -p flag was not added until Solaris 8.  Our intent is to
+    # split the kernel release fact value on the dot, take the second element,
+    # and disable the -p flag for values < 8 when.
+    kernelrelease = Facter.value(:kernelrelease)
+    (major_version, minor_version) = kernelrelease.split(".").map { |str| str.to_i }
+    cmd = "/usr/sbin/psrinfo"
+    result = nil
+    if (major_version > 5) or (major_version == 5 and minor_version >= 8) then
+      result = Facter::Util::Resolution.exec("#{cmd} -p")
+    else
+      output = Facter::Util::Resolution.exec(cmd)
+      result = output.split("\n").length.to_s
+    end
   end
 end


### PR DESCRIPTION
Without this patch applied Facter produces the following error output
when run on versions of Solaris prior to version 8.

```
$ facter -d physicalprocessorcount
/usr/sbin/psrinfo: illegal option -- p
usage:
        psrinfo [-v] [processor_id ...]
        psrinfo -s processor_id
```

This is a problem because the value is not actually returned to the end user.

This patch fixes the problem by avoiding the use of the `-p` flag in versions
of Solaris prior to kernel release 5.8 (Solaris 8).  In these scenarios, we
simply count the number of lines in the output of the `psrinfo` command.
