### PR TITLE
Remove redundant attr_accessor :interpreter

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -23,7 +23,7 @@ class Facter::Util::Resolution
   attr_accessor :timeout
 
   # @api private
-  attr_accessor :interpreter, :code, :name
+  attr_accessor :code, :name
   attr_writer :value, :weight
 
   INTERPRETER = Facter::Util::Config.is_windows? ? "cmd.exe" : "/bin/sh"


### PR DESCRIPTION
This attr_accessor is redundant as both reader and writer are defined at line 417, which generate harmless warnings for method redefinitions.
In my environment many ruby scripts are run with '-w' option for historical reasons, and those warnings are annoying.
