### PR TITLE
Add Facter::Util::BSD for a consistent way of dealing with sysctl(8).

### DIFF
--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -10,6 +10,7 @@
 #
 # Caveats:
 #
+require 'facter/util/posix'
 
 Facter.add(:kernelrelease) do
   setcode 'uname -r'
@@ -23,7 +24,7 @@ end
 Facter.add("kernelrelease") do
   confine :kernel => :openbsd
   setcode do
-    Facter::Util::Resolution.exec("/sbin/sysctl -n kern.version").split(' ')[1]
+    Facter::Util::POSIX.sysctl("kern.version").split(' ')[1]
   end
 end
 

--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -85,7 +85,7 @@ end
 Facter.add("SwapEncrypted") do
   confine :kernel => :openbsd
   setcode do
-    sysctl_encrypted = Facter::Util::Resolution.exec("sysctl -n vm.swapencrypt.enable").to_i
+    sysctl_encrypted = Facter::Util::POSIX.sysctl("vm.swapencrypt.enable").to_i
     !(sysctl_encrypted.zero?)
   end
 end
@@ -93,7 +93,7 @@ end
 Facter.add("SwapEncrypted") do
   confine :kernel => :Darwin
   setcode do
-    swap = Facter::Util::Resolution.exec('sysctl vm.swapusage')
+    swap = Facter::Util::POSIX.sysctl('vm.swapusage')
     encrypted = false
     if swap =~ /\(encrypted\)/ then encrypted = true; end
     encrypted
@@ -149,8 +149,8 @@ end
 Facter.add("swapsize_mb") do
   confine :kernel => :dragonfly
   setcode do
-    page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
-    swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
+    page_size = Facter::Util::POSIX.sysctl("hw.pagesize").to_f
+    swaptotal = Facter::Util::POSIX.sysctl("vm.swap_size").to_f * page_size
     "%.2f" % [(swaptotal.to_f / 1024.0) / 1024.0]
   end
 end
@@ -158,10 +158,10 @@ end
 Facter.add("swapfree_mb") do
   confine :kernel => :dragonfly
   setcode do
-    page_size = Facter::Util::Resolution.exec("/sbin/sysctl -n hw.pagesize").to_f
-    swaptotal = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_size").to_f * page_size
-    swap_anon_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_anon_use").to_f * page_size
-    swap_cache_use = Facter::Util::Resolution.exec("/sbin/sysctl -n vm.swap_cache_use").to_f * page_size
+    page_size = Facter::Util::POSIX.sysctl("hw.pagesize").to_f
+    swaptotal = Facter::Util::POSIX.sysctl("vm.swap_size").to_f * page_size
+    swap_anon_use = Facter::Util::POSIX.sysctl("vm.swap_anon_use").to_f * page_size
+    swap_cache_use = Facter::Util::POSIX.sysctl("vm.swap_cache_use").to_f * page_size
     swapfree = swaptotal - swap_anon_use - swap_cache_use
     "%.2f" % [(swapfree.to_f / 1024.0) / 1024.0]
   end

--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -9,6 +9,8 @@
 #
 # Caveats:
 #
+require 'facter/util/posix'
+
 Facter.add('physicalprocessorcount') do
   confine :kernel => :linux
 
@@ -83,6 +85,6 @@ end
 Facter.add('physicalprocessorcount') do
   confine :kernel => :openbsd
   setcode do
-    Facter::Util::Resolution.exec("sysctl -n hw.ncpufound")
+    Facter::Util::POSIX.sysctl("hw.ncpufound")
   end
 end

--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -21,6 +21,7 @@
 
 require 'thread'
 require 'facter/util/processor'
+require 'facter/util/posix'
 
 # We have to enumerate these outside a Facter.add block to get the processorN
 # descriptions iteratively (but we need them inside the Facter.add block above
@@ -108,7 +109,9 @@ end
 
 Facter.add("ProcessorCount") do
   confine :kernel => :Darwin
-  setcode "sysctl -n hw.ncpu"
+  setcode do
+    Facter::Util::POSIX.sysctl("hw.ncpu")
+  end
 end
 
 if Facter.value(:kernel) == "windows"
@@ -151,12 +154,16 @@ end
 
 Facter.add("Processor") do
   confine :kernel => [:dragonfly,:freebsd]
-  setcode "sysctl -n hw.model"
+  setcode do
+    Facter::Util::POSIX.sysctl("hw.model")
+  end
 end
 
 Facter.add("ProcessorCount") do
   confine :kernel => [:dragonfly,:freebsd,:openbsd]
-  setcode "sysctl -n hw.ncpu"
+  setcode do
+    Facter::Util::POSIX.sysctl("hw.ncpu")
+  end
 end
 
 Facter.add("ProcessorCount") do

--- a/lib/facter/util/blockdevices/freebsd.rb
+++ b/lib/facter/util/blockdevices/freebsd.rb
@@ -1,3 +1,5 @@
+require 'facter/util/posix'
+
 module Facter::Util::Blockdevices
 
   module FreeBSD
@@ -19,7 +21,7 @@ module Facter::Util::Blockdevices
     end
 
     def self.devices
-      Facter::Util::Resolution.exec('/sbin/sysctl -n kern.disks').split(' ').sort
+      Facter::Util::POSIX.sysctl('kern.disks').split(' ').sort
     end
 
     private

--- a/lib/facter/util/manufacturer.rb
+++ b/lib/facter/util/manufacturer.rb
@@ -1,8 +1,9 @@
 # mamufacturer.rb
 # Support methods for manufacturer specific facts
 
-module Facter::Manufacturer
+require 'facter/util/posix'
 
+module Facter::Manufacturer
   def self.get_dmi_table()
     case Facter.value(:kernel)
     when 'Linux', 'GNU/kFreeBSD'
@@ -54,7 +55,7 @@ module Facter::Manufacturer
     name.each do |sysctlkey,facterkey|
       Facter.add(facterkey) do
         confine :kernel => [:openbsd, :darwin]
-        setcode "sysctl -n #{sysctlkey} 2>/dev/null"
+        setcode Facter::Util::POSIX.sysctl(sysctlkey)
       end
     end
   end

--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -2,6 +2,8 @@
 ## Support module for memory related facts
 ##
 
+require 'facter/util/posix'
+
 module Facter::Memory
   def self.meminfo_number(tag)
     memsize = ""
@@ -112,9 +114,9 @@ module Facter::Memory
   def self.mem_size_info(kernel = Facter.value(:kernel))
     case kernel
     when /Dragonfly/i, /FreeBSD/i, /OpenBSD/i
-      Facter::Util::Resolution.exec("sysctl -n hw.physmem")
+      Facter::Util::POSIX.sysctl("hw.physmem")
     when /Darwin/i
-      Facter::Util::Resolution.exec("sysctl -n hw.memsize")
+      Facter::Util::POSIX.sysctl("hw.memsize")
     when /AIX/i
       if Facter::Util::Resolution.exec("/usr/bin/svmon -O unit=KB") =~ /^memory\s+(\d+)\s+/
         $1
@@ -152,7 +154,7 @@ module Facter::Memory
     when /FreeBSD/i
       Facter::Util::Resolution.exec('swapinfo -k')
     when /Darwin/i
-      Facter::Util::Resolution.exec('sysctl vm.swapusage')
+      Facter::Util::POSIX.sysctl('vm.swapusage')
     when /SunOS/i
       Facter::Util::Resolution.exec('/usr/sbin/swap -l')
     end

--- a/lib/facter/util/posix.rb
+++ b/lib/facter/util/posix.rb
@@ -1,0 +1,16 @@
+module Facter
+module Util
+module POSIX
+  # Provides a consistent way of invoking sysctl(8) across POSIX platforms
+  #
+  # @param mib [String] the sysctl(8) MIB name
+  #
+  # @api private
+  def sysctl(mib)
+    Facter::Util::Resolution.exec("/sbin/sysctl -n #{mib} 2>/dev/null")
+  end
+
+  module_function :sysctl
+end
+end
+end

--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -1,3 +1,4 @@
+require 'facter/util/posix'
 require 'facter/util/file_read'
 
 module Facter::Util::Virtual
@@ -92,7 +93,7 @@ module Facter::Util::Virtual
      txt = if FileTest.exists?("/proc/cpuinfo")
        File.read("/proc/cpuinfo")
      elsif ["FreeBSD", "OpenBSD"].include? Facter.value(:kernel)
-       Facter::Util::Resolution.exec("/sbin/sysctl -n hw.model")
+       Facter::Util::POSIX.sysctl("hw.model")
      end
      if txt =~ /QEMU Virtual CPU/ then true
      elsif txt =~ /Common KVM processor/ then true

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -86,7 +86,7 @@ Facter.add("virtual") do
   confine :kernel => 'OpenBSD'
 
   setcode do
-    output = Facter::Util::Resolution.exec('sysctl -n hw.product 2>/dev/null')
+    output = Facter::Util::POSIX.sysctl("hw.product")
     Facter::Util::Virtual.parse_virtualization(output)
   end
 end

--- a/spec/unit/blockdevices_spec.rb
+++ b/spec/unit/blockdevices_spec.rb
@@ -19,7 +19,7 @@ describe "Block device facts" do
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
 
-      Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n kern.disks").returns("cd0 da0 ada0 ad10 mfi0")
+      Facter::Util::POSIX.stubs(:sysctl).with("kern.disks").returns("cd0 da0 ada0 ad10 mfi0")
 
       Facter::Util::Resolution.stubs(:exec).with("/sbin/camcontrol inquiry cd0 -D").returns("pass0: <TEAC DV-28E-N 1.6A> Removable CD-ROM SCSI-0 device")
       Facter::Util::Resolution.stubs(:exec).with("/sbin/camcontrol inquiry da0 -D").returns("pass1: <HP 73.4G MAU3073NC HPC2> Fixed Direct Access SCSI-3 device")

--- a/spec/unit/kernelrelease_spec.rb
+++ b/spec/unit/kernelrelease_spec.rb
@@ -57,12 +57,12 @@ describe "Kernel release fact" do
     end
 
     it 'parses 5.3-current sysctl output' do
-      Facter::Util::Resolution.expects(:exec).with("/sbin/sysctl -n kern.version").returns(my_fixture_read('openbsd-5.3-current'))
+      Facter::Util::POSIX.stubs(:sysctl).with("kern.version").returns(my_fixture_read('openbsd-5.3-current'))
       Facter.value(:kernelrelease).should == '5.3-current'
     end
 
     it 'parses 5.3 sysctl output' do
-      Facter::Util::Resolution.expects(:exec).with("/sbin/sysctl -n kern.version").returns(my_fixture_read('openbsd-5.3'))
+      Facter::Util::POSIX.stubs(:sysctl).with("kern.version").returns(my_fixture_read('openbsd-5.3'))
       Facter.value(:kernelrelease).should == '5.3'
     end
   end

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -47,9 +47,9 @@ describe "Memory facts" do
   describe "on Darwin" do
     before(:each) do
       Facter.fact(:kernel).stubs(:value).returns("Darwin")
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.memsize').returns('8589934592')
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.memsize').returns('8589934592')
       Facter::Util::Resolution.stubs(:exec).with('vm_stat').returns(my_fixture_read('darwin-vm_stat'))
-      Facter::Util::Resolution.stubs(:exec).with('sysctl vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 1.00M  free = 63.00M  (encrypted)")
+      Facter::Util::POSIX.stubs(:sysctl).with('vm.swapusage').returns("vm.swapusage: total = 64.00M  used = 1.00M  free = 63.00M  (encrypted)")
 
       Facter.collection.internal_loader.load(:memory)
     end
@@ -183,9 +183,9 @@ describe "Memory facts" do
 
       Facter::Util::Resolution.stubs(:exec).with('vmstat').returns(my_fixture_read('openbsd-vmstat'))
 
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.physmem').returns('267321344')
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.physmem').returns('267321344')
 
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n vm.swapencrypt.enable').returns('1')
+      Facter::Util::POSIX.stubs(:sysctl).with('vm.swapencrypt.enable').returns('1')
 
       Facter.collection.internal_loader.load(:memory)
     end
@@ -307,14 +307,14 @@ describe "Memory facts" do
         Facter.fact(:kernel).stubs(:value).returns("dragonfly")
 
         swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
-        Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n hw.pagesize').returns("4096")
-        Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_size').returns("128461")
-        Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_anon_use').returns("2635")
-        Facter::Util::Resolution.stubs(:exec).with('/sbin/sysctl -n vm.swap_cache_use').returns("0")
+        Facter::Util::POSIX.stubs(:sysctl).with('hw.pagesize').returns("4096")
+        Facter::Util::POSIX.stubs(:sysctl).with('vm.swap_size').returns("128461")
+        Facter::Util::POSIX.stubs(:sysctl).with('vm.swap_anon_use').returns("2635")
+        Facter::Util::POSIX.stubs(:sysctl).with('vm.swap_cache_use').returns("0")
 
         Facter::Util::Resolution.stubs(:exec).with('vmstat').returns my_fixture_read('dragonfly-vmstat')
 
-        Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.physmem").returns('248512512')
+        Facter::Util::POSIX.stubs(:sysctl).with("hw.physmem").returns('248512512')
 
         Facter.collection.internal_loader.load(:memory)
       end
@@ -346,7 +346,7 @@ describe "Memory facts" do
         Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
 
         Facter::Util::Resolution.stubs(:exec).with('vmstat -H').returns my_fixture_read('freebsd-vmstat')
-        Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.physmem').returns '1056276480'
+        Facter::Util::POSIX.stubs(:sysctl).with('hw.physmem').returns '1056276480'
       end
 
       after(:each) do

--- a/spec/unit/physicalprocessorcount_spec.rb
+++ b/spec/unit/physicalprocessorcount_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'facter/util/posix'
 
 describe "Physical processor count facts" do
 
@@ -144,7 +145,7 @@ describe "Physical processor count facts" do
   describe "on openbsd" do
     it "should return 4 physical CPUs" do
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
-      Facter::Util::Resolution.expects(:exec).with("sysctl -n hw.ncpufound").returns("4")
+      Facter::Util::POSIX.expects(:sysctl).with("hw.ncpufound").returns("4")
       Facter.fact(:physicalprocessorcount).value.should == "4"
     end
   end

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 
+require 'facter/util/posix'
 require 'facter/util/processor'
 require 'spec_helper'
 
@@ -202,38 +203,39 @@ describe "Processor facts" do
 
     it "should be 2 on dual-processor Darwin box" do
       Facter.fact(:kernel).stubs(:value).returns("Darwin")
-      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.ncpu").returns('2')
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.ncpu").returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should be 2 on dual-processor OpenBSD box" do
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
-      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.ncpu").returns('2')
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.ncpu").returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should be 2 on dual-processor FreeBSD box" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.ncpu").returns('2')
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.ncpu").returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should print the correct CPU Model on FreeBSD" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.model").returns('SomeVendor CPU 3GHz')
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.model").returns('SomeVendor CPU 3GHz')
 
       Facter.fact(:processor).value.should == "SomeVendor CPU 3GHz"
     end
 
     it "should be 2 on dual-processor DragonFly box" do
       Facter.fact(:kernel).stubs(:value).returns("DragonFly")
-      Facter::Util::Resolution.stubs(:exec).with("sysctl -n hw.ncpu").returns('2')
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.ncpu").returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
+
     describe "on solaris" do
       before :all do
         @fixture_kstat_sparc  = File.read(fixtures('processorcount','solaris-sparc-kstat-cpu-info'))

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -229,14 +229,14 @@ EOT
   it "should detect kvm on FreeBSD" do
     FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(false)
     Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-    Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n hw.model").returns("QEMU Virtual CPU version 0.12.4")
+    Facter::Util::POSIX.stubs(:sysctl).with("hw.model").returns("QEMU Virtual CPU version 0.12.4")
     Facter::Util::Virtual.should be_kvm
   end
 
   it "should detect kvm on OpenBSD" do
     FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(false)
     Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
-    Facter::Util::Resolution.stubs(:exec).with("/sbin/sysctl -n hw.model").returns('QEMU Virtual CPU version (cpu64-rhel6) ("AuthenticAMD" 686-class, 512KB L2 cache)')
+    Facter::Util::POSIX.stubs(:sysctl).with("hw.model").returns('QEMU Virtual CPU version (cpu64-rhel6) ("AuthenticAMD" 686-class, 512KB L2 cache)')
     Facter::Util::Virtual.should be_kvm
   end
 

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -265,22 +265,22 @@ describe "Virtual fact" do
     end
 
     it "should be parallels with Parallels product name from sysctl" do
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.product 2>/dev/null').returns("Parallels Virtual Platform")
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("Parallels Virtual Platform")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
     it "should be vmware with VMware product name from sysctl" do
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.product 2>/dev/null').returns("VMware Virtual Platform")
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("VMware Virtual Platform")
       Facter.fact(:virtual).value.should == "vmware"
     end
 
     it "should be virtualbox with VirtualBox product name from sysctl" do
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.product 2>/dev/null').returns("VirtualBox")
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("VirtualBox")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
 
     it "should be xenhvm with Xen HVM product name from sysctl" do
-      Facter::Util::Resolution.stubs(:exec).with('sysctl -n hw.product 2>/dev/null').returns("HVM domU")
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("HVM domU")
       Facter.fact(:virtual).value.should == "xenhvm"
     end
   end


### PR DESCRIPTION
As suggested by @adrienthebo, here's an implementation of Facter::Util::BSD. There were various ways of calling sysctl(8) across and this unifies them.
