### PR TITLE
(maint) Remove unused facter.conf

### DIFF
--- a/etc/facter.conf
+++ b/etc/facter.conf
@@ -1,5 +1,0 @@
-Hostname
-OperatingSystem
-OperatingSystemRelease
-SSHDSAKey
-CfKey


### PR DESCRIPTION
Facter.conf is not used anywhere in facter and has not been modified in the
entire git history of facter. This commit removes the file and directory to
reduce clutter.
