### PR TITLE
(FACT-481) Infinite loop when EC2 metadata server times out

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -28,14 +28,15 @@ module Facter
           if e.message.match /404 Not Found/i
             able_to_connect = false
           else
+            attempts = attempts + 1
             retry if attempts < retry_limit
           end
         rescue Timeout::Error
+          attempts = attempts + 1
           retry if attempts < retry_limit
         rescue *CONNECTION_ERRORS
-          retry if attempts < retry_limit
-        ensure
           attempts = attempts + 1
+          retry if attempts < retry_limit
         end
 
         able_to_connect

--- a/spec/unit/ec2/rest_spec.rb
+++ b/spec/unit/ec2/rest_spec.rb
@@ -18,6 +18,11 @@ shared_examples_for "an ec2 rest querier" do
       subject.expects(:open).with(anything).once.raises(OpenURI::HTTPError.new("404 Not Found", StringIO.new("woo")))
       expect(subject).to_not be_reachable
     end
+
+    it "is false if the connection always times out" do
+      Timeout.expects(:timeout).with(0.2).times(3).raises(Timeout::Error)
+      expect(subject).to_not be_reachable
+    end
   end
 
 end


### PR DESCRIPTION
The retry loop for contacting the EC2 metadata server failed to increment the
attempt counter on each iteration, as the 'ensure' block only executes once
the entire begin/rescue block has been completed, not on each retry.
