### PR TITLE
Remove hardcoded version from source in facter

### DIFF
--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,6 +1,15 @@
 module Facter
-  if not defined? FACTERVERSION then
-    FACTERVERSION = 'DEVELOPMENT'
+
+  version = 'DEVELOPMENT'
+  if version == 'DEVELOPMENT'
+    %x{git rev-parse --is-inside-work-tree > /dev/null 2>&1}
+    if $?.success?
+      version = %x{git describe --tags --always 2>&1}.chomp
+    end
+  end
+
+  if not defined? FACTERVERSION
+    FACTERVERSION = version
   end
 
   def self.version


### PR DESCRIPTION
This commit removes the hardcoded version in the facter source
code. This allows us to lay down the version file in packaging
while avoiding a commit to source prior to tagging a release.
Once a release passes tests, it should be tagged and shipped,
without needing an extra commit below the tag.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
