### PR TITLE
fix recent net-tools support and unify ifconfig usage ( fixes bug #13396 )

### DIFF
--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -28,7 +28,7 @@ Facter.add(:ipaddress) do
   confine :kernel => :linux
   setcode do
     ip = nil
-    if output = Facter::Util::IP.get_ifconfig
+    if output = Facter::Util::IP.exec_ifconfig(["2>/dev/null"])
       regexp = /inet (?:addr:)?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
       if match = regexp.match(output)
         match[1] unless /^127/.match(match[1])
@@ -41,7 +41,7 @@ Facter.add(:ipaddress) do
   confine :kernel => %w{FreeBSD OpenBSD Darwin DragonFly}
   setcode do
     ip = nil
-    output = %x{/sbin/ifconfig}
+    output = Facter::Util::IP.exec_ifconfig
 
     output.split(/^\S/).each { |str|
       if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
@@ -61,7 +61,7 @@ Facter.add(:ipaddress) do
   confine :kernel => %w{NetBSD SunOS}
   setcode do
     ip = nil
-    output = %x{/sbin/ifconfig -a}
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
 
     output.split(/^\S/).each { |str|
       if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
@@ -81,7 +81,7 @@ Facter.add(:ipaddress) do
   confine :kernel => %w{AIX}
   setcode do
     ip = nil
-    output = %x{/usr/sbin/ifconfig -a}
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
 
     output.split(/^\S/).each { |str|
       if str =~ /inet ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/

--- a/lib/facter/ipaddress6.rb
+++ b/lib/facter/ipaddress6.rb
@@ -38,7 +38,7 @@ end
 Facter.add(:ipaddress6) do
   confine :kernel => :linux
   setcode do
-    output = Facter::Util::Resolution.exec('/sbin/ifconfig 2>/dev/null')
+    output = Facter::Util::IP.exec_ifconfig(["2>/dev/null"])
 
     get_address_after_token(output, 'inet6 addr:')
   end
@@ -47,7 +47,7 @@ end
 Facter.add(:ipaddress6) do
   confine :kernel => %w{SunOS}
   setcode do
-    output = Facter::Util::Resolution.exec('/usr/sbin/ifconfig -a')
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
 
     get_address_after_token(output, 'inet6')
   end
@@ -56,7 +56,7 @@ end
 Facter.add(:ipaddress6) do
   confine :kernel => %w{Darwin FreeBSD OpenBSD}
   setcode do
-    output = Facter::Util::Resolution.exec('/sbin/ifconfig -a')
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
 
     get_address_after_token(output, 'inet6', true)
   end

--- a/lib/facter/iphostnumber.rb
+++ b/lib/facter/iphostnumber.rb
@@ -19,7 +19,7 @@ Facter.add(:iphostnumber) do
   confine :kernel => :darwin, :kernelrelease => "R6"
   setcode do
     ether = nil
-    output = %x{/sbin/ifconfig}
+    output = Facter::Util::IP.exec_ifconfig
 
     output =~ /HWaddr (\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
     ether = $1

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -26,7 +26,8 @@ Facter.add(:macaddress) do
   confine :kernel => 'Linux'
   setcode do
     ether = []
-    output = Facter::Util::Resolution.exec("/sbin/ifconfig -a 2>/dev/null")
+    output = Facter::Util::IP.exec_ifconfig(["-a","2>/dev/null"])
+
     output.each_line do |s|
       ether.push($1) if s =~ /(?:ether|HWaddr) ((\w{1,2}:){5,}\w{1,2})/
     end
@@ -38,7 +39,7 @@ Facter.add(:macaddress) do
   confine :kernel => %w{SunOS GNU/kFreeBSD}
   setcode do
     ether = []
-    output = Facter::Util::Resolution.exec("/sbin/ifconfig -a")
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
     output.each_line do |s|
       ether.push($1) if s =~ /(?:ether|HWaddr) ((\w{1,2}:){5,}\w{1,2})/
     end
@@ -62,7 +63,7 @@ Facter.add(:macaddress) do
   confine :operatingsystem => %w{FreeBSD OpenBSD DragonFly}
   setcode do
     ether = []
-    output = Facter::Util::Resolution.exec("/sbin/ifconfig")
+    output = Facter::Util::IP.exec_ifconfig
     output.each_line do |s|
       if s =~ /(?:ether|lladdr)\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/
         ether.push($1)
@@ -82,7 +83,7 @@ Facter.add(:macaddress) do
   setcode do
     ether = []
     ip = nil
-    output = %x{/usr/sbin/ifconfig -a}
+    output = Facter::Util::IP.exec_ifconfig(["-a"])
     output.each_line do |str|
       if str =~ /([a-z]+\d+): flags=/
         devname = $1

--- a/spec/unit/ipaddress6_spec.rb
+++ b/spec/unit/ipaddress6_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'facter/util/ip'
 
 def ifconfig_fixture(filename)
   File.read(fixtures('ifconfig', filename))
@@ -20,7 +21,8 @@ describe "IPv6 address fact" do
 
   it "should return ipaddress6 information for Darwin" do
     Facter::Util::Resolution.stubs(:exec).with('uname -s').returns('Darwin')
-    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a').
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["-a"]).
       returns(ifconfig_fixture('darwin_ifconfig_all_with_multiple_interfaces'))
 
     Facter.value(:ipaddress6).should == "2610:10:20:209:223:32ff:fed5:ee34"
@@ -28,7 +30,8 @@ describe "IPv6 address fact" do
 
   it "should return ipaddress6 information for Linux" do
     Facter::Util::Resolution.stubs(:exec).with('uname -s').returns('Linux')
-    Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig 2>/dev/null').
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["2>/dev/null"]).
       returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces'))
 
     Facter.value(:ipaddress6).should == "2610:10:20:209:212:3fff:febe:2201"
@@ -36,7 +39,8 @@ describe "IPv6 address fact" do
 
   it "should return ipaddress6 information for Solaris" do
     Facter::Util::Resolution.stubs(:exec).with('uname -s').returns('SunOS')
-    Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/ifconfig -a').
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/usr/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["-a"]).
       returns(ifconfig_fixture('sunos_ifconfig_all_with_multiple_interfaces'))
 
     Facter.value(:ipaddress6).should == "2610:10:20:209:203:baff:fe27:a7c"

--- a/spec/unit/ipaddress_spec.rb
+++ b/spec/unit/ipaddress_spec.rb
@@ -5,7 +5,7 @@ require 'facter/util/ip'
 
 shared_examples_for "ifconfig output" do |platform, address, fixture|
   it "correctly on #{platform}" do
-    Facter::Util::IP.stubs(:get_ifconfig).returns(my_fixture_read(fixture))
+    Facter::Util::IP.stubs(:exec_ifconfig).returns(my_fixture_read(fixture))
     subject.value.should == address
   end
 end

--- a/spec/unit/macaddress_spec.rb
+++ b/spec/unit/macaddress_spec.rb
@@ -1,6 +1,8 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'facter/util/ip'
+
 
 def ifconfig_fixture(filename)
   File.read(fixtures('ifconfig', filename))
@@ -21,17 +23,18 @@ describe "macaddress fact" do
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter.fact(:operatingsystem).stubs(:value).returns("Linux")
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
     end
 
     it "should return the macaddress of the first interface" do
-      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a 2>/dev/null').
+      Facter::Util::IP.stubs(:exec_ifconfig).with(["-a","2>/dev/null"]).
         returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces'))
 
       Facter.value(:macaddress).should == "00:12:3f:be:22:01"
     end
 
     it "should return nil when no macaddress can be found" do
-      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a 2>/dev/null').
+      Facter::Util::IP.stubs(:exec_ifconfig).with(["-a","2>/dev/null"]).
         returns(ifconfig_fixture('linux_ifconfig_no_mac'))
 
       proc { Facter.value(:macaddress) }.should_not raise_error
@@ -40,7 +43,7 @@ describe "macaddress fact" do
 
     # some interfaces dont have a real mac addresses (like venet inside a container)
     it "should return nil when no interface has a real macaddress" do
-      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig -a 2>/dev/null').
+      Facter::Util::IP.stubs(:exec_ifconfig).with(["-a","2>/dev/null"]).
         returns(ifconfig_fixture('linux_ifconfig_venet'))
 
       proc { Facter.value(:macaddress) }.should_not raise_error
@@ -51,7 +54,8 @@ describe "macaddress fact" do
   describe "when run on BSD" do
     it "should return macaddress information" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Util::Resolution.stubs(:exec).with('/sbin/ifconfig').
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+      Facter::Util::IP.stubs(:exec_ifconfig).
         returns(ifconfig_fixture('bsd_ifconfig_all_with_multiple_interfaces'))
 
       Facter.value(:macaddress).should == "00:0b:db:93:09:67"

--- a/spec/unit/util/ip_spec.rb
+++ b/spec/unit/util/ip_spec.rb
@@ -411,6 +411,45 @@ describe Facter::Util::IP do
     end
   end
 
+  describe "exec_ifconfig" do
+    it "uses get_ifconfig" do
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig").once
+
+      Facter::Util::IP.exec_ifconfig
+    end
+    it "support additional arguments" do
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+
+      Facter::Util::Resolution.stubs(:exec).with("/sbin/ifconfig -a")
+
+      Facter::Util::IP.exec_ifconfig(["-a"])
+    end
+    it "joins multiple arguments correctly" do
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+
+      Facter::Util::Resolution.stubs(:exec).with("/sbin/ifconfig -a -e -i -j")
+
+      Facter::Util::IP.exec_ifconfig(["-a","-e","-i","-j"])
+    end
+  end
+  describe "get_ifconfig" do
+    it "assigns /sbin/ifconfig if it is executable" do
+      File.stubs(:executable?).returns(false)
+      File.stubs(:executable?).with("/sbin/ifconfig").returns(true)
+      Facter::Util::IP.get_ifconfig.should eq("/sbin/ifconfig")
+    end
+    it "assigns /usr/sbin/ifconfig if it is executable" do
+      File.stubs(:executable?).returns(false)
+      File.stubs(:executable?).with("/usr/sbin/ifconfig").returns(true)
+      Facter::Util::IP.get_ifconfig.should eq("/usr/sbin/ifconfig")
+    end
+    it "assigns /bin/ifconfig if it is executable" do
+      File.stubs(:executable?).returns(false)
+      File.stubs(:executable?).with("/bin/ifconfig").returns(true)
+      Facter::Util::IP.get_ifconfig.should eq("/bin/ifconfig")
+    end
+  end
+
   context "with bonded ethernet interfaces on Linux" do
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("Linux")


### PR DESCRIPTION
( this is an improved reversion of pull request #385 )

Without this patch applied linux systems with recent net-tools loose
support for ipaddress,macaddress and other network related facts.
This is due to a path change from /sbin/ifconfig to /bin/ifconfig.
This patch fixes this issue by unifying the lookup and execution of
ifconfig and testing where the ifconfig binary is installed.
