### PR TITLE
(#8210) Add a heavy virtual fact using virt-what

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -1,4 +1,19 @@
 module Facter::Util::Virtual
+  ##
+  # virt_what is a delegating helper method intended to make it easier to stub
+  # the system call without affecting other calls to
+  # Facter::Util::Resolution.exec
+  def self.virt_what(command = "virt-what")
+    Facter::Util::Resolution.exec command
+  end
+
+  ##
+  # lspci is a delegating helper method intended to make it easier to stub the
+  # system call without affecting other calls to Facter::Util::Resolution.exec
+  def self.lspci(command = "lspci 2>/dev/null")
+    Facter::Util::Resolution.exec command
+  end
+
   def self.openvz?
     FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
   end


### PR DESCRIPTION
Without this patch facter does not return kvm when running inside of an
enterprise linux guest VM hosted on an enterprise linux kvm host.

This is a problem because facter improperly reports the virtual machine
is actually running on physical hardware, which is not true.  This
causes downstream problems for anyone relying on the virtual fact being
accurate.

This patch fixes the problem by adding a new resolver for the virtual
fact that has a very high weight.  The new resolver calls `virt-what`,
available on Enterprise Linux machines by installing the `virt-what`
package.  The last line of output is used to determine the virtual
machine hypervisor type.

If virt-what is not available or returns no output, then existing lower
weight resolvers are used instead.
