### PR TITLE
(#17840) Use enum_cpuinfo for x86 arch

### DIFF
--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -217,7 +217,7 @@ module Processor
     if File.exists?(cpuinfo)
       model = Facter.value(:architecture)
       case model
-      when "x86_64", "amd64", "i386", /parisc/, "hppa", "ia64"
+      when "x86_64", "amd64", "i386", "x86", /parisc/, "hppa", "ia64"
         Thread::exclusive do
           File.readlines(cpuinfo).each do |l|
             if l =~ /processor\s+:\s+(\d+)/

--- a/spec/fixtures/unit/util/processor/x86-pentium2
+++ b/spec/fixtures/unit/util/processor/x86-pentium2
@@ -1,0 +1,41 @@
+processor : 0
+vendor_id : GenuineIntel
+cpu family  : 6
+model   : 5
+model name  : Pentium II (Deschutes)
+stepping  : 1
+cpu MHz   : 333.379
+cache size  : 512 KB
+fdiv_bug  : no
+hlt_bug   : no
+f00f_bug  : no
+coma_bug  : no
+fpu   : yes
+fpu_exception : yes
+cpuid level : 2
+wp    : yes
+flags   : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 mmx fxsr
+bogomips  : 667.53
+clflush size  : 32
+power management:
+
+processor : 1
+vendor_id : GenuineIntel
+cpu family  : 6
+model   : 5
+model name  : Pentium II (Deschutes)
+stepping  : 1
+cpu MHz   : 333.379
+cache size  : 512 KB
+fdiv_bug  : no
+hlt_bug   : no
+f00f_bug  : no
+coma_bug  : no
+fpu   : yes
+fpu_exception : yes
+cpuid level : 2
+wp    : yes
+flags   : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 mmx fxsr
+bogomips  : 666.44
+clflush size  : 32
+power management:

--- a/spec/unit/util/processor_spec.rb
+++ b/spec/unit/util/processor_spec.rb
@@ -50,6 +50,22 @@ describe Facter::Util::Processor do
     Facter::Util::Processor.enum_cpuinfo[3].should == "Quad-Core AMD Opteron(tm) Processor 2374 HE"
   end
 
+  describe "with architecture x86" do
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter.fact(:architecture).stubs(:value).returns("x86")
+      File.stubs(:exists?).with("/proc/cpuinfo").returns(true)
+      File.stubs(:readlines).with("/proc/cpuinfo").returns(my_fixture_read("x86-pentium2").lines)
+    end
+
+    subject { Facter::Util::Processor.enum_cpuinfo }
+
+    it "should have the correct processor titles" do
+      subject[0].should == "Pentium II (Deschutes)"
+      subject[1].should == "Pentium II (Deschutes)"
+    end
+  end
+
   it "should get the processor description on Solaris (x86)" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
     Facter.fact(:architecture).stubs(:value).returns("i86pc")


### PR DESCRIPTION
Windows and Gentoo consider 32 bit x86 architectures to be called 'x86',
but this value was not handled when checking for processorcount
information. This patch adds x86 alongside the other synonyms for this
architecture.
