### PR TITLE
(#17855) Rescue Timeout::Error

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -26,9 +26,8 @@ def userdata()
   end
 end
 
-if (Facter::Util::EC2.has_euca_mac? || Facter::Util::EC2.has_openstack_mac? || 
+if (Facter::Util::EC2.has_euca_mac? || Facter::Util::EC2.has_openstack_mac? ||
     Facter::Util::EC2.has_ec2_arp?) && Facter::Util::EC2.can_connect?
-
   metadata
   userdata
 else

--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -14,6 +14,8 @@ module Facter::Util::EC2
       url = "http://169.254.169.254:80/"
       Timeout::timeout(wait_sec) {open(url)}
       return true
+    rescue Timeout::Error
+      return false
     rescue
       return false
     end

--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -170,5 +170,11 @@ describe "ec2 facts" do
 
       Facter.fact(:ec2_userdata).should == nil
     end
+
+    it "should rescue the exception" do
+      Facter::Util::EC2.expects(:open).with("#{api_prefix}:80/").raises(Timeout::Error)
+
+      Facter::Util::EC2.should_not be_can_connect
+    end
   end
 end


### PR DESCRIPTION
Previously, if the Facter::EC2.can_connect? method timed-out, an
instance of Timeout::Error would be raised. Under ruby 1.8.7, this class
is not a StandardError, and so wasn't rescued. And since the
can_connect? method is called when the ec2 code is loaded (as opposed to
a setcode block), the exception was never caught causing facter to exit.

In ruby 1.9.3, Timeout::Error is a StandardError, so the default
`rescue` block catches it.

This issue was caused by commit b336259e when trying to fix #17493.

This commit restores the explicit rescue of Timeout::Error so that it
behaves consistently on all supported ruby versions.
