### PR TITLE
(#12504) Read non-configurable file for operatingsystemrelease on Ubuntu

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -5,7 +5,7 @@
 # Resolution:
 #   On RedHat derivatives, returns their '/etc/<variant>-release' file.
 #   On Debian, returns '/etc/debian_version'.
-#   On Ubuntu, parses '/etc/issue' for the release version.
+#   On Ubuntu, parses '/etc/lsb-release' for the release version.
 #   On Suse, derivatives, parses '/etc/SuSE-release' for a selection of version
 #   information.
 #   On Slackware, parses '/etc/slackware-version'.

--- a/spec/unit/operatingsystemrelease_spec.rb
+++ b/spec/unit/operatingsystemrelease_spec.rb
@@ -184,14 +184,14 @@ describe "Operating System Release fact" do
   end
 
   context "Ubuntu" do
-    let(:issue) { "Ubuntu 10.04.4 LTS \\n \\l\n\n" }
+    let(:lsbrelease) { 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=10.04\nDISTRIB_CODENAME=lucid\nDISTRIB_DESCRIPTION="Ubuntu 10.04.4 LTS"'}
     before :each do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter.fact(:operatingsystem).stubs(:value).returns("Ubuntu")
     end
 
     it "Returns only the major and minor version (not patch version)" do
-      Facter::Util::FileRead.stubs(:read).with("/etc/issue").returns(issue)
+      Facter::Util::FileRead.stubs(:read).with("/etc/lsb-release").returns(lsbrelease)
       Facter.fact(:operatingsystemrelease).value.should == "10.04"
     end
   end


### PR DESCRIPTION
Without this patch, the operatingsystemrelease for Ubuntu is gathered by
parsing /etc/issue. This is a problem as /etc/issue is meant to have
configurable content to optionally be displayed when logging in to a
system. This patch uses /etc/lsb-release which is meant to have static
data describing the release version.
