### PR TITLE
(maint) Add acceptance test for stderr facter output

### DIFF
--- a/acceptance/tests/no_stderr_output.rb
+++ b/acceptance/tests/no_stderr_output.rb
@@ -1,0 +1,6 @@
+test_name "Facter should not write to STDERR if all is well"
+
+step "Run facter on the agent"
+on agents, facter do
+  assert_equal("", stderr, "Facter is writing to STDERR, that's not good.")
+end


### PR DESCRIPTION
Facter often has facts which don't correctly capture or suppress stderr,
allowing it to be displayed during the facter run. This can cause problems with
either facter runs through cron, or if puppet is running through cron, puppet
will also throw the same output to stderr. This commit adds a simple acceptance
test that runs facter and verifies that the stderr stream was empty after the
run to avoid this problem.
