### PR TITLE
(FACT-207) Remove all uses of :ldapname

### DIFF
--- a/lib/facter/hostname.rb
+++ b/lib/facter/hostname.rb
@@ -11,7 +11,7 @@
 # Caveats:
 #
 
-Facter.add(:hostname, :ldapname => "cn") do
+Facter.add(:hostname) do
   setcode do
     hostname = nil
     if name = Facter::Util::Resolution.exec('hostname')

--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -121,7 +121,7 @@ Facter.add(:ipaddress) do
   end
 end
 
-Facter.add(:ipaddress, :ldapname => "iphostnumber", :timeout => 2) do
+Facter.add(:ipaddress, :timeout => 2) do
   setcode do
     if Facter.value(:kernel) == 'windows'
       require 'win32/resolv'

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -101,18 +101,6 @@ describe Facter do
     end
   end
 
-  describe "Facter[:hostname]" do
-    it "should have its ldapname set to 'cn'" do
-      Facter[:hostname].ldapname.should == "cn"
-    end
-  end
-
-  describe "Facter[:ipaddress]" do
-    it "should have its ldapname set to 'iphostnumber'" do
-      Facter[:ipaddress].ldapname.should == "iphostnumber"
-    end
-  end
-
   # #33 Make sure we only get one mac address
   it "should only return one mac address" do
     if macaddress = Facter.value(:macaddress)

--- a/spec/unit/util/collection_spec.rb
+++ b/spec/unit/util/collection_spec.rb
@@ -27,15 +27,7 @@ describe Facter::Util::Collection do
     end
 
     it "should accept options" do
-      collection.add(:myname, :ldapname => "whatever") { }
-    end
-
-    it "should set any appropriate options on the fact instances" do
-      # Use a real fact instance, because we're using respond_to?
-      fact = Facter::Util::Fact.new(:myname)
-
-      collection.add(:myname, :ldapname => "testing")
-      collection.fact(:myname).ldapname.should == "testing"
+      collection.add(:myname, :timeout => 1) { }
     end
 
     it "should set appropriate options on the resolution instance" do
@@ -46,19 +38,6 @@ describe Facter::Util::Collection do
       fact.expects(:add).returns resolve
 
       collection.add(:myname, :timeout => "myval") {}
-    end
-
-    it "should not pass fact-specific options to resolutions" do
-      fact = Facter::Util::Fact.new(:myname)
-      Facter::Util::Fact.expects(:new).with(:myname).returns fact
-
-      resolve = Facter::Util::Resolution.new(:myname) {}
-      fact.expects(:add).returns resolve
-
-      fact.expects(:ldapname=).with("foo")
-      resolve.expects(:timeout=).with("myval")
-
-      collection.add(:myname, :timeout => "myval", :ldapname => "foo") {}
     end
 
     it "should fail if invalid options are provided" do


### PR DESCRIPTION
Commit 1da7261da deprecated the use of :ldapname for facts; this commit
removes the use of :ldapname from the related facts and test coverage.
