### PR TITLE
(packaging) Use the packaging loader for tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,10 @@ require 'facter/version'
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), 'tasks')
 
+require 'rake'
+
 begin
+  load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
   require 'rubygems'
   require 'rspec'
   require 'rspec/core/rake_task'
@@ -14,10 +17,7 @@ begin
 rescue LoadError
 end
 
-require 'rake'
-
 Dir['tasks/**/*.rake'].each { |t| load t }
-Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
 
 build_defs_file = 'ext/build_defaults.yaml'
 if File.exist?(build_defs_file)


### PR DESCRIPTION
The packaging repo now uses an explicit loader which handles loading the
various rake tasks in packaging. This commit updates the facter Rakefile to use
the loader instead of a blind glob of the ext/packaging/tasks directory. We
move this load into the rescue LoadError block because the packaging repo won't
always be there, and require 'rake' ahead of time.
