### PR TITLE
(packaging) Add dependency on virt-what for rpm and deb packages

### DIFF
--- a/ext/debian/changelog.erb
+++ b/ext/debian/changelog.erb
@@ -1,32 +1,14 @@
-facter (<%= @debversion %>) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
+facter (<%= @debversion %>) hardy lucid oneiric unstable sid wheezy lucid squeeze precise quantal; urgency=low
 
   * Update to version <% @debversion %>
 
  -- Puppet Labs Release <info@puppetlabs.com>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z")%>
 
-facter (2.0.0-0.1rc4puppetlabs1) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
+facter (1.7.0-0.1rc1puppetlabs1) hardy lucid oneiric unstable sid wheezy lucid squeeze precise; urgency=low
 
-  * Imported upstream 2.0.0rc4. 
+  * Add dependency on virt-what to facter for better virutalization detection
 
- -- Moses Mendoza <moses@puppetlabs.com>  Thu, 24 May 2012 17:09:25 +0000
-
-facter (2.0.0-0.1rc3puppetlabs1) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
-
-  * Imported upstream 2.0.0rc3. 
-
- -- Moses Mendoza <moses@puppetlabs.com>  Tue, 22 May 2012 11:48:25 +0000
-
-facter (2.0.0-0.1rc2puppetlabs1) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
-
-  * Imported upstream 2.0.0rc2. 
-
- -- Moses Mendoza <moses@puppetlabs.com>  Thu, 17 May 2012 13:15:25 +0000
-
-facter (2.0.0-0.1rc1puppetlabs1) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
-
-  * Imported upstream 2.0.0rc1. Updated debian/control to include ruby1.9 options.
-
- -- Matthaus Litteken <matthaus@puppetlabs.com>  Tue, 15 May 2012 23:43:25 +0000
+ -- Matthaus Owens <matthaus@puppetlabs.com>  Mon, 01 Apr 2013 13:11:30 +0000
 
 facter (1.6.8-1puppetlabs1) hardy lucid maverick natty oneiric unstable lenny sid wheezy lucid squeeze precise; urgency=low
 

--- a/ext/debian/control
+++ b/ext/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.puppetlabs.com
 
 Package: facter
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode [i386 amd64 ia64], pciutils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode [i386 amd64 ia64], virt-what, pciutils
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.

--- a/ext/redhat/facter.spec.erb
+++ b/ext/redhat/facter.spec.erb
@@ -31,6 +31,7 @@ Requires:       which
 Requires:       dmidecode
 Requires:       pciutils
 %endif
+Requires:       virt-what
 Requires:       ruby(abi) >= 1.8
 BuildRequires:  ruby >= 1.8.5
 
@@ -71,6 +72,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  1:<%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Mon Apr 01 2013 Matthaus Owens <matthaus@puppetlabs.com> - 1:1.7.0-0.1rc1
+- Add dependency on virt-what to facter for better virutalization detection
 
 * Wed Aug 08 2012 Moses Mendoza <moses@puppetlabs.com> - 1.6.11-2
 - Use correct ruby libdir for fedora 17 / ruby 1.9


### PR DESCRIPTION
In commit cf43fc0092f0476d378ea05dd8e21fc170a51bdf (#8210), virt-what was added
as a utility for better virtualization detection. Without virt-what installed,
that better detection is not available, so this commit adds virt-what as a
dependency for debian and rpm packages. virt-what is a lightweight package
(~25k), that is available on all currently supported flavors of debian and rpm
based systems.
