### PR TITLE
(FACT-197) Backport Solaris processorcount fix

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -153,7 +153,7 @@ Facter.add("ProcessorCount") do
     (major_version, minor_version) = kernelrelease.split(".").map { |str| str.to_i }
     result = nil
 
-    if (major_version > 5) or (major_version == 5 and minor_version >= 8) then
+    if (major_version < 5) or (major_version == 5 and minor_version < 8) then
       if kstat = Facter::Core::Execution.exec("/usr/bin/kstat cpu_info")
         result = kstat.scan(/\bcore_id\b\s+\d+/).uniq.length
       end

--- a/spec/unit/processor_spec.rb
+++ b/spec/unit/processor_spec.rb
@@ -234,7 +234,7 @@ describe "Processor facts" do
     let(:kstat_sparc) { @fixture_kstat_sparc }
     let(:kstat_x86_64) { @fixture_kstat_x86_64 }
 
-    %w{ 5.8 5.9 5.10 5.11 }.each do |release|
+    %w{ 5.5.1 5.6 5.7 }.each do |release|
       %w{ sparc x86_64 }.each do |arch|
         it "uses kstat on release #{release} (#{arch})" do
           Facter.stubs(:value).with(:kernelrelease).returns(release)
@@ -246,7 +246,7 @@ describe "Processor facts" do
       end
     end
 
-    %w{ 5.5.1 5.6 5.7 }.each do |release|
+    %w{ 5.8 5.9 5.10 5.11 }.each do |release|
       it "uses psrinfo on release #{release}" do
         Facter.stubs(:value).with(:kernelrelease).returns(release)
 


### PR DESCRIPTION
A fix for redmine #18215 was comitted to master as commits
db87076..4c035e8. This squashes those commits and rebases them to the
stable branch as a bugfix for the next facter release. Commit messages
from the original commits follow

The first commit's message is:
Refined logic for SunOS processorCount

Refined logic to use kstat only on SunOS < 5.8, psrinfo on everything
from 5.8 and above.

This is the 2nd commit message:

(#18215) Updated processor_spec.rb for Solaris changes

Updated processor_spec.rb for Solaris changes to support fixes for
issue #18215.

This is the 3rd commit message:

processorcount spec wrongly used physicalprocessorcount fact

This is the 4th commit message:

adding psrinfo from Solaris with 24 CPUs and using it in processor spec.

This is the 5th commit message:

removing double quotes in a spec

This is the 6th commit message:

removed duplicate tests for Solaris

Conflicts:
    lib/facter/processor.rb
    spec/unit/processor_spec.rb
