### PR TITLE
(maint) restrict redcarpet gem to <= 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ platforms :ruby do
   gem 'watchr', :group => :development
   gem 'pry', :group => :development
   gem 'yard', :group => :development
-  gem 'redcarpet', :group => :development
+  gem 'redcarpet', '<= 2.3.0', :group => :development
 end
 
 group :development, :test do


### PR DESCRIPTION
Per the tag annotation from the redcarpet 3.0.0 release, 2.3.0 is the last
version compatible with ruby 1.8.7.

https://github.com/vmg/redcarpet/releases/tag/v3.0.0
