### PR TITLE
(#17487) Tweak sed call to handle HP-UX interfaces with asterisks.

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -78,7 +78,9 @@ module Facter::Util::IP
     when 'SunOS'
       output = %x{/usr/sbin/ifconfig -a}
     when 'HP-UX'
-      output = %x{/bin/netstat -in | sed -e 1d}
+      # see discussion at https://github.com/puppetlabs/facter/pull/232 and
+      # https://projects.puppetlabs.com/issues/11612.
+      output = %x{/bin/netstat -in | sed -e '1d; /none/d; s/*//g'}
     when 'windows'
       output = %x|#{ENV['SYSTEMROOT']}/system32/netsh.exe interface ip show interface|
       output += %x|#{ENV['SYSTEMROOT']}/system32/netsh.exe interface ipv6 show interface|


### PR DESCRIPTION
Without this patch applied facter prints errors 'ifconfig: no such interface'
to the screen.  The patch is based on code submitted by Hongbo Hu.

I have not submitted RSpec tests because I believe quite a lot of ip.rb
would need to be refactored before valid unit tests could be written.  The
change is trivial and isolated inside an HP-UX case block.

The refactoring I have proposed is tracked in (#17710).
