### PR TITLE
Consolidate several queries for hw.physmem on BSD.

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -111,14 +111,10 @@ module Facter::Memory
 
   def self.mem_size_info(kernel = Facter.value(:kernel))
     case kernel
-    when /OpenBSD/i
-      Facter::Util::Resolution.exec("sysctl hw.physmem | cut -d'=' -f2")
-    when /FreeBSD/i
+    when /Dragonfly/i, /FreeBSD/i, /OpenBSD/i
       Facter::Util::Resolution.exec("sysctl -n hw.physmem")
     when /Darwin/i
       Facter::Util::Resolution.exec("sysctl -n hw.memsize")
-    when /Dragonfly/i
-      Facter::Util::Resolution.exec("sysctl -n hw.physmem")
     when /AIX/i
       if Facter::Util::Resolution.exec("/usr/bin/svmon -O unit=KB") =~ /^memory\s+(\d+)\s+/
         $1

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -183,7 +183,7 @@ describe "Memory facts" do
 
       Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(my_fixture_read('openbsd-vmstat'))
 
-      Facter::Util::Resolution.stubs(:exec).with("sysctl hw.physmem | cut -d'=' -f2").returns('267321344')
+      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.physmem').returns('267321344')
 
       Facter.collection.internal_loader.load(:memory)
     end


### PR DESCRIPTION
There's no need to have three different checks for the same way of calling 'sysctl -n hw.physmem'. While here, adjust the spec test for OpenBSD as using 'sysctl -n' is equivalent to the cut(1) dance.
