### PR TITLE
(FACT-409) Preserve semantics of .exec

### DIFF
--- a/lib/facter/core/execution.rb
+++ b/lib/facter/core/execution.rb
@@ -83,10 +83,20 @@ module Facter
         @@impl.with_env(values, &block)
       end
 
-      # Executes a program and return the output of that program.
+      # Try to execute a command and return the output.
       #
-      # Returns nil if the program can't be found, or if there is a problem
-      # executing the code.
+      # @param code [String] the program to run
+      #
+      # @return [String] the output of the program, or nil if the command does
+      #   not exist or could not be executed.
+      #
+      # @deprecated Use #{execute} instead
+      # @api public
+      def exec(command)
+        @@impl.execute(command, :on_fail => nil)
+      end
+
+      # Execute a command and return the output of that program.
       #
       # @param code [String] the program to run
       # @param options [Hash]
@@ -102,8 +112,9 @@ module Facter
       #   command execution failed and :on_fail was specified.
       #
       # @api public
-      def exec(command, options = {})
-        @@impl.exec(command, options)
+      # @since 2.0.1
+      def execute(command, options = {})
+        @@impl.execute(command, options)
       end
 
       class ExecutionFailure < StandardError; end

--- a/lib/facter/core/execution/base.rb
+++ b/lib/facter/core/execution/base.rb
@@ -27,7 +27,7 @@ class Facter::Core::Execution::Base
     rv
   end
 
-  def exec(command, options = {})
+  def execute(command, options = {})
 
     on_fail = options.fetch(:on_fail, :raise)
 

--- a/lib/facter/hostname.rb
+++ b/lib/facter/hostname.rb
@@ -14,7 +14,7 @@
 Facter.add(:hostname) do
   setcode do
     hostname = nil
-    if name = Facter::Core::Execution.exec('hostname')
+    if name = Facter::Core::Execution.execute('hostname')
       if name =~ /(.*?)\./
         hostname = $1
       else

--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -155,7 +155,7 @@ Facter.add(:ipaddress, :timeout => 2) do
     if hostname = Facter.value(:hostname)
       # we need Hostname to exist for this to work
       host = nil
-      if host = Facter::Core::Execution.exec("host #{hostname}")
+      if host = Facter::Core::Execution.execute("host #{hostname}")
         list = host.chomp.split(/\s/)
         if defined? list[-1] and
           list[-1] =~ /[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/

--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -23,7 +23,7 @@ end
 Facter.add(:kernelrelease) do
   confine :kernel => "hp-ux"
   setcode do
-    version = Facter::Core::Execution.exec('uname -r') 
+    version = Facter::Core::Execution.execute('uname -r')
     version[2..-1]
   end
 end

--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -128,7 +128,7 @@ class Facter::Util::Resolution
   def setcode(string = nil, &block)
     if string
       @code = Proc.new do
-        output = Facter::Core::Execution.exec(string, :on_fail => nil)
+        output = Facter::Core::Execution.execute(string, :on_fail => nil)
         if output.nil? or output.empty?
           nil
         else

--- a/lib/facter/util/uptime.rb
+++ b/lib/facter/util/uptime.rb
@@ -20,7 +20,7 @@ module Facter::Util::Uptime
   private
 
   def self.uptime_proc_uptime
-    output = Facter::Core::Execution.exec("/bin/cat #{uptime_file} 2>/dev/null")
+    output = Facter::Core::Execution.execute("/bin/cat #{uptime_file} 2>/dev/null")
 
     if not output.empty?
       output.chomp.split(" ").first.to_i
@@ -28,14 +28,14 @@ module Facter::Util::Uptime
   end
 
   def self.uptime_sysctl
-    output = Facter::Core::Execution.exec("#{uptime_sysctl_cmd} 2>/dev/null", :on_fail => nil)
+    output = Facter::Core::Execution.execute("#{uptime_sysctl_cmd} 2>/dev/null", :on_fail => nil)
     if output
       compute_uptime(Time.at(output.match(/\d+/)[0].to_i))
     end
   end
 
   def self.uptime_executable
-    output = Facter::Core::Execution.exec("#{uptime_executable_cmd} 2>/dev/null", :on_fail => nil)
+    output = Facter::Core::Execution.execute("#{uptime_executable_cmd} 2>/dev/null", :on_fail => nil)
 
     if output
       up=0

--- a/spec/unit/core/execution/base_spec.rb
+++ b/spec/unit/core/execution/base_spec.rb
@@ -62,11 +62,11 @@ describe Facter::Core::Execution::Base do
     end
   end
 
-  describe "#exec" do
+  describe "#execute" do
 
     it "switches LANG to C when executing the command" do
       subject.expects(:with_env).with('LANG' => 'C')
-      subject.exec('foo')
+      subject.execute('foo')
     end
 
     it "switches LC_ALL to C when executing the command"
@@ -74,18 +74,18 @@ describe Facter::Core::Execution::Base do
     it "expands the command before running it" do
       subject.stubs(:`).returns ''
       subject.expects(:expand_command).with('foo').returns '/bin/foo'
-      subject.exec('foo')
+      subject.execute('foo')
     end
 
     describe "and the command is not present" do
       it "raises an error when the :on_fail behavior is :raise" do
         subject.expects(:expand_command).with('foo').returns nil
-        expect { subject.exec('foo') }.to raise_error(Facter::Core::Execution::ExecutionFailure)
+        expect { subject.execute('foo') }.to raise_error(Facter::Core::Execution::ExecutionFailure)
       end
 
       it "returns the given value when :on_fail is set to a value" do
         subject.expects(:expand_command).with('foo').returns nil
-        expect(subject.exec('foo', :on_fail => nil)).to be_nil
+        expect(subject.execute('foo', :on_fail => nil)).to be_nil
       end
     end
 
@@ -96,11 +96,11 @@ describe Facter::Core::Execution::Base do
       end
 
       it "raises an error when the :on_fail behavior is :raise" do
-        expect { subject.exec('foo') }.to raise_error(Facter::Core::Execution::ExecutionFailure)
+        expect { subject.execute('foo') }.to raise_error(Facter::Core::Execution::ExecutionFailure)
       end
 
       it "returns the given value when :on_fail is set to a value" do
-        expect(subject.exec('foo', :on_fail => nil)).to be_nil
+        expect(subject.execute('foo', :on_fail => nil)).to be_nil
       end
     end
 
@@ -112,21 +112,21 @@ describe Facter::Core::Execution::Base do
       Thread.expects(:new).yields
       Process.expects(:waitall).once
 
-      subject.exec("foo", :on_fail => nil)
+      subject.execute("foo", :on_fail => nil)
     end
 
     it "returns the output of the command" do
       subject.expects(:`).with("/bin/foo").returns 'hi'
       subject.expects(:expand_command).with('foo').returns '/bin/foo'
 
-      expect(subject.exec("foo")).to eq 'hi'
+      expect(subject.execute("foo")).to eq 'hi'
     end
 
     it "strips off trailing newlines" do
       subject.expects(:`).with("/bin/foo").returns "hi\n"
       subject.expects(:expand_command).with('foo').returns '/bin/foo'
 
-      expect(subject.exec("foo")).to eq 'hi'
+      expect(subject.execute("foo")).to eq 'hi'
     end
   end
 end

--- a/spec/unit/core/execution_spec.rb
+++ b/spec/unit/core/execution_spec.rb
@@ -30,8 +30,13 @@ describe Facter::Core::Execution do
     subject.expand_command('waffles')
   end
 
-  it "delegates #exec to the implementation" do
-    impl.expects(:exec).with('waffles', {})
+  it "delegates #exec to #execute" do
+    impl.expects(:execute).with('waffles', {:on_fail => nil})
     subject.exec('waffles')
+  end
+
+  it "delegates #execute to the implementation" do
+    impl.expects(:execute).with('waffles', {})
+    subject.execute('waffles')
   end
 end

--- a/spec/unit/hardwareisa_spec.rb
+++ b/spec/unit/hardwareisa_spec.rb
@@ -6,35 +6,35 @@ require 'facter'
 describe "Hardwareisa fact" do
   it "should match uname -p on Linux" do
     Facter.fact(:kernel).stubs(:value).returns("Linux")
-    Facter::Core::Execution.stubs(:exec).with("uname -p", anything).returns("Inky")
+    Facter::Core::Execution.stubs(:execute).with("uname -p", anything).returns("Inky")
 
     Facter.fact(:hardwareisa).value.should == "Inky"
   end
 
   it "should match uname -p on Darwin" do
     Facter.fact(:kernel).stubs(:value).returns("Darwin")
-    Facter::Core::Execution.stubs(:exec).with("uname -p", anything).returns("Blinky")
+    Facter::Core::Execution.stubs(:execute).with("uname -p", anything).returns("Blinky")
 
     Facter.fact(:hardwareisa).value.should == "Blinky"
   end
 
   it "should match uname -p on SunOS" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    Facter::Core::Execution.stubs(:exec).with("uname -p", anything).returns("Pinky")
+    Facter::Core::Execution.stubs(:execute).with("uname -p", anything).returns("Pinky")
 
     Facter.fact(:hardwareisa).value.should == "Pinky"
   end
 
   it "should match uname -p on FreeBSD" do
     Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-    Facter::Core::Execution.stubs(:exec).with("uname -p", anything).returns("Clyde")
+    Facter::Core::Execution.stubs(:execute).with("uname -p", anything).returns("Clyde")
 
     Facter.fact(:hardwareisa).value.should == "Clyde"
   end
 
   it "should match uname -m on HP-UX" do
     Facter.fact(:kernel).stubs(:value).returns("HP-UX")
-    Facter::Core::Execution.stubs(:exec).with("uname -m", anything).returns("Pac-Man")
+    Facter::Core::Execution.stubs(:execute).with("uname -m", anything).returns("Pac-Man")
 
     Facter.fact(:hardwareisa).value.should == "Pac-Man"
   end

--- a/spec/unit/hardwaremodel_spec.rb
+++ b/spec/unit/hardwaremodel_spec.rb
@@ -6,7 +6,7 @@ require 'facter'
 describe "Hardwaremodel fact" do
   it "should match uname -m by default" do
     Facter.fact(:kernel).stubs(:value).returns("Darwin")
-    Facter::Core::Execution.stubs(:exec).with("uname -m", anything).returns("Inky")
+    Facter::Core::Execution.stubs(:execute).with("uname -m", anything).returns("Inky")
 
     Facter.fact(:hardwaremodel).value.should == "Inky"
   end

--- a/spec/unit/hostname_spec.rb
+++ b/spec/unit/hostname_spec.rb
@@ -11,17 +11,17 @@ describe "Hostname facts" do
     end
 
     it "should use the hostname command" do
-      Facter::Core::Execution.expects(:exec).with('hostname').at_least_once
+      Facter::Core::Execution.expects(:execute).with('hostname').at_least_once
       Facter.fact(:hostname).value.should be_nil
     end
 
     it "should use hostname as the fact if unqualified" do
-      Facter::Core::Execution.stubs(:exec).with('hostname').returns('host1')
+      Facter::Core::Execution.stubs(:execute).with('hostname').returns('host1')
       Facter.fact(:hostname).value.should == "host1"
     end
 
     it "should truncate the domain name if qualified" do
-      Facter::Core::Execution.stubs(:exec).with('hostname').returns('host1.example.com')
+      Facter::Core::Execution.stubs(:execute).with('hostname').returns('host1.example.com')
       Facter.fact(:hostname).value.should == "host1"
     end
   end
@@ -33,7 +33,7 @@ describe "Hostname facts" do
     end
 
     it "should use scutil to get the hostname" do
-      Facter::Core::Execution.expects(:exec).with('/usr/sbin/scutil --get LocalHostName', anything).returns("host1")
+      Facter::Core::Execution.expects(:execute).with('/usr/sbin/scutil --get LocalHostName', anything).returns("host1")
       Facter.fact(:hostname).value.should == "host1"
     end
   end

--- a/spec/unit/id_spec.rb
+++ b/spec/unit/id_spec.rb
@@ -12,7 +12,7 @@ describe "id fact" do
       it "should return the current user" do
         given_a_configuration_of(:is_windows => k == 'windows')
         Facter.fact(:kernel).stubs(:value).returns(k)
-        Facter::Core::Execution.expects(:exec).once.with('whoami', anything).returns 'bar'
+        Facter::Core::Execution.expects(:execute).once.with('whoami', anything).returns 'bar'
 
         Facter.fact(:id).value.should == 'bar'
       end
@@ -21,8 +21,8 @@ describe "id fact" do
 
   it "should return the current user on Solaris" do
     given_a_configuration_of(:is_windows => false)
-    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('SunOS')
-    Facter::Core::Execution.expects(:exec).once.with('/usr/xpg4/bin/id -un', anything).returns 'bar'
+    Facter.fact(:kernel).stubs(:value).returns 'SunOS'
+    Facter::Core::Execution.expects(:execute).once.with('/usr/xpg4/bin/id -un', anything).returns 'bar'
 
     Facter.fact(:id).value.should == 'bar'
   end

--- a/spec/unit/ipaddress_spec.rb
+++ b/spec/unit/ipaddress_spec.rb
@@ -60,7 +60,7 @@ describe "ipaddress fact" do
     context "when you have no active network adapter" do
       it "should return nil if there are no active (or any) network adapters" do
         Facter::Util::WMI.expects(:execquery).with(Facter::Util::IP::Windows::WMI_IP_INFO_QUERY).returns([])
-        Facter::Core::Execution.stubs(:exec)
+        Facter::Core::Execution.stubs(:execute)
 
         Facter.value(:ipaddress).should == nil
       end

--- a/spec/unit/kernelrelease_spec.rb
+++ b/spec/unit/kernelrelease_spec.rb
@@ -21,7 +21,7 @@ describe "Kernel release fact" do
   describe "on AIX" do
     before do
       Facter.fact(:kernel).stubs(:value).returns("aix")
-      Facter::Core::Execution.stubs(:exec).with('oslevel -s', anything).returns("test_kernel")
+      Facter::Core::Execution.stubs(:execute).with('oslevel -s', anything).returns("test_kernel")
     end
 
     it "should return the kernel release" do
@@ -32,7 +32,7 @@ describe "Kernel release fact" do
   describe "on HP-UX" do
     before do
       Facter.fact(:kernel).stubs(:value).returns("hp-ux")
-      Facter::Core::Execution.stubs(:exec).with('uname -r').returns("B.11.31")
+      Facter::Core::Execution.stubs(:execute).with('uname -r').returns("B.11.31")
     end
 
     it "should remove preceding letters" do
@@ -43,7 +43,7 @@ describe "Kernel release fact" do
   describe "on everything else" do
     before do
       Facter.fact(:kernel).stubs(:value).returns("linux")
-      Facter::Core::Execution.stubs(:exec).with('uname -r', anything).returns("test_kernel")
+      Facter::Core::Execution.stubs(:execute).with('uname -r', anything).returns("test_kernel")
     end
 
     it "should return the kernel release" do

--- a/spec/unit/kernelversion_spec.rb
+++ b/spec/unit/kernelversion_spec.rb
@@ -7,7 +7,7 @@ describe "Kernel version fact" do
   describe "on Solaris/Sun OS" do
     before do
       Facter.fact(:kernel).stubs(:value).returns('sunos')
-      Facter::Core::Execution.stubs(:exec).with('uname -v', anything).returns("1.234.5")
+      Facter::Core::Execution.stubs(:execute).with('uname -v', anything).returns("1.234.5")
     end
 
     it "should return the kernel version using 'uname -v'" do

--- a/spec/unit/lsbdistcodename_spec.rb
+++ b/spec/unit/lsbdistcodename_spec.rb
@@ -11,7 +11,7 @@ describe "lsbdistcodename fact" do
       end
 
       it "returns the codename through lsb_release -c -s 2>/dev/null" do
-        Facter::Core::Execution.impl.stubs(:exec).with('lsb_release -c -s 2>/dev/null', anything).returns 'n/a'
+        Facter::Core::Execution.impl.stubs(:execute).with('lsb_release -c -s 2>/dev/null', anything).returns 'n/a'
         expect(Facter.fact(:lsbdistcodename).value).to eq 'n/a'
       end
 

--- a/spec/unit/lsbdistid_spec.rb
+++ b/spec/unit/lsbdistid_spec.rb
@@ -11,7 +11,7 @@ describe "lsbdistid fact" do
       end
 
       it "returns the id through lsb_release -i -s 2>/dev/null" do
-        Facter::Core::Execution.impl.stubs(:exec).with('lsb_release -i -s 2>/dev/null', anything).returns 'Gentoo'
+        Facter::Core::Execution.impl.stubs(:execute).with('lsb_release -i -s 2>/dev/null', anything).returns 'Gentoo'
         expect(Facter.fact(:lsbdistid).value).to eq 'Gentoo'
       end
 

--- a/spec/unit/lsbdistrelease_spec.rb
+++ b/spec/unit/lsbdistrelease_spec.rb
@@ -11,12 +11,12 @@ describe "lsbdistrelease fact" do
       end
 
       it "should return the release through lsb_release -r -s 2>/dev/null" do
-        Facter::Core::Execution.stubs(:exec).with('lsb_release -r -s 2>/dev/null', anything).returns '2.1'
+        Facter::Core::Execution.stubs(:execute).with('lsb_release -r -s 2>/dev/null', anything).returns '2.1'
         Facter.fact(:lsbdistrelease).value.should == '2.1'
       end
 
       it "should return nil if lsb_release is not installed" do
-        Facter::Core::Execution.stubs(:exec).with('lsb_release -r -s 2>/dev/null', anything).returns nil
+        Facter::Core::Execution.stubs(:execute).with('lsb_release -r -s 2>/dev/null', anything).returns nil
         Facter.fact(:lsbdistrelease).value.should be_nil
       end
     end

--- a/spec/unit/lsbrelease_spec.rb
+++ b/spec/unit/lsbrelease_spec.rb
@@ -11,7 +11,7 @@ describe "lsbrelease fact" do
       end
 
       it "returns the release through lsb_release -v -s 2>/dev/null" do
-        Facter::Core::Execution.impl.stubs(:exec).with('lsb_release -v -s 2>/dev/null', anything).returns 'n/a'
+        Facter::Core::Execution.impl.stubs(:execute).with('lsb_release -v -s 2>/dev/null', anything).returns 'n/a'
         expect(Facter.fact(:lsbrelease).value).to eq 'n/a'
       end
 

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -185,35 +185,35 @@ describe "Processor facts" do
 
     it "should be 2 on dual-processor Darwin box" do
       Facter.fact(:kernel).stubs(:value).returns("Darwin")
-      Facter::Core::Execution.stubs(:exec).with("sysctl -n hw.ncpu", anything).returns('2')
+      Facter::Core::Execution.stubs(:execute).with("sysctl -n hw.ncpu", anything).returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should be 2 on dual-processor OpenBSD box" do
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
-      Facter::Core::Execution.stubs(:exec).with("sysctl -n hw.ncpu", anything).returns('2')
+      Facter::Core::Execution.stubs(:execute).with("sysctl -n hw.ncpu", anything).returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should be 2 on dual-processor FreeBSD box" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Core::Execution.stubs(:exec).with("sysctl -n hw.ncpu", anything).returns('2')
+      Facter::Core::Execution.stubs(:execute).with("sysctl -n hw.ncpu", anything).returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end
 
     it "should print the correct CPU Model on FreeBSD" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
-      Facter::Core::Execution.stubs(:exec).with("sysctl -n hw.model", anything).returns('SomeVendor CPU 3GHz')
+      Facter::Core::Execution.stubs(:execute).with("sysctl -n hw.model", anything).returns('SomeVendor CPU 3GHz')
 
       Facter.fact(:processor).value.should == "SomeVendor CPU 3GHz"
     end
 
     it "should be 2 on dual-processor DragonFly box" do
       Facter.fact(:kernel).stubs(:value).returns("DragonFly")
-      Facter::Core::Execution.stubs(:exec).with("sysctl -n hw.ncpu", anything).returns('2')
+      Facter::Core::Execution.stubs(:execute).with("sysctl -n hw.ncpu", anything).returns('2')
 
       Facter.fact(:processorcount).value.should == "2"
     end

--- a/spec/unit/uniqueid_spec.rb
+++ b/spec/unit/uniqueid_spec.rb
@@ -6,21 +6,21 @@ require 'facter'
 describe "Uniqueid fact" do
   it "should match hostid on Solaris" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    Facter::Core::Execution.stubs(:exec).with("hostid", anything).returns("Larry")
+    Facter::Core::Execution.stubs(:execute).with("hostid", anything).returns("Larry")
 
     Facter.fact(:uniqueid).value.should == "Larry"
   end
 
   it "should match hostid on Linux" do
     Facter.fact(:kernel).stubs(:value).returns("Linux")
-    Facter::Core::Execution.stubs(:exec).with("hostid", anything).returns("Curly")
+    Facter::Core::Execution.stubs(:execute).with("hostid", anything).returns("Curly")
 
     Facter.fact(:uniqueid).value.should == "Curly"
   end
 
   it "should match hostid on AIX" do
     Facter.fact(:kernel).stubs(:value).returns("AIX")
-    Facter::Core::Execution.stubs(:exec).with("hostid", anything).returns("Moe")
+    Facter::Core::Execution.stubs(:execute).with("hostid", anything).returns("Moe")
 
     Facter.fact(:uniqueid).value.should == "Moe"
   end

--- a/spec/unit/util/resolution_spec.rb
+++ b/spec/unit/util/resolution_spec.rb
@@ -74,7 +74,7 @@ describe Facter::Util::Resolution do
     describe "and the code is a string" do
       it "returns the result of executing the code" do
         resolution.setcode "/bin/foo"
-        Facter::Core::Execution.expects(:exec).once.with("/bin/foo", anything).returns "yup"
+        Facter::Core::Execution.expects(:execute).once.with("/bin/foo", anything).returns "yup"
 
         expect(resolution.value).to eq "yup"
       end

--- a/spec/unit/util/uptime_spec.rb
+++ b/spec/unit/util/uptime_spec.rb
@@ -99,14 +99,14 @@ describe Facter::Util::Uptime do
 
           test_cases.each do |uptime, expected|
             it "should return #{expected} for #{uptime}" do
-              Facter::Core::Execution.stubs(:exec).with('uptime 2>/dev/null', {:on_fail => nil}).returns(uptime)
+              Facter::Core::Execution.stubs(:execute).with('uptime 2>/dev/null', {:on_fail => nil}).returns(uptime)
               Facter.fact(:uptime_seconds).value.should == expected
             end
           end
 
           describe "nor is 'uptime' command" do
             before :each do
-              Facter::Core::Execution.stubs(:exec).with('uptime 2>/dev/null', {:on_fail => nil}).returns(nil)
+              Facter::Core::Execution.stubs(:execute).with('uptime 2>/dev/null', {:on_fail => nil}).returns(nil)
             end
 
             it "should return nil" do

--- a/spec/unit/zonename_spec.rb
+++ b/spec/unit/zonename_spec.rb
@@ -7,7 +7,7 @@ describe "zonename fact" do
 
   it "should return global zone" do
     Facter.fact(:kernel).stubs(:value).returns("SunOS")
-    Facter::Core::Execution.stubs(:exec).with("zonename", anything).returns('global')
+    Facter::Core::Execution.stubs(:execute).with("zonename", anything).returns('global')
 
     Facter.fact(:zonename).value.should == "global"
   end


### PR DESCRIPTION
Raising an error when .exec tries to run a non-existent command is a
major backwards incompatible change. While we're on a breaking change
boundary we're trying to minimize the upgrade pain, so to reduce this
the behavior of .exec is preserved when running non-existent commands.
In the long run .exec should be deprecated in favor of .execute.
