### PR TITLE
(FACT-351) Fix netmask fact on Darwin and *BSD

### DIFF
--- a/lib/facter/util/netmask.rb
+++ b/lib/facter/util/netmask.rb
@@ -20,7 +20,7 @@ module Facter::NetMask
     when 'FreeBSD','NetBSD','OpenBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly'
       ops = {
         :ifconfig_opts => ['-a'],
-        :regex => %r{\s+ inet \s #{Facter.ipaddress} \s netmask \s 0x(\w{8})}x,
+        :regex => %r{\s+ inet \s #{Facter.value(:ipaddress)} \s netmask \s 0x(\w{8})}x,
         :munge => Proc.new { |mask| mask.scan(/../).collect do |byte| byte.to_i(16) end.join('.') }
       }
     end

--- a/spec/fixtures/unit/netmask/darwin_10_8_5.txt
+++ b/spec/fixtures/unit/netmask/darwin_10_8_5.txt
@@ -1,0 +1,30 @@
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	options=3<RXCSUM,TXCSUM>
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+	inet 127.0.0.1 netmask 0xff000000
+	inet6 ::1 prefixlen 128
+gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
+stf0: flags=0<> mtu 1280
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	ether 28:cf:e9:1a:8a:2d
+	inet6 fe80::2acf:e9ff:fe1a:8a2d%en0 prefixlen 64 scopeid 0x5
+	inet 10.16.141.17 netmask 0xfffffc00 broadcast 10.16.143.255
+	media: autoselect
+	status: active
+p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
+	ether 0a:cf:e9:1a:8a:2d
+	media: autoselect
+	status: inactive
+vmnet1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	ether 00:50:56:c0:00:01
+	inet 192.168.51.1 netmask 0xffffff00 broadcast 192.168.51.255
+vmnet8: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	ether 00:50:56:c0:00:08
+	inet 172.16.138.1 netmask 0xffffff00 broadcast 172.16.138.255
+en3: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+	options=4<VLAN_MTU>
+	ether 70:11:24:8c:33:df
+	inet6 fe80::7211:24ff:fe8c:33df%en3 prefixlen 64 scopeid 0x7
+	inet 10.16.16.205 netmask 0xfffffc00 broadcast 10.16.19.255
+	media: autoselect (100baseTX <full-duplex>)
+	status: active

--- a/spec/unit/netmask_spec.rb
+++ b/spec/unit/netmask_spec.rb
@@ -27,6 +27,15 @@ describe "The netmask fact" do
       "ifconfig_ubuntu_1204.txt"
   end
 
+  context "on Darwin" do
+    before :each do
+      Facter.fact(:kernel).stubs(:value).returns("Darwin")
+    end
+
+    example_behavior_for "netmask from ifconfig output",
+      "Darwin 10.8.5", "255.255.252.0", "darwin_10_8_5.txt"
+  end
+
   context "on Windows" do
     require 'facter/util/wmi'
     require 'facter/util/registry'


### PR DESCRIPTION
During facter2 development, the method_missing logic for resolving fact
values has been removed, e.g. Facter.ipaddress. There was one case left
over that when called would produce:

```
Could not retrieve fact='netmask', resolution='<anonymous>':
undefined method `ipaddress' for Facter:Module
```

and no backtrace.

This commit patches up the fact and adds a spec test.
