### PR TITLE
(maint) Fix physicalprocessorcount with multiple cores

### DIFF
--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -48,7 +48,7 @@ Facter.add('physicalprocessorcount') do
       # We assume that /proc/cpuinfo has what we need and is so then we need
       # to make sure that we only count unique entries ...
       #
-      n = File.read('/proc/cpuinfo').split(/\n/).grep(/^physical id/).count
+      n = File.read('/proc/cpuinfo').split(/\n/).grep(/^physical id/).uniq.count
       n > 0 ? n : nil
     end
   end

--- a/spec/fixtures/unit/physicalprocessorcount/amd64dual
+++ b/spec/fixtures/unit/physicalprocessorcount/amd64dual
@@ -1,0 +1,57 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 23
+model name	: Intel(R) Core(TM)2 Duo CPU     P8700  @ 2.53GHz
+stepping	: 10
+cpu MHz		: 689.302
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 2
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fdiv_bug	: no
+hlt_bug		: no
+f00f_bug	: no
+coma_bug	: no
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 5
+wp		: yes
+flags		: fpu vme de pse tsc msr mce cx8 apic mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht constant_tsc pni ssse3
+bogomips	: 1378.60
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 23
+model name	: Intel(R) Core(TM)2 Duo CPU     P8700  @ 2.53GHz
+stepping	: 10
+cpu MHz		: 689.302
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 2
+core id		: 1
+cpu cores	: 2
+apicid		: 1
+initial apicid	: 1
+fdiv_bug	: no
+hlt_bug		: no
+f00f_bug	: no
+coma_bug	: no
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 5
+wp		: yes
+flags		: fpu vme de pse tsc msr mce cx8 apic mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht constant_tsc pni ssse3
+bogomips	: 1687.45
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 36 bits physical, 48 bits virtual
+power management:

--- a/spec/unit/physicalprocessorcount_spec.rb
+++ b/spec/unit/physicalprocessorcount_spec.rb
@@ -7,30 +7,48 @@ describe "Physical processor count facts" do
   describe "on linux" do
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
-      File.stubs(:exists?).with('/sys/devices/system/cpu').returns(true)
     end
+    context "with /sys/devices/system/cpu and not /proc/cpuinfo" do
+      before :each do
+        File.stubs(:exists?).with('/sys/devices/system/cpu').returns(true)
+      end
 
-    it "should return one physical CPU" do
-      Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu*/topology/physical_package_id").returns(["/sys/devices/system/cpu/cpu0/topology/physical_package_id"])
-      File.stubs(:read).with("/sys/devices/system/cpu/cpu0/topology/physical_package_id").returns("0")
+      it "should return one physical CPU" do
+        Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu*/topology/physical_package_id").returns(["/sys/devices/system/cpu/cpu0/topology/physical_package_id"])
+        File.stubs(:read).with("/sys/devices/system/cpu/cpu0/topology/physical_package_id").returns("0")
 
-      Facter.fact(:physicalprocessorcount).value.should == 1
-    end
+        Facter.fact(:physicalprocessorcount).value.should == 1
+      end
 
-    it "should return four physical CPUs" do
-      Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu*/topology/physical_package_id").returns(%w{
+      it "should return four physical CPUs" do
+        Dir.stubs(:glob).with("/sys/devices/system/cpu/cpu*/topology/physical_package_id").returns(%w{
         /sys/devices/system/cpu/cpu0/topology/physical_package_id
         /sys/devices/system/cpu/cpu1/topology/physical_package_id
         /sys/devices/system/cpu/cpu2/topology/physical_package_id
         /sys/devices/system/cpu/cpu3/topology/physical_package_id
-      })
+                                                                                                   })
 
-      File.stubs(:read).with("/sys/devices/system/cpu/cpu0/topology/physical_package_id").returns("0")
-      File.stubs(:read).with("/sys/devices/system/cpu/cpu1/topology/physical_package_id").returns("1")
-      File.stubs(:read).with("/sys/devices/system/cpu/cpu2/topology/physical_package_id").returns("2")
-      File.stubs(:read).with("/sys/devices/system/cpu/cpu3/topology/physical_package_id").returns("3")
+        File.stubs(:read).with("/sys/devices/system/cpu/cpu0/topology/physical_package_id").returns("0")
+        File.stubs(:read).with("/sys/devices/system/cpu/cpu1/topology/physical_package_id").returns("1")
+        File.stubs(:read).with("/sys/devices/system/cpu/cpu2/topology/physical_package_id").returns("2")
+        File.stubs(:read).with("/sys/devices/system/cpu/cpu3/topology/physical_package_id").returns("3")
 
-      Facter.fact(:physicalprocessorcount).value.should == 4
+        Facter.fact(:physicalprocessorcount).value.should == 4
+      end
+    end
+
+    context "with /proc/cpuinfo and not /sys/devices/system/cpu" do
+      before :all do
+        @cpuinfo = my_fixture_read('amd64dual')
+      end
+      before :each do
+        File.stubs(:exists?).with('/sys/devices/system/cpu').returns(false)
+      end
+
+      it "should return 1 physical CPU when there are multiple cores" do
+        File.stubs(:read).with("/proc/cpuinfo").returns(@cpuinfo)
+        Facter.fact(:physicalprocessorcount).value.should == 1
+      end
     end
   end
 


### PR DESCRIPTION
Without this patch applied the physicalprocessorcount fact reports the
wrong number of processors.  Instead of reporting the number of physical
processing units, it reports the number of cores.  This patch addresses
the problem by changing the behavior to count only the number of unique
processor identities as suggested by Stefan Schulte.

We didn't catch this issue while rebasing GH-266 in GH-388 because this
behavior had no specified expectations.  This patch adds an example of
the expected behavior when there are multiple cores per processor.
