### PR TITLE
(#14522) Don't read /proc/self/status on Solaris

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -45,6 +45,8 @@ module Facter::Util::Virtual
   end
 
   def self.vserver?
+    # /proc/self/status is not easily readable on Solaris. See http://projects.puppetlabs.com/issues/14522
+    return false if Facter.value(:osfamily) == "Solaris"
     return false unless FileTest.exists?("/proc/self/status")
     txt = File.open("/proc/self/status", "rb").read
     return true if txt =~ /^(s_context|VxID):[[:blank:]]*[0-9]/

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -58,6 +58,13 @@ describe Facter::Util::Virtual do
     Facter::Util::Virtual.should_not be_zone
   end
 
+  it "should not read /proc/self/status on Solaris" do
+    Facter.expects(:value).with(:osfamily).returns("Solaris")
+    FileTest.expects(:exists?).with("/proc/self/status").never
+    File.expects(:open).with("/proc/self/status").never
+    Facter::Util::Virtual.vserver?.should == false
+  end
+
   it "should not detect vserver if no self status" do
     FileTest.stubs(:exists?).with("/proc/self/status").returns(false)
     Facter::Util::Virtual.should_not be_vserver


### PR DESCRIPTION
/proc/self/status isn't a standard file on Solaris and can't be read as such.
Attempting to read it when using ruby 1.9.3 produces errors such as 'invalid
byte sequence in US-ASCII'. According to
http://www.ruby-forum.com/topic/163804, /proc/self/status is a sparse file with
a map at /proc/self/map to indicate which parts of the file to read. As a
stopgap measure, this commit simply returns false on Solaris, rather than
trying to read the file.
