### PR TITLE
(#20216) Print timings to stderr instead of stdout

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -106,7 +106,7 @@ module Facter
   #
   # @api private
   def self.show_time(string)
-    puts "#{GREEN}#{string}#{RESET}" if string and Facter.timing?
+    $stderr.puts "#{GREEN}#{string}#{RESET}" if string and Facter.timing?
   end
 
   # Returns whether timing output is turned on


### PR DESCRIPTION
Facter prints both timings and facts to stdout if timing is enabled.
To facilitate separating both outputs the timings should be printed to
stderr instead.
