### PR TITLE
(maint) Recognize `fc` as a type of redhat platform in acceptance setup

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -4,7 +4,7 @@ module Puppet
   module Acceptance
     module InstallUtils
       PLATFORM_PATTERNS = {
-        :redhat  => /fedora|el|centos/,
+        :redhat  => /fedora|fc|el|centos/,
         :debian  => /debian|ubuntu/,
         :solaris => /solaris/,
         :windows => /windows/,


### PR DESCRIPTION
The beaker config file for fedora 18 in this project has a platform
starting with `fc` instead of `fedora`.
