### PR TITLE
(FACT-476) Make the 'processor' fact for OpenBSD consistent with other systems

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -7,8 +7,8 @@
 #   On Linux and kFreeBSD, parse '/proc/cpuinfo' for each processor.
 #   On AIX, parse the output of 'lsdev' for its processor section.
 #   On Solaris, parse the output of 'kstat' for each processor.
-#   On OpenBSD, use 'uname -p' and the sysctl variable for 'hw.ncpu' for CPU
-#   count.
+#   On OpenBSD, use the sysctl variables 'hw.model' and 'hw.ncpu'
+#   for the CPU model and the CPU count respectively.
 #
 # Caveats:
 #
@@ -102,11 +102,6 @@ Facter.add("ProcessorCount") do
   end
 end
 
-Facter.add("Processor") do
-  confine :kernel => :openbsd
-  setcode "uname -p"
-end
-
 Facter.add("ProcessorCount") do
   confine :kernel => :Darwin
   setcode do
@@ -151,7 +146,7 @@ if Facter.value(:kernel) == "windows"
 end
 
 Facter.add("Processor") do
-  confine :kernel => [:dragonfly,:freebsd]
+  confine :kernel => [:dragonfly,:freebsd,:openbsd]
   setcode do
     Facter::Util::POSIX.sysctl("hw.model")
   end

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -230,6 +230,13 @@ describe "Processor facts" do
       Facter.fact(:processorcount).value.should == "2"
     end
 
+    it "should print the correct CPU Model on OpenBSD" do
+      Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
+      Facter::Util::POSIX.stubs(:sysctl).with("hw.model").returns('SomeVendor CPU 4.2GHz')
+
+      Facter.fact(:processor).value.should == "SomeVendor CPU 4.2GHz"
+    end
+
     it "should be 2 on dual-processor FreeBSD box" do
       Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
       Facter::Util::POSIX.stubs(:sysctl).with("hw.ncpu").returns('2')


### PR DESCRIPTION
Turns out 'processor => sparc64' is too terse, we already get that information via other facts so make the 'processor' fact on OpenBSD behave like other systems and return a value like "SUNW,UltraSPARC-T1 (rev 0.0) @ 1000 MHz"
