### PR TITLE
Capture STDERR from call to dmidecode

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -32,6 +32,10 @@ module Facter::Util::Virtual
     Facter::Util::Resolution.exec command
   end
 
+  def self.dmidecode(command = "dmidecode 2>/dev/null")
+    Facter::Util::Resolution.exec command
+  end
+
   def self.openvz?
     FileTest.directory?("/proc/vz") and not self.openvz_cloudlinux?
   end

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -122,7 +122,7 @@ Facter.add("virtual") do
     end
 
     # Parse dmidecode
-    output = Facter::Util::Resolution.exec('dmidecode')
+    output = Facter::Util::Virtual.dmidecode
     if output
       lines = output.split("\n")
       next "parallels"  if lines.any? {|l| l =~ /Parallels/ }


### PR DESCRIPTION
- When run by an unprivileged user on Linux, the call to dmidecode
  resulted it "/dev/mem: Permission denied" being sent to STDERR.
- Add a method in lib/facter/util/virtual.rb, and call that from
  lib/facter/virtual.rb
