### PR TITLE
(maint) Refactor duplicate code in macosx

### DIFF
--- a/lib/facter/macosx.rb
+++ b/lib/facter/macosx.rb
@@ -27,20 +27,15 @@
 require 'facter/util/macosx'
 
 if Facter.value(:kernel) == "Darwin"
-  Facter::Util::Macosx.hardware_overview.each do |fact, value|
-    Facter.add("sp_#{fact}") do
-      confine :kernel => :darwin
-      setcode do
-        value.to_s
-      end
-    end
-  end
-
-  Facter::Util::Macosx.os_overview.each do |fact, value|
-    Facter.add("sp_#{fact}") do
-      confine :kernel => :darwin
-      setcode do
-        value.to_s
+  [ Facter::Util::Macosx.hardware_overview, 
+    Facter::Util::Macosx.os_overview
+  ].each do |hash|
+    hash.each do |fact, value|
+      Facter.add("sp_#{fact}") do
+        confine :kernel => :darwin
+        setcode do
+          value.to_s
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit the macosx facts contained duplicated code for
resoluton of hardware overview and the os overview. This commit
refactors that code into a common block.
