### PR TITLE
Issue/facter 2/fact 482 remove thread locking

### DIFF
--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -104,21 +104,19 @@ end
 if Facter.value(:kernel) == "windows"
   processor_list = []
 
-  Thread::exclusive do
-    require 'facter/util/wmi'
+  require 'facter/util/wmi'
 
-    # get each physical processor
-    Facter::Util::WMI.execquery("select * from Win32_Processor").each do |proc|
-      # not supported before 2008
-      if proc.respond_to?(:NumberOfLogicalProcessors)
-        processor_num = proc.NumberOfLogicalProcessors
-      else
-        processor_num = 1
-      end
+  # get each physical processor
+  Facter::Util::WMI.execquery("select * from Win32_Processor").each do |proc|
+    # not supported before 2008
+    if proc.respond_to?(:NumberOfLogicalProcessors)
+      processor_num = proc.NumberOfLogicalProcessors
+    else
+      processor_num = 1
+    end
 
-      processor_num.times do |i|
-        processor_list << proc.Name.squeeze(" ")
-      end
+    processor_num.times do |i|
+      processor_list << proc.Name.squeeze(" ")
     end
   end
 

--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -271,16 +271,14 @@ module Processor
   def self.enum_kstat
     processor_num = -1
     processor_list = []
-    Thread::exclusive do
-      kstat = Facter::Core::Execution.exec('/usr/bin/kstat cpu_info')
-      if kstat
-        kstat.each_line do |l|
-          if l =~ /cpu_info(\d+)/
-            processor_num = $1.to_i
-          elsif l =~ /brand\s+(.*)\s*$/
-            processor_list[processor_num] = $1 unless processor_num == -1
-            processor_num = -1
-          end
+    kstat = Facter::Core::Execution.exec('/usr/bin/kstat cpu_info')
+    if kstat
+      kstat.each_line do |l|
+        if l =~ /cpu_info(\d+)/
+          processor_num = $1.to_i
+        elsif l =~ /brand\s+(.*)\s*$/
+          processor_list[processor_num] = $1 unless processor_num == -1
+          processor_num = -1
         end
       end
     end


### PR DESCRIPTION
```
(FACT-482) Remove thread locking

Facter has sporadic instances where facts implement their own locking
when resolving facts. Facter itself has never made any guarantees about
thread safety so the existing locking is useless at best and broken at
worst.

When Mcollective resolves facts it acquires a threadlock before running
to ensure that facts are generated in an atomic fashion. However the
lock used is not scoped to the given critical region; it is global so
`Thread.exclusive` cannot be reentered in a single thread:

    [3] pry(main)> Thread.exclusive do
    [3] pry(main)*   Thread.exclusive do
    [3] pry(main)*     puts "hi"
    [3] pry(main)*   end
    [3] pry(main)* end
    ThreadError: deadlock; recursive locking
    from <internal:prelude>:8:in `lock'

Because of this the facter facts source could not be used on Windows
because Mcollective and Facter would deadlock. This commit removes the
locking from Facter and places the responsibility for thread safety on
the code invoking Facter.
```
