### PR TITLE
(#19989) Filter virt-what warnings from virtual fact

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -4,7 +4,9 @@ module Facter::Util::Virtual
   # the system call without affecting other calls to
   # Facter::Util::Resolution.exec
   def self.virt_what(command = "virt-what")
-    Facter::Util::Resolution.exec command
+    redirected_cmd = "#{command} 2>/dev/null"
+    output = Facter::Util::Resolution.exec redirected_cmd
+    output.gsub(/^virt-what: .*$/, '')
   end
 
   ##

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -252,6 +252,14 @@ describe "Virtual fact" do
         Facter.value(:virtual).should == "fake_vserver_type"
       end
     end
+
+    describe "when virt-what issues warnings to stdout" do
+      virt_what_warning = "virt-what: this script must be run as root"
+      it "should not end up in the virtual fact" do
+        Facter::Util::Resolution.expects(:exec).with('virt-what 2>/dev/null').returns virt_what_warning
+        Facter::Util::Virtual.virt_what.should_not match /^virt-what: /
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Presently, the virt-what command puts errors on stdout, prefixed with
virt-what:.  This ends up in the virtual fact, which is undesirable.

If/when a fixed virt-what is released and available for supported
systems, the ' |grep ^virt-what:' can be removed from the virt-what
command in Facter::Util::Virtual.

A virt-what fix was submitted at https://bugzilla.redhat.com/719611.

I am not sure that the test for this commit is correct.  I don't have an environment setup for running the tests.  Apologies for that, but hopefully the fix is obviously correct and someone can help out with the test if it is not sufficient.
