### PR TITLE
(#17894) Add fix to handle processorX facts on HP Superdomes.

### DIFF
--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -87,6 +87,8 @@ module Processor
         elsif line.match(/\d+\s+((?:PA-RISC|Intel).*processors.*)/) then
           cpu = $1.to_s
           cpu.sub!(/processors/, "processor")
+        elsif line.match(/\s+(Intel.*Processor.*)/) then
+          cpu = $1.to_s
         end
       end
     end

--- a/spec/fixtures/hpux/machinfo/superdome-server-SD32B
+++ b/spec/fixtures/hpux/machinfo/superdome-server-SD32B
@@ -1,0 +1,53 @@
+CPU info:
+   Number of CPUs = 8
+   Number of enabled CPUs = 2
+   Number of enabled sockets = 2
+   Cores per socket = 2
+   Clock speed = 1598 MHz
+   Bus speed   = 533 MT/s
+   CPUID registers
+      vendor information =       "GenuineIntel"
+      processor serial number =  0x0000000000000000
+      processor version info =   0x0000000020000704
+         architecture revision:       0
+         processor family:           32   Intel(R) Itanium 2 9000 series
+         processor model:             1   Intel(R) Itanium 2 9000 series
+   Bus features
+      implemented =  0xbdf0000020000000
+      selected    =  0x0020000000000000
+         Exclusive Bus Cache Line Replacement Enabled
+         processor revision:          7   Stepping C2
+         largest CPUID reg:           4
+      processor capabilities =   0x0000000000000005
+                      implements long branch:  1
+        implements 16-byte atomic operations:  1
+
+Cache info (per core):
+   L1 Instruction: size =   16 KB, associativity = 4
+   L1 Data:        size =   16 KB, associativity = 4
+   L2 Instruction: size = 1024 KB, associativity = 8
+   L2 Data:        size =  256 KB, associativity = 8
+   L3 Unified:     size = 12288 KB, associativity = 12
+
+Memory = 32700 MB (31.933594 GB)
+
+Firmware info:
+   Firmware revision = 9.66
+   FP SWA driver revision: 1.18
+   IPMI is supported on this system.
+   ERROR: Unable to obtain manageability firmware revision info.
+
+Platform info:
+   model string =          "ia64 hp superdome server SD32B"
+   machine id number =     STRING_WITH_DASHES
+   machine serial number = STRING
+
+OS info:
+   sysname  = HP-UX
+   nodename = HOSTNAME
+   release  = B.11.23
+   version  = U (unlimited-user license)
+   machine  = ia64
+   idnumber = NUMBER
+   vmunix _release_version:               
+@(#) $Revision: vmunix:    B11.23_LR FLAVOR=perf Fri Aug 29 22:35:38 PDT 2003 $

--- a/spec/fixtures/hpux/machinfo/superdome2-16s
+++ b/spec/fixtures/hpux/machinfo/superdome2-16s
@@ -1,0 +1,31 @@
+CPU info:
+   Intel(R)  Itanium(R)  Processor 9340 (1.6 GHz, 15 MB)
+   4 cores, 8 logical processors per socket
+   4.79 GT/s QPI, CPU version E0
+          Active processor count:
+          2 sockets
+          6 cores (3 per socket)
+          12 logical processors (6 per socket)
+          LCPU attribute is enabled
+
+Memory: 14332 MB (14 GB)
+
+Firmware info:
+   Firmware revision:  004.044.000
+   FP SWA driver revision: 1.18
+   IPMI is supported on this system.
+   BMC firmware revision: 2.53
+
+Platform info:
+   Model:                  "ia64 hp Superdome2 16s"
+   Machine ID number:      STRING_WITH_DASHES
+   Machine serial number:  STRING
+
+OS info:
+   Nodename:  HOSTNAME
+   Release:   HP-UX B.11.31
+   Version:   U (unlimited-user license)
+   Machine:   ia64
+   ID Number: NUMBER
+   vmunix _release_version:
+@(#) $Revision: vmunix:    B.11.31_LR FLAVOR=perf

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -317,6 +317,8 @@ describe "processorX facts" do
       examples << [File.read(fixtures('hpux','machinfo','ia64-rx6600')), "Intel(R) Itanium 2 9100 series processor (1.59 GHz, 18 MB)"]
       examples << [File.read(fixtures('hpux','machinfo','ia64-rx8640')), "Intel(R) Itanium 2 9100 series"]
       examples << [File.read(fixtures('hpux','machinfo','hppa-rp4440')), "PA-RISC 8800 processor (1000 MHz, 64 MB)"]
+      examples << [File.read(fixtures('hpux','machinfo','superdome-server-SD32B')), "Intel(R) Itanium 2 9000 series"]
+      examples << [File.read(fixtures('hpux','machinfo','superdome2-16s')), "Intel(R)  Itanium(R)  Processor 9340 (1.6 GHz, 15 MB)"]
       examples
     end
 


### PR DESCRIPTION
Without this patch applied, the processorX facts fail on the Superdome2-16s
model servers.  The patch includes machinfo fixtures for the Superdome2-16s
as well as the Superdome SD32B as provided by Luke M.
