### PR TITLE
(maint) Reset facter search path when resetting facts

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -184,6 +184,7 @@ module Facter
   # @api public
   def self.reset
     @collection = nil
+    reset_search_path!
   end
 
   # Loads all facts.
@@ -194,8 +195,6 @@ module Facter
   def self.loadfacts
     collection.load_all
   end
-
-  @search_path = []
 
   # Register directories to be searched for facts. The registered directories
   # must be absolute paths or they will be ignored.
@@ -217,6 +216,16 @@ module Facter
   def self.search_path
     @search_path.dup
   end
+
+  # Reset the Facter search directories.
+  #
+  # @api private
+  # @return [void]
+  def self.reset_search_path!
+    @search_path = []
+  end
+
+  reset_search_path!
 
   # Registers directories to be searched for external facts.
   #

--- a/spec/unit/facter_spec.rb
+++ b/spec/unit/facter_spec.rb
@@ -109,7 +109,7 @@ describe Facter do
   end
 
   describe "when registering directories to search" do
-    after { Facter.instance_variable_set("@search_path", []) }
+    after { Facter.reset_search_path! }
 
     it "should allow registration of a directory" do
       Facter.search "/my/dir"


### PR DESCRIPTION
The previous implementation of Facter search paths was only additive and
there was no way to remove Facter search paths once added. This is
especially problematic when running the Puppet specs which wind up
reloading Facter frequently and adding search paths, and can wind up
adding thousands of meaningless paths. This commit resets the Facter
search path on `Facter.reset` so that when facts are reset, the known
search pats are reset as well.
