### PR TITLE
Add tests for OpenBSD ifconfig with bridge(4) rules (issue #16630)

### DIFF
--- a/spec/fixtures/ifconfig/openbsd_bridge_rules
+++ b/spec/fixtures/ifconfig/openbsd_bridge_rules
@@ -1,0 +1,11 @@
+bridge0: flags=41
+        groups: bridge
+        priority 32768 hellotime 2 fwddelay 15 maxage 20 holdcnt 6 proto rstp
+        vlan1 flags=3
+                port 5 ifpriority 0 ifcost 0
+        em0 flags=7
+                port 1 ifpriority 0 ifcost 0
+block out on em0 src 00:24:21:ef:1b:de
+pflog0: flags=41 mtu 33152
+        priority: 0
+        groups: pflog

--- a/spec/unit/macaddress_spec.rb
+++ b/spec/unit/macaddress_spec.rb
@@ -62,4 +62,16 @@ describe "macaddress fact" do
     end
   end
 
+  describe "when run on OpenBSD with bridge(4) rules" do
+    it "should return macaddress information" do
+      Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
+      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+      Facter::Util::IP.stubs(:exec_ifconfig).
+        returns(ifconfig_fixture('openbsd_bridge_rules'))
+
+      proc { Facter.value(:macaddress) }.should_not raise_error
+      Facter.value(:macaddress).should be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
It seems the issue as described in #16630 has been autofixed since the reporter opened the ticket.
@ahpook requested a fixture, which I added and running the test made me realize the behaviour is correct now; a nil mac address is returned.

http://projects.puppetlabs.com/issues/16630
