### PR TITLE
(#22233) Warn but do not fail if find gce facts without json lib

### DIFF
--- a/lib/facter/util/gce.rb
+++ b/lib/facter/util/gce.rb
@@ -109,7 +109,7 @@ module Facter::Util::GCE
       # Read the list of supported API versions
       Timeout.timeout(timeout) do
         if body = read_uri("#{METADATA_URL}")
-          require_json
+          return false if !require_json
           metadata_facts("gce", JSON.parse(body))
         end
       end
@@ -155,7 +155,9 @@ module Facter::Util::GCE
 
   # @api private
   def self.require_json
-    raise(LoadError, "no json gem") if !Facter.json?
+    return true if Facter.json?
+    Facter.warn("Cannot load GCE facts: no JSON gem available")
+    return false
   end
 
 end

--- a/spec/unit/util/gce_spec.rb
+++ b/spec/unit/util/gce_spec.rb
@@ -17,23 +17,12 @@ require 'spec_helper'
 require 'facter/util/gce'
 
 describe Facter::Util::GCE do
-  # This is the standard prefix for making an API call in GCE (or fake)
-  # environments.
-  let(:api_prefix) { "http://metadata/computeMetadata" }
-  let(:api_version) { "v1beta1" }
-
-  describe "Facter::Util::GCE.with_metadata_server", :focus => true do
-    before :each do
-      Facter::Util::GCE.stubs(:read_uri).returns(:api_version)
-    end
-
-    subject do
-      Facter::Util::GCE.with_metadata_server
-    end
+  describe "with_metadata_server", :focus => true do
+    let(:gce) { Facter::Util::GCE }
 
     it 'returns false when not running on gce' do
       Facter.stubs(:value).with('virtual').returns('vmware')
-      subject.should be_false
+      expect(gce.with_metadata_server).to be_false
     end
 
     context 'default options and running on a gce virtual machine' do
@@ -44,25 +33,36 @@ describe Facter::Util::GCE do
 
       it 'returns false when the metadata server is unreachable' do
         described_class.stubs(:read_uri).raises(Errno::ENETUNREACH)
-        subject.should be_false
+        expect(gce.with_metadata_server).to be_false
       end
 
       it 'does not execute the block if the connection raises an exception' do
         described_class.stubs(:read_uri).raises(Timeout::Error)
-        subject.should be_false
+        expect(gce.with_metadata_server).to be_false
       end
 
       it 'succeeds on the third retry' do
         retry_metadata = sequence('metadata')
         Timeout.expects(:timeout).twice.in_sequence(retry_metadata).raises(Timeout::Error)
         Timeout.expects(:timeout).once.in_sequence(retry_metadata).returns(true)
-        subject.should be_true
+        expect(gce.with_metadata_server).to be_true
       end
 
-      it 'raises an error if json gem is not present' do
-        Facter.stubs(:json?).returns(false)
-        described_class.stubs(:read_uri).returns('{"some":"json"}')
-        expect { subject }.to raise_error(LoadError, /json/)
+      context 'with gce' do
+        before do
+          described_class.stubs(:read_uri).returns('{"some":"json"}')
+        end
+
+        it 'does not raise an error but returns false if json gem is not present' do
+          Facter.stubs(:json?).returns(false)
+          expect(gce.with_metadata_server).to be_false
+        end
+
+        it 'warns if json gem is not present' do
+          Facter.stubs(:json?).returns(false)
+          Facter.expects(:warn).with("Cannot load GCE facts: no JSON gem available")
+          expect(gce.with_metadata_server).to be_false
+        end
       end
     end
   end


### PR DESCRIPTION
Previous patch to GCE would fail outright if there were GCE facts to
parse, but we had no JSON library.  It is better if Facter is allowed to
gather what facts it can rather than failing outright, so this change
just warns that we cannot load GCE facts due to missing JSON gem,
similar to how we warn if there is a problem parsing the GCE facts.

Also fixes up specs a little for consistency and to remove unused
references.
