### PR TITLE
(#22857) officially support ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.0.0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ processors, etc.
 
 See `bin/facter` for an example of the interface.
 
+Installation
+------------
+
+Generally, you need the following things installed:
+
+* A supported Ruby version. Ruby 1.8.7, 1.9.3, and 2.0.0 are fully supported.
+
 Running Facter
 --------------
 


### PR DESCRIPTION
To corespond with puppet >= 3.2 Ruby 2.0 support:
    http://docs.puppetlabs.com/puppet/3/reference/release_notes.html#ruby-20-support
