### PR TITLE
(#23368) script based external facts are broken on 2003

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -119,7 +119,13 @@ module Facter::Util::Parser
 
   class ScriptParser < Base
     def parse_results
-      KeyValuePairOutputFormat.parse Facter::Util::Resolution.exec(filename)
+      KeyValuePairOutputFormat.parse Facter::Util::Resolution.exec(quote(filename))
+    end
+
+    private
+
+    def quote(filename)
+      filename.index(' ') ? "\"#{filename}\"" : filename
     end
   end
 

--- a/spec/unit/util/parser_spec.rb
+++ b/spec/unit/util/parser_spec.rb
@@ -120,6 +120,14 @@ describe Facter::Util::Parser do
       expects_script_to_return(cmd, nil, {})
     end
 
+    it "quotes scripts with spaces" do
+      path = "/h a s s p a c e s#{ext}"
+
+      Facter::Util::Resolution.expects(:exec).with("\"#{path}\"").returns(data_in_txt)
+
+      expects_script_to_return(path, data_in_txt, data)
+    end
+
     context "exe, bat, cmd, and com files" do
       let :cmds do ["/tmp/foo.bat", "/tmp/foo.cmd", "/tmp/foo.exe", "/tmp/foo.com"] end
 


### PR DESCRIPTION
The Facter::Util::Resolution.exec method expects that commands with spaces are quoted. On 2003, external facts are typically under `C:\Documents and Settings\All Users\Application Data`. As a result, facter would always fail to execute external executable facts on 2003.

This is not an issue on 2008 and up, because external facts are typically located under `C:\ProgramData`.

This is not an issue for powershell scripts, because we pass the quoted name of the script to powershell.

This is not an issue for text based external facts, because `File.read` do not require paths with spaces to be quoted (since its not a command and possibly arguments, or just a command with spaces).

This commit adds a `quote` method to the ScriptParser so that we quote the script if it has spaces.
