### PR TITLE
Correct file system paths in apple pkg file layout

### DIFF
--- a/ext/osx/file_mapping.yaml
+++ b/ext/osx/file_mapping.yaml
@@ -10,12 +10,12 @@ directories:
     group: 'wheel'
     perms: '0755'
   facter:
-    path: 'var/lib/facter'
+    path: 'private/var/lib/facter'
     owner: 'root'
     group: 'wheel'
     perms: '0644'
   etc:
-    path: 'etc'
+    path: 'private/etc'
     owner: 'root'
     group: 'wheel'
     perms: '0644'


### PR DESCRIPTION
Currently, the osx packaging for facter places things in /var
and /etc, which are actually symlinks on OSX systems to /private/var
and /private/etc. Due to a bug in the 10.5 installer, trying to package
in /var, /etc instead of /private/{var,etc} would actually just clobber
the symlink instead of dropping into the target locations, if we used
the newer 'flat package' building method. This fix allows us to build
flat packages without clobbering the symlinks.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
