### PR TITLE
15586 - rdoc::usage failing on ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gem 'trollop', '>= 2.0.0'
+
 group :development do
   gem 'watchr'
 end

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Puppet Labs"]
+  s.add_dependency('trollop', '>= 2.0.0')
   s.date = "2012-08-08"
   s.description = "You can prove anything with facts!"
   s.email = "info@puppetlabs.com"

--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -1,13 +1,64 @@
 module Facter
   module Application
     def self.run(argv)
-      require 'optparse'
+      require 'trollop'
       require 'facter'
 
-      options = parse(argv)
+      options = Trollop::options do
+        version "#{Facter.version}"
+        banner <<-EOS
+SYNOPSIS
+========
+Collect and display facts about the system.
+
+DESCRIPTION
+===========
+Collect and display facts about the current system. The library behind
+Facter is easy to expand, making Facter an easy way to collect
+information about a system from within the shell or within Ruby.
+
+If no facts are specifically asked for, then all facts will be returned.
+
+EXAMPLE
+=======
+  facter kernel
+
+AUTHOR
+======
+Luke Kanies
+
+COPYRIGHT
+=========
+Copyright (c) 2011-2012 Puppet Labs, Inc Licensed under the Apache 2.0
+license
+
+USAGE
+=====
+
+EOS
+        opt :yaml, "Emit facts in YAML format."
+        opt :json, "Emit facts in JSON format."
+        opt :timing, "Enable timing."
+        opt :trace, "Enable backtraces."
+        opt :debug, "Enable debugging."
+        opt :puppet, "Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts."
+        opt :version, "Print the version and exit."
+      end
 
       # Accept fact names to return from the command line
       names = argv
+
+      if options[:debug]
+        Facter.debugging(1)
+      end
+
+      if options[:timing]
+        Facter.timing(1)
+      end
+
+      if options[:puppet]
+        self.load_puppet
+      end
 
       # Create the facts hash that is printed to standard out.
       unless names.empty?
@@ -43,6 +94,7 @@ module Facter
           exit(1)
         end
       end
+
 
       # Print the value of a single fact, otherwise print a list sorted by fact
       # name and separated by "=>"


### PR DESCRIPTION
This is built from an earlier closed pull request ([#299](https://github.com/puppetlabs/facter/pull/299)). Since <tt>RDoc::Usage</tt> is gone in Ruby 1.9.x, the displaying & parsing of options has been converted to Trollop.

The original work was done by @apenney and a short conversation with @jeffmccune resulted in pulling out the vendored copy of Trollop and replacing it with a dependency. This has been reflected in the Gemfile as well as the gemspec.

While this includes the relevant changes to the banner, it does not include the RDoc changes to [bin/facter](https://github.com/apenney/facter/commit/a4fa9121971e5c7d08be93659b64bb3ffc89d01e). I thought someone with a little more concern for the tool might want to figure out what stays and what goes in the user-face executable.

Ashley also noted the follow major change from existing <tt>-h|--help</tt> behavior:
- Additional support for things like <tt>--no-trace</tt> and <tt>--no-debug</tt>, not that we need that with the current set of options.
