### PR TITLE
Adding LinuxMint support to operatingsystem

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -36,6 +36,8 @@ Facter.add(:operatingsystem) do
   setcode do
     if Facter.value(:lsbdistid) == "Ubuntu"
        "Ubuntu"
+    elsif FileTest.exists?("/etc/linuxmint/info")
+      "LinuxMint"
     elsif FileTest.exists?("/etc/debian_version")
       "Debian"
     elsif FileTest.exists?("/etc/openwrt_release")


### PR DESCRIPTION
This needs to be so high in the list since LinuxMint also has an
/etc/debain-relase and will otherwise incorrectly report itself as
being Debian.
