### PR TITLE
(maint) Handle Fedora as a proper Redhat variant

### DIFF
--- a/lib/facter/util/operatingsystem.rb
+++ b/lib/facter/util/operatingsystem.rb
@@ -6,7 +6,6 @@ module Operatingsystem
   OPERATINGSYSTEM_FILES = {
     "/etc/openwrt_release"     => "OpenWrt",
     "/etc/gentoo-release"      => "Gentoo",
-    "/etc/fedora-release"      => "Fedora",
     "/etc/mandriva-release"    => "Mandriva",
     "/etc/mandrake-release"    => "Mandrake",
     "/etc/meego-release"       => "MeeGo",
@@ -30,6 +29,7 @@ module Operatingsystem
     /^XenServer/i                   => "XenServer",
     /XCP/                           => "XCP",
     /^Parallels Server Bare Metal/i => "PSBM",
+    /^Fedora release/               => "Fedora",
   }
 
   SUSE_VARIANTS = {

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -57,7 +57,6 @@ describe "Operating System fact" do
     {
       "Debian"      => "/etc/debian_version",
       "Gentoo"      => "/etc/gentoo-release",
-      "Fedora"      => "/etc/fedora-release",
       "Mandriva"    => "/etc/mandriva-release",
       "Mandrake"    => "/etc/mandrake-release",
       "MeeGo"       => "/etc/meego-release",
@@ -109,6 +108,7 @@ describe "Operating System fact" do
       "CloudLinux" => "CloudLinux Server release 5.5",
       "XenServer"  => "XenServer release 5.6.0-31188p (xenenterprise)",
       "XCP"        => "XCP release 1.6.10-61809c",
+      "Fedora"     => "Fedora release 18 (Spherical Cow)",
     }.each_pair do |operatingsystem, string|
       it "should be #{operatingsystem} based on /etc/redhat-release contents #{string}" do
         FileTest.expects(:exists?).with("/etc/redhat-release").returns true


### PR DESCRIPTION
The refactor of the operatingsystem fact in ec2bac8 split up fact
resolution but removed the strict ordering of the resolution method.
Fedora has /etc/redhat-release present which caused the redhat fact to
take precedence, but the release string was not matched. The behavior of
the redhat fact defaults to `redhat` if no exact version was matched.
Since the fact was resolved, a lower resolution fact could not be used

This commit adds fedora as a recognized release string so the redhat
resolution behaves as expected.
