### PR TITLE
Convert-Interface-Names: not replace : and .

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -71,7 +71,7 @@ class Facter::Util::IP
   #
   # @api private
   def self.alphafy(interface)
-    interface.to_s.gsub(/[^a-z0-9_]/i, '_')
+    interface.to_s.gsub(/[^a-z0-9_:.]/i, '_')
   end
 
   # Returns an array of supported platforms in string format. These array values


### PR DESCRIPTION
The interface fact makes no differentiation between virtual IPs (eth0:1) and interfaces (eth0.1). Both interfaces are converted to eth0_1.
