### PR TITLE
(maint) Add notice to package builders in facter.gemspec

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -1,6 +1,16 @@
 #
 # -*- encoding: utf-8 -*-
 
+# Note to package builders:
+#
+# This gemspec is only present for use with Bundler, and is not intended for
+# building gems. Facter should be packaged as a gem with the following commands:
+#
+#     rake package:bootstrap
+#     rake package:gem
+#
+# For more information, see https://github.com/puppetlabs/packaging
+
 begin
   require 'facter/version'
 rescue LoadError => detail


### PR DESCRIPTION
The facter gemspec file is only being used for bundler and is not
intended for building gems. This commit updates the gemspec with an
advisory explaining this and explains the preferred way to build the
package.
