### PR TITLE
(#7621) - Added operatingsystemrelease support to Windows

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -181,6 +181,34 @@ Facter.add(:operatingsystemrelease) do
   end
 end
 
+Facter.add(:operatingsystemrelease) do
+  confine :operatingsystem => :windows
+  setcode do
+    require 'facter/util/wmi'
+    result = nil
+    Facter::Util::WMI.execquery("SELECT version, producttype FROM Win32_OperatingSystem").each do |os|
+      result =
+        case os.version
+        when /^6\.2/
+          os.producttype == 1 ? "8" : "2012"
+        when /^6\.1/
+          os.producttype == 1 ? "7" : "2008 R2"
+        when /^6\.0/
+          os.producttype == 1 ? "Vista" : "2008"
+        when /^5\.2/
+          if os.producttype == 1
+            "XP"
+          else
+            os.othertypedescription == "R2" ? "2003 R2" : "2003"
+          end
+        else
+          Facter[:kernelrelease].value
+        end
+      break
+    end
+    result
+  end
+end
 
 Facter.add(:operatingsystemrelease) do
   setcode do Facter[:kernelrelease].value end

--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -183,6 +183,57 @@ describe "Operating System Release fact" do
     end
   end
 
+  describe "with operatingsystem reported as Windows" do
+    require 'facter/util/wmi'
+    before do
+      Facter.fact(:kernel).stubs(:value).returns("windows")
+    end
+
+    {
+      ['5.2.3790', 1] => "XP",
+      ['6.0.6002', 1] => "Vista",
+      ['6.0.6002', 2] => "2008",
+      ['6.0.6002', 3] => "2008",
+      ['6.1.7601', 1] => "7",
+      ['6.1.7601', 2] => "2008 R2",
+      ['6.1.7601', 3] => "2008 R2",
+      ['6.2.9200', 1] => "8",
+      ['6.2.9200', 2] => "2012",
+      ['6.2.9200', 3] => "2012",
+    }.each do |os_values, expected_output|
+      it "should be #{expected_output}  with Version #{os_values[0]}  and ProductType #{os_values[1]}" do
+        os = mock('os', :version => os_values[0], :producttype => os_values[1])
+        Facter::Util::WMI.expects(:execquery).returns([os])
+        Facter.fact(:operatingsystemrelease).value.should == expected_output
+      end
+    end
+
+    {
+      ['5.2.3790', 2, ""]   => "2003",
+      ['5.2.3790', 2, "R2"] => "2003 R2",
+      ['5.2.3790', 3, ""]   => "2003",
+      ['5.2.3790', 3, "R2"] => "2003 R2",
+    }.each do |os_values, expected_output|
+      it "should be #{expected_output}  with Version #{os_values[0]}  and ProductType #{os_values[1]} and OtherTypeDescription #{os_values[2]}" do
+        os = mock('os', :version => os_values[0], :producttype => os_values[1], :othertypedescription => os_values[2])
+        Facter::Util::WMI.expects(:execquery).returns([os])
+        Facter.fact(:operatingsystemrelease).value.should == expected_output
+      end
+    end
+
+    context "Unknown Windows version" do
+      before :each do
+        Facter.fact(:kernelrelease).stubs(:value).returns("X.Y.ZZZZ")
+      end
+
+      it "should be kernel version value with unknown values " do
+        os = mock('os', :version => "X.Y.ZZZZ")
+        Facter::Util::WMI.expects(:execquery).returns([os])
+        Facter.fact(:operatingsystemrelease).value.should == "X.Y.ZZZZ"
+      end
+    end
+  end
+
   context "Ubuntu" do
     let(:issue) { "Ubuntu 10.04.4 LTS \\n \\l\n\n" }
     before :each do


### PR DESCRIPTION
Without this patch, the fact 'operatingsystemrelease' was set to kernel version fact for all the windows flavors. This patchs brings the option of having the common release name for the windows machines, something that can help in writing specific puppet manifests and other tasks according to the specific windows version.

The patch is based on a WMI call to Win32_OperatingSystem. This aproach has some drawbacks but I think the code is simple and easy to mantain and update. Anyway, extracting the windows version is not an easy task for Microsoft as well: http://msdn.microsoft.com/en-us/library/windows/desktop/ms724429%28v=vs.85%29.aspx
