### PR TITLE
(fact-81) Use Emit.dump rather than to_plist

### DIFF
--- a/lib/facter/util/plist/generator.rb
+++ b/lib/facter/util/plist/generator.rb
@@ -51,7 +51,7 @@ module Plist
     # Writes the serialized object's plist to the specified filename.
     def self.save_plist(obj, filename)
       File.open(filename, 'wb') do |f|
-        f.write(obj.to_plist)
+        f.write(Plist::Emit.dump(obj))
       end
     end
 


### PR DESCRIPTION
See https://github.com/puppetlabs/facter/pull/499 and the linked
redmine tickets for backstory. The basic issue here is that
CFPropertyList monkey-patches some core ruby classes with a
to_plist method, which defaults to returning binary data. This
code was originally written to the vendored CFPropertyList
previously included in facter (but unvendored in fact-94),
which provided a different to_plist implementation returning
text data.

This commit avoids the conflicting to_plist implementations by
calling its own dump method, thus no change in behavior.
