### PR TITLE
(#22334) Use Facter's logging system for warn

### DIFF
--- a/lib/facter/util/loader.rb
+++ b/lib/facter/util/loader.rb
@@ -97,7 +97,7 @@ class Facter::Util::Loader
       # Don't store the path if the file can't be loaded
       # in case it's loadable later on.
       @loaded.delete(file)
-      warn "Error loading fact #{file} #{detail}"
+      Facter.warn "Error loading fact #{file} #{detail}"
     end
   end
 

--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -174,7 +174,7 @@ class Facter::Util::Resolution
         # command not found on Windows
         return nil
       rescue => detail
-        $stderr.puts detail
+        Facter.warn(detail)
         return nil
       end
       
@@ -307,7 +307,7 @@ class Facter::Util::Resolution
         end
       end
     rescue Timeout::Error => detail
-      warn "Timed out seeking value for %s" % self.name
+      Facter.warn "Timed out seeking value for %s" % self.name
 
       # This call avoids zombies -- basically, create a thread that will
       # dezombify all of the child processes that we're ignoring because
@@ -315,7 +315,7 @@ class Facter::Util::Resolution
       Thread.new { Process.waitall }
       return nil
     rescue => details
-      warn "Could not retrieve %s: %s" % [self.name, details]
+      Facter.warn "Could not retrieve %s: %s" % [self.name, details]
       return nil
     end
 

--- a/spec/unit/ec2_spec.rb
+++ b/spec/unit/ec2_spec.rb
@@ -136,8 +136,8 @@ describe "ec2 facts" do
     end
 
     it "should return nil if open fails" do
+      Facter.stubs(:warn) # do not pollute test output
       Facter.expects(:warn).with('Could not retrieve ec2 metadata: host unreachable')
-      Facter::Util::Resolution.any_instance.stubs(:warn) # do not pollute test output
 
       Object.any_instance.expects(:open).
         with("#{api_prefix}/2008-02-01/meta-data/").

--- a/spec/unit/util/loader_spec.rb
+++ b/spec/unit/util/loader_spec.rb
@@ -315,7 +315,7 @@ describe Facter::Util::Loader do
       Dir.expects(:entries).with("/one/dir").returns %w{a.rb}
 
       Kernel.expects(:load).with("/one/dir/a.rb").raises(LoadError)
-      @loader.expects(:warn)
+      Facter.expects(:warn)
 
       lambda { @loader.load_all }.should_not raise_error
     end

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -240,7 +240,7 @@ describe Facter::Util::Resolution do
     describe "and the code is a block" do
       it "should warn but not fail if the code fails" do
         @resolve.setcode { raise "feh" }
-        @resolve.expects(:warn)
+        Facter.expects(:warn)
         @resolve.value.should be_nil
       end
 
@@ -269,7 +269,7 @@ describe Facter::Util::Resolution do
       end
 
       it "should timeout after the provided timeout" do
-        @resolve.expects(:warn)
+        Facter.expects(:warn)
         @resolve.timeout = 0.1
         @resolve.setcode { sleep 2; raise "This is a test" }
         Thread.expects(:new).yields
@@ -278,7 +278,7 @@ describe Facter::Util::Resolution do
       end
 
       it "should waitall to avoid zombies if the timeout is exceeded" do
-        @resolve.stubs(:warn)
+        Facter.stubs(:warn)
         @resolve.timeout = 0.1
         @resolve.setcode { sleep 2; raise "This is a test" }
 


### PR DESCRIPTION
Several points in facter would use ruby's built in warn method, which always
prints to stderr. This made unstoppable messages show up on the stderr such
as:

  [vagrant@localhost ~]$ facter virtual
 Could not retrieve virtual: Permission denied -
/sys/firmware/dmi/entries/1-0/raw
 virtualbox

By using facter's normal logging system, the user has control of these 
showing up and they won't end up in stderr (which might be going nowhere in a
daemonized process).
