### PR TITLE
(#16511) Do not call arp -an on Solaris nodes

### DIFF
--- a/spec/fixtures/unit/util/ec2/solaris8_arp_a_not_ec2.out
+++ b/spec/fixtures/unit/util/ec2/solaris8_arp_a_not_ec2.out
@@ -1,0 +1,7 @@
+Net to Media Table: IPv4
+Device   IP Address               Mask      Flags   Phys Addr  
+------ -------------------- --------------- ----- --------------- 
+dnet0  pecan                255.255.255.255       08:00:20:05:21:33 
+dnet0  horseshoe            255.255.255.255       00:00:0c:e0:80:b1 
+dnet0  crab                 255.255.255.255  SP   08:00:20:22:fd:51
+dnet0  BASE-ADDRESS.MCAST.NET 240.0.0.0      SM   01:00:5e:00:00:00

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -57,6 +57,21 @@ describe Facter::Util::EC2 do
         Facter::Util::EC2.has_ec2_arp?.should == false
       end
     end
+
+    describe "on solaris" do
+      before :each do
+        Facter.stubs(:value).with(:kernel).returns("SunOS")
+      end
+
+      it "should fail if arp table does not contain fe:ff:ff:ff:ff:ff" do
+        ec2arp = my_fixture_read("solaris8_arp_a_not_ec2.out")
+
+        Facter::Util::Resolution.expects(:exec).with("arp -a").
+          at_least_once.returns(ec2arp)
+
+        Facter::Util::EC2.has_ec2_arp?.should == false
+      end
+    end
   end
 
   describe "is_euca_mac? method" do


### PR DESCRIPTION
Without this patch applied the EC2 facts cause Facter to execute the
`arp -an` system command on Solaris systems.  This is an invalid command
on Solaris 8, but not 9 or 10.  This is a problem because the following
output is displayed to the user every run:

```
arp: -an: unknown host
```

The other problem is that facts which depend on this behavior working
are themselves broken and do not resolve on Solaris.

This patch _papers over the problem_, but does not fix the core issues
present in the EC2 facts.  The core problem is that way too much EC2
specific work is being done in the main scope, causing this behavior and
code paths to be exercised on systems like Solaris 8 that will never run
in EC2.

The example `arp -a` command example is copied from
http://docstore.mik.ua/orelly/networking_2ndEd/tcp/ch13_04.htm
