### PR TITLE
(#18336) osfamily for mandrake

### DIFF
--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -28,6 +28,8 @@ Facter.add(:osfamily) do
       "Gentoo"
     when "Archlinux"
       "Archlinux"
+    when "Mandrake", "Mandriva"
+      "Mandrake"
     else
       Facter.value("kernel")
     end

--- a/spec/unit/osfamily_spec.rb
+++ b/spec/unit/osfamily_spec.rb
@@ -30,7 +30,9 @@ describe "OS Family fact" do
     'SLES'        => 'Suse',
     'SLED'        => 'Suse',
     'OpenSuSE'    => 'Suse',
-    'SuSE'        => 'Suse'
+    'SuSE'        => 'Suse',
+    'Mandriva'    => 'Mandrake',
+    'Mandrake'    => 'Mandrake'
   }.each do |os,family|
     it "should return #{family} on operatingsystem #{os}" do
       Facter.fact(:operatingsystem).stubs(:value).returns os
@@ -39,8 +41,6 @@ describe "OS Family fact" do
   end
 
   [
-    'Mandriva',
-    'Mandrake',
     'MeeGo',
     'VMWareESX',
     'Bluewhite64',


### PR DESCRIPTION
This commit will add another osfamily entry for Mandrake that includes
the Mandriva derivative. It will also allow for change in the urpmi
package provider as noted in ticket #18335.
