### PR TITLE
Add SwapEncrypted fact for OpenBSD

### DIFF
--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -82,15 +82,21 @@ end
   end
 end
 
-if Facter.value(:kernel) == "Darwin"
-  Facter.add("SwapEncrypted") do
-    confine :kernel => :Darwin
-    setcode do
-      swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
-      encrypted = false
-      if swap =~ /\(encrypted\)/ then encrypted = true; end
-      encrypted
-    end
+Facter.add("SwapEncrypted") do
+  confine :kernel => :openbsd
+  setcode do
+    sysctl_encrypted = Facter::Util::Resolution.exec("sysctl -n vm.swapencrypt.enable").to_i
+    !(sysctl_encrypted.zero?)
+  end
+end
+
+Facter.add("SwapEncrypted") do
+  confine :kernel => :Darwin
+  setcode do
+    swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
+    encrypted = false
+    if swap =~ /\(encrypted\)/ then encrypted = true; end
+    encrypted
   end
 end
 

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -185,6 +185,8 @@ describe "Memory facts" do
 
       Facter::Util::Resolution.stubs(:exec).with("sysctl hw.physmem | cut -d'=' -f2").returns('267321344')
 
+      Facter::Util::Resolution.stubs(:exec).with('sysctl -n vm.swapencrypt.enable').returns('1')
+
       Facter.collection.internal_loader.load(:memory)
     end
 
@@ -206,6 +208,10 @@ describe "Memory facts" do
 
     it "should return the current memory size in MB" do
       Facter.fact(:memorysize_mb).value.should == "254.94"
+    end
+
+    it "should return whether swap is encrypted" do
+      Facter.fact(:swapencrypted).value.should == true
     end
   end
 


### PR DESCRIPTION
This adds support for the swapencrypted fact on OpenBSD, now with fixed tests.

https://projects.puppetlabs.com/issues/21497
