### PR TITLE
(maint) Remove Facter.method_missing

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -166,39 +166,6 @@ module Facter
     end
   end
 
-  class << self
-    # Allow users to call fact names directly on the Facter class,
-    # either retrieving the value or comparing it to an existing value.
-    #
-    # @api private
-    def method_missing(name, *args)
-      question = false
-      if name.to_s =~ /\?$/
-        question = true
-        name = name.to_s.sub(/\?$/,'')
-      end
-
-      if fact = collection.fact(name)
-        if question
-          value = fact.value.downcase
-          args.each do |arg|
-            if arg.to_s.downcase == value
-              return true
-            end
-          end
-
-          # If we got this far, there was no match.
-          return false
-        else
-          return fact.value
-        end
-      else
-        # Else, fail like a normal missing method.
-        raise NoMethodError, "Could not find fact '%s'" % name
-      end
-    end
-  end
-
   # Clears all cached values and removes all facts from memory.
   #
   # @return [void]

--- a/lib/facter/util/netmask.rb
+++ b/lib/facter/util/netmask.rb
@@ -8,13 +8,13 @@ module Facter::NetMask
     when 'Linux'
       ops = {
         :ifconfig_opts => ['2>/dev/null'],
-        :regex => %r{#{Facter.ipaddress}.*?(?:Mask:|netmask)\s*(#{ipregex})}x,
+        :regex => %r{#{Facter.value(:ipaddress)}.*?(?:Mask:|netmask)\s*(#{ipregex})}x,
         :munge => nil,
       }
     when 'SunOS'
       ops = {
         :ifconfig_opts => ['-a'],
-        :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s (\w{8})}x,
+        :regex => %r{\s+ inet \s #{Facter.value(:ipaddress)} \s netmask \s (\w{8})}x,
         :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
       }
     when 'FreeBSD','NetBSD','OpenBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -77,22 +77,6 @@ describe Facter do
     end
   end
 
-  describe "when asked for a fact as an undefined Facter class method" do
-    describe "and the collection is already initialized" do
-      it "should return the fact's value" do
-        Facter.collection
-        Facter.ipaddress.should == Facter['ipaddress'].value
-      end
-    end
-
-    describe "and the collection has been just reset" do
-      it "should return the fact's value" do
-        Facter.reset
-        Facter.ipaddress.should == Facter['ipaddress'].value
-      end
-    end
-  end
-
   describe "when passed code as a block" do
     it "should execute the provided block" do
       Facter.add("block_testing") { setcode { "foo" } }


### PR DESCRIPTION
The ability to use method_missing was added in 2006 but was never
documented, explained, or generally acknowledge. It was a constant
surprise when invoking a non-existent method on Facter would cause all
facts to be loaded and possibly a completely nonsensical value would be
returned. This commit removes the given code so we can return to a more
sane state of affairs.
