### PR TITLE
(Maint) Ignore Gemfile.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc
 .bundle/
 vendor/
 Gemfile.lock
+Gemfile.local


### PR DESCRIPTION
This ignores the Gemfile.local so that specific gems like fuubar can be applied.
