### PR TITLE
(#22233) Guarded json require for gce fact

### DIFF
--- a/lib/facter/util/gce.rb
+++ b/lib/facter/util/gce.rb
@@ -22,7 +22,6 @@
 
 require 'timeout'
 require 'open-uri'
-require 'json'
 
 # Provide a set of utility static methods that help with resolving the GCE
 # fact.
@@ -110,6 +109,7 @@ module Facter::Util::GCE
       # Read the list of supported API versions
       Timeout.timeout(timeout) do
         if body = read_uri("#{METADATA_URL}")
+          require_json
           metadata_facts("gce", JSON.parse(body))
         end
       end
@@ -150,4 +150,12 @@ module Facter::Util::GCE
     @add_gce_facts_has_run = true
     with_metadata_server :timeout => 50
   end
+
+  private
+
+  # @api private
+  def self.require_json
+    raise(LoadError, "no json gem") if !Facter.json?
+  end
+
 end

--- a/spec/unit/util/gce_spec.rb
+++ b/spec/unit/util/gce_spec.rb
@@ -28,9 +28,7 @@ describe Facter::Util::GCE do
     end
 
     subject do
-      Facter::Util::GCE.with_metadata_server do
-        true
-      end
+      Facter::Util::GCE.with_metadata_server
     end
 
     it 'returns false when not running on gce' do
@@ -39,22 +37,32 @@ describe Facter::Util::GCE do
     end
 
     context 'default options and running on a gce virtual machine' do
+
       before :each do
         Facter.stubs(:value).with('virtual').returns('gce')
       end
+
       it 'returns false when the metadata server is unreachable' do
         described_class.stubs(:read_uri).raises(Errno::ENETUNREACH)
         subject.should be_false
       end
+
       it 'does not execute the block if the connection raises an exception' do
         described_class.stubs(:read_uri).raises(Timeout::Error)
         subject.should be_false
       end
+
       it 'succeeds on the third retry' do
         retry_metadata = sequence('metadata')
         Timeout.expects(:timeout).twice.in_sequence(retry_metadata).raises(Timeout::Error)
         Timeout.expects(:timeout).once.in_sequence(retry_metadata).returns(true)
         subject.should be_true
+      end
+
+      it 'raises an error if json gem is not present' do
+        Facter.stubs(:json?).returns(false)
+        described_class.stubs(:read_uri).returns('{"some":"json"}')
+        expect { subject }.to raise_error(LoadError, /json/)
       end
     end
   end


### PR DESCRIPTION
The gce fact was requiring json, creating a dependency in Facter where
non had existed (except on development/test instances).  This was
producing unwanted errors in Ruby 1.8.7 where the json gem was not
present, and no gce facts were available anyway.

This commit ensures that we only attempt to load json if we are in the
gce environment (as determined by a metadata url resolving) and actually
have gce data to parse.
