### PR TITLE
(maint) Pin rake to the last 1.8 compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ platforms :ruby do
 end
 
 group :development, :test do
-  gem 'rake'
+  gem 'rake', "~> 10.1.0"
   gem 'rspec', "~> 2.11.0"
   gem 'mocha', "~> 0.10.5"
   gem 'json', "~> 1.7", :platforms => :ruby


### PR DESCRIPTION
Rake 10.2.0 breaks compatibility with Ruby 1.8.7, so we need to pin the rake version for the near future.
