### PR TITLE
(#22097) Use LC_ALL instead of LANG

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -197,9 +197,9 @@ class Facter::Util::Resolution
   def self.exec(code, interpreter = nil)
     Facter.warnonce "The interpreter parameter to 'exec' is deprecated and will be removed in a future version." if interpreter
 
-    ## Set LANG to force i18n to C for the duration of this exec; this ensures that any code that parses the
+    ## Set LC_ALL to force i18n to C for the duration of this exec; this ensures that any code that parses the
     ## output of the command can expect it to be in a consistent / predictable format / locale
-    with_env "LANG" => "C" do
+    with_env "LC_ALL" => "C" do
 
       if expanded_code = expand_command(code)
         # if we can find the binary, we'll run the command with the expanded path to the binary

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -594,8 +594,8 @@ describe Facter::Util::Resolution do
       Facter::Util::Resolution.exec(echo_command).should == "foo"
     end
 
-    it "should override the LANG environment variable" do
-      Facter::Util::Resolution.exec(echo_env_var_command % 'LANG').should == "C"
+    it "should override the LC_ALL environment variable" do
+      Facter::Util::Resolution.exec(echo_env_var_command % 'LC_ALL').should == "C"
     end
 
     it "should respect other overridden environment variables" do
@@ -604,27 +604,27 @@ describe Facter::Util::Resolution do
       end
     end
 
-    it "should restore overridden LANG environment variable after execution" do
+    it "should restore overridden LC_ALL environment variable after execution" do
       # we're going to call with_env in a nested fashion, to make sure that the environment gets restored properly
       # at each level
-      Facter::Util::Resolution.with_env( {"LANG" => "foo"} ) do
-        # Resolution.exec always overrides 'LANG' for its own execution scope
-        Facter::Util::Resolution.exec(echo_env_var_command % 'LANG').should == "C"
+      Facter::Util::Resolution.with_env( {"LC_ALL" => "foo"} ) do
+        # Resolution.exec always overrides 'LC_ALL' for its own execution scope
+        Facter::Util::Resolution.exec(echo_env_var_command % 'LC_ALL').should == "C"
         # But after 'exec' completes, we should see our value restored
-        ENV['LANG'].should == "foo"
+        ENV['LC_ALL'].should == "foo"
         # Now we'll do a nested call to with_env
-        Facter::Util::Resolution.with_env( {"LANG" => "bar"} ) do
+        Facter::Util::Resolution.with_env( {"LC_ALL" => "bar"} ) do
           # During 'exec' it should still be 'C'
-          Facter::Util::Resolution.exec(echo_env_var_command % 'LANG').should == "C"
+          Facter::Util::Resolution.exec(echo_env_var_command % 'LC_ALL').should == "C"
           # After exec it should be restored to our current value for this level of the nesting...
-          ENV['LANG'].should == "bar"
+          ENV['LC_ALL'].should == "bar"
         end
         # Now we've dropped out of one level of nesting,
-        ENV['LANG'].should == "foo"
+        ENV['LC_ALL'].should == "foo"
         # Call exec one more time just for kicks
-        Facter::Util::Resolution.exec(echo_env_var_command % 'LANG').should == "C"
+        Facter::Util::Resolution.exec(echo_env_var_command % 'LC_ALL').should == "C"
         # One last check at our current nesting level.
-        ENV['LANG'].should == "foo"
+        ENV['LC_ALL'].should == "foo"
       end
     end
 


### PR DESCRIPTION
since LANG doesn't override LC_\* when set explicitly:

  $ LC_MESSAGES=de_DE.UTF-8 LANG=C ifconfig
  eth0 Link encap:Ethernet Hardware Adresse 52:54:00:0E:3F:E5
  inet Adresse:10.174.252.56  Bcast:10.174.255.255  Maske:255.255.252.0

See the Adresse vs. the expected addr, whereas:

  $ LC_MESSAGES=de_DE.UTF-8 LC_ALL=C ifconfig
  eth0 Link encap:Ethernet HWaddr 52:54:00:0E:3F:E5
  inet addr:10.174.252.56  Bcast:10.174.255.255  Mask:255.255.252.0

See http://pubs.opengroup.org/onlinepubs/007908799/xbd/envvar.html
