### PR TITLE
Fix zfs_version on older versions of Solaris 10

### DIFF
--- a/lib/facter/zfs_version.rb
+++ b/lib/facter/zfs_version.rb
@@ -3,7 +3,7 @@ require 'facter'
 Facter.add('zfs_version') do
   setcode do
     if Facter::Util::Resolution.which('zfs')
-      zfs_help = Facter::Util::Resolution.exec('zfs 2>&1')
+      zfs_help = Facter::Util::Resolution.exec('zfs -?')
       zfs_has_upgrade = zfs_help.match(/^\s+upgrade/) unless zfs_help.nil?
       if zfs_has_upgrade
         zfs_v = Facter::Util::Resolution.exec('zfs upgrade -v')

--- a/spec/fixtures/unit/zfs_version/zfs_new
+++ b/spec/fixtures/unit/zfs_version/zfs_new
@@ -1,4 +1,3 @@
-missing command
 usage: zfs command args ...
 where 'command' is one of the following:
 

--- a/spec/fixtures/unit/zfs_version/zfs_old
+++ b/spec/fixtures/unit/zfs_version/zfs_old
@@ -1,4 +1,3 @@
-missing command
 usage: zfs command args ...
 where 'command' is one of the following:
 

--- a/spec/unit/zfs_version_spec.rb
+++ b/spec/unit/zfs_version_spec.rb
@@ -17,42 +17,42 @@ describe "zfs_version fact" do
   end
 
   it "should return nil on old versions of Solaris 10" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_old'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_old'))
     Facter.fact(:zfs_version).value.should == nil
   end
 
   it "should return correct version on Solaris 10" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_10'))
     Facter.fact(:zfs_version).value.should == "3"
   end
 
   it "should return correct version on Solaris 11" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_11'))
     Facter.fact(:zfs_version).value.should == "5"
   end
 
   it "should return correct version on FreeBSD 8.2" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_8.2'))
     Facter.fact(:zfs_version).value.should == "4"
   end
 
   it "should return correct version on FreeBSD 9.0" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_9.0'))
     Facter.fact(:zfs_version).value.should == "5"
   end
 
   it "should return correct version on Linux with ZFS-fuse" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))
     Facter.fact(:zfs_version).value.should == "4"
   end
 
   it "should return correct version on Linux with zfsonlinux" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(my_fixture_read('zfs_new'))
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('zfsonlinux_0.6.1'))
     Facter.fact(:zfs_version).value.should == "5"
   end
@@ -64,7 +64,7 @@ describe "zfs_version fact" do
   end
 
   it "should return nil if zfs fails to run" do
-    Facter::Util::Resolution.stubs(:exec).with("zfs 2>&1").returns(nil)
+    Facter::Util::Resolution.stubs(:exec).with("zfs -?").returns(nil)
     Facter.fact(:zfs_version).value.should == nil
   end
 
@@ -76,7 +76,7 @@ describe "zfs_version fact" do
       with("zfs").
       returns(nil,nil,nil,nil,"/usr/bin/zfs")
     Facter::Util::Resolution.stubs(:exec).
-      with("zfs 2>&1").
+      with("zfs -?").
       returns(my_fixture_read('zfs_new'))
     Facter::Util::Resolution.stubs(:exec).
       with("zfs upgrade -v").


### PR DESCRIPTION
The zfs upgrade command used by zfs_version does not exist on some older versions of Solaris 10.

This checks for the existence of the command before trying to run it.
