### PR TITLE
(#17177) Add MTU information to interfaces

### DIFF
--- a/lib/facter/interfaces.rb
+++ b/lib/facter/interfaces.rb
@@ -31,7 +31,7 @@ Facter::Util::IP.get_interfaces.each do |interface|
   # Make a fact for each detail of each interface.  Yay.
   #   There's no point in confining these facts, since we wouldn't be able to create
   # them if we weren't running on a supported platform.
-  %w{ipaddress ipaddress6 macaddress netmask}.each do |label|
+  %w{ipaddress ipaddress6 macaddress netmask mtu}.each do |label|
     Facter.add(label + "_" + Facter::Util::IP.alphafy(interface)) do
       setcode do
         Facter::Util::IP.get_interface_value(interface, label)

--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -8,20 +8,23 @@ module Facter::Util::IP
       :ipaddress  => /inet addr:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
       :ipaddress6 => /inet6 addr: ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
       :macaddress => /(?:ether|HWaddr)\s+((\w{1,2}:){5,}\w{1,2})/,
-      :netmask  => /Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
+      :netmask  => /Mask:([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
+      :mtu  => /MTU:(\d+)/
     },
     :bsd   => {
       :aliases  => [:openbsd, :netbsd, :freebsd, :darwin, :"gnu/kfreebsd", :dragonfly],
       :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
       :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
       :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
-      :netmask  => /netmask\s+0x(\w{8})/
+      :netmask  => /netmask\s+0x(\w{8})/,
+      :mtu => /mtu\s+(\d+)/
     },
     :sunos => {
       :ipaddress  => /inet\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
       :ipaddress6 => /inet6 ((?![fe80|::1])(?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/,
       :macaddress => /(?:ether|lladdr)\s+(\w?\w:\w?\w:\w?\w:\w?\w:\w?\w:\w?\w)/,
-      :netmask  => /netmask\s+(\w{8})/
+      :netmask  => /netmask\s+(\w{8})/,
+      :mtu => /mtu\s+(\d+)/
     },
     :"hp-ux" => {
       :ipaddress  => /\s+inet (\S+)\s.*/,

--- a/spec/unit/util/ip_spec.rb
+++ b/spec/unit/util/ip_spec.rb
@@ -263,6 +263,33 @@ describe Facter::Util::IP do
     Facter::Util::IP.get_arp_value("eth0").should == "00:00:0c:9f:f0:04"
   end
 
+  it "should return mtu information on Linux" do
+    linux_ifconfig = my_fixture_read("linux_ifconfig_all_with_single_interface")
+    Facter::Util::IP.stubs(:get_all_interface_output).returns(linux_ifconfig)
+    Facter.stubs(:value).with(:kernel).returns("Linux")
+
+    Facter::Util::IP.get_interface_value("eth0", "mtu").should == "1500"
+    Facter::Util::IP.get_interface_value("lo", "mtu").should == "16436"
+  end
+  
+  it "should return mtu information on Darwin" do
+    darwin_ifconfig_interface = my_fixture_read("darwin_ifconfig_single_interface")
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("en1").returns(darwin_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Darwin")
+
+    Facter::Util::IP.get_interface_value("en1", "mtu").should == "1500"
+  end
+  
+  it "should return mtu information for Solaris" do
+    solaris_ifconfig_interface = my_fixture_read("solaris_ifconfig_single_interface")
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("e1000g0").returns(solaris_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("SunOS")
+
+    Facter::Util::IP.get_interface_value("e1000g0", "mtu").should == "1500"
+  end
+  
   describe "on Windows" do
     before :each do
       Facter.stubs(:value).with(:kernel).returns("windows")


### PR DESCRIPTION
I thought about making this a plugin but we're already gathering the information here and ignoring it.
- add regex strings for linux bsd, and sunos to pull mtu information
- add tests to confirm that information is valid
- add the mtu label to interfaces.rb

http://projects.puppetlabs.com/issues/17177
