### PR TITLE
(maint) Return the empty string on exec error

### DIFF
--- a/lib/facter/core/execution.rb
+++ b/lib/facter/core/execution.rb
@@ -165,7 +165,7 @@ module Facter
             # if we can find the binary, we'll run the command with the expanded path to the binary
             code = expanded_code
           else
-            return nil
+            return ''
           end
 
           out = ''
@@ -174,7 +174,7 @@ module Facter
             out = %x{#{code}}.chomp
           rescue => detail
             Facter.warn(detail)
-            return nil
+            return ''
           end
 
           out


### PR DESCRIPTION
Commit 8a14998 removed most of the special casing around executing
commands and changed calling code to always assume that .exec would
return a string. However the error cases in .exec would still return
nil which would break this assumption.

This commit updates .exec to return the empty string on error. It's
somewhat questionable to do this but if we want to fail hard on errors
we should raise an exception instead of returning nil.
