### PR TITLE
ip address fact return full ifconfig output on some systems

### DIFF
--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -33,11 +33,13 @@ Facter.add(:ipaddress) do
       regexp = /inet (?:addr:)?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
       output.split("\n").each do |line|
         match = regexp.match(line)
-        if match
-          break match[1] unless /^127/.match(match[1])
+        if match and not /^127\./.match(match[1])
+          ip = match[1]
+          break
         end
       end
     end
+    ip
   end
 end
 

--- a/spec/fixtures/unit/ipaddress/ifconfig_non_english_locale.txt
+++ b/spec/fixtures/unit/ipaddress/ifconfig_non_english_locale.txt
@@ -1,0 +1,18 @@
+lo        Link encap:Boucle locale  
+          inet adr:127.0.0.1  Masque:255.0.0.0
+          adr inet6: ::1/128 Scope:Hote
+          UP LOOPBACK RUNNING  MTU:65536  Metric:1
+          RX packets:1001 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:1001 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 lg file transmission:0 
+          RX bytes:52562 (51.3 KiB)  TX bytes:52562 (51.3 KiB)
+
+wlan0     Link encap:Ethernet  HWaddr ac:81:12:2d:86:25  
+          inet adr:192.168.1.83  Bcast:192.168.1.255  Masque:255.255.255.0
+          adr inet6: fe80::ae81:12ff:fe2d:8625/64 Scope:Lien
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:493220 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:390375 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 lg file transmission:1000 
+          RX bytes:569234568 (542.8 MiB)  TX bytes:69778980 (66.5 MiB)
+

--- a/spec/unit/ipaddress_spec.rb
+++ b/spec/unit/ipaddress_spec.rb
@@ -32,5 +32,7 @@ describe "The ipaddress fact" do
       "Linux with multiple loopback addresses",
       "10.0.222.20",
       "ifconfig_multiple_127_addresses.txt"
+    example_behavior_for "ifconfig output",
+      "Linux with non english locale", nil, "ifconfig_non_english_locale.txt"
   end
 end


### PR DESCRIPTION
Hi,

In the version 1.7.2 of facter, the fact ip address returns the full ifconfig output on some systems. 

The function ipaddres for linux (ipaddress.rb:27) returns the variable ouptput when it does not find any ip rather than nil. And facter stops the processing instead of using  ohter functions.

I've the case on linux system with a french locale.

```
% LC_ALL=fr_FR.UTF-8 ruby -I lib bin/facter ipaddress
lo        Link encap:Boucle locale  
          inet adr:127.0.0.1  Masque:255.0.0.0
          adr inet6: ::1/128 Scope:Hôte
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:4 errors:0 dropped:0 overruns:0 frame:0
          TX packets:4 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 lg file transmission:0 
          RX bytes:260 (260.0 B)  TX bytes:260 (260.0 B)

wlan0     Link encap:Ethernet  HWaddr ac:81:12:2d:86:25  
          inet adr:192.168.1.83  Bcast:192.168.1.255  Masque:255.255.255.0
          adr inet6: fe80::ae81:12ff:fe2d:8625/64 Scope:Lien
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:31416 errors:0 dropped:0 overruns:0 frame:0
          TX packets:22385 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 lg file transmission:1000 
          RX bytes:39065815 (37.2 MiB)  TX bytes:3580072 (3.4 MiB)

% LC_ALL=C ruby -I lib bin/facter ipaddress         
192.168.1.83
```

As the regex don't match, the function return the variable `output`.

I've attached a fix for this issue.

With the new code, the functions ipaddress for linux and *BSD are almost identical. The regex has an optionnal field addr in supplement. I think the two functions can be merged, i don't try as i don't have a bsd to test.

Thanks to @nekolover for his help.

Regards
