### PR TITLE
(#20017) Add virt-what dependency in Debian packaging

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.puppetlabs.com
 
 Package: facter
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode, pciutils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, libopenssl-ruby | libopenssl-ruby1.8 | libopenssl-ruby1.9.1, dmidecode, pciutils, virt-what
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.


### PR DESCRIPTION
The pull request at puppetlabs/facter#340 introduced detecting the
virtualization type with virt-what, which is much more reliable than
facter's own techniques.

This pull request adds a dependency on virt-what in the Debian
packaging since virt-what is included in Debian at least since squeeze
and in Ubuntu since lucid and has negligible overhead.
