### PR TITLE
Prevent infinite loop when /proc/meminfo displays mixed case

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -21,7 +21,7 @@ module Facter::Memory
     suffixes = ['', 'kB', 'MB', 'GB', 'TB']
 
     s = suffixes.shift
-    while s != multiplier
+    until s.downcase == multiplier.downcase
       s = suffixes.shift
     end
 


### PR DESCRIPTION
I found on Fedora 19 that `puppet apply` was hanging even with an empty manifest file. I tracked this down to facter (which would also hang when run alone) and ultimately this while loop using strace. I'm running Fedora 19 with kernel 3.12.7-200.fc19.x86_64. The issue was that this loop is attempting to explicitly match against 'kB' while some of the entries in `/proc/meminfo` are being displayed as 'KB'.

I've also inverted the loop to an until to match ruby style guide best practices.

The contents of my /proc/meminfo were (provided here to show the issue):

```
MemTotal:         524288 KB
MemFree:          404788 KB
Buffers:               0 KB
Cached:            66768 KB
SwapCached:            0 kB
Active:           114668 KB
Inactive:           4544 KB
Active(anon):      52520 KB
Inactive(anon):     3232 KB
Active(file):      62148 KB
Inactive(file):     1312 KB
Unevictable:           0 KB
Mlocked:              20 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:                20 kB
Writeback:             0 kB
AnonPages:         94168 kB
Mapped:            45276 kB
Shmem:              5920 kB
Slab:             160116 kB
SReclaimable:     121840 kB
SUnreclaim:        38276 kB
KernelStack:        1104 kB
PageTables:         6716 kB
NFS_Unstable:          0 kB
Bounce:                0 kB
WritebackTmp:          0 kB
CommitLimit:     6153312 kB
Committed_AS:     378772 kB
VmallocTotal:   34359738367 kB
VmallocUsed:       31072 kB
VmallocChunk:   34359696816 kB
HardwareCorrupted:     0 kB
AnonHugePages:         0 kB
HugePages_Total:       0
HugePages_Free:        0
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
DirectMap4k:       57336 kB
DirectMap2M:    12525568 kB
```
