### PR TITLE
Fix swap facts for SmartOS container

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -204,7 +204,7 @@ module Facter::Memory
         0
       end
     when /SunOS/i
-      if line =~ /^\/\S+\s.*\s+(\d+)\s+(\d+)$/
+      if line =~ /^\S+\s.*\s+(\d+)\s+(\d+)$/
         (is_size) ? $1.to_i : $2.to_i
       else
         0

--- a/spec/fixtures/unit/memory/smartos_zone_swap_l-single
+++ b/spec/fixtures/unit/memory/smartos_zone_swap_l-single
@@ -1,0 +1,2 @@
+swapfile             dev    swaplo   blocks     free
+swap                  -          8 100663296 68968568

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -229,6 +229,7 @@ SVMON
     end
   end
 
+
   describe "on Solaris" do
     before(:each) do
       Facter.clear
@@ -265,6 +266,7 @@ SVMON
       it "should return the current swap size in MB" do
         Facter.fact(:swapsize_mb).value.should == "1023.99"
       end
+
     end
 
     describe "when multiple swaps exist" do
@@ -313,6 +315,22 @@ SVMON
         Facter.fact(:swapsize_mb).value.should == "0.00"
       end
     end
+
+    describe "when in a SmartOS zone" do
+      before(:each) do
+        Facter::Core::Execution.stubs(:exec).with('/usr/sbin/swap -l 2>/dev/null').returns my_fixture_read('smartos_zone_swap_l-single')
+        Facter.collection.internal_loader.load(:memory)
+      end
+
+      it "should return the current swap size in MB" do
+        Facter.fact(:swapsize_mb).value.should == "49152.00"
+      end
+
+      it "should return the current swap free in MB" do
+        Facter.fact(:swapfree_mb).value.should == "33676.06"
+      end
+    end
+
   end
 
     describe "on DragonFly BSD" do


### PR DESCRIPTION
- inside a SmartOS container swap facts report 0 for size and free even
  though a swap volume is allocated

This is due to the way swap is allocated in the container, the swap device does not start with a "/"
