### PR TITLE
(#20321) Be more descriptive in deprecation message

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -169,7 +169,7 @@ class Facter::Util::Resolution
 
       begin
         out = %x{#{code}}.chomp
-        Facter.warnonce 'Using Facter::Util::Resolution.exec with a shell built-in is deprecated. Most built-ins can be replaced with native ruby commands. If you really have to run a built-in, pass "cmd /c your_builtin" as a command' unless expanded_code
+        Facter.warnonce "Using Facter::Util::Resolution.exec with a shell built-in is deprecated. Most built-ins can be replaced with native ruby commands. If you really have to run a built-in, pass \"cmd /c your_builtin\" as a command (command responsible for this message was \"#{code}\")" unless expanded_code
       rescue Errno::ENOENT => detail
         # command not found on Windows
         return nil

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -685,7 +685,7 @@ describe Facter::Util::Resolution do
         it "should try to run the command and return output of a shell-builtin" do
           Facter::Util::Resolution.expects(:expand_command).with(%q{echo foo}).returns nil
           Facter::Util::Resolution.expects(:`).with(%q{echo foo}).returns 'foo'
-          Facter.expects(:warnonce).with('Using Facter::Util::Resolution.exec with a shell built-in is deprecated. Most built-ins can be replaced with native ruby commands. If you really have to run a built-in, pass "cmd /c your_builtin" as a command')
+          Facter.expects(:warnonce).with 'Using Facter::Util::Resolution.exec with a shell built-in is deprecated. Most built-ins can be replaced with native ruby commands. If you really have to run a built-in, pass "cmd /c your_builtin" as a command (command responsible for this message was "echo foo")'
           Facter::Util::Resolution.exec(%q{echo foo}).should == 'foo'
         end
         it "should try to run the command and return nil if not shell-builtin" do


### PR DESCRIPTION
Facter::Util::Resoultion.exec can be used to run arbitrary commands. On
windows it is currently allowed to pass a shell builtin but we raise a
deprecation warning.

But the deprecation warning did not include the actual commandline it is
complaining about so if you have custom facts that make use of this
feature you may ask yourself why you see the message.

Add the actual command to the deprecation message so it easier to
resolve the issue.
