### PR TITLE
(maint) Remove bad test of manufacturer fact on Solaris

### DIFF
--- a/spec/unit/util/manufacturer_spec.rb
+++ b/spec/unit/util/manufacturer_spec.rb
@@ -31,16 +31,6 @@ describe Facter::Manufacturer do
     Facter.value(:productname).should == "SPARC Enterprise T5220"
   end
 
-  it "should not set manufacturer or productname if prtdiag output is nil" do
-    # Stub kernel so we don't have windows fall through to its own mechanism
-    Facter.fact(:kernel).stubs(:value).returns("SunOS")
-
-    Facter::Util::Resolution.stubs(:exec).returns(nil)
-    Facter::Manufacturer.prtdiag_sparc_find_system_info()
-    Facter.value(:manufacturer).should be_nil
-    Facter.value(:productname).should be_nil
-  end
-
   it "should strip white space on dmi output with spaces" do
     dmidecode_output = my_fixture_read("linux_dmidecode_with_spaces")
     Facter::Manufacturer.expects(:get_dmi_table).returns(dmidecode_output)


### PR DESCRIPTION
Without this patch, the following test is failing when run in a Solaris
10 virtual machine:

```
1) Facter::Manufacturer should not set manufacturer or productname if prtdiag output is nil
   Failure/Error: Facter.value(:manufacturer).should be_nil
     expected: nil
          got: "VMware, Inc."
   # ./spec/unit/util/manufacturer_spec.rb:40
```

This problem is self-evident and is caused by the fact that the test is
simply wrong.  Other implementations of the manufacturer spec may
provide a valid result, which is exactly what is happening in this
situation.  In the situation where `prtdiag` is nil, the manufacturer of
the machine appears to be VMware, which is expected behavior.
