### PR TITLE
Don't build debuginfo rpm package

### DIFF
--- a/ext/redhat/facter.spec.erb
+++ b/ext/redhat/facter.spec.erb
@@ -6,6 +6,10 @@
 %global facter_libdir   %(ruby -rrbconfig -e 'puts RbConfig::CONFIG["sitelibdir"]')
 %endif
 
+
+# Building debuginfo is pointless, as this has no symbols.
+%global debug_package %{nil}
+
 # VERSION is subbed out during rake srpm process
 %global realversion <%= @version %>
 %global rpmversion <%= @rpmversion %>
@@ -72,6 +76,9 @@ rm -rf %{buildroot}
 %changelog
 * <%= Time.now.strftime("%a %b %d %Y") %> Puppet Labs Release <info@puppetlabs.com> -  1:<%= @rpmversion %>-<%= @rpmrelease %>
 - Build for <%= @version %>
+
+* Fri Jul 05 2013 Michael Stahnke <stahnma@puppetlabs.com> - 1:1.7.2-0.1rc1
+- Do not build debuginfo any more
 
 * Mon Apr 01 2013 Matthaus Owens <matthaus@puppetlabs.com> - 1:1.7.0-0.1rc1
 - Add dependency on virt-what to facter for better virutalization detection


### PR DESCRIPTION
Prior to this commit, mock would spit out a debuginfo package on facter.
This is pointless as facter contains zero compiled code. It would be a
noarch package, save for some arch-specific dependencies. So, since I
can't fix that bug in RPM, I can make it so I don't have to remove the
debuginfo package every single time.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
