### PR TITLE
FreeBSD uses the same mechanisms that OpenBSD uses to gather information

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -96,13 +96,6 @@ Facter.add("Processor") do
 end
 
 Facter.add("ProcessorCount") do
-  confine :kernel => :openbsd
-  setcode do
-    Facter::Util::Resolution.exec("sysctl -n hw.ncpu")
-  end
-end
-
-Facter.add("ProcessorCount") do
   confine :kernel => :Darwin
   setcode do
     Facter::Util::Resolution.exec("sysctl -n hw.ncpu")
@@ -155,7 +148,7 @@ Facter.add("Processor") do
 end
 
 Facter.add("ProcessorCount") do
-  confine :kernel => [:dragonfly,:freebsd]
+  confine :kernel => [:dragonfly,:freebsd,:openbsd]
   setcode do
     Facter::Util::Resolution.exec("sysctl -n hw.ncpu")
   end


### PR DESCRIPTION
about the processor.  This commit extends that logic to include FreeBSD.
