### PR TITLE
(FACT-234) Add uuid_<partition>

### DIFF
--- a/lib/facter/blockdevices.rb
+++ b/lib/facter/blockdevices.rb
@@ -34,7 +34,6 @@
 #   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
 #
 
-
 # Fact: blockdevices
 #
 # Purpose:
@@ -45,6 +44,30 @@
 #
 # Caveats:
 #   Block devices must have been identified using sysfs information
+#
+
+# Fact: blockdevice_<devicename>_partitions
+#
+# Purpose:
+#   Returns a comma separated list of partitions on the block device.
+#
+# Resolution:
+#   Parses the contents of /sys/block/<device/<device>* 
+#
+# Caveats:
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#
+
+# Fact: blockdevice_<devicename><partition>_uuid
+#
+# Purpose:
+#   Returns the UUID of the partitions on blockdevices.
+#
+# Resolution:
+#   Parses /dev/disk/by-uuid and resolves the links back to the partitions in /dev
+#
+# Caveats:
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
 #
 
 # Author: Jason Gill <jasongill@gmail.com>
@@ -67,7 +90,19 @@ if Facter::Util::Blockdevices.available?
     end
 
     Facter.add("blockdevice_#{device}_model") do
-      setcode { Facter::Util::Blockdevices.device_model(device)}
+      setcode { Facter::Util::Blockdevices.device_model(device) }
+    end
+
+    Facter.add("blockdevice_#{device}_partitions") do
+      confine :kernel => "Linux"
+      setcode { Facter::Util::Blockdevices.device_partitions(device).join(',') }
+    end
+
+    Facter::Util::Blockdevices.device_partitions(device).each do |part|
+      Facter.add("blockdevice_#{part}_uuid") do
+        confine :kernel => "Linux"
+        setcode { Facter::Util::Blockdevices.partition_uuid(part) }
+      end
     end
   end
 end

--- a/lib/facter/util/blockdevices.rb
+++ b/lib/facter/util/blockdevices.rb
@@ -12,6 +12,10 @@ module Facter::Util::Blockdevices
     def self.devices
       []
     end
+
+    def self.device_partitions
+      []
+    end
   end
 
   def self.implementation
@@ -32,6 +36,18 @@ module Facter::Util::Blockdevices
 
   def self.device_size(device_name)
     implementation.device_size(device_name)
+  end
+
+  def self.device_partitions(device_name)
+    if Facter.value(:kernel) == 'Linux'
+      implementation.device_partitions(device_name)
+    else
+      NoImplementation.device_partitions
+    end
+  end
+
+  def self.partition_uuid(partition_name)
+    implementation.partition_uuid(partition_name)
   end
 
   def self.available?

--- a/lib/facter/util/blockdevices/linux.rb
+++ b/lib/facter/util/blockdevices/linux.rb
@@ -2,7 +2,8 @@ module Facter::Util::Blockdevices
 
   module Linux
     # Only Linux 2.6+ kernels support sysfs which is required to easily get device details
-    SYSFS_BLOCK_DIRECTORY = '/sys/block/'
+    SYSFS_BLOCK_DIRECTORY     = '/sys/block/'
+    DEVDISK_BY_UUID_DIRECTORY = '/dev/disk/by-uuid/'
 
     def self.read_if_exists(f)
       if File.exist?(f)
@@ -45,6 +46,31 @@ module Facter::Util::Blockdevices
 
     def self.device_dir(device)
       SYSFS_BLOCK_DIRECTORY + device + "/device"
+    end
+    
+    def self.device_partitions(device)
+      Dir.glob( SYSFS_BLOCK_DIRECTORY + device + "/#{device}*" ).map do |d|
+        File.basename(d)
+      end
+    end
+
+    def self.partition_uuid(partition)
+      if File.directory?(DEVDISK_BY_UUID_DIRECTORY)
+        Dir.entries(DEVDISK_BY_UUID_DIRECTORY).each do |file|
+          uuid = nil
+          qualified_file = "#{DEVDISK_BY_UUID_DIRECTORY}#{file}"
+
+          #A uuid is 16 octets long (RFC4122) which is 32hex chars + 4 '-'s
+          next unless file.length == 36
+          next unless File.symlink?(qualified_file)
+          next unless File.readlink(qualified_file).match(%r[(?:\.\./\.\./|/dev/)#{partition}$])
+
+          uuid = file
+          return uuid
+        end
+      end
+      
+      uuid
     end
 
   end

--- a/spec/unit/blockdevices_spec.rb
+++ b/spec/unit/blockdevices_spec.rb
@@ -129,6 +129,44 @@ describe "Block device facts" do
             IO.stubs(:read).with(stubdir + "/device/vendor").returns(vendor) if vendor
             IO.stubs(:read).with(stubdir + "/device/model").returns(model) if model
           end
+
+          #Stubs relating to the Partition UUID facts
+          File.stubs(:exist?).with('/dev/disk/by-uuid/').returns(true)
+
+          Dir.stubs(:glob).with("/sys/block/hda/hda*").returns([])
+
+          Dir.stubs(:glob).with("/sys/block/sda/sda*").returns([
+            '/sys/block/sda/sda1',
+            '/sys/block/sda/sda2',
+          ])
+
+          Dir.stubs(:glob).with("/sys/block/sdb/sdb*").returns([
+            '/sys/block/sda/sdb1',
+            '/sys/block/sda/sdb2',
+          ])
+
+          File.stubs(:directory?).returns(true)
+          
+          Dir.stubs(:entries).with('/dev/disk/by-uuid/').returns([
+            ".",                                    #wont match the length requirements
+            "..",                                   #wont match the length requirements
+            "11111111-1111-1111-1111-111111111111", #Should be valid
+            "22222222-2222-2222-2222-222222222222", #Should be valid
+            "33333333-3333-3333-3333-333333333333", #Should be valid
+            "44444444-4444-4444-4444-444444444444", #Wont match the link regex
+            "55555555-5555-5555-5555-555555555555"  #Wont be a symlink
+          ])
+
+          File.stubs(:readlink).with('/dev/disk/by-uuid/11111111-1111-1111-1111-111111111111').returns('../../sda1')
+          File.stubs(:readlink).with('/dev/disk/by-uuid/22222222-2222-2222-2222-222222222222').returns('../../sda2')
+          File.stubs(:readlink).with('/dev/disk/by-uuid/33333333-3333-3333-3333-333333333333').returns('../../sdb1')
+          File.stubs(:readlink).with('/dev/disk/by-uuid/44444444-4444-4444-4444-444444444444').returns('/dont/match/regex/sdb2')
+
+          File.stubs(:symlink?).with('/dev/disk/by-uuid/11111111-1111-1111-1111-111111111111').returns(true)
+          File.stubs(:symlink?).with('/dev/disk/by-uuid/22222222-2222-2222-2222-222222222222').returns(true)
+          File.stubs(:symlink?).with('/dev/disk/by-uuid/33333333-3333-3333-3333-333333333333').returns(true)
+          File.stubs(:symlink?).with('/dev/disk/by-uuid/44444444-4444-4444-4444-444444444444').returns(true)
+          File.stubs(:symlink?).with('/dev/disk/by-uuid/55555555-5555-5555-5555-555555555555').returns(false)
         end
 
         it "should report three block devices, hda, sda, and sdb, with accurate information from sda and sdb, and without invalid . or .. entries" do
@@ -146,16 +184,32 @@ describe "Block device facts" do
             Facter.value("blockdevice_#{device}_size".to_sym).should_not == nil
             Facter.value("blockdevice_#{device}_vendor".to_sym).should_not == nil
             Facter.value("blockdevice_#{device}_model".to_sym).should_not == nil
+            Facter.value("blockdevice_#{device}_partitions".to_sym).should_not == nil
           end
 
           Facter.fact(:blockdevice_sda_model).value.should == "WDC WD5000AAKS-0"
           Facter.fact(:blockdevice_sda_vendor).value.should == "ATA"
           Facter.fact(:blockdevice_sda_size).value.should == 500107862016
+          Facter.fact(:blockdevice_sda_partitions).value.should == 'sda1,sda2'
 
           Facter.fact(:blockdevice_sdb_model).value.should == "PERC H700"
           Facter.fact(:blockdevice_sdb_vendor).value.should == "DELL"
           Facter.fact(:blockdevice_sdb_size).value.should == 4499246678016
+          Facter.fact(:blockdevice_sdb_partitions).value.should == 'sdb1,sdb2'  
 
+          #These partitions should have a UUID
+          %w{ sda1 sda2 sdb1 }.each do |d|
+            Facter.value("blockdevice_#{d}_uuid".to_sym).should_not == nil
+          end
+
+          #These should not create a UUID fact
+          [ ".", "..", "sdb2" ].each do |d|
+            Facter.value("partition_#{d}_uuid".to_sym).should == nil
+          end
+
+          Facter.fact(:blockdevice_sda1_uuid).value.should == "11111111-1111-1111-1111-111111111111"
+          Facter.fact(:blockdevice_sda2_uuid).value.should == "22222222-2222-2222-2222-222222222222"
+          Facter.fact(:blockdevice_sdb1_uuid).value.should == "33333333-3333-3333-3333-333333333333"
         end
 
       end
@@ -170,6 +224,9 @@ describe "Block device facts" do
           File.stubs(:exist?).with("/sys/block/../device").returns(false)
           File.stubs(:exist?).with("/sys/block/xda/device").returns(false)
           File.stubs(:exist?).with("/sys/block/ydb/device").returns(false)
+
+          #This is here to surpress errors when Dir.entries is run in relation to uuids
+          Dir.stubs(:entries).with('/dev/disk/by-uuid/').returns([])
         end
 
         it "should not exist with invalid entries in /sys/block" do
@@ -186,6 +243,5 @@ describe "Block device facts" do
       end
 
     end
-
   end
 end


### PR DESCRIPTION
Add facts to show the uuid of partitions.

Parses the output of blkid.  Depending the distro, users may not have
read access to the /dev/<device>'s in which case blkid will not reveal
them and the facts will be absent.  Running as root will resolve this.
