### PR TITLE
(#20893) Empty output from facts.d scripts crashes facter

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -111,13 +111,14 @@ module Facter::Util::Parser
 
   class ScriptParser < Base
     def results
-      output = Facter::Util::Resolution.exec(filename)
-
       result = {}
-      re = /^(.+)=(.+)$/
-      output.each_line do |line|
-        if match_data = re.match(line.chomp)
-          result[match_data[1]] = match_data[2]
+
+      if output = Facter::Util::Resolution.exec(filename)
+        re = /^(.+)=(.+)$/
+        output.each_line do |line|
+          if match_data = re.match(line.chomp)
+            result[match_data[1]] = match_data[2]
+          end
         end
       end
       result


### PR DESCRIPTION
Without this patch facter will crash with 'Error: undefined method `each_line' for nil:NilClass' if a script in /etc/facter/facts.d has no output.

The problem is caused because Facter::Util::Resolution.exec can return nil. The calling function doesn't check for this and does an each_line on nil. This patch adds the check for nil.
