### PR TITLE
Enhance the release fact for OpenBSD

### DIFF
--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -20,6 +20,13 @@ Facter.add(:kernelrelease) do
   setcode 'oslevel -s'
 end
 
+Facter.add("kernelrelease") do
+  confine :kernel => :openbsd
+  setcode do
+    Facter::Util::Resolution.exec("/sbin/sysctl -n kern.version").split(' ')[1]
+  end
+end
+
 Facter.add(:kernelrelease) do
   confine :kernel => "hp-ux"
   setcode do


### PR DESCRIPTION
Currently facter only outputs the main release version number without
the actual substring information.
e.g. 5.3 versus 5.3-beta

http://projects.puppetlabs.com/issues/19293
