### PR TITLE
(#7643) Export the Win32_OperatingSystem WMI/CIM class

### DIFF
--- a/lib/facter/win32_operatingsystem.rb
+++ b/lib/facter/win32_operatingsystem.rb
@@ -1,0 +1,14 @@
+if Facter.fact(:kernel).value == "windows"
+  require 'facter/util/wmi'
+
+  result = Facter::Util::WMI.connect("winmgmts:{impersonationLevel=impersonate}!//./root/cimv2:win32_operatingsystem=@")
+
+  result.properties_.each do |property|
+    Facter.add("wmi_win32_operatingsystem_#{property.name}") do
+      confine :kernel => :windows
+      setcode do
+        property.value
+      end
+    end
+  end
+end

--- a/spec/unit/win32_operatingsystem_spec.rb
+++ b/spec/unit/win32_operatingsystem_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'WMI win32_operatingsystem class based facts' do
+  before :each do
+    Facter.clear
+    Facter.fact(:kernel).stubs(:value).returns("windows")
+  end
+
+  def load(props)
+    require 'facter/util/wmi'
+
+    os_ole = stubs 'result'
+    os_ole.stubs(:properties_).returns(props)
+
+    Facter::Util::WMI.stubs(:connect).with("winmgmts:{impersonationLevel=impersonate}!//./root/cimv2:win32_operatingsystem=@").returns(os_ole)
+    Facter.collection.internal_loader.load(:win32_operatingsystem)
+  end
+
+  describe 'for properties with a value' do
+    before :each do
+      props = []
+      3.times do |i|
+        prop = stubs 'property'
+        prop.stubs(:name).returns("property_#{i}")
+        prop.stubs(:value).returns("value_#{i}")
+        props << prop
+      end
+
+      load(props)
+    end
+
+    it 'should be created for each property' do
+      3.times do |i|
+        Facter.fact("wmi_win32_operatingsystem_property_#{i}".to_sym).value.should == "value_#{i}"
+      end
+    end
+  end
+
+  describe 'for properties with nil value' do
+    before :each do
+      prop = stubs 'prop'
+      prop.stubs(:name).returns('property_nil')
+      prop.stubs(:value).returns(nil)
+
+      load(Array(prop))
+    end
+
+    it 'should be nil' do
+      Facter.fact('wmi_win32_operatingsystem_property_nil').value.should == nil
+    end
+  end
+end


### PR DESCRIPTION
Without this patch, there is a large set of data available in Windows that
users do not have the ability to make decisions on.

This patch adds exposes all the properties in the singleton
Win32_OperatingSystem WMI/CIM class as facts. The facts will have
'wmi_win32_operatingsystem_' prepended. The data received from the
WMI/CIM class is exposed raw in the facts. This is actually preferable
as users can refer to MSDN documentation for the class to understand the
purpose of different values.
