### PR TITLE
Include Bochs as Windows virtual machine type.

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -162,6 +162,8 @@ Facter.add("virtual") do
           result = "vmware"
         when /KVM/
           result = "kvm"
+        when /Bochs/
+          result = "bochs"
         end
 
         if result.nil? and computersystem.manufacturer =~ /Xen/


### PR DESCRIPTION
Update virtual.rb to include Windows VM detection when virtual machine is detected as model 'Bochs'
