### PR TITLE
(19873) Add OS major release fact

### DIFF
--- a/lib/facter/operatingsystemmajrelease.rb
+++ b/lib/facter/operatingsystemmajrelease.rb
@@ -1,0 +1,32 @@
+# Fact: operatingsystemmajrelease
+#
+# Purpose: Returns the major release of the operating system.
+#
+# Resolution: splits down the operatingsystemrelease fact at decimal point for
+#  osfamily RedHat derivatives and Debian.
+#
+# This should be the same as lsbmajdistrelease, but on minimal systems there
+# are too many dependencies to use LSB
+#
+# List of operatingsystems at time of writing:
+#"Alpine" "Amazon" "Archlinux" "Ascendos" "Bluewhite64" "CentOS" "CloudLinux" 
+#"Debian" "Fedora" "Gentoo" "Mandrake" "Mandriva" "MeeGo" "OEL" "OpenSuSE" 
+#"OracleLinux" "OVS" "PSBM" "RedHat" "Scientific" "Slackware" "Slamd64" "SLC"
+#"SLED" "SLES" "SuSE" "Ubuntu" "VMWareESX"
+Facter.add(:operatingsystemmajrelease) do
+  confine :operatingsystem => [
+    :Amazon,
+    :CentOS,
+    :CloudLinux,
+    :Debian,
+    :Fedora,
+    :OEL,
+    :OracleLinux,
+    :OVS,
+    :RedHat,
+    :Scientific,
+    :SLC]
+  setcode do
+    Facter.value('operatingsystemrelease').split('.').first
+  end
+end

--- a/spec/unit/operatingsystemmajrelease_spec.rb
+++ b/spec/unit/operatingsystemmajrelease_spec.rb
@@ -1,0 +1,16 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+require 'facter'
+
+describe "OS Major Release fact" do
+  ['Amazon','CentOS','CloudLinux','Debian','Fedora','OEL','OracleLinux','OVS','RedHat','Scientific','SLC'].each do |operatingsystem|
+    context "on #{operatingsystem} operatingsystems" do
+      it "should be derived from operatingsystemrelease" do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        Facter.fact(:operatingsystem).stubs(:value).returns(operatingsystem)
+        Facter.fact(:operatingsystemrelease).stubs(:value).returns("6.3")
+        Facter.fact(:operatingsystemmajrelease).value.should == "6"
+      end
+    end 
+  end
+end


### PR DESCRIPTION
Cloning ticket 15714 and submitting new PR with recommended changes to try to get this taken care of.

On RHEL clones and Debian
(Amazon,CentOS,CloudLinux,Debian,Fedora,OEL,OracleLinux,OVS,RedHat,Scientific,SLC)
it would be useful to pull out the major release version

ie 5.8=>5, 6.3=>6, 6.0.3=>6 (this is especially useful when creating URLs for package downloads)

This is available as the lsbmajdistrelease but there are too many dependencies on LSB for minimal installs
