### PR TITLE
Add Docker support for virtual and is_virtual

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -138,8 +138,19 @@ module Facter::Util::Virtual
   def self.lxc?
     path = Pathname.new('/proc/1/cgroup')
     return false unless path.readable?
-    lxc_hierarchies = path.readlines.map {|l| l.split(":")[2].to_s.start_with? '/lxc/' }
-    return true if lxc_hierarchies.include?(true)
+    in_lxc = path.readlines.any? {|l| l.split(":")[2].to_s.start_with? '/lxc/' }
+    return true if in_lxc
+    return false
+  end
+
+  ##
+  # docker? returns true if the process is running inside of a docker container.
+  # Implementation derived from observation of a boot2docker system
+  def self.docker?
+    path = Pathname.new('/proc/1/cgroup')
+    return false unless path.readable?
+    in_docker = path.readlines.any? {|l| l.split(":")[2].to_s.start_with? '/docker/' }
+    return true if in_docker
     return false
   end
 

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -265,6 +265,17 @@ Facter.add("virtual") do
   end
 end
 
+##
+# virtual fact specific to docker containers.
+Facter.add("virtual") do
+  has_weight 750
+  confine :kernel => "Linux"
+
+  setcode do
+    "docker" if Facter::Util::Virtual.docker?
+  end
+end
+
 # Fact: is_virtual
 #
 # Purpose: returning true or false for if a machine is virtualised or not.

--- a/spec/fixtures/virtual/proc_1_cgroup/in_a_docker_container
+++ b/spec/fixtures/virtual/proc_1_cgroup/in_a_docker_container
@@ -1,0 +1,8 @@
+9:perf_event:/
+8:blkio:/
+7:freezer:/
+6:devices:/docker/0e3c605ac1470c776c34a8eff362a0c816bcaac78559a43955173bd786281b7f
+5:memory:/
+4:cpuacct:/
+3:cpu:/docker/0e3c605ac1470c776c34a8eff362a0c816bcaac78559a43955173bd786281b7f
+2:cpuset:/

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -321,4 +321,34 @@ describe Facter::Util::Virtual do
       end
     end
   end
+
+  describe '.docker?' do
+    subject do
+      Facter::Util::Virtual.docker?
+    end
+
+    fixture_path = fixtures('virtual', 'proc_1_cgroup')
+
+    context '/proc/1/cgroup has at least one hierarchy rooted in /docker/' do
+      before :each do
+        fakepath = Pathname.new(File.join(fixture_path, 'in_a_docker_container'))
+        Pathname.stubs(:new).with('/proc/1/cgroup').returns(fakepath)
+      end
+
+      it 'is true' do
+        subject.should be_true
+      end
+    end
+
+    context '/proc/1/cgroup has no hierarchies rooted in /docker/' do
+      before :each do
+        fakepath = Pathname.new(File.join(fixture_path, 'not_in_a_container'))
+        Pathname.stubs(:new).with('/proc/1/cgroup').returns(fakepath)
+      end
+
+      it 'is false' do
+        subject.should be_false
+      end
+    end
+  end
 end

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -6,6 +6,7 @@ require 'facter/util/macosx'
 
 describe "Virtual fact" do
   before(:each) do
+    Facter::Util::Virtual.stubs(:docker?).returns(false)
     Facter::Util::Virtual.stubs(:lxc?).returns(false)
     Facter::Util::Virtual.stubs(:zone?).returns(false)
     Facter::Util::Virtual.stubs(:openvz?).returns(false)
@@ -179,6 +180,17 @@ describe "Virtual fact" do
       it 'is "lxc" when Facter::Util::Virtual.lxc? is true' do
         Facter::Util::Virtual.stubs(:lxc?).returns(true)
         Facter.fact(:virtual).value.should == 'lxc'
+      end
+    end
+
+    context "In a Docker Container (docker)" do
+      before :each do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+      end
+
+      it 'is "docker" when Facter::Util::Virtual.docker? is true' do
+        Facter::Util::Virtual.stubs(:docker?).returns(true)
+        Facter.fact(:virtual).value.should == 'docker'
       end
     end
 
@@ -483,6 +495,12 @@ describe "is_virtual fact" do
   it "should be true when running in LXC" do
     Facter.fact(:kernel).stubs(:value).returns("Linux")
     Facter.fact(:virtual).stubs(:value).returns("lxc")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
+
+  it "should be true when running in docker" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("docker")
     Facter.fact(:is_virtual).value.should == "true"
   end
 end


### PR DESCRIPTION
Similar to 632041b2aba05ee85b431a802288273b922ca639 but specifically detects a `docker` container rather than the more general form of an `lxc` container.
