### PR TITLE
Fix/master/bug16081

### DIFF
--- a/lib/facter/architecture.rb
+++ b/lib/facter/architecture.rb
@@ -4,18 +4,31 @@
 #   Return the CPU hardware architecture.
 #
 # Resolution:
-#   On OpenBSD, Linux and Debian's kfreebsd, use the hardwaremodel fact.
+#   On non-AIX IBM, OpenBSD, Linux and Debian's kfreebsd, use the hardwaremodel fact.
+#   On AIX get the arch value from lsattr -El proc0 -a type
 #   Gentoo and Debian call "x86_86" "amd64".
 #   Gentoo also calls "i386" "x86".
 #
 # Caveats:
 #
 
+require 'facter/util/architecture'
+
 Facter.add(:architecture) do
   setcode do
     model = Facter.value(:hardwaremodel)
     case model
       # most linuxen use "x86_64"
+    when /IBM*/
+      case Facter.value(:operatingsystem)
+      when "AIX"
+         arch = Facter::Util::Architecture.lsattr
+         if (match = arch.match /type\s(\S+)\s/)
+           match[1]
+         end
+      else
+        model
+      end
     when "x86_64"
       case Facter.value(:operatingsystem)
       when "Debian", "Gentoo", "GNU/kFreeBSD", "Ubuntu"

--- a/lib/facter/util/architecture.rb
+++ b/lib/facter/util/architecture.rb
@@ -1,0 +1,19 @@
+# A module to help test architecture facts on non-AIX test hardware
+
+module Facter::Util::Architecture
+  ##
+  # lsattr is intended to directly delegate to Facter::Util::Resolution.exec in
+  # an effort to make the processorX facts easier to test.  See also the
+  # {lsdev} method.
+  def self.lsattr(command="lsattr -El proc0 -a type")
+    Facter::Util::Resolution.exec(command)
+  end
+
+  ##
+  # kernel_fact_value is intended to directly delegate to Facter.value(:kernel)
+  # to make it easier to stub the kernel fact without affecting the entire
+  # system.
+  def self.kernel_fact_value
+    Facter.value(:kernel)
+  end
+end

--- a/spec/unit/architecture_spec.rb
+++ b/spec/unit/architecture_spec.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'spec_helper'
+require 'facter/util/architecture'
 
 describe "Architecture fact" do
 
@@ -50,6 +51,13 @@ describe "Architecture fact" do
 
      Facter.fact(:architecture).value.should == result
     end
+  end
+  
+  it "(#16081) should be PowerPC_POWER7 if os is AIX" do
+    Facter.fact(:kernel).stubs(:value).returns("AIX")
+    Facter::Util::Architecture.stubs(:lsattr).returns("type PowerPC_POWER7 Processor type False")
+    Facter.fact(:hardwaremodel).stubs(:value).returns("IBM,8233-E8B")
+    Facter.fact(:architecture).value.should == "PowerPC_POWER7"
   end
 
 end


### PR DESCRIPTION
(#16081) Facter reports bogus arch on AIX …

Without this patch applied facter reports the hardware model of the system rather than the processor architecture.

For example,

root@l488pp139_pub[/software/pe-aix/init] > /opt/puppet/bin/facter
architecture => IBM,9179-MHB

With the patch, the architecture for this system is:

l488pp056_pub > facter architecture
PowerPC_POWER7

while the hardwaremodel remains:

l488pp056_pub > facter hardwaremodel
IBM,9179-MHB
