### PR TITLE
Add physicalprocessorcount fact for OpenBSD

### DIFF
--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -79,3 +79,10 @@ Facter.add('physicalprocessorcount') do
     end
   end
 end
+
+Facter.add('physicalprocessorcount') do
+  confine :kernel => :openbsd
+    setcode do
+      Facter::Util::Resolution.exec("sysctl -n hw.ncpufound")
+    end
+end

--- a/spec/unit/physicalprocessorcount_spec.rb
+++ b/spec/unit/physicalprocessorcount_spec.rb
@@ -140,4 +140,12 @@ describe "Physical processor count facts" do
       end
     end
   end
+  
+  describe "on openbsd" do
+    it "should return 4 physical CPUs" do
+      Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
+      Facter::Util::Resolution.expects(:exec).with("sysctl -n hw.ncpufound").returns("4")
+      Facter.fact(:physicalprocessorcount).value.should == "4"
+    end
+  end
 end


### PR DESCRIPTION
This fact was missing, the regular processorcount was already implemented.
