### PR TITLE
cleans up lsbmajdistrelease

### DIFF
--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -7,14 +7,9 @@
 #   Parses the lsbdistrelease fact for numbers followed by a period and
 #   returns those, or just the lsbdistrelease fact if none were found.
 #
-# Caveats:
-#
-
-# lsbmajdistrelease.rb
-#
 require 'facter'
 
-Facter.add("lsbmajdistrelease") do
+Facter.add('lsbmajdistrelease') do
   confine :kernel => %w{Linux GNU/kFreeBSD}
   setcode do
     if /(\d*)\./i =~ Facter.value(:lsbdistrelease)

--- a/spec/unit/lsbmajdistrelease_spec.rb
+++ b/spec/unit/lsbmajdistrelease_spec.rb
@@ -1,13 +1,23 @@
 #!/usr/bin/env ruby
-
+#
+# Refactor - Copyright (C) 2013 Garrett Honeycutt <code@garretthoneycutt.com
+#
 require 'spec_helper'
 require 'facter'
 
-describe "LSB distribution major release fact" do
-    it "should be derived from lsb_release" do
-        Facter.fact(:kernel).stubs(:value).returns("Linux")
-        Facter.stubs(:value).with(:lsbdistrelease).returns("10.10")
-
-        Facter.fact(:lsbmajdistrelease).value.should == "10"
-    end
+describe 'LSB distribution major release fact' do
+  it 'should be derived from lsbdistrelease and return X from version X.Y' do
+    Facter.fact(:kernel).stubs(:value).returns('Linux')
+    Facter.stubs(:value).with(:lsbdistrelease).returns('6.4')
+    Facter.fact(:lsbmajdistrelease).value.should == '6'
+  end
+  it 'should be derived from lsbdistrelease and return X from version X.Y.Z' do
+    Facter.fact(:kernel).stubs(:value).returns('Linux')
+    Facter.stubs(:value).with(:lsbdistrelease).returns('6.4.1')
+    Facter.fact(:lsbmajdistrelease).value.should == '6'
+  end
+  it 'should not be present on an unsupported kernel' do
+    Facter.fact(:kernel).stubs(:value).returns('NotLinuxOrGNU/kFreeBSD')
+    Facter.fact(:lsbmajdistrelease).value.should == nil
+  end
 end


### PR DESCRIPTION
The old spec file incorrect attributed lsb_release instead of lsbdistrelease and used version 10.10, which is ambiguous as the test did not show if the got the first 10 or the incorrect second 10.

Tests now reflect that lsbmajdistrelease is derived from lsbdistrelease, use a sensible version string, and check for the case of an unsupported kernel.
