### PR TITLE
(maint) Update virtual spec to match dmidecode invocation

### DIFF
--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -91,7 +91,7 @@ describe Facter::Util::Virtual do
 
   it "should identify kvm" do
     Facter::Util::Virtual.stubs(:kvm?).returns(true)
-    Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("something")
+    Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("something")
     Facter::Util::Virtual.kvm_type().should == "kvm"
   end
 

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -108,7 +108,7 @@ describe "Virtual fact" do
 
     it "should be vmware with VMWare vendor name from dmidecode" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
       Facter.fact(:virtual).value.should == "vmware"
     end
 
@@ -134,33 +134,33 @@ describe "Virtual fact" do
 
     it "should be xenhvm with Xen HVM vendor name from dmidecode" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Xen\nProduct Name: HVM domU")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("System Information\nManufacturer: Xen\nProduct Name: HVM domU")
       Facter.fact(:virtual).value.should == "xenhvm"
     end
 
     it "should be parallels with Parallels vendor name from dmidecode" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device Information\nType: Video\nStatus: Disabled\nDescription: Parallels Video Adapter")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("On Board Device Information\nType: Video\nStatus: Disabled\nDescription: Parallels Video Adapter")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
     it "should be virtualbox with VirtualBox vendor name from dmidecode" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("BIOS Information\nVendor: innotek GmbH\nVersion: VirtualBox\n\nSystem Information\nManufacturer: innotek GmbH\nProduct Name: VirtualBox\nFamily: Virtual Machine")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("BIOS Information\nVendor: innotek GmbH\nVersion: VirtualBox\n\nSystem Information\nManufacturer: innotek GmbH\nProduct Name: VirtualBox\nFamily: Virtual Machine")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
 
     it "should be rhev with RHEV Hypervisor product name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("Product Name: RHEV Hypervisor")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("Product Name: RHEV Hypervisor")
       Facter.fact(:virtual).value.should == "rhev"
     end
 
     it "should be ovirt with oVirt Node product name from dmidecode" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("Product Name: oVirt Node")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("Product Name: oVirt Node")
       Facter.fact(:virtual).value.should == "ovirt"
     end
 
@@ -171,7 +171,7 @@ describe "Virtual fact" do
 
     it "should be hyperv with Microsoft vendor name from dmidecode" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("System Information\nManufacturer: Microsoft Corporation\nProduct Name: Virtual Machine")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("System Information\nManufacturer: Microsoft Corporation\nProduct Name: Virtual Machine")
       Facter.fact(:virtual).value.should == "hyperv"
     end
 
@@ -208,7 +208,7 @@ describe "Virtual fact" do
 
     it "(#20236) is vmware when dmidecode contains vmware and lspci returns insufficient information" do
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns("garbage\ninformation\n")
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns("On Board Device 1 Information\nType: Video\nStatus: Disabled\nDescription: VMware SVGA II")
       Facter.fact(:virtual).value.should eq("vmware")
     end
   end
@@ -222,7 +222,7 @@ describe "Virtual fact" do
     it "should be vmware with VMWare vendor name from prtdiag" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
       Facter.fact(:virtual).value.should == "vmware"
     end
@@ -230,7 +230,7 @@ describe "Virtual fact" do
     it "should be parallels with Parallels vendor name from prtdiag" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: Parallels Virtual Platform")
       Facter.fact(:virtual).value.should == "parallels"
     end
@@ -238,7 +238,7 @@ describe "Virtual fact" do
     it "should be virtualbox with VirtualBox vendor name from prtdiag" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('prtdiag').returns("System Configuration: innotek GmbH VirtualBox")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
@@ -250,7 +250,7 @@ describe "Virtual fact" do
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Util::Resolution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
-      Facter::Util::Resolution.stubs(:exec).with('dmidecode').returns(nil)
+      Facter::Util::Resolution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
     end
 
     it "should be parallels with Parallels product name from sysctl" do


### PR DESCRIPTION
A previous commit updated the dmidecode invocation in util/virtual.rb, but it
did not update the corresponding spec test, which stubs the invocation to
return 'something'. This commit updates the virtual spec tests to stub the
updated invocation.
