### PR TITLE
(#22636) Allow list of external fact directories to be appended to

### DIFF
--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -29,23 +29,33 @@ module Facter::Util::Config
     end
   end
 
+  def self.external_facts_dirs=(dir)
+    @external_facts_dirs = dir
+  end
+
   def self.external_facts_dirs
+    @external_facts_dirs
+  end
+
+  def self.setup_default_ext_facts_dirs
     if Facter::Util::Root.root?
       windows_dir = windows_data_dir
       if windows_dir.nil? then
-        ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+        @external_facts_dirs = ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
       else
-        [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
+        @external_facts_dirs = [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
       end
     else
-      [File.expand_path(File.join("~", ".facter", "facts.d"))]
+      @external_facts_dirs = [File.expand_path(File.join("~", ".facter", "facts.d"))]
     end
   end
-end
 
-if Facter::Util::Config.is_windows?
-  require 'win32/dir'
-  require 'facter/util/windows_root'
-else
-  require 'facter/util/unix_root'
+  if Facter::Util::Config.is_windows?
+    require 'win32/dir'
+    require 'facter/util/windows_root'
+  else
+    require 'facter/util/unix_root'
+  end
+
+  setup_default_ext_facts_dirs
 end

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -41,24 +41,44 @@ describe Facter::Util::Config do
     it "should return the default value for linux" do
       Facter::Util::Config.stubs(:is_windows?).returns(false)
       Facter::Util::Config.stubs(:windows_data_dir).returns(nil)
+      Facter::Util::Config.setup_default_ext_facts_dirs
       Facter::Util::Config.external_facts_dirs.should == ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
     end
 
     it "should return the default value for windows 2008" do
       Facter::Util::Config.stubs(:is_windows?).returns(true)
       Facter::Util::Config.stubs(:windows_data_dir).returns("C:\\ProgramData")
+      Facter::Util::Config.setup_default_ext_facts_dirs
       Facter::Util::Config.external_facts_dirs.should == [File.join("C:\\ProgramData", 'PuppetLabs', 'facter', 'facts.d')]
     end
 
     it "should return the default value for windows 2003R2" do
       Facter::Util::Config.stubs(:is_windows?).returns(true)
       Facter::Util::Config.stubs(:windows_data_dir).returns("C:\\Documents")
+      Facter::Util::Config.setup_default_ext_facts_dirs
       Facter::Util::Config.external_facts_dirs.should == [File.join("C:\\Documents", 'PuppetLabs', 'facter', 'facts.d')]
     end
 
     it "returns the users home directory when not root" do
       Facter::Util::Root.stubs(:root?).returns(false)
+      Facter::Util::Config.setup_default_ext_facts_dirs
       Facter::Util::Config.external_facts_dirs.should == [File.expand_path(File.join("~", ".facter", "facts.d"))]
     end
+
+    it "includes additional values when user appends to the list" do
+      Facter::Util::Config.setup_default_ext_facts_dirs
+      original_values = Facter::Util::Config.external_facts_dirs.dup
+      new_value = '/usr/share/newdir'
+      Facter::Util::Config.external_facts_dirs << new_value
+      Facter::Util::Config.external_facts_dirs.should == original_values + [new_value]
+    end
+
+    it "should only output new values when explicitly set" do
+      Facter::Util::Config.setup_default_ext_facts_dirs
+      new_value = ['/usr/share/newdir']
+      Facter::Util::Config.external_facts_dirs = new_value
+      Facter::Util::Config.external_facts_dirs.should == new_value
+    end
+
   end
 end


### PR DESCRIPTION
Currently, the only way to override the external facts directories is to write your own Facter::Util::FactLoader and replace the existing loader with this.  This commit allows you to simply set or append to the already existing ext_facts_dirs variable which makes it much more extensible for use by other programs like puppet.
