### PR TITLE
19810 proc confines

### DIFF
--- a/lib/facter/util/confine.rb
+++ b/lib/facter/util/confine.rb
@@ -39,7 +39,12 @@ class Facter::Util::Confine
     return @values.any? do |v|
       # Always use Ruby 1.9+ semantics on Proc confines.
       if v.kind_of? Proc then
-        v.call(value)
+        begin
+          v.call(value)
+        rescue StandardError => error
+          Facter.debug "Confine raised #{error.class} #{error}"
+          false
+        end
       else
         convert(v) === value
       end

--- a/spec/unit/util/confine_spec.rb
+++ b/spec/unit/util/confine_spec.rb
@@ -131,5 +131,9 @@ describe Facter::Util::Confine do
     it "should return false if the Proc returns false" do
       confined("foo", Proc.new { |v| false } ).should be_false
     end
+
+    it "should return false if the Proc raises a StandardError" do
+      confined("foo", Proc.new { |v| raise StandardError, "foo" } ).should be_false
+    end
   end
 end


### PR DESCRIPTION
The confines use === for comparison which in Ruby 1.9+ resolves to
call(value) in Proc objects, this allows them to be used in all Ruby
versions.

Redone pull #407 against 1.7.x
