### PR TITLE
(#17808) Add MTU facts for HP-UX

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -29,7 +29,9 @@ module Facter::Util::IP
     :"hp-ux" => {
       :ipaddress  => /\s+inet (\S+)\s.*/,
       :macaddress => /(\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2}:\w{1,2})/,
-      :netmask  => /.*\s+netmask (\S+)\s.*/
+      :netmask  => /.*\s+netmask (\S+)\s.*/,
+      :mtu => /MTU:(\d+)/   # see comments below about the HP-UX hack
+                            # for MAC address and MTU.
     },
     :windows => {
       :ipaddress  => /\s+IP Address:\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/,
@@ -136,11 +138,17 @@ module Facter::Util::IP
     when 'SunOS'
       output = %x{/usr/sbin/ifconfig #{interface}}
     when 'HP-UX'
-       mac = ""
-       ifc = hpux_ifconfig_interface(interface)
-       hpux_lanscan.scan(/(\dx\S+).*UP\s+(\w+\d+)/).each {|i| mac = i[0] if i.include?(interface) }
-       mac = mac.sub(/0x(\S+)/,'\1').scan(/../).join(":")
-       output = ifc + "\n" + mac
+      # (#17808)[https://projects.puppetlabs.com/issues/17808] HP-UX hack.
+      # This hack adds MAC address and MTU information from the 'lanscan' and 'netstat -in'
+      # commands respectively after the output from ifconfig <interface>.  This allows ip.rb
+      # to make the (otherwise incorrect) assumption that ifconfig tells us the MAC address
+      # and MTU on all Unix-like operating systems.
+      mac = ""; mtu = ""
+      ifc = hpux_ifconfig_interface(interface)
+      hpux_netstat_in.each_line {|l| x, y, z = l.split(/\s+/); mtu = y if x == interface}
+      hpux_lanscan.scan(/(\dx\S+).*UP\s+(\w+\d+)/).each {|i| mac = i[0] if i.include?(interface) }
+      mac = mac.sub(/0x(\S+)/,'\1').scan(/../).join(":")
+      output = "#{ifc}\n#{mac} MTU:#{mtu}"
     end
     output
   end

--- a/spec/unit/util/ip_spec.rb
+++ b/spec/unit/util/ip_spec.rb
@@ -338,14 +338,13 @@ describe Facter::Util::IP do
       expected_netmask = array_of_expected_netmasks[i]
       expected_mac = array_of_expected_macs[i]
 
-      # (#17808) These tests fail because MTU facts haven't been implemented for HP-UX.
-      #it "should return MTU #{expected_mtu} on #{nic} for #{description} example" do
-      #  Facter.stubs(:value).with(:kernel).returns("HP-UX")
-      #  Facter::Util::IP.stubs(:hpux_netstat_in).returns(netstat_in_fixture)
-      #  Facter::Util::IP.stubs(:hpux_lanscan).returns(lanscan_fixture)
-      #  Facter::Util::IP.stubs(:hpux_ifconfig_interface).with(nic).returns(ifconfig_fixture)
-      #  Facter::Util::IP.get_interface_value(nic, "mtu").should == expected_mtu
-      #end
+      it "should return MTU #{expected_mtu} on #{nic} for #{description} example" do
+        Facter.stubs(:value).with(:kernel).returns("HP-UX")
+        Facter::Util::IP.stubs(:hpux_netstat_in).returns(netstat_in_fixture)
+        Facter::Util::IP.stubs(:hpux_lanscan).returns(lanscan_fixture)
+        Facter::Util::IP.stubs(:hpux_ifconfig_interface).with(nic).returns(ifconfig_fixture)
+        Facter::Util::IP.get_interface_value(nic, "mtu").should == expected_mtu
+      end
 
       it "should return IP #{expected_ip} on #{nic} for #{description} example" do
         Facter.stubs(:value).with(:kernel).returns("HP-UX")


### PR DESCRIPTION
This patch extends the hack that was used to add MAC address
facts on HP-UX.  The patch also documents the hack to make
the code slightly easier to understand.

Unit tests were provided in the patch for (#17487) and are
simply uncommented by the present patch.

All of these hacks can be removed by implementation of
refactor (#17710).
