### PR TITLE
(#17794) remove :kernel confinement of {zfs,zpool}_version

### DIFF
--- a/lib/facter/zfs_version.rb
+++ b/lib/facter/zfs_version.rb
@@ -1,10 +1,10 @@
 require 'facter'
 
 Facter.add('zfs_version') do
-  confine :kernel => %w(SunOS FreeBSD GNU/kFreeBSD)
-
-  setcode do
-    zfs_v = Facter::Util::Resolution.exec('zfs upgrade -v')
-    zfs_version = zfs_v.scan(/^\s+(\d+)\s+/m).flatten.last unless zfs_v.nil?
+  if Facter::Util::Resolution.which('zfs')
+    setcode do
+      zfs_v = Facter::Util::Resolution.exec('zfs upgrade -v')
+      zfs_version = zfs_v.scan(/^\s+(\d+)\s+/m).flatten.last unless zfs_v.nil?
+    end
   end
 end

--- a/lib/facter/zpool_version.rb
+++ b/lib/facter/zpool_version.rb
@@ -1,10 +1,10 @@
 require 'facter'
 
 Facter.add('zpool_version') do
-  confine :kernel => %w(SunOS FreeBSD GNU/kFreeBSD)
-
-  setcode do
-    zpool_v = Facter::Util::Resolution.exec('zpool upgrade -v')
-    zpool_version = zpool_v.match(/ZFS pool version (\d+)./).captures.first unless zpool_v.nil?
+  if Facter::Util::Resolution.which('zpool')
+    setcode do
+      zpool_v = Facter::Util::Resolution.exec('zpool upgrade -v')
+      zpool_version = zpool_v.match(/ZFS pool version (\d+)./).captures.first unless zpool_v.nil?
+    end
   end
 end

--- a/spec/fixtures/unit/zfs_version/linux-fuse_0.6.9
+++ b/spec/fixtures/unit/zfs_version/linux-fuse_0.6.9
@@ -1,0 +1,14 @@
+The following filesystem versions are supported:
+
+VER  DESCRIPTION
+---  --------------------------------------------------------
+ 1   Initial ZFS filesystem version
+ 2   Enhanced directory entries
+ 3   Case insensitive and File system unique identifier (FUID)
+ 4   userquota, groupquota properties
+
+For more information on a particular version, including supported releases, see:
+
+http://www.opensolaris.org/os/community/zfs/version/zpl/N
+
+Where 'N' is the version number.

--- a/spec/fixtures/unit/zpool_version/linux-fuse_0.6.9
+++ b/spec/fixtures/unit/zpool_version/linux-fuse_0.6.9
@@ -1,0 +1,35 @@
+This system is currently running ZFS pool version 23.
+
+The following versions are supported:
+
+VER  DESCRIPTION
+---  --------------------------------------------------------
+ 1   Initial ZFS version
+ 2   Ditto blocks (replicated metadata)
+ 3   Hot spares and double parity RAID-Z
+ 4   zpool history
+ 5   Compression using the gzip algorithm
+ 6   bootfs pool property
+ 7   Separate intent log devices
+ 8   Delegated administration
+ 9   refquota and refreservation properties
+ 10  Cache devices
+ 11  Improved scrub performance
+ 12  Snapshot properties
+ 13  snapused property
+ 14  passthrough-x aclinherit
+ 15  user/group space accounting
+ 16  stmf property support
+ 17  Triple-parity RAID-Z
+ 18  Snapshot user holds
+ 19  Log device removal
+ 20  Compression using zle (zero-length encoding)
+ 21  Deduplication
+ 22  Received properties
+ 23  Slim ZIL
+
+For more information on a particular version, including supported releases, see:
+
+http://www.opensolaris.org/os/community/zfs/version/N
+
+Where 'N' is the version number.

--- a/spec/unit/zfs_version_spec.rb
+++ b/spec/unit/zfs_version_spec.rb
@@ -14,52 +14,38 @@ describe "zfs_version fact" do
   # Solaris 10 8/11 (u10) 29  5
   # Solaris 11 11/11 (ga) 33  5
 
-  describe "for Solaris" do
-    before :each do
-      Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    end
-
-    it "should return correct version on Solaris 10" do
-      Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_10'))
-      Facter.fact(:zfs_version).value.should == "3"
-    end
-
-    it "should return correct version on Solaris 11" do
-      Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_11'))
-      Facter.fact(:zfs_version).value.should == "5"
-    end
-
-    it "should return nil if zfs command is not available" do
-      Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(nil)
-      Facter.fact(:zfs_version).value.should == nil
-    end
+  it "should return correct version on Solaris 10" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_10'))
+    Facter.fact(:zfs_version).value.should == "3"
   end
 
-  ['FreeBSD', 'GNU/kFreeBSD'].each do |kernel|
-    describe "for #{kernel}" do
-      before :each do
-        Facter.fact(:kernel).stubs(:value).returns("#{kernel}")
-      end
+  it "should return correct version on Solaris 11" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_11'))
+    Facter.fact(:zfs_version).value.should == "5"
+  end
 
-      it "should return correct version on #{kernel} 8.2" do
-        Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_8.2'))
-        Facter.fact(:zfs_version).value.should == "4"
-      end
+  it "should return correct version on FreeBSD 8.2" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_8.2'))
+    Facter.fact(:zfs_version).value.should == "4"
+  end
 
-      it "should return correct version on #{kernel} 9.0" do
-        Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_9.0'))
-        Facter.fact(:zfs_version).value.should == "5"
-      end
+  it "should return correct version on FreeBSD 9.0" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_9.0'))
+    Facter.fact(:zfs_version).value.should == "5"
+  end
 
-      it "should return nil if zfs command is not available" do
-        Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(nil)
-        Facter.fact(:zfs_version).value.should == nil
-      end
-    end
-  end 
+  it "should return correct version on Linux with ZFS-fuse" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))
+    Facter.fact(:zfs_version).value.should == "4"
+  end
 
-  it "should not run on Linux" do
-    Facter.fact(:kernel).stubs(:value).returns("Linux")
+  it "should return nil if zfs command is not available" do
+    Facter::Util::Resolution.stubs(:which).with("zfs").returns(nil)
+    Facter.fact(:zfs_version).value.should == nil
+  end
+
+  it "should return nil if zfs fails to run" do
+    Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(nil)
     Facter.fact(:zfs_version).value.should == nil
   end
 end

--- a/spec/unit/zpool_version_spec.rb
+++ b/spec/unit/zpool_version_spec.rb
@@ -14,52 +14,38 @@ describe "zpool_version fact" do
   # Solaris 10 8/11 (u10) 29  5
   # Solaris 11 11/11 (ga) 33  5
 
-  describe "for Solaris" do
-    before :each do
-      Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    end
-
-    it "should return correct version on Solaris 10" do
-      Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('solaris_10'))
-      Facter.fact(:zpool_version).value.should == "22"
-    end
-
-    it "should return correct version on Solaris 11" do
-      Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('solaris_11'))
-      Facter.fact(:zpool_version).value.should == "33"
-    end
-
-    it "should return nil if zpool is not available" do
-      Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(nil)
-      Facter.fact(:zpool_version).value.should == nil
-    end
+  it "should return correct version on Solaris 10" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('solaris_10'))
+    Facter.fact(:zpool_version).value.should == "22"
   end
 
-  ['FreeBSD', 'GNU/kFreeBSD'].each do |kernel|
-    describe "on #{kernel}" do
-      before :each do
-        Facter.fact(:kernel).stubs(:value).returns("#{kernel}")
-      end
+  it "should return correct version on Solaris 11" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('solaris_11'))
+    Facter.fact(:zpool_version).value.should == "33"
+  end
 
-      it "should return correct version on #{kernel} 8.2" do
-        Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('freebsd_8.2'))
-        Facter.fact(:zpool_version).value.should == "15"
-      end
+  it "should return correct version on FreeBSD 8.2" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('freebsd_8.2'))
+    Facter.fact(:zpool_version).value.should == "15"
+  end
 
-      it "should return correct version on #{kernel} 9.0" do
-        Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('freebsd_9.0'))
-        Facter.fact(:zpool_version).value.should == "28"
-      end
+  it "should return correct version on FreeBSD 9.0" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('freebsd_9.0'))
+    Facter.fact(:zpool_version).value.should == "28"
+  end
 
-      it "should return nil if zpool is not available" do
-        Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(nil)
-        Facter.fact(:zpool_version).value.should == nil
-      end
-    end
-  end 
-  it "should not run on Linux" do
-    Facter.fact(:kernel).stubs(:value).returns("Linux")
+  it "should return correct version on Linux with ZFS-fuse" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))
+    Facter.fact(:zpool_version).value.should == "23"
+  end
+
+  it "should return nil if zpool is not available" do
+    Facter::Util::Resolution.stubs(:which).with("zpool").returns(nil)
+    Facter.fact(:zpool_version).value.should == nil
+  end
+
+  it "should return nil if zpool fails to run" do
+    Facter::Util::Resolution.stubs(:exec).with("zpool upgrade -v").returns(nil)
     Facter.fact(:zpool_version).value.should == nil
   end
 end
- 


### PR DESCRIPTION
As ZFS is now available on more or less every Solaris and BSD variant,
as well as on Linux (via FUSE), it doesn't make sense to confine these
facts to an evergrowing list of kernels.

This patch:
- removes every reference to :kernel, as well as the SunOS/FreeBSD
  subsections from the tests
- runs the "setcode" block only if the zfs/zpool commands are present
  on the system, and adds a test for this case
- adds sample output of zfs/zpool on Linux (FUSE) to fixtures + a test
  using them
- removes the "should not run on Linux" test.

The zfs/zpool providers in puppet have been recently updated in a
similar fashion (55f953bc).
