### PR TITLE
Ticket #18175 Wrong operatingsystem reported for Xen Cloud Platform

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -65,6 +65,8 @@ Facter.add(:operatingsystem) do
         "PSBM"
       elsif txt =~ /Ascendos/i
         "Ascendos"
+      elsif txt =~ /XCP/
+        "XCP"
       else
         "RedHat"
       end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -87,6 +87,7 @@ describe "Operating System fact" do
       "SLC"        => "Scientific Linux CERN SLC release 5.7 (Boron)",
       "Ascendos"   => "Ascendos release 6.0 (Nameless)",
       "CloudLinux" => "CloudLinux Server release 5.5",
+      "XCP"        => "XCP release 1.6.10-61809c",
     }.each_pair do |operatingsystem, string|
       it "should be #{operatingsystem} based on /etc/redhat-release contents #{string}" do
         FileTest.expects(:exists?).with("/etc/redhat-release").returns true


### PR DESCRIPTION
Facter will now return XCP for the fact operatingsystem when
/etc/redhat-release contains the XCP version string.
