### PR TITLE
(#12116) Windows domain/fqdn error when no domain

### DIFF
--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -29,11 +29,14 @@ Facter.add(:domain) do
     # Due to dangerous behavior of 'hostname -f' on old OS, we will explicitly opt-in
     # 'hostname -f' --hkenney May 9, 2012
     basic_hostname = 'hostname 2> /dev/null'
+    windows_hostname = 'hostname > NUL'
     full_hostname = 'hostname -f 2> /dev/null'
     can_do_hostname_f = Regexp.union /Linux/i, /FreeBSD/i, /Darwin/i
 
     hostname_command = if Facter.value(:kernel) =~ can_do_hostname_f
                          full_hostname
+                       elsif Facter.value(:kernel) == "windows"
+                         windows_hostname
                        else
                          basic_hostname
                        end
@@ -42,7 +45,7 @@ Facter.add(:domain) do
       and name =~ /.*?\.(.+$)/
 
       return_value = $1
-    elsif domain = Facter::Util::Resolution.exec('dnsdomainname 2> /dev/null') \
+    elsif Facter.value(:kernel) != "windows" and domain = Facter::Util::Resolution.exec('dnsdomainname 2> /dev/null') \
       and domain =~ /.+/
 
       return_value = domain
@@ -80,6 +83,9 @@ Facter.add(:domain) do
         break
       }
     end
+
+    domain ||= ''
+
     domain.gsub(/\.$/, '')
   end
 end

--- a/spec/unit/domain_spec.rb
+++ b/spec/unit/domain_spec.rb
@@ -172,6 +172,22 @@ describe "Domain name facts" do
 
         Facter.fact(:domain).value.should == 'foo.com'
       end
+
+      context "without any network adapters with a specified DNSDomain" do
+        let(:hostname_command) { 'hostname > NUL' }
+
+        it "should return nil" do
+          nic = stubs 'nic'
+          nic.stubs(:DNSDomain).returns(nil)
+          Facter::Util::Resolution.stubs(:exec).with(hostname_command).returns('sometest')
+          FileTest.stubs(:exists?).with("/etc/resolv.conf").returns(false)
+
+          require 'facter/util/wmi'
+          Facter::Util::WMI.stubs(:execquery).with("select DNSDomain from Win32_NetworkAdapterConfiguration where IPEnabled = True").returns([nic])
+
+          Facter.fact(:domain).value.should be_nil
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This fixes an annoying issue that causes facter to throw errors when domain is
not properly configured or doesn't exist. With this fix, it will properly
return an empty domain and empty fqdn without errorring.

When moving up the chain to the less specific domain fact, added a
windows_hostname command and a check so that it also does not fail with path
not found errors.

Paired-with: Josh Cooper josh@puppetlabs.com
