### PR TITLE
(maint) run the tests under travis again

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,12 @@ $LOAD_PATH << File.join(File.dirname(__FILE__), 'tasks')
 
 require 'rake'
 
+require 'rubygems'
+require 'rspec'
+require 'rspec/core/rake_task'
+
 begin
   load File.join(File.dirname(__FILE__), 'ext', 'packaging', 'packaging.rake')
-  require 'rubygems'
-  require 'rspec'
-  require 'rspec/core/rake_task'
   require 'rcov'
 rescue LoadError
 end


### PR DESCRIPTION
NOTE: This probably isn't safe to merge yet, as it uncovers a bunch of failing examples that had been allowed to slide by.

rcov and ext/packaging/packaging.rake are failing to load, but that means it's
also failing to load the rspec and rspec/core/rake_task so the command we use
to test the gem is silently succeeding all the time rather than actually
running the spec tests.
