### PR TITLE
(FACT-464) Improve support of Mandrake-derived osfamily detection

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -60,6 +60,8 @@ Facter.add(:operatingsystem) do
       "Gentoo"
     elsif FileTest.exists?("/etc/fedora-release")
       "Fedora"
+    elsif FileTest.exists?("/etc/mageia-release")
+      "Mageia"
     elsif FileTest.exists?("/etc/mandriva-release")
       "Mandriva"
     elsif FileTest.exists?("/etc/mandrake-release")

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -28,6 +28,8 @@ Facter.add(:osfamily) do
       "Gentoo"
     when "Archlinux"
       "Archlinux"
+    when "Mageia", "Mandriva", "Mandrake"
+      "Mandrake"
     else
       Facter.value("kernel")
     end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -58,6 +58,7 @@ describe "Operating System fact" do
       "Debian"      => "/etc/debian_version",
       "Gentoo"      => "/etc/gentoo-release",
       "Fedora"      => "/etc/fedora-release",
+      "Mageia"      => "/etc/mageia-release",
       "Mandriva"    => "/etc/mandriva-release",
       "Mandrake"    => "/etc/mandrake-release",
       "MeeGo"       => "/etc/meego-release",

--- a/spec/unit/osfamily_spec.rb
+++ b/spec/unit/osfamily_spec.rb
@@ -31,6 +31,9 @@ describe "OS Family fact" do
     'SLED'         => 'Suse',
     'OpenSuSE'     => 'Suse',
     'SuSE'         => 'Suse',
+    'Mageia'       => 'Mandrake',
+    'Mandriva'     => 'Mandrake',
+    'Mandrake'     => 'Mandrake',
   }.each do |os,family|
     it "should return #{family} on operatingsystem #{os}" do
       Facter.fact(:operatingsystem).stubs(:value).returns os


### PR DESCRIPTION
Previously, there were two issues:
- Mageia was not correctly separated from Mandriva as an
  operatingsystem
- All mandrake-derived distros showed up as "Linux" in osfamily

This adds a proper operatingsystem detection for Mageia and creates a
Mandrake osfamily for all mandrake-derived distros detected by the
operatingsystem fact.
