### PR TITLE
Add support for Mageia to osfamily.rb

### DIFF
--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -28,7 +28,7 @@ Facter.add(:osfamily) do
       "Gentoo"
     when "Archlinux"
       "Archlinux"
-    when "Mandrake", "Mandriva"
+    when "Mandrake", "Mandriva", "Mageia"
       "Mandrake"
     else
       Facter.value("kernel")

--- a/spec/unit/osfamily_spec.rb
+++ b/spec/unit/osfamily_spec.rb
@@ -32,6 +32,7 @@ describe "OS Family fact" do
     'SLED'        => 'Suse',
     'OpenSuSE'    => 'Suse',
     'SuSE'        => 'Suse',
+    'Mageia'      => 'Mandrake',
     'Mandriva'    => 'Mandrake',
     'Mandrake'    => 'Mandrake'
   }.each do |os,family|
@@ -48,7 +49,6 @@ describe "OS Family fact" do
     'Slamd64',
     'Slackware',
     'Alpine',
-    'Mageia',
     'ESXi',
     'windows',
     'HP-UX'


### PR DESCRIPTION
The addition of Mageia OS in https://github.com/puppetlabs/facter/commit/e2f040a5bc4ed7539ecc54a5c3d26f93a9ed6a18 (Ticket #9929) was incomplete. Mageia is derived from Mandrake and Mandriva, and so is in the same family.
