### PR TITLE
(#20301) Handle different error in ruby 1.9

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -117,9 +117,9 @@ if Facter.value(:kernel) == "windows"
     # get each physical processor
     Facter::Util::WMI.execquery("select * from Win32_Processor").each do |proc|
       # not supported before 2008
-      begin
+      if proc.respond_to?(:NumberOfLogicalProcessors)
         processor_num = proc.NumberOfLogicalProcessors
-      rescue RuntimeError => e
+      else
         processor_num = 1
       end
 

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -29,13 +29,14 @@ describe "Processor facts" do
     describe "2003" do
       before :each do
         proc = stubs 'proc'
-        proc.stubs(:NumberOfLogicalProcessors).raises(RuntimeError)
         proc.stubs(:Name).returns("Intel(R)    Celeron(R)   processor")
 
         load(Array.new(2, proc))
       end
 
       it "should count 2 processors" do
+        proc.expects(:NumberOfLogicalProcessors).never
+
         Facter.fact(:processorcount).value.should == "2"
       end
 


### PR DESCRIPTION
The NumberOfLogicalProcessor property of the Win32_Processor WMI class
does not exist in the base win2003 install. Previously, we were trying
to access the property, and then catching the resulting error if the
property did not exist.

In ruby 1.8, it would raise a RuntimeError, but in ruby 1.9, it raises a
StandardError, causing the fact to blow up on ruby 1.9.

This commit checks to see if the process object responds to that method,
and only then does it try to call it.
