### PR TITLE
Factor.Util.Resolution.exec no longer handles executable scripts.

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -111,7 +111,7 @@ module Facter::Util::Parser
 
   class ScriptParser < Base
     def results
-      output = Facter::Util::Resolution.exec(filename)
+      output = Facter::Util::Resolution.exec("sh #{filename}")
 
       result = {}
       re = /^(.+)=(.+)$/

--- a/spec/unit/util/parser_spec.rb
+++ b/spec/unit/util/parser_spec.rb
@@ -92,7 +92,7 @@ describe Facter::Util::Parser do
     let :data_in_txt do "one=two\nthree=four\n" end
 
     before :each do
-      Facter::Util::Resolution.stubs(:exec).with(cmd).returns(data_in_txt)
+      Facter::Util::Resolution.stubs(:exec).with("sh #{cmd}").returns(data_in_txt)
       File.stubs(:executable?).with(cmd).returns(true)
     end
 


### PR DESCRIPTION
This commit prefixes the file path in script_parser with a shell (sh). The reason this is now required is that Factor now searches for a binary before executing the command in Factor.Util.Resolution.exec and if the binary doesn't exist, nil is returned.  By prefixing the filename with 'sh' and not running the file itself as an executable, Resolution.exec perfoms as expected.
