### PR TITLE
(FACT-459) Fix MTU interface facts not being reported for Archlinux.

### DIFF
--- a/lib/facter/util/ip/linux.rb
+++ b/lib/facter/util/ip/linux.rb
@@ -37,7 +37,7 @@ class Facter::Util::IP::Linux < Facter::Util::IP::Base
   # @return [Regexp]
   #
   # @api private
-  MTU_REGEX = /MTU:(\d+)/
+  MTU_REGEX = /MTU:?\s*(\d+)/i
 
   # Linux doesn't display netmask in hex.
   #

--- a/spec/unit/util/ip/linux_spec.rb
+++ b/spec/unit/util/ip/linux_spec.rb
@@ -143,9 +143,7 @@ describe Facter::Util::IP::Linux do
         end
 
         it "extracts the mtu" do
-          pending "Resolution of Archlinux, which outputs BSD style output, getting parsed using Linux formatting" do
-            described_class.value_for_interface_and_label("em1", "mtu").should eq "1500"
-          end
+          described_class.value_for_interface_and_label("em1", "mtu").should eq "1500"
         end
 
         it "extracts the netmask" do
@@ -159,9 +157,7 @@ describe Facter::Util::IP::Linux do
         end
 
         it "extracts the mtu" do
-          pending "Resolution of Archlinux, which outputs BSD style output, getting parsed using Linux formatting" do
-            described_class.value_for_interface_and_label("lo", "mtu").should eq "16436"
-          end
+          described_class.value_for_interface_and_label("lo", "mtu").should eq "16436"
         end
 
         it "extracts the netmask" do


### PR DESCRIPTION
The regular expression being used assumes that MTU is uppercase and
followed by a colon. On Archlinux, ifconfig (net-tools 1.60+) reports a lowercase "mtu"
followed by a space (BSD format).

I don't see a reason why the Linux regex can't support both formats.
