### PR TITLE
debian/control: Recommend lsb-release.

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -9,6 +9,7 @@ Homepage: http://www.puppetlabs.com
 Package: facter
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, dmidecode [i386 amd64 ia64], virt-what, pciutils
+Recommends: lsb-release
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.


### PR DESCRIPTION
In the past few days several people on IRC have had issues with Facter
not filling in `lsbdistcodename` which can usually be traced back to one
of the lsb-\* packages missing on Debian.

By depending on `lsb-core` we ensure that core LSB functionality is there.
This package additionally depends on `lsb-base`, `lsb-release` and
`lsb-security` ensuring everything is in place for Facter.
