### PR TITLE
(#22349) Read from user's home when non-root

### DIFF
--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -30,16 +30,22 @@ module Facter::Util::Config
   end
 
   def self.external_facts_dirs
-    windows_dir = windows_data_dir
-    if windows_dir.nil? then
-      ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+    if Facter::Util::Root.root?
+      windows_dir = windows_data_dir
+      if windows_dir.nil? then
+        ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+      else
+        [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
+      end
     else
-      [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
+      [File.expand_path(File.join("~", ".facter", "facts.d"))]
     end
   end
 end
 
 if Facter::Util::Config.is_windows?
-  require 'rubygems'
   require 'win32/dir'
+  require 'facter/util/windows_root'
+else
+  require 'facter/util/unix_root'
 end

--- a/lib/facter/util/unix_root.rb
+++ b/lib/facter/util/unix_root.rb
@@ -1,0 +1,5 @@
+module Facter::Util::Root
+  def self.root?
+    Process.uid == 0
+  end
+end

--- a/lib/facter/util/windows_root.rb
+++ b/lib/facter/util/windows_root.rb
@@ -1,0 +1,33 @@
+module Facter::Util::Root
+  extend ::Windows::SystemInfo
+  extend ::Windows::Security
+
+  def self.root?
+    # if Vista or later, check for unrestricted process token
+    return Win32::Security.elevated_security? unless windows_version < 6.0
+
+    # otherwise 2003 or less
+    check_token_membership
+  end
+
+  def self.check_token_membership
+    sid = 0.chr * 80
+    size = [80].pack('L')
+    member = 0.chr * 4
+
+    unless CreateWellKnownSid(WinBuiltinAdministratorsSid, nil, sid, size)
+      raise Puppet::Util::Windows::Error.new("Failed to create administrators SID")
+    end
+
+    unless IsValidSid(sid)
+      raise Puppet::Util::Windows::Error.new("Invalid SID")
+    end
+
+    unless CheckTokenMembership(nil, sid, member)
+      raise Puppet::Util::Windows::Error.new("Failed to check membership")
+    end
+
+    # Is administrators SID enabled in calling thread's access token?
+    member.unpack('L')[0] == 1
+  end
+end

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -34,6 +34,10 @@ describe Facter::Util::Config do
   end
 
   describe "external_facts_dirs" do
+    before :each do
+      Facter::Util::Root.stubs(:root?).returns(true)
+    end
+
     it "should return the default value for linux" do
       Facter::Util::Config.stubs(:is_windows?).returns(false)
       Facter::Util::Config.stubs(:windows_data_dir).returns(nil)
@@ -50,6 +54,11 @@ describe Facter::Util::Config do
       Facter::Util::Config.stubs(:is_windows?).returns(true)
       Facter::Util::Config.stubs(:windows_data_dir).returns("C:\\Documents")
       Facter::Util::Config.external_facts_dirs.should == [File.join("C:\\Documents", 'PuppetLabs', 'facter', 'facts.d')]
+    end
+
+    it "returns the users home directory when not root" do
+      Facter::Util::Root.stubs(:root?).returns(false)
+      Facter::Util::Config.external_facts_dirs.should == [File.expand_path(File.join("~", ".facter", "facts.d"))]
     end
   end
 end


### PR DESCRIPTION
The external facts directory always assumed that the user was root, or at
least had read access to the global facts.d directory. This created problems
for users with restricted permissions when running as non-root. Instead of
trying to handle the permissions problem, which would have made facter run,
this changes facter to follow the same non-root style as puppet, which is to
look in the home directory for a .facter/facts.d external facts directory.
Simply handling the error would have had two undesirable consequences: 1) it
would have hidden a problem from the user and 2) it would have made external
facts cumbersome to use as non-root as the user would always have to specify
--external-dir, which is not currently possible when facter is used by
puppet.
