### PR TITLE
Catch exceptions when detecting SELinux status

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -36,8 +36,11 @@ Facter.add("selinux") do
     result = "false"
     if FileTest.exists?("#{selinux_mount_point}/enforce")
       if FileTest.exists?("/proc/self/attr/current")
-        if (File.read("/proc/self/attr/current") != "kernel\0")
-          result = "true"
+        begin 
+          if (File.read("/proc/self/attr/current") != "kernel\0")
+            result = "true"
+          end
+        rescue
         end
       end
     end


### PR DESCRIPTION
When SELinux is disabled on RHEL6, exception occurs when reading /proc/self/attr/current. Due to the exception the "selinux" fact is later **missing**.

```
# sestatus 
SELinux status:                 disabled
# facter selinux
Could not retrieve selinux: Invalid argument - /proc/self/attr/current
# cat /proc/self/attr/current
cat: /proc/self/attr/current: Invalid argument
```

Following simple patch catches any exception on File read. "selinux" fact then contains value "false".
