### PR TITLE
#17029 add osfamily Gentoo with a single member of operatingsystem type Gentoo....

### DIFF
--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -24,6 +24,8 @@ Facter.add(:osfamily) do
       "Suse"
     when "Solaris", "Nexenta", "OmniOS", "OpenIndiana", "SmartOS"
       "Solaris"
+    when "Gentoo"
+      "Gentoo" 
     else
       Facter.value("kernel")
     end


### PR DESCRIPTION
... Tests for popular Gentoo derivaties like Sabayon are not in the tree so this patch is not adding them to the Gentoo osfamily.
