### PR TITLE
(maint) Remove duplication from virtual fact

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -135,6 +135,16 @@ module Facter::Util::Virtual
     "zlinux"
   end
 
+  def self.parse_virtualization(output)
+    if output
+      lines = output.split("\n")
+      return "parallels"  if lines.any? {|l| l =~ /Parallels/ }
+      return "vmware"     if lines.any? {|l| l =~ /VM[wW]are/ }
+      return "virtualbox" if lines.any? {|l| l =~ /VirtualBox/ }
+      return "xenhvm"     if lines.any? {|l| l =~ /HVM domU/ }
+    end
+  end
+
   ##
   # read_sysfs Reads the raw data as per the documentation at [Detecting if You
   # Are Running in Google Compute

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -62,13 +62,7 @@ Facter.add("virtual") do
     resolver.timeout = 6
     resolver.setcode('prtdiag')
     output = resolver.value
-    if output
-      lines = output.split("\n")
-      next "parallels"  if lines.any? {|l| l =~ /Parallels/ }
-      next "vmware"     if lines.any? {|l| l =~ /VM[wW]are/ }
-      next "virtualbox" if lines.any? {|l| l =~ /VirtualBox/ }
-      next "xenhvm"     if lines.any? {|l| l =~ /HVM domU/ }
-    end
+    Facter::Util::Virtual.parse_virtualization(output)
   end
 end
 
@@ -93,13 +87,7 @@ Facter.add("virtual") do
 
   setcode do
     output = Facter::Util::Resolution.exec('sysctl -n hw.product 2>/dev/null')
-    if output
-      lines = output.split("\n")
-      next "parallels"  if lines.any? {|l| l =~ /Parallels/ }
-      next "vmware"     if lines.any? {|l| l =~ /VMware/ }
-      next "virtualbox" if lines.any? {|l| l =~ /VirtualBox/ }
-      next "xenhvm"     if lines.any? {|l| l =~ /HVM domU/ }
-    end
+    Facter::Util::Virtual.parse_virtualization(output)
   end
 end
 


### PR DESCRIPTION
Prior to this commit the SunOS and OpenBSD resolutions for the virtual
fact had duplicate logic. This commit abstracts the logic into the
`Facter::Util::Virtual.parse_virtualization` helper.
