### PR TITLE
(maint) Define Util::Resolution#resolution_type

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -62,6 +62,10 @@ class Facter::Util::Resolution
     @weight = nil
   end
 
+  def resolution_type
+    :simple
+  end
+
   # Evaluate the given block in the context of this resolution. If a block has
   # already been evaluated emit a warning to that effect.
   #


### PR DESCRIPTION
The resolution_type method is needed when reopening a fact definition
with the Facter 2.0 API:

Facter.define_fact(:myfact) do
  define_resolution(:myres) do
    # [...]

The aggregate resolution type implemented this but Util::Resolution did
not, which could cause errors using the new syntax. This corrects the
omission.
