### PR TITLE
(#20072) Redirect stderr to the correct null device on windows

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -10,7 +10,11 @@ module Facter::Util::Virtual
   # method ensures stderr is redirected and that error messages are stripped
   # from stdout.
   def self.virt_what(command = "virt-what")
-    redirected_cmd = "#{command} 2>/dev/null"
+    if Facter.value(:kernel) == 'windows'
+      redirected_cmd = "#{command} 2>NUL"
+    else
+      redirected_cmd = "#{command} 2>/dev/null"
+    end
     output = Facter::Util::Resolution.exec redirected_cmd
     output.gsub(/^virt-what: .*$/, '') if output
   end

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -238,7 +238,20 @@ describe Facter::Util::Virtual do
 
   it "should strip out warnings on stdout from virt-what" do
     virt_what_warning = "virt-what: this script must be run as root"
+    Facter.fact(:kernel).expects(:value).returns("linux")
     Facter::Util::Resolution.expects(:exec).with('virt-what 2>/dev/null').returns virt_what_warning
     Facter::Util::Virtual.virt_what.should_not match /^virt-what: /
+  end
+
+  ["windows","linux","unix"].each do |kernel|
+    describe "virt_what should redirect to the correct null device" do
+      let(:null_device) { kernel == "windows" ? "2>NUL" : "2>/dev/null" }
+
+      it "on #{kernel}" do
+        Facter.fact(:kernel).expects(:value).returns(kernel)
+        Facter::Util::Resolution.expects(:exec).with("virt-what #{null_device}")
+        Facter::Util::Virtual.virt_what
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously the virt_what method redirected stderr to /dev/null, which fails on
windows. This commit adds a case for windows where the stderr is redirected to
NUL, the windows null device. It also adds tests to ensure this behavior.
