### PR TITLE
(Maint) Remove aliases for spec from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,12 +55,8 @@ task :default do
   sh %{rake -T}
 end
 
-# Aliases for spec
-task :tests   => [:test]
-task :specs   => [:test]
-
 desc "Run all specs"
-RSpec::Core::RakeTask.new(:test) do |t|
+RSpec::Core::RakeTask.new do |t|
   t.pattern ='spec/{unit,integration}/**/*_spec.rb'
   t.fail_on_error = true
 end


### PR DESCRIPTION
Previously `rake test`, `rake specs`, `rake tests` were all equivalent. 
However, there was also `rake spec` which existed, but was not listed by
`rake -T`, but also did not fail. The `rake spec` task is the most common one
for running spec tests. As things were setup, the `rake spec` test would run,
exit with 0, but not actually execute any tests.

This commit removes the various aliases and leavs us with just `rake spec`.
