### PR TITLE
(maint) Redirect dmidecode stderr to /dev/null

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -133,7 +133,7 @@ Facter.add("virtual") do
     end
 
     # Parse dmidecode
-    output = Facter::Util::Resolution.exec('dmidecode')
+    output = Facter::Util::Resolution.exec('dmidecode 2> /dev/null')
     if output
       lines = output.split("\n")
       next "parallels"  if lines.any? {|l| l =~ /Parallels/ }


### PR DESCRIPTION
Previously most calls to dmidecode had stderr redirected to /dev/null.
dmidecode tends to have error messages that go to stderr during execution,
which pollutes facter runs. This commit updates the remaining calls to
dmidecode to also redirect stderr to /dev/null so that facter runs can continue
in blissful ignorance of any dmidecode errors.
