### PR TITLE
(#19845) block confines

### DIFF
--- a/lib/facter/util/confine.rb
+++ b/lib/facter/util/confine.rb
@@ -10,19 +10,40 @@ class Facter::Util::Confine
 
   # Add the restriction.  Requires the fact name, an operator, and the value
   # we're comparing to.
-  def initialize(fact, *values)
-    raise ArgumentError, "The fact name must be provided" unless fact
-    raise ArgumentError, "One or more values must be provided" if values.empty?
+  #
+  # @param fact [Symbol] Name of the fact
+  # @param values [Array] One or more values to match against.
+  #   They can be any type that provides a === method.
+  # @param block [Proc] Alternatively a block can be supplied as a check.  The fact
+  #   value will be passed as the argument to the block.  If the block returns
+  #   true then the fact will be enabled, otherwise it will be disabled.
+  def initialize(fact = nil, *values, &block)
+    raise ArgumentError, "The fact name must be provided" unless fact or block_given?
+    if values.empty? and not block_given?
+      raise ArgumentError, "One or more values or a block must be provided"
+    end
     @fact = fact
     @values = values
+    @block = block
   end
 
   def to_s
+    return @block.to_s if @block
     return "'%s' '%s'" % [@fact, @values.join(",")]
   end
 
   # Evaluate the fact, returning true or false.
+  # if we have a block paramter then we only evaluate that instead
   def true?
+    if @block and not @fact then
+      begin
+        return !! @block.call
+      rescue StandardError => error
+        Facter.debug "Confine raised #{error.class} #{error}"
+        return false
+      end
+    end
+
     unless fact = Facter[@fact]
       Facter.debug "No fact for %s" % @fact
       return false
@@ -31,6 +52,15 @@ class Facter::Util::Confine
 
     return false if value.nil?
 
-    return @values.any? { |v| convert(v) === value }
+    if @block then
+      begin
+        return !! @block.call(value)
+      rescue StandardError => error
+        Facter.debug "Confine raised #{error.class} #{error}"
+        return false
+      end
+    end
+
+    return @values.any? do |v| convert(v) === value end
   end
 end

--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -186,10 +186,39 @@ class Facter::Util::Resolution
     end
   end
 
-  # Add a new confine to the resolution mechanism.
-  def confine(confines)
-    confines.each do |fact, values|
-      @confines.push Facter::Util::Confine.new(fact, *values)
+  ##
+  # Add a new confine to the resolution mechanism.  There are three main use
+  # cases this method supports.
+  #
+  # 1: key/value pairs passed as a hash.  `confine :operatingsystem =>
+  #    'Linux'`.  Values will be compared, using case comparison (`===`),
+  #    against the fact value identified by the key.
+  # 2: A key and a block. `confine :operatingsystem { |os| os == "Linux" }`
+  # 3: A stand alone block `confine { File.exists? '/bin/zsh' }`
+  #
+  # @param confines [String, Symbol, Hash]
+  #
+  # @param block [Proc] If provided along with a String or Symbol confines
+  # parameter, then the value of the fact identified by the confines parameter
+  # will be yielded to the block.  Otherwise, the block will be executed and
+  # the fact evaluated only if the block returns true.
+  #
+  # @api public
+  def confine(confines = nil, &block)
+    case confines
+    when Hash
+      confines.each do |fact, values|
+        @confines.push Facter::Util::Confine.new(fact, *values)
+      end
+    else
+      if block
+        if confines
+          @confines.push Facter::Util::Confine.new(confines, &block)
+        else
+          @confines.push Facter::Util::Confine.new(&block)
+        end
+      else
+      end
     end
   end
 

--- a/spec/unit/util/confine_spec.rb
+++ b/spec/unit/util/confine_spec.rb
@@ -123,5 +123,26 @@ describe Facter::Util::Confine do
     it "should return false if none of the provided ranges matches the fact's value" do
       confined(8, (5..7)).should be_false
     end
+
+    it "should accept and evaluate a block argument against the fact" do
+      @fact.expects(:value).returns 'foo'
+      confine = Facter::Util::Confine.new :yay do |f| f === 'foo' end
+      confine.true?.should be_true
+    end
+
+    it "should return false if the block raises a StandardError when checking a fact" do
+      @fact.stubs(:value).returns 'foo'
+      confine = Facter::Util::Confine.new :yay do |f| raise StandardError end
+      confine.true?.should be_false
+    end
+
+    it "should accept and evaluate only a block argument" do
+      Facter::Util::Confine.new { true }.true?.should be_true
+      Facter::Util::Confine.new { false }.true?.should be_false
+    end
+
+    it "should return false if the block raises a StandardError" do
+      Facter::Util::Confine.new { raise StandardError }.true?.should be_false
+    end
   end
 end

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -344,6 +344,27 @@ describe Facter::Util::Resolution do
       @resolve.confine "one" => "foo", "two" => "fee"
     end
 
+    it "should accept a single fact with a block parameter" do
+      lambda { @resolve.confine :one do true end }.should_not raise_error
+    end
+
+    it "should create a Util::Confine instance for the provided fact with block parameter" do
+      block = lambda { true }
+      Facter::Util::Confine.expects(:new).with("one")
+
+      @resolve.confine("one", &block)
+    end
+
+    it "should accept a single block parameter" do
+      lambda { @resolve.confine() do true end }.should_not raise_error
+    end
+
+    it "should create a Util::Confine instance for the provided block parameter" do
+      block = lambda { true }
+      Facter::Util::Confine.expects(:new)
+
+      @resolve.confine(&block)
+    end
   end
 
   describe "when determining suitability" do


### PR DESCRIPTION
Allow confine to take a block parameter, like:

``` ruby
confine { code... }
```

Builds on top of pull #408 
