### PR TITLE
Patch blockdevices to work around Kernel bug

### DIFF
--- a/lib/facter/blockdevices.rb
+++ b/lib/facter/blockdevices.rb
@@ -75,19 +75,19 @@ if Facter.value(:kernel) == 'Linux'
 
       if File.exist?(sizefile)
         Facter.add("blockdevice_#{device}_size".to_sym) do
-          setcode { IO.read(sizefile).strip.to_i * 512 }
+          setcode { Facter::Util::Resolution.exec("cat #{sizefile}").strip.to_i * 512 }
         end
       end
 
       if File.exist?(vendorfile)
         Facter.add("blockdevice_#{device}_vendor".to_sym) do
-          setcode { IO.read(vendorfile).strip }
+          setcode { Facter::Util::Resolution.exec("cat #{vendorfile}").strip }
         end
       end
 
       if File.exist?(modelfile)
         Facter.add("blockdevice_#{device}_model".to_sym) do
-          setcode { IO.read(modelfile).strip }
+          setcode { Facter::Util::Resolution.exec("cat #{modelfile}").strip }
         end
       end
 


### PR DESCRIPTION
There is a known bug in certain Linux kernel versions (that some of our
customers use), which causes IO.read in ruby to hang, when reading from
proc filesystem.

This patch works around that issue for the blockdevice facts.

The behavior should match the existing spec tests as far as I can tell.
