### PR TITLE
(#19761) Added virtual and is_virtual fact on Windows

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -169,6 +169,27 @@ Facter.add("virtual") do
   end
 end
 
+Facter.add("virtual") do
+  confine :kernel => "windows"
+  setcode do
+      require 'facter/util/wmi'
+      result = nil
+      Facter::Util::WMI.execquery("SELECT manufacturer, model FROM Win32_ComputerSystem").each do |computersystem|
+        result =
+          case computersystem.model
+          when /VirtualBox/ then "virtualbox"
+          when /Virtual Machine/
+            computersystem.manufacturer =~ /Microsoft/ ? "hyperv" : nil
+          when /VMware/ then "vmware"
+          when /KVM/ then "kvm"
+          else "physical"
+          end
+        break
+      end
+      result
+  end
+end
+
 ##
 # virtual fact based on virt-what command.
 #
@@ -229,7 +250,7 @@ end
 #
 
 Facter.add("is_virtual") do
-  confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD}
+  confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD windows}
 
   setcode do
     physical_types = %w{physical xen0 vmware_server vmware_workstation openvzhn}

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -268,6 +268,37 @@ describe "Virtual fact" do
     end
   end
 
+  describe "on Windows" do
+    require 'facter/util/wmi'
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("windows")
+    end
+
+    it "should be kvm with KVM model name from Win32_ComputerSystem" do
+      computersystem = mock('computersystem', :model => 'KVM')
+      Facter::Util::WMI.expects(:execquery).returns([computersystem])
+      Facter.fact(:virtual).value.should == "kvm"
+    end
+
+    it "should be hyperv with Virtual Machine model name and Microsoft Corporation manufacturer from Win32_ComputerSystem" do
+      computersystem = mock('computersystem', :manufacturer => 'Microsoft Corporation', :model => 'Virtual Machine')
+      Facter::Util::WMI.expects(:execquery).returns([computersystem])
+      Facter.fact(:virtual).value.should == "hyperv"
+    end
+
+    it "should be virtualbox with VirtualBox model name from Win32_ComputerSystem" do
+      computersystem = mock('computersystem', :model => 'VirtualBox')
+      Facter::Util::WMI.expects(:execquery).returns([computersystem])
+      Facter.fact(:virtual).value.should == "virtualbox"
+    end
+
+    it "should be vmware with VMware like model name from Win32_ComputerSystem" do
+      computersystem = mock('computersystem', :model => 'VMware Virtual Platform')
+      Facter::Util::WMI.expects(:execquery).returns([computersystem])
+      Facter.fact(:virtual).value.should == "vmware"
+    end
+  end
+
   describe "with the virt-what command available (#8210)" do
     describe "when the output of virt-what disagrees with lower weight facts" do
       virt_what_map = {


### PR DESCRIPTION
Without this patch, the virtual and is_virtual fact is not set on Windows computers. This patch fixes the problem, giving an initial coverage for some hypervisors.

The solution proposed is based on the manufacturer and model properties from WMI object Win32_ComputerSystem. This first version is able to detect the following systems: HyperV, VirtualBox, Vmware and KVM.
