### PR TITLE
(#15708) fixes facter file mappings for pkgbuild

### DIFF
--- a/ext/osx/file_mapping.yaml
+++ b/ext/osx/file_mapping.yaml
@@ -10,12 +10,12 @@ directories:
     group: 'wheel'
     perms: '0755'
   facter:
-    path: 'var/lib/facter'
+    path: 'private/var/lib/facter'
     owner: 'root'
     group: 'wheel'
     perms: '0644'
   etc:
-    path: 'etc'
+    path: 'private/etc'
     owner: 'root'
     group: 'wheel'
     perms: '0644'


### PR DESCRIPTION
changes ext and var to be private/etc and private/var

previous behavior would break systems running 10.5 if this was installed
as a flat package (pkgbuild's format)
