### PR TITLE
(FACT-186) Express windows specific gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,14 +20,18 @@ group :development, :test do
   gem 'puppetlabs_spec_helper'
 end
 
-platform :mswin, :mingw do
-  gem "ffi", "1.9.0", :require => false
-  gem "sys-admin", "1.5.6", :require => false
-  gem "win32-api", "1.4.8", :require => false
-  gem "win32-dir", "0.4.3", :require => false
-  gem "windows-api", "0.4.2", :require => false
-  gem "windows-pr", "1.2.2", :require => false
-  gem "win32console", "1.3.2", :require => false
+require 'yaml'
+data = YAML.load_file(File.join(File.dirname(__FILE__), 'ext', 'project_data.yaml'))
+bundle_platforms = data['bundle_platforms']
+data['gem_platform_dependencies'].each_pair do |gem_platform, info|
+  if bundle_deps = info['gem_runtime_dependencies']
+    bundle_platform = bundle_platforms[gem_platform] or raise "Missing bundle_platform"
+    platform(bundle_platform.intern) do
+      bundle_deps.each_pair do |name, version|
+        gem(name, version, :require => false)
+      end
+    end
+  end
 end
 
 gem 'facter', ">= 1.0.0", :path => File.expand_path("..", __FILE__)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -14,12 +14,18 @@ gem_test_files: 'spec/**/*'
 gem_executables: 'facter'
 gem_default_executables: 'facter'
 gem_platform_dependencies:
+  universal-darwin:
+    gem_runtime_dependencies:
+      CFPropertyList: '2.2.6'
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.0'
-      sys-admin: '~> 1.5.6'
-      win32-api: '~> 1.4.8'
-      win32-dir: '~> 0.4.3'
-      windows-api: '~> 0.4.2'
-      windows-pr: '~> 1.2.2'
-      win32console: '~> 1.3.2'
+      ffi: '1.9.0'
+      sys-admin: '1.5.6'
+      win32-api: '1.4.8'
+      win32-dir: '0.4.3'
+      windows-api: '0.4.2'
+      windows-pr: '1.2.2'
+      win32console: '1.3.2'
+bundle_platforms:
+  universal-darwin: ruby
+  x86-mingw32: mingw


### PR DESCRIPTION
Previously, if a ruby module on windows tried to use facter as a
library, the calling module had to know about facter's platform specific
dependencies. This comes up when trying to develop and test puppet
modules on windows.

This commit adds the windows specific gems (which mirror the Gemfile) to
project_data.yaml. The build pipeline will automatically create an
x86-mingw32 gem in addition to the generic one.
