### PR TITLE
(#22060) Fix undefined path in macaddress.rb

### DIFF
--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -12,19 +12,6 @@ require 'facter/util/ip'
 
 Facter.add(:macaddress) do
   confine :kernel => 'Linux'
-  has_weight  10                # about an order of magnitude faster
-  setcode do
-    begin
-      Dir.glob('/sys/class/net/*').reject {|x| x[-3..-1] == '/lo' }.first
-      path and File.read(path + '/address')
-    rescue Exception
-      nil
-    end
-  end
-end
-
-Facter.add(:macaddress) do
-  confine :kernel => 'Linux'
   setcode do
     ether = []
     output = Facter::Util::IP.exec_ifconfig(["-a","2>/dev/null"])


### PR DESCRIPTION
While running `puppet agent --no-daemonize --debug`, and IFF somewhere in the
code I have $DEBUG = true, then if I Ctrl-C to kill the agent I see the
following exception:

  Exception `NilClass' at .../facter/lib/facter/macaddress.rb:19 -
  undefined local variable or method`path' for :Facter::Util::Resolution

This is followed by an "infinite" recursion / stackoverflow.
