### PR TITLE
21760/22005 update preflight to delete old lib dir

### DIFF
--- a/ext/osx/preflight.erb
+++ b/ext/osx/preflight.erb
@@ -9,7 +9,7 @@
 # when being installed to volumes other than the current OS.
 
 <%- ["@apple_libdir", "@apple_sbindir", "@apple_bindir", "@apple_docdir", "@package_name"].each do |i| -%>
-  <%- val = eval(i) -%>
+  <%- val = instance_variable_get(i) -%>
   <%- raise "Critical variable #{i} is unset!" if val.nil? or val.empty? -%>
 <%- end -%>
 


### PR DESCRIPTION
In order to install in the top-level site_ruby directory, we need to clean out
any installs in the old site_ruby/1.8 location. We're doing this by setting a
variable in the package:apple task. If it's set, we remove all files there as
well as files in the new location.

While I'm here:
- update erb to strip leading and trailing spaces
- validate critical variables so a script is never generated with dangerous paths
- only target top-level files/dirs in lib, since we're doing rm -RF anyway
