### PR TITLE
Make kernelmajversion useful in FreeBSD

### DIFF
--- a/lib/facter/kernelmajversion.rb
+++ b/lib/facter/kernelmajversion.rb
@@ -3,7 +3,8 @@
 # Purpose: Return the operating system's release number's major value.
 #
 # Resolution:
-#   Takes the first 2 elements of the kernel version as delimited by periods.
+#   Takes the first 2 elements of the kernel version as delimited by periods. 
+#   Takes the first element of the kernel version on FreeBSD
 #
 # Caveats:
 #


### PR DESCRIPTION
FreeBSD has used a 2-element release number since before 3.0. The current kernalmajversion returns the first two elements of kernelversion, which is exactly the same as kernelversion on FreeBSD. This  fact now returns just the first element when on FreeBSD.
