### PR TITLE
(#16948) Fix hardwaremodel fact on windows 32 bit

### DIFF
--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -36,12 +36,13 @@ Facter.add(:hardwaremodel) do
     # windows 8 release.  --jeffweiss 23 May 2012
     require 'facter/util/wmi'
     model = ""
-    Facter::Util::WMI.execquery("select Architecture, Level from Win32_Processor").each do |cpu|
+    Facter::Util::WMI.execquery("select Architecture, Level, AddressWidth from Win32_Processor").each do |cpu|
       model =
         case cpu.Architecture
         when 11 then 'neutral'        # PROCESSOR_ARCHITECTURE_NEUTRAL
         when 10 then 'i686'           # PROCESSOR_ARCHITECTURE_IA32_ON_WIN64
-        when 9 then 'x64'             # PROCESSOR_ARCHITECTURE_AMD64
+        when 9 then                   # PROCESSOR_ARCHITECTURE_AMD64
+          cpu.AddressWidth == 32 ? "i#{cpu.Level}86" : 'x64' # 32 bit OS on 64 bit CPU
         when 8 then 'msil'            # PROCESSOR_ARCHITECTURE_MSIL
         when 7 then 'alpha64'         # PROCESSOR_ARCHITECTURE_ALPHA64
         when 6 then 'ia64'            # PROCESSOR_ARCHITECTURE_IA64

--- a/spec/unit/hardwaremodel_spec.rb
+++ b/spec/unit/hardwaremodel_spec.rb
@@ -25,10 +25,17 @@ describe "Hardwaremodel fact" do
     end
 
     it "should detect x64" do
-      cpu = mock('cpu', :Architecture => 9)
+      cpu = mock('cpu', :Architecture => 9, :AddressWidth => 64)
       Facter::Util::WMI.expects(:execquery).returns([cpu])
 
       Facter.fact(:hardwaremodel).value.should == "x64"
+    end
+
+    it "(#16948) reports i686 when a 32 bit OS is running on a 64 bit CPU" do
+      cpu = mock('cpu', :Architecture => 9, :AddressWidth => 32, :Level => 6)
+      Facter::Util::WMI.expects(:execquery).returns([cpu])
+
+      Facter.fact(:hardwaremodel).value.should == "i686"
     end
   end
 end


### PR DESCRIPTION
Without this patch applied the hardwaremodel fact will return 'x64' when
a 32 bit operating system is running inside of a 64 bit CPU.  This is a
problem because it is inconsistent with the way Facter operates on other
platforms where the behavior is to inspect the operating system rather
than the CPU itself.

This patch fixes the problem by checking the AddressWidth attribute
which will report 32 when a 32 bit OS is running on a 64 bit CPU.  The
attribute will report 64 when a 64 bit OS is running.
