### PR TITLE
(#17925) Fix ec2_userdata: 404 Not Found Error

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -21,7 +21,9 @@ end
 def userdata()
   Facter.add(:ec2_userdata) do
     setcode do
-      open("http://169.254.169.254/2008-02-01/user-data/").read.split
+      if userdata = Facter::Util::EC2.userdata
+        userdata.split
+      end
     end
   end
 end

--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -58,4 +58,44 @@ module Facter::Util::EC2
       return false
     end
   end
+
+  ##
+  # userdata returns a single string containing the body of the response of the
+  # GET request for the URI http://169.254.169.254/latest/user-data/  If the
+  # metadata server responds with a 404 Not Found error code then this method
+  # retuns `nil`.
+  #
+  # @param version [String] containing the API version for the request.
+  # Defaults to "latest" and other examples are documented at
+  # http://aws.amazon.com/archives/Amazon%20EC2
+  #
+  # @api public
+  #
+  # @return [String] containing the response body or `nil`
+  def self.userdata(version="latest")
+    uri = "http://169.254.169.254/#{version}/user-data/"
+    begin
+      read_uri(uri)
+    rescue OpenURI::HTTPError => detail
+      case detail.message
+      when /404 Not Found/i
+        Facter.debug "No user-data present at #{uri}: server responded with #{detail.message}"
+        return nil
+      else
+        raise detail
+      end
+    end
+  end
+
+  ##
+  # read_uri provides a seam method to easily test the HTTP client
+  # functionality of a HTTP based metadata server.
+  #
+  # @api private
+  #
+  # @return [String] containing the body of the response
+  def self.read_uri(uri)
+    open(uri).read
+  end
+  private_class_method :read_uri
 end

--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -68,9 +68,9 @@ describe "ec2 facts" do
         with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.returns(StringIO.new(""))
 
-      Facter::Util::Resolution.any_instance.expects(:open).
-        with("#{api_prefix}/2008-02-01/user-data/").
-        at_least_once.returns(StringIO.new("test"))
+      Facter::Util::EC2.stubs(:read_uri).
+        with("#{api_prefix}/latest/user-data/").
+        returns("test")
 
       Facter.collection.loader.load(:ec2)
       Facter.fact(:ec2_userdata).value.should == ["test"]
@@ -94,9 +94,9 @@ describe "ec2 facts" do
         with("#{api_prefix}/2008-02-01/meta-data/").\
         at_least_once.returns(StringIO.new(""))
 
-      Facter::Util::Resolution.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
-        at_least_once.returns(StringIO.new("test"))
+      Facter::Util::EC2.stubs(:read_uri).
+        with("#{api_prefix}/latest/user-data/").
+        returns("test")
 
       # Force a fact load
       Facter.collection.loader.load(:ec2)
@@ -122,9 +122,9 @@ describe "ec2 facts" do
         with("#{api_prefix}/2008-02-01/meta-data/").\
         at_least_once.returns(StringIO.new(""))
 
-      Facter::Util::Resolution.any_instance.expects(:open).\
-        with("#{api_prefix}/2008-02-01/user-data/").\
-        at_least_once.returns(StringIO.new("test"))
+      Facter::Util::EC2.stubs(:read_uri).
+        with("#{api_prefix}/latest/user-data/").
+        returns("test")
 
       # Force a fact load
       Facter.collection.loader.load(:ec2)
@@ -140,9 +140,9 @@ describe "ec2 facts" do
         with("#{api_prefix}/2008-02-01/meta-data/").
         at_least_once.raises(RuntimeError, 'host unreachable')
 
-      Facter::Util::Resolution.any_instance.expects(:open).
-        with("#{api_prefix}/2008-02-01/user-data/").
-        at_least_once.raises(RuntimeError, 'host unreachable')
+      Facter::Util::EC2.stubs(:read_uri).
+        with("#{api_prefix}/latest/user-data/").
+        raises(RuntimeError, 'host unreachable')
 
       # Force a fact load
       Facter.collection.loader.load(:ec2)

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -151,4 +151,30 @@ describe Facter::Util::EC2 do
       end
     end
   end
+
+  describe "Facter::Util::EC2.userdata" do
+    let :not_found_error do
+      OpenURI::HTTPError.new("404 Not Found", StringIO.new)
+    end
+
+    let :example_userdata do
+      "owner=jeff@puppetlabs.com\ngroup=platform_team"
+    end
+
+    it 'returns nil when no userdata is present' do
+      Facter::Util::EC2.stubs(:read_uri).raises(not_found_error)
+      Facter::Util::EC2.userdata.should be_nil
+    end
+
+    it "returns the string containing the body" do
+      Facter::Util::EC2.stubs(:read_uri).returns(example_userdata)
+      Facter::Util::EC2.userdata.should == example_userdata
+    end
+
+    it "uses the specified API version" do
+      expected_uri = "http://169.254.169.254/2008-02-01/user-data/"
+      Facter::Util::EC2.expects(:read_uri).with(expected_uri).returns(example_userdata)
+      Facter::Util::EC2.userdata('2008-02-01').should == example_userdata
+    end
+  end
 end


### PR DESCRIPTION
Without this patch applied Facter returns the following error message to
the user when no user-data is present in the instance metadata server
when Facter is running on an instance in Amazon AWS EC2.

```
$ facter ec2_userdata
Could not retrieve ec2_userdata: 404 Not Found
```

This patch addresses the problem by handling the exception produced from
the HTTP 404 Not Found error.  In this circumstance of no user-data
being present, the fact value is not set.

With this patch applied the behavior is as follows:

```
$ userdata=$(facter ec2_userdata); echo "userdata: [${userdata}]"
userdata: []
```

And the error is not silently dropped with debugging turned on:

```
$ facter --debug ec2_userdata
No user-data present at http://169.254.169.254/latest/user-data/: server responded with 404 Not Found
value for ec2_userdata is still nil
```
