### PR TITLE
(21868) Move facter libary target to /Library/Ruby/Site

### DIFF
--- a/ext/osx/file_mapping.yaml
+++ b/ext/osx/file_mapping.yaml
@@ -1,6 +1,6 @@
 directories:
   lib:
-    path: 'usr/lib/ruby/site_ruby/1.8'
+    path: 'Library/Ruby/Site'
     owner: 'root'
     group: 'wheel'
     perms: '0644'


### PR DESCRIPTION
We currently drop the facter library files in /usr/lib/ruby/site_ruby/1.8
OSX, which is a symlink to /Library/Ruby/Site/1.8. As of OSX 10.9 Mavericks
this will no longer work because it will be ruby 2.0.0. There are hard way
and easy ways to solve this problem. A hard way would be to somehow
introspect the target host at install time, and then dynamically copy the
payload into the correct ruby version specific path. Another hard way woul be
to create different OSX packages for different versions of OSX. Or, we could
pick the easy way, which is to just install into /Library/Ruby/Site (the
equivalent of /usr/lib/ruby/site_ruby). Since facter will work on all rubies
shipped with supported versions of OSX, this will "just work".

Signed-off-by: Moses Mendoza moses@puppetlabs.com
