### PR TITLE
 (FACT-233) support nmcli >=0.9.9 syntax

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -17,8 +17,8 @@ require 'facter/util/dhcp_servers'
 
 
 Facter.add(:dhcp_servers) do
-  confine :operatingsystem => "Fedora", :operatingsystemrelease => "19"
   confine do
+    confine :kernel => :linux
     Facter::Core::Execution.which('nmcli')
   end
 

--- a/lib/facter/util/dhcp_servers.rb
+++ b/lib/facter/util/dhcp_servers.rb
@@ -13,7 +13,17 @@ module Facter::Util::DHCPServers
 
   def self.device_dhcp_server(device)
     if Facter::Core::Execution.which('nmcli')
-      Facter::Core::Execution.exec("nmcli d list iface #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
+      if self.nmcli_version and self.nmcli_version >= 990
+        Facter::Core::Execution.exec("nmcli d show #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
+      else
+        Facter::Core::Execution.exec("nmcli d list iface #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
+      end
+    end
+  end
+
+  def self.nmcli_version
+    if version = Facter::Core::Execution.exec("nmcli --version").scan(/version\s([\d\.]+)/).flatten.first
+      version.gsub(/\./,'').to_i
     end
   end
 end

--- a/spec/unit/dhcp_servers_spec.rb
+++ b/spec/unit/dhcp_servers_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe "DHCP server facts" do
   describe "on Linux OS's" do
     before :each do
-      Facter.fact(:operatingsystem).stubs(:value).returns 'Fedora'
-      Facter.fact(:operatingsystemrelease).stubs(:value).returns '19'
+      Facter.fact(:kernel).stubs(:value).returns 'Linux'
       Facter::Core::Execution.stubs(:exec).with("route -n").returns(my_fixture_read("route"))
     end
 
-    describe "with nmcli available" do
+    describe "with nmcli version <= 0.9.8 available" do
       before :each do
         Facter::Core::Execution.stubs(:which).with('nmcli').returns('/usr/bin/nmcli')
+        Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.8.0')
       end
 
       describe "with a main interface configured with DHCP" do
@@ -55,6 +55,72 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
+        end
+
+        it "should not produce a dhcp_servers fact" do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+
+      describe "with no CONNECTED devices" do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
+        end
+
+        it "should not produce a dhcp_servers fact" do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+    end
+
+    describe "with nmcli version >= 0.9.9 available" do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('nmcli').returns('/usr/bin/nmcli')
+        Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.9.0-20.git20131003.fc20')
+      end
+
+      describe "with a main interface configured with DHCP" do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
+          Facter.fact(:dhcp_servers).value.should == { 'system' => '192.168.1.1', 'eth0' => '192.168.1.1', 'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with a main interface NOT configured with DHCP" do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
+          Facter.fact(:dhcp_servers).value.should == {'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with no default gateway" do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with("route -n").returns(my_fixture_read("route_nogw"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+        end
+
+        it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
+          Facter.fact(:dhcp_servers).value.should == {'eth0' => '192.168.1.1', 'wlan0' => '192.168.2.1' }
+        end
+      end
+
+      describe "with no DHCP enabled interfaces" do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
+          Facter::Core::Execution.stubs(:exec).with("nmcli d show wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
         end
 
         it "should not produce a dhcp_servers fact" do

--- a/spec/unit/util/dhcp_servers_spec.rb
+++ b/spec/unit/util/dhcp_servers_spec.rb
@@ -1,0 +1,27 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+require 'facter/util/dhcp_servers'
+
+describe Facter::Util::DHCPServers do
+  describe "nmcli_version" do
+    {
+      'nmcli tool, version 0.9.8.0' => 980,
+      'nmcli tool, version 0.9.8.9' => 989,
+      'nmcli tool, version 0.9.9.0' => 990,
+      'nmcli tool, version 0.9.9.9' => 999,
+      'version 0.9.9.0-20.git20131003.fc20' => 990,
+    }.each do |version, expected|
+      it "should turn #{version} into the integer #{expected}" do
+        Facter::Core::Execution.stubs(:which).with('nmcli').returns('/usr/bin/nmcli')
+        Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns(version)
+        
+        result = Facter::Util::DHCPServers.nmcli_version
+        result.is_a?(Integer).should be true
+        result.should == expected
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
Adding support for nmcli version >= 0.9.9 that ships in Fedora 20 and RHEL7.
