### PR TITLE
(maint) convert fc to fedora in acceptance configs

### DIFF
--- a/acceptance/config/fedora-18.cfg
+++ b/acceptance/config/fedora-18.cfg
@@ -4,13 +4,13 @@ HOSTS:
       - master
       - database
       - agent
-    platform: fc-18-x86_64
+    platform: fedora-18-x86_64
     template: fedora-18-x86_64
     hypervisor: vcloud
   fedora-18-64-2:
     roles:
       - agent
-    platform: fc-18-x86_64
+    platform: fedora-18-x86_64
     template: fedora-18-x86_64
     hypervisor: vcloud
 CONFIG:

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -4,7 +4,7 @@ module Puppet
   module Acceptance
     module InstallUtils
       PLATFORM_PATTERNS = {
-        :redhat  => /fedora|fc|el|centos/,
+        :redhat  => /fedora|el|centos/,
         :debian  => /debian|ubuntu/,
         :solaris => /solaris/,
         :windows => /windows/,


### PR DESCRIPTION
Beaker cares about the platform for package installation, and does not
recognize `fc` as a valid platform. The expected string is `fedora`
