### PR TITLE
(#22322) Squash stderr on Solaris and AIX when there is no swap

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -148,7 +148,7 @@ module Facter::Memory
   def self.swap_info(kernel = Facter.value(:kernel))
     case kernel
     when /AIX/i
-      (Facter.value(:id) == "root") ? Facter::Util::Resolution.exec('swap -l') : nil
+      (Facter.value(:id) == "root") ? Facter::Util::Resolution.exec('swap -l 2> /dev/null') : nil
     when /OpenBSD/i
       Facter::Util::Resolution.exec('swapctl -s')
     when /FreeBSD/i
@@ -156,7 +156,7 @@ module Facter::Memory
     when /Darwin/i
       Facter::Util::POSIX.sysctl('vm.swapusage')
     when /SunOS/i
-      Facter::Util::Resolution.exec('/usr/sbin/swap -l')
+      Facter::Util::Resolution.exec('/usr/sbin/swap -l 2> /dev/null')
     end
   end
 


### PR DESCRIPTION
This patch redirects stderr to /dev/null on SOlaris and AIX when the swap -l command is issued. If no swap device is present, then the message "No swap devices configured" is printed to stderr. This, in addition to causing unnecassary log messages, causes certain cron jobs used by Puppet Enterprise to generate emails to root.
