### PR TITLE
(#22143) Add 'gid' fact to resolve users primary group.

### DIFF
--- a/lib/facter/gid.rb
+++ b/lib/facter/gid.rb
@@ -1,0 +1,15 @@
+# Fact: gid
+#
+# Purpose: Return the gid of the user running Puppet
+#
+# Resolution:
+#
+# Caveats:
+# Not supported in windows yet.
+
+Facter.add(:gid) do
+  confine do
+    Facter::Util::Resolution.which('id')
+  end
+  setcode 'id -ng'
+end

--- a/spec/unit/gid_spec.rb
+++ b/spec/unit/gid_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe "gid fact" do
+
+  describe "on systems with id" do
+    it "should return the current group" do
+      Facter::Util::Resolution.expects(:which).with('id').returns(true)
+      Facter::Util::Resolution.expects(:exec).once.with('id -ng').returns 'bar'
+
+      Facter.fact(:gid).value.should == 'bar'
+    end
+  end
+
+  describe "on systems without id" do
+    it "is not supported" do
+      Facter::Util::Resolution.expects(:which).with('id').returns(false)
+
+      Facter.fact(:gid).value.should == nil
+    end
+  end
+
+end


### PR DESCRIPTION
A very simple fact to fetch the primary group.  I've only tested
this on Linux/OSX/FreeBSD but id -ng seems to be global.  I even
got a user to test it on Hurd and it worked.
