### PR TITLE
Only run Facter::Memory.meminfo_number on supported platforms

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -75,8 +75,8 @@ end
 }.each do |fact, name|
   Facter.add(fact) do
     confine :kernel => [ :linux, :"gnu/kfreebsd" ]
-    meminfo = Facter::Memory.meminfo_number(name)
     setcode do
+      meminfo = Facter::Memory.meminfo_number(name)
       "%.2f" % [meminfo]
     end
   end


### PR DESCRIPTION
Having this code outside of the setcode block means it gets evaluated and
generates a spurious warning on unsupported platforms.
