### PR TITLE
(FACT-233) Add dhcp_server fact.

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -1,0 +1,39 @@
+# Fact: dhcp_servers
+#
+# Purpose:
+#   Return the DHCP server addresses for all interfaces as a hash.
+#   If the interface that is the default gateway is dhcp assigned, there
+#   will also be a 'system' entry in the hash.
+#
+# Resolution:
+#   Parses the output of nmcli to find the DHCP server for the interface if available
+#
+# Caveats:
+#   Requires nmcli to be available and the interface must use network-manager.
+#
+
+require 'facter'
+require 'facter/util/dhcp_servers'
+
+
+Facter.add(:dhcp_servers) do
+  confine :kernel => :linux
+  confine do
+    Facter::Core::Execution.which('nmcli')
+  end
+
+  setcode do
+    gwdev   = Facter::Util::Dhcp_servers.gateway_device
+    devices = Facter::Util::Dhcp_servers.devices
+
+    dhcp_servers = {}
+    devices.each do |device|
+      if server = Facter::Util::Dhcp_servers.device_dhcp_server(device)
+        dhcp_servers['system'] = server if device == gwdev
+        dhcp_servers[device]   = server
+      end
+    end
+
+    dhcp_servers.keys.length > 0 ? dhcp_servers : nil
+  end
+end

--- a/lib/facter/util/dhcp_servers.rb
+++ b/lib/facter/util/dhcp_servers.rb
@@ -1,0 +1,19 @@
+module Facter::Util::Dhcp_servers
+  def self.gateway_device
+    Facter::Util::Resolution.exec("route -n").scan(/^0\.0\.0\.0.*?(\S+)$/).flatten.first
+  end
+
+  def self.devices
+    if Facter::Core::Execution.which('nmcli')
+      Facter::Util::Resolution.exec("nmcli d").split("\n").select {|d| d =~ /\sconnected/i }.collect{ |line| line.split[0] }
+    else
+      []
+    end
+  end
+
+  def self.device_dhcp_server(device)
+    if Facter::Core::Execution.which('nmcli')
+      Facter::Util::Resolution.exec("nmcli d list iface #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
+    end
+  end
+end

--- a/spec/fixtures/unit/dhcp_servers/nmcli_devices
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_devices
@@ -1,0 +1,4 @@
+DEVICE     TYPE              STATE        
+wlan0      802-11-wireless   connected    
+eth0       802-3-ethernet    connected
+eth1       802-3-ethernet    disconnected

--- a/spec/fixtures/unit/dhcp_servers/nmcli_devices_disconnected
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_devices_disconnected
@@ -1,0 +1,4 @@
+DEVICE     TYPE              STATE        
+wlan0      802-11-wireless   disconnected    
+eth0       802-3-ethernet    disconnected
+eth1       802-3-ethernet    disconnected

--- a/spec/fixtures/unit/dhcp_servers/nmcli_eth0_dhcp
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_eth0_dhcp
@@ -1,0 +1,36 @@
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           802-3-ethernet
+GENERAL.VENDOR:                         Realtek Semiconductor Co., Ltd.
+GENERAL.PRODUCT:                        RTL8111/8168 PCI Express Gigabit Ethernet controller
+GENERAL.DRIVER:                         r8169
+GENERAL.DRIVER-VERSION:                 2.3LK-NAPI
+GENERAL.FIRMWARE-VERSION:               
+GENERAL.HWADDR:                         D4:BE:D9:34:67:68
+GENERAL.STATE:                          100 (connected)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.UDI:                            /sys/devices/pci0000:00/0000:00:1c.0/0000:07:00.0/net/eth0
+GENERAL.IP-IFACE:                       eth0
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.CONNECTION:                     /org/freedesktop/NetworkManager/ActiveConnection/9
+CAPABILITIES.CARRIER-DETECT:            yes
+CAPABILITIES.SPEED:                     1000 Mb/s
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/{1,2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   acafdb99-23e4-49e5-a3e6-0a00575312b5 | Office
+CONNECTIONS.AVAILABLE-CONNECTIONS[2]:   d6aaee51-2ed8-4b05-82ac-365c9c74b44e | DHCP
+WIRED-PROPERTIES.CARRIER:               on
+IP4.ADDRESS[1]:                         ip = 192.168.1.10, gw = 192.168.1.1
+IP4.DNS[1]:                             192.168.1.1
+DHCP4.OPTION[1]:                        time_offset = 0
+DHCP4.OPTION[2]:                        expiry = 1401991971
+DHCP4.OPTION[3]:                        broadcast_address = 192.168.1.255
+DHCP4.OPTION[4]:                        dhcp_message_type = 5
+DHCP4.OPTION[5]:                        dhcp_lease_time = 9999999
+DHCP4.OPTION[6]:                        ip_address = 192.168.1.10
+DHCP4.OPTION[7]:                        subnet_mask = 255.255.255.0
+DHCP4.OPTION[8]:                        routers = 192.168.1.1
+DHCP4.OPTION[9]:                        domain_name_servers = 192.168.1.1
+DHCP4.OPTION[10]:                       network_number = 192.168.1.0
+DHCP4.OPTION[11]:                       default_ip_ttl = 64
+DHCP4.OPTION[12]:                       dhcp_server_identifier = 192.168.1.1

--- a/spec/fixtures/unit/dhcp_servers/nmcli_eth0_static
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_eth0_static
@@ -1,0 +1,24 @@
+GENERAL.DEVICE:                         eth0
+GENERAL.TYPE:                           802-3-ethernet
+GENERAL.VENDOR:                         Realtek Semiconductor Co., Ltd.
+GENERAL.PRODUCT:                        RTL8111/8168 PCI Express Gigabit Ethernet controller
+GENERAL.DRIVER:                         r8169
+GENERAL.DRIVER-VERSION:                 2.3LK-NAPI
+GENERAL.FIRMWARE-VERSION:               
+GENERAL.HWADDR:                         D4:BE:D9:34:67:68
+GENERAL.STATE:                          100 (connected)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.UDI:                            /sys/devices/pci0000:00/0000:00:1c.0/0000:07:00.0/net/eth0
+GENERAL.IP-IFACE:                       eth0
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.CONNECTION:                     /org/freedesktop/NetworkManager/ActiveConnection/9
+CAPABILITIES.CARRIER-DETECT:            yes
+CAPABILITIES.SPEED:                     1000 Mb/s
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/{1,2}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   acafdb99-23e4-49e5-a3e6-0a00575312b5 | Office
+CONNECTIONS.AVAILABLE-CONNECTIONS[2]:   d6aaee51-2ed8-4b05-82ac-365c9c74b44e | DHCP
+WIRED-PROPERTIES.CARRIER:               on
+IP4.ADDRESS[1]:                         ip = 192.168.1.10, gw = 192.168.1.1
+IP4.DNS[1]:                             192.168.1.1

--- a/spec/fixtures/unit/dhcp_servers/nmcli_wlan0_dhcp
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_wlan0_dhcp
@@ -1,0 +1,49 @@
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           802-11-wireless
+GENERAL.VENDOR:                         Intel Corporation
+GENERAL.PRODUCT:                        Centrino Advanced-N 6235 AGN
+GENERAL.DRIVER:                         iwlwifi
+GENERAL.DRIVER-VERSION:                 3.11.0-12-generic
+GENERAL.FIRMWARE-VERSION:               18.168.6.1
+GENERAL.HWADDR:                         C4:85:08:06:2C:55
+GENERAL.STATE:                          100 (connected)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.UDI:                            /sys/devices/pci0000:00/0000:00:1c.2/0000:08:00.0/net/wlan0
+GENERAL.IP-IFACE:                       wlan0
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.CONNECTION:                     /org/freedesktop/NetworkManager/ActiveConnection/10
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     13 Mb/s
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/{3}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   7a82c94b-afba-498b-9a62-30ebb335b365 | Auto OptusCD3_80ac32
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+AP[1].SSID:                             'TestSSid'
+AP[1].BSSID:                            C8:F9:F9:BE:F1:4E
+AP[1].MODE:                             Infrastructure
+AP[1].FREQ:                             5745 MHz
+AP[1].RATE:                             54 MB/s
+AP[1].SIGNAL:                           72
+AP[1].SECURITY:                         WPA WPA2 Enterprise
+AP[1].ACTIVE:                           no
+IP4.ADDRESS[1]:                         ip = 192.168.2.10/24, gw = 192.168.2.1
+IP4.DNS[1]:                             192.168.2.1
+DHCP4.OPTION[1]:                        time_offset = 0
+DHCP4.OPTION[2]:                        expiry = 1401991971
+DHCP4.OPTION[3]:                        broadcast_address = 192.168.0.255
+DHCP4.OPTION[4]:                        dhcp_message_type = 5
+DHCP4.OPTION[5]:                        dhcp_lease_time = 9999999
+DHCP4.OPTION[6]:                        ip_address = 192.168.2.10
+DHCP4.OPTION[7]:                        subnet_mask = 255.255.255.0
+DHCP4.OPTION[8]:                        routers = 192.168.2.1
+DHCP4.OPTION[9]:                        domain_name_servers = 192.168.2.1
+DHCP4.OPTION[10]:                       network_number = 192.168.2.0
+DHCP4.OPTION[11]:                       default_ip_ttl = 64
+DHCP4.OPTION[12]:                       dhcp_server_identifier = 192.168.2.1

--- a/spec/fixtures/unit/dhcp_servers/nmcli_wlan0_static
+++ b/spec/fixtures/unit/dhcp_servers/nmcli_wlan0_static
@@ -1,0 +1,37 @@
+GENERAL.DEVICE:                         wlan0
+GENERAL.TYPE:                           802-11-wireless
+GENERAL.VENDOR:                         Intel Corporation
+GENERAL.PRODUCT:                        Centrino Advanced-N 6235 AGN
+GENERAL.DRIVER:                         iwlwifi
+GENERAL.DRIVER-VERSION:                 3.11.0-12-generic
+GENERAL.FIRMWARE-VERSION:               18.168.6.1
+GENERAL.HWADDR:                         C4:85:08:06:2C:55
+GENERAL.STATE:                          100 (connected)
+GENERAL.REASON:                         0 (No reason given)
+GENERAL.UDI:                            /sys/devices/pci0000:00/0000:00:1c.2/0000:08:00.0/net/wlan0
+GENERAL.IP-IFACE:                       wlan0
+GENERAL.NM-MANAGED:                     yes
+GENERAL.AUTOCONNECT:                    yes
+GENERAL.FIRMWARE-MISSING:               no
+GENERAL.CONNECTION:                     /org/freedesktop/NetworkManager/ActiveConnection/10
+CAPABILITIES.CARRIER-DETECT:            no
+CAPABILITIES.SPEED:                     13 Mb/s
+CONNECTIONS.AVAILABLE-CONNECTION-PATHS: /org/freedesktop/NetworkManager/Settings/{3}
+CONNECTIONS.AVAILABLE-CONNECTIONS[1]:   7a82c94b-afba-498b-9a62-30ebb335b365 | Auto OptusCD3_80ac32
+WIFI-PROPERTIES.WEP:                    yes
+WIFI-PROPERTIES.WPA:                    yes
+WIFI-PROPERTIES.WPA2:                   yes
+WIFI-PROPERTIES.TKIP:                   yes
+WIFI-PROPERTIES.CCMP:                   yes
+WIFI-PROPERTIES.AP:                     yes
+WIFI-PROPERTIES.ADHOC:                  yes
+AP[1].SSID:                             'TestSSid'
+AP[1].BSSID:                            C8:F9:F9:BE:F1:4E
+AP[1].MODE:                             Infrastructure
+AP[1].FREQ:                             5745 MHz
+AP[1].RATE:                             54 MB/s
+AP[1].SIGNAL:                           72
+AP[1].SECURITY:                         WPA WPA2 Enterprise
+AP[1].ACTIVE:                           no
+IP4.ADDRESS[1]:                         ip = 192.168.2.10/24, gw = 192.168.2.1
+IP4.DNS[1]:                             192.168.2.1

--- a/spec/fixtures/unit/dhcp_servers/route
+++ b/spec/fixtures/unit/dhcp_servers/route
@@ -1,0 +1,4 @@
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+0.0.0.0         192.168.1.1     0.0.0.0         UG    0      0        0 eth0
+192.168.2.0     0.0.0.0         255.255.255.0   U     9      0        0 wlan0

--- a/spec/fixtures/unit/dhcp_servers/route_nogw
+++ b/spec/fixtures/unit/dhcp_servers/route_nogw
@@ -1,0 +1,4 @@
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+192.168.1.0     0.0.0.0         255.255.255.0   UG    0      0        0 eth0
+192.168.2.0     0.0.0.0         255.255.255.0   U     9      0        0 wlan0

--- a/spec/unit/dhcp_servers_spec.rb
+++ b/spec/unit/dhcp_servers_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe "DHCP server facts" do
+  describe "on Linux OS's" do
+    before :each do
+      Facter::Util::Resolution.stubs(:exec).with("route -n").returns(my_fixture_read("route"))
+    end
+
+    describe "with nmcli available" do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('nmcli').returns('/usr/bin/nmcli')
+      end
+
+      describe "with a main interface configured with DHCP" do
+        before :each do
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
+          Facter.fact(:dhcp_servers).value.should == { 'system' => '192.168.1.1', 'eth0' => '192.168.1.1', 'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with a main interface NOT configured with DHCP" do
+        before :each do
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
+          Facter.fact(:dhcp_servers).value.should == {'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with no default gateway" do
+        before :each do
+          Facter::Util::Resolution.stubs(:exec).with("route -n").returns(my_fixture_read("route_nogw"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
+          Facter.fact(:dhcp_servers).value.should == {'eth0' => '192.168.1.1', 'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with no DHCP enabled interfaces" do
+        before :each do
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
+        end
+
+        it "should not produce a dhcp_servers fact" do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+
+      describe "with no CONNECTED devices" do
+        before :each do
+          Facter::Util::Resolution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
+        end
+
+        it "should not produce a dhcp_servers fact" do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+    end
+
+    describe "without nmcli available" do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('nmcli').returns(nil)
+      end
+
+      it "should not produce a dhcp_server fact" do
+        Facter.fact(:dhcp_servers).value.should be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a dynamic fact to interfaces detailing the DHCP server servicing
that interface if any.

Creates: dhcp_server_<iface>

Tries to use `nmcli -d list iface <iface>` if nmcli is available and the
interface is managed using NetworkManager.

If not, it will try hard to find a leases file for the interface and
read the dhcp server from that.

JIRA: https://tickets.puppetlabs.com/browse/FACT-233
