### PR TITLE
Update xendomains.rb

### DIFF
--- a/lib/facter/util/xendomains.rb
+++ b/lib/facter/util/xendomains.rb
@@ -1,16 +1,20 @@
 # A module to gather running Xen Domains
 #
 module Facter::Util::Xendomains
+  XEN_COMMANDS = ['/usr/sbin/xl', '/usr/sbin/xm']
+
+  def self.xen_command
+    XEN_COMMANDS.find { |cmd| Facter::Util::Resolution.which(cmd) }
+  end
+
   def self.get_domains
-    attr_reader :xen_commands
-    @xen_commands = ['/usr/sbin/xl', '/usr/sbin/xm']
-    command = @xen_commands.find { |cmd| Facter::Util::Resolution.which(cmd) }
+    command = self.xen_command
     if command
-                        if xm_list = Facter::Util::Resolution.exec("#{command} list 2>/dev/null")
-                                domains = xm_list.split("\n").reject { |line| line =~ /^(Name|Domain-0)/ }
-                                domains.map { |line| line.split(/\s/)[0] }.join(',')
-                        end
-                end
+      if domains_list = Facter::Util::Resolution.exec("#{command} list 2>/dev/null")
+        domains = domains_list.split("\n").reject { |line| line =~ /^(Name|Domain-0)/ }
+        domains.map { |line| line.split(/\s/)[0] }.join(',')
+      end
+    end
   end
 end
 

--- a/spec/unit/util/xendomains_spec.rb
+++ b/spec/unit/util/xendomains_spec.rb
@@ -17,22 +17,30 @@ describe Facter::Util::Xendomains do
           Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(nil)
           Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
         end
+        describe ".xen_command" do
+          it "shuld return xl" do
+            Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns('/usr/sbin/xl')
+            Facter::Util::Xendomains.xen_command.should == "/usr/sbin/xl"
+          end
+        end
       end
       describe "when xm exists on system too" do
         it "should return a list of running Xen Domains on Xen0" do
           xen0_domains = my_fixture_read("xendomains")
           Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns('/usr/sbin/xl')
-          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/sbin/xl')
+          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/sbin/xm')
 
           Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xl list 2>/dev/null').returns(xen0_domains)
-          Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(nil)
           Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
         end
-
-        it "xl should be first element of xen_commands array" do
-	  Facter::Util::Xendomains.instance_variable_get(:@xen_commands).first.should == '/usr/sbin/xl'
+        describe ".xen_command" do
+          it "shuld return xl" do
+            Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns('/usr/sbin/xl')
+            Facter::Util::Xendomains.xen_command.should == "/usr/sbin/xl"
+          end
         end
       end
+
     end
 
     describe "when xl not exists on system and xm exists" do
@@ -41,9 +49,15 @@ describe Facter::Util::Xendomains do
         Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
         Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/sbin/xm')
 
-#        Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xl list 2>/dev/null').returns(nil)
         Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(xen0_domains)
         Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
+      end
+      describe ".xen_command" do
+        it "shuld return xm" do
+          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
+          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/sbin/xm')
+          Facter::Util::Xendomains.xen_command.should == "/usr/sbin/xm"
+        end
       end
     end
 
@@ -51,9 +65,14 @@ describe Facter::Util::Xendomains do
       it "should be nil" do
         Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
         Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns(nil)
-#        Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(nil)
-#        Facter::Util::Resolution.stubs(:exec).with('/usr/sbin/xl list 2>/dev/null').returns(nil)
         Facter::Util::Xendomains.get_domains.should == nil
+      end
+      describe ".xen_command" do
+        it "shuld return nil" do
+          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
+          Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns(nil)
+          Facter::Util::Xendomains.xen_command.should == nil
+        end
       end
     end
 


### PR DESCRIPTION
New xen (>4) use /usr/sbin/xl command (instead of /usr/sbin/xm in earlier versions of xen). That why xendomains fact doesn't work on machins with new xen. This change make xendomains fact working in both, old and new xens.
