### PR TITLE
Support getting the hostid on FreeBSD (which is only available through sysctl.hostid)

### DIFF
--- a/lib/facter/hostuuid.rb
+++ b/lib/facter/hostuuid.rb
@@ -1,0 +1,6 @@
+Facter.add(:hostuuid) do
+  confine :kernel => :freebsd
+  setcode do
+    Facter::Util::Resolution.exec('sysctl -n kern.hostuuid')
+  end
+end

--- a/lib/facter/uniqueid.rb
+++ b/lib/facter/uniqueid.rb
@@ -2,3 +2,10 @@ Facter.add(:uniqueid) do
   setcode 'hostid'
   confine :kernel => %w{SunOS Linux AIX GNU/kFreeBSD}
 end
+
+Facter.add(:uniqueid) do
+  confine :kernel => :freebsd
+  setcode do
+    Facter::Util::Resolution.exec('sysctl -n kern.hostid')
+  end
+end

--- a/spec/unit/hostuuid_spec.rb
+++ b/spec/unit/hostuuid_spec.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'facter'
+
+describe "host UUID fact" do
+  it "should match kern.hostuuid on FreeBSD" do
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with("sysctl -n kern.hostuuid").returns("a0391b10-6c8c-11e1-b960-001b21b8d7b0")
+
+    Facter.fact(:hostuuid).value.should == "a0391b10-6c8c-11e1-b960-001b21b8d7b0"
+  end
+end

--- a/spec/unit/uniqueid_spec.rb
+++ b/spec/unit/uniqueid_spec.rb
@@ -22,4 +22,11 @@ describe "Uniqueid fact" do
 
     Facter.fact(:uniqueid).value.should == "Moe"
   end
+
+  it "should match kern.hostid on FreeBSD" do
+    Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+    Facter::Util::Resolution.stubs(:exec).with("sysctl -n kern.hostid").returns("Shemp")
+
+    Facter.fact(:uniqueid).value.should == "Shemp"
+  end
 end


### PR DESCRIPTION
...ysctl kern.hostid -- there is no hostid(1) command). Also support getting the host's UUID, currently only on FreeBSD but should be supported on other platforms (Windows and anything that can run dmidecode). Add unit tests for both on FreeBSD.

Committing on behalf of Garrett Wollman, ticket number 13051.
