### PR TITLE
(#17191) ipaddress returns localhost instead of error

### DIFF
--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -70,11 +70,7 @@ Facter.add(:ipaddress) do
 
     output.split(/^\S/).each { |str|
       if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-        tmp = $1
-        unless tmp =~ /^127\./ or tmp == "0.0.0.0"
-          ip = tmp
-          break
-        end
+        ip = $1
       end
     }
 


### PR DESCRIPTION
If the local interface is the only one with an IP, then ipaddress will
not be returned without this patch.
