### PR TITLE
(#19764) Fix ipaddress issue scanning beyond the first address

### DIFF
--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -28,10 +28,14 @@ Facter.add(:ipaddress) do
   confine :kernel => :linux
   setcode do
     ip = nil
-    if output = Facter::Util::IP.exec_ifconfig(["2>/dev/null"])
+    output = Facter::Util::IP.exec_ifconfig(["2>/dev/null"])
+    if output
       regexp = /inet (?:addr:)?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-      if match = regexp.match(output)
-        match[1] unless /^127/.match(match[1])
+      output.split("\n").each do |line|
+        match = regexp.match(line)
+        if match
+          break match[1] unless /^127/.match(match[1])
+        end
       end
     end
   end

--- a/spec/fixtures/unit/ipaddress/ifconfig_multiple_127_addresses.txt
+++ b/spec/fixtures/unit/ipaddress/ifconfig_multiple_127_addresses.txt
@@ -1,0 +1,20 @@
+lo        Link encap:Local Loopback
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+          RX packets:9031461 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:9031461 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:3205490447 (2.9 GiB)  TX bytes:3205490447 (2.9 GiB)
+
+venet0    Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+          inet addr:127.0.0.1  P-t-P:127.0.0.1  Bcast:0.0.0.0  Mask:255.255.255.255
+          UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1
+          RX packets:38161277 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:24601924 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0
+          RX bytes:3847964603 (3.5 GiB)  TX bytes:5770630041 (5.3 GiB)
+
+venet0:1  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+          inet addr:10.0.222.20  P-t-P:10.0.222.20  Bcast:10.0.222.20  Mask:255.255.255.255
+          UP BROADCAST POINTOPOINT RUNNING NOARP  MTU:1500  Metric:1

--- a/spec/unit/ipaddress_spec.rb
+++ b/spec/unit/ipaddress_spec.rb
@@ -28,5 +28,9 @@ describe "The ipaddress fact" do
       "Ubuntu 12.04", "10.87.80.110", "ifconfig_ubuntu_1204.txt"
     example_behavior_for "ifconfig output",
       "Fedora 17", "131.252.209.153", "ifconfig_net_tools_1.60.txt"
+    example_behavior_for "ifconfig output",
+      "Linux with multiple loopback addresses",
+      "10.0.222.20",
+      "ifconfig_multiple_127_addresses.txt"
   end
 end


### PR DESCRIPTION
Without this patch the refactoring of the ipaddress fact in 0e514b8
changed the determination behavior unintentionally.  This is a problem
because the behavior change caused the setcode block to scan only one
address in the output of ifconfig.  If the first address is a loopback
(127) address, then no additional addresses will be checked.

This patch addresses the problem by restoring the behavior of splitting
the output of `ifconfig` into lines, then scanning each line.  If an
address is matched that begins with 127, then scanning continues.
Otherwise the matched address is determined to be the ipaddress.

The fixture has been extracted from the description of the issue
published in the comment at http://git.io/MbXKEg
