### PR TITLE
(maint) Remove hard dependency on rspec from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,15 @@ require 'facter/version'
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), 'tasks')
 
-require 'rubygems'
-require 'rspec'
-require 'rspec/core/rake_task'
-require 'rake'
-
 begin
+  require 'rubygems'
+  require 'rspec'
+  require 'rspec/core/rake_task'
   require 'rcov'
 rescue LoadError
 end
+
+require 'rake'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
@@ -55,17 +55,19 @@ task :default do
   sh %{rake -T}
 end
 
-desc "Run all specs"
-RSpec::Core::RakeTask.new do |t|
-  t.pattern ='spec/{unit,integration}/**/*_spec.rb'
-  t.fail_on_error = true
-end
+if defined?(RSpec::Core::RakeTask)
+  desc "Run all specs"
+  RSpec::Core::RakeTask.new do |t|
+    t.pattern ='spec/{unit,integration}/**/*_spec.rb'
+    t.fail_on_error = true
+  end
 
-RSpec::Core::RakeTask.new('spec:rcov') do |t|
-  t.pattern ='spec/{unit,integration}/**/*_spec.rb'
-  t.fail_on_error = true
-  if defined?(Rcov)
-    t.rcov = true
-    t.rcov_opts = ['--exclude', 'spec/*,test/*,results/*,/usr/lib/*,/usr/local/lib/*,gems/*']
+  RSpec::Core::RakeTask.new('spec:rcov') do |t|
+    t.pattern ='spec/{unit,integration}/**/*_spec.rb'
+    t.fail_on_error = true
+    if defined?(Rcov)
+      t.rcov = true
+      t.rcov_opts = ['--exclude', 'spec/*,test/*,results/*,/usr/lib/*,/usr/local/lib/*,gems/*']
+    end
   end
 end


### PR DESCRIPTION
Rspec is currently required to run any rake tasks in Facter, or even to list
the available rake tasks. For users wishing to just build packages, this is a
high bar. This commit moves the rspec and rubygem requires into a begin/rescue
block so that loaderrors can be caught and ignored. It also moves the tasks
that are defined using Rspec::Core::RakeTask into a conditional on whether
Rspec::Core::RakeTask is available to use. This allows the rake tasks to be
listed and run without rspec installed.
