### PR TITLE
(#17521) Add osfamily fact ArchLinux

### DIFF
--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -26,6 +26,8 @@ Facter.add(:osfamily) do
       "Solaris"
     when "Gentoo"
       "Gentoo"
+    when "Archlinux"
+      "Archlinux"
     else
       Facter.value("kernel")
     end


### PR DESCRIPTION
Archlinux doesn't have a osfamily fact.

I believe Archlinux needs one because of the following:
- Manjaro Linux based on Archlinux http://blog.manjaro.org/
- Archbang based on Archlinux http://archbang.org/
- More archlinux based distro's: https://wiki.archlinux.org/index.php/Arch_Based_Distributions_(Active)

And because it is 7th with Distrowatch.
It has puppet 3.0.1 and facter 1.6.14 in it Archlinux User Repo:
https://aur.archlinux.org/packages/puppet
https://aur.archlinux.org/packages/facter/
