### PR TITLE
(#9546) Do not execute com, cmd, exe, or bat files if not on windows

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -127,7 +127,7 @@ module Facter::Util::Parser
     if Facter::Util::Config.is_windows?
       extension_matches?(filename, %w{bat cmd com exe}) && File.file?(filename)
     else
-      File.executable?(filename) && File.file?(filename)
+      File.executable?(filename) && File.file?(filename) && ! extension_matches?(filename, %w{bat cmd com exe})
     end
   end
 

--- a/spec/unit/util/parser_spec.rb
+++ b/spec/unit/util/parser_spec.rb
@@ -128,6 +128,28 @@ describe Facter::Util::Parser do
         parser.results.should == data
       end
     end
+
+    context "exe, bat, cmd, and com files" do
+      let :cmds do ["/tmp/foo.bat", "/tmp/foo.cmd", "/tmp/foo.exe", "/tmp/foo.com"] end
+
+      before :each do
+        cmds.each {|cmd|
+          File.stubs(:executable?).with(cmd).returns(true)
+          File.stubs(:file?).with(cmd).returns(true)
+        }
+      end
+
+      it "should return nothing parser if not on windows" do
+        Facter::Util::Config.stubs(:is_windows?).returns(false)
+        cmds.each {|cmd| Facter::Util::Parser.parser_for(cmd).should be_an_instance_of(Facter::Util::Parser::NothingParser) }
+      end
+
+      it "should return script  parser if on windows" do
+        Facter::Util::Config.stubs(:is_windows?).returns(true)
+        cmds.each {|cmd| Facter::Util::Parser.parser_for(cmd).should be_an_instance_of(Facter::Util::Parser::ScriptParser) }
+      end
+
+     end
   end
 
   describe "powershell parser" do


### PR DESCRIPTION
Facter currently only executes com, exe, and bat files if on a windows
system.  It should also exclude these on unix flavored systems since
the interpreter for these "cmd.exe" will not be present.

This also supports the use of pluginsync for external facts where in a
hybrid environment external facts for windows may end up getting syncd
to a unix system.
