### PR TITLE
(FACT-179) Resolve fqdn fact when domain is empty

### DIFF
--- a/lib/facter/fqdn.rb
+++ b/lib/facter/fqdn.rb
@@ -15,6 +15,8 @@ Facter.add(:fqdn) do
     domain = Facter.value(:domain)
     if host and domain
       [host, domain].join(".")
+    elsif host
+      host
     else
       nil
     end

--- a/spec/unit/fqdn_spec.rb
+++ b/spec/unit/fqdn_spec.rb
@@ -1,0 +1,16 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+
+describe "fqdn fact" do
+  it "should concatenate hostname and domain" do
+    Facter.fact(:hostname).stubs(:value).returns("foo")
+    Facter.fact(:domain).stubs(:value).returns("bar")
+    Facter.fact(:fqdn).value.should == "foo.bar"
+  end
+  it "should return hostname when domain is nil" do
+    Facter.fact(:hostname).stubs(:value).returns("foo")
+    Facter.fact(:domain).stubs(:value).returns(nil)
+    Facter.fact(:fqdn).value.should == "foo"
+  end
+end


### PR DESCRIPTION
Previously, the fqdn fact would only resolve if both hostname and
domain were available on a host. Having a nil result when `hostname
-f` would return just the hostname is surprising to users, and we
should instead simply return the hostname when we cannot resolve a
domain.
