### PR TITLE
[#20860] Add a fact for the current Puppet parser

### DIFF
--- a/lib/facter/puppetparser.rb
+++ b/lib/facter/puppetparser.rb
@@ -1,0 +1,24 @@
+# Fact: puppetparser
+#
+# Purpose: Returns the parser Puppet is running under.
+#
+# Resolution:
+#   Requres puppet via Ruby and returns it's parser value.
+#
+# Caveats:
+#
+
+Facter.add(:puppetparser) do
+  setcode do
+    begin
+      unless defined?(Puppet)
+        require "puppet"
+      end
+
+      Puppet[:parser].to_s
+    rescue LoadError
+      nil
+    end
+  end
+end
+

--- a/spec/unit/puppetparser_spec.rb
+++ b/spec/unit/puppetparser_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+class Puppet
+  @@settings = {}
+
+  def self.[]
+    @@settings
+  end
+
+  def self.[] key, val
+    @@settings[key] = val
+  end
+end
+
+describe "puppet parser facts" do
+  it "when puppet parser is future returns future" do
+    Puppet.stubs(:[]).with(:parser).returns("future")
+    Facter.fact(:puppetparser).value.should == "future"
+  end
+
+  it "when puppet parser is current returns current" do
+    Puppet.stubs(:[]).with(:parser).returns("current")
+    Facter.fact(:puppetparser).value.should == "current"
+  end
+
+  it "when puppet cannot be required returns nil" do
+    Puppet.stubs(:[]).with(:parser).raises(LoadError)
+    Facter.fact(:puppetparser).value.should == nil
+  end
+end


### PR DESCRIPTION
With the future Puppet parser in 3.2, modules and related Puppet code will need to start adding special-case code.
The easiest way to expose this is via a Fact for the Puppet parser.

Redmine ticket: http://projects.puppetlabs.com/issues/20860
