### PR TITLE
(#21533) Verify facter doesn't write to stderr

### DIFF
--- a/acceptance/tests/no_errors_on_stderr.rb
+++ b/acceptance/tests/no_errors_on_stderr.rb
@@ -1,0 +1,6 @@
+test_name "Running facter should not output anything to stderr"
+
+on(hosts, facter) do |result|
+  fail_test "Hostname fact is missing" unless stdout =~ /hostname\s*=>\s*\S*/
+  fail_test "Facter should not have written to stderr: #{stderr}" unless stderr == ""
+end


### PR DESCRIPTION
This commit doesn't fix #21533, but it adds an acceptance test to detect
if executing `facter` writes to stdout.
