### PR TITLE
Add initial functionality for exposing Rackspace Cloud data (#20468)

### DIFF
--- a/lib/facter/rackspace.rb
+++ b/lib/facter/rackspace.rb
@@ -12,8 +12,6 @@ Facter.add(:is_rsc) do
     result = Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/provider")
     if result == "Rackspace"
       "true"
-    else
-      "false"
     end
   end
 end

--- a/spec/unit/rackspace_spec.rb
+++ b/spec/unit/rackspace_spec.rb
@@ -32,9 +32,9 @@ describe "rackspace facts" do
       Facter.collection.internal_loader.load(:rackspace)
     end
 
-    it "should set is_rsc to false" do
+    it "shouldn't set is_rsc" do
       Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider").returns("other")
-      Facter.fact(:is_rsc).value.should == "false"
+      Facter.fact(:is_rsc).value.should == nil
     end
   end
 end


### PR DESCRIPTION
Rackspace Cloud doesn't expose the metadata service provided by OpenStack.  You can get some basic information about region and what the instance id is from xenstore, though
