### PR TITLE
(#11609) Fix processorX facts for AIX systems

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -24,9 +24,9 @@ require 'facter/util/processor'
 
 ## We have to enumerate these outside a Facter.add block to get the processorN descriptions iteratively
 ## (but we need them inside the Facter.add block above for tests on processorcount to work)
-processor_list = case Facter.value(:kernel)
+processor_list = case Facter::Util::Processor.kernel_fact_value
 when "AIX"
-  Facter::Util::Processor.enum_lsdev
+  Facter::Util::Processor.aix_processor_list
 when "SunOS"
   Facter::Util::Processor.enum_kstat
 else
@@ -71,7 +71,7 @@ end
 Facter.add("ProcessorCount") do
   confine :kernel => :aix
   setcode do
-    processor_list = Facter::Util::Processor.enum_lsdev
+    processor_list = Facter::Util::Processor.aix_processor_list
 
     processor_list.length.to_s
   end

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 
+require 'facter/util/processor'
 require 'spec_helper'
 
 def cpuinfo_fixture(filename)
@@ -194,14 +195,6 @@ describe "Processor facts" do
       Facter.fact(:processorcount).value.should == "2"
     end
 
-    it "should be 6 on six-processor AIX box" do
-      Facter.fact(:kernel).stubs(:value).returns("AIX")
-      Facter::Util::Resolution.stubs(:exec).with("lsdev -Cc processor").returns("proc0 Available 00-00 Processor\nproc2 Available 00-02 Processor\nproc4 Available 00-04 Processor\nproc6 Available 00-06 Processor\nproc8 Available 00-08 Processor\nproc10 Available 00-10 Processor")
-      Facter::Util::Resolution.stubs(:exec).with("lsattr -El proc0 -a type").returns("type PowerPC_POWER3 Processor type False")
-
-      Facter.fact(:processorcount).value.should == "6"
-    end
-
     it "should be 2 via sysfs when cpu0 and cpu1 are present" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       File.stubs(:exists?).with('/sys/devices/system/cpu').returns(true)
@@ -277,6 +270,41 @@ describe "Processor facts" do
 
           Facter::Util::Resolution.expects(:exec).with("/usr/sbin/psrinfo").returns(psrinfo)
           Facter.fact(:physicalprocessorcount).value.should == "2"
+        end
+      end
+    end
+  end
+end
+
+describe "processorX facts" do
+  describe "on AIX" do
+    def self.lsdev_examples
+      examples = []
+      examples << "proc0  Available 00-00 Processor\n" +
+        "proc4  Available 00-04 Processor\n" +
+        "proc8  Defined   00-08 Processor\n" +
+        "proc12 Defined   00-12 Processor\n"
+      examples
+    end
+
+    let(:lsattr) do
+      "type PowerPC_POWER5 Processor type False\n"
+    end
+
+    lsdev_examples.each_with_index do |lsdev_example, i|
+      context "lsdev example ##{i}" do
+        before :each do
+          Facter.fact(:kernel).stubs(:value).returns("AIX")
+          Facter::Util::Processor.stubs(:lsdev).returns(lsdev_example)
+          Facter::Util::Processor.stubs(:lsattr).returns(lsattr)
+          Facter.collection.loader.load(:processor)
+        end
+
+        lsdev_example.split("\n").each_with_index do |line, idx|
+          aix_idx = idx * 4
+          it "maps proc#{aix_idx} to processor#{idx} (#11609)" do
+            Facter.value("processor#{idx}").should == "PowerPC_POWER5"
+          end
         end
       end
     end

--- a/spec/unit/util/processor_spec.rb
+++ b/spec/unit/util/processor_spec.rb
@@ -50,14 +50,6 @@ describe Facter::Util::Processor do
     Facter::Util::Processor.enum_cpuinfo[3].should == "Quad-Core AMD Opteron(tm) Processor 2374 HE"
   end
 
-  it "should get the processor type on AIX box" do
-    Facter.fact(:kernel).stubs(:value).returns("AIX")
-    Facter::Util::Resolution.stubs(:exec).with("lsdev -Cc processor").returns("proc0 Available 00-00 Processor\nproc2 Available 00-02 Processor\nproc4 Available 00-04 Processor\nproc6 Available 00-06 Processor\nproc8 Available 00-08 Processor\nproc10 Available 00-10 Processor")
-    Facter::Util::Resolution.stubs(:exec).with("lsattr -El proc0 -a type").returns("type PowerPC_POWER3 Processor type False")
-
-    Facter::Util::Processor.enum_lsdev[0].should == "PowerPC_POWER3"
-  end
-
   it "should get the processor description on Solaris (x86)" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
     Facter.fact(:architecture).stubs(:value).returns("i86pc")


### PR DESCRIPTION
Without this patch Facter running on AIX systems will output misleading
information in the indexed processorX facts.  This misleading
information looks like:

```
$ facter processor0
processor0 => 0PowerPC_POWER5
processor1 => 6PowerPC_POWER5
processor2 => 2PowerPC_POWER5
processor3 => 4PowerPC_POWER5
```

There are a number of problems here.  First, the mapping of values to
their index is not stable, resulting in non-deterministic behavior.
Second, the AIX specific identifiers are leaking into the fact values.

I learned my lesson when I implemented the Mac OS X System Profiler sp_*
facts.  The lesson learned is that we should not implement facts
specific to a single platform, but instead re-use the existing
platform-agnostic and consistent facts we have.

To this end, this patch solves the problem by mapping the platform
specific processor identifiers to our incrementing index identifiers.
The patch makes sure to sort the list so the results are idempotent.

The new output is:

```
$ facter processor0
processor0 => PowerPC_POWER5
processor1 => PowerPC_POWER5
processor2 => PowerPC_POWER5
processor3 => PowerPC_POWER5
```
