### PR TITLE
(#22107) Force ASCII-8BIT encoding on raw data in property lists

### DIFF
--- a/lib/facter/util/cfpropertylist/lib/rbCFPropertyList.rb
+++ b/lib/facter/util/cfpropertylist/lib/rbCFPropertyList.rb
@@ -164,7 +164,12 @@ module Facter::Util::CFPropertyList
       when Object.const_defined?('BigDecimal') && object.is_a?(BigDecimal)
         CFReal.new(object)
       when object.respond_to?(:read)
-        CFData.new(object.read(), CFData::DATA_RAW)
+        raw_data = object.read
+        # treat the data as a bytestring (ASCII-8BIT) if Ruby supports it.  Do this by forcing
+        # the encoding, on the assumption that the bytes were read correctly, and just tagged with
+        # an inappropriate encoding, rather than transcoding.
+        raw_data.force_encoding(Encoding::ASCII_8BIT) if raw_data.respond_to?(:force_encoding)
+        CFData.new(raw_data, CFData::DATA_RAW)
       when options[:converter_method] && object.respond_to?(options[:converter_method])
         if options[:converter_with_opts]
           Facter::Util::CFPropertyList.guess(object.send(options[:converter_method],options),options)


### PR DESCRIPTION
Ruby-1.9 and up default to UTF-8 encoding for strings, but CFData is
used to store bytestrings in plists as read from file-like objects.  So,
disregard the encoding returned from `obj.read`, treating the string as
a bytestring.

I'll admit that it's more than a little yucky that a puppet provider is depending on a library stashed away in puppet/util.
