### PR TITLE
(FACT-547) Limit the output of prtdiag on Solaris

### DIFF
--- a/lib/facter/util/manufacturer.rb
+++ b/lib/facter/util/manufacturer.rb
@@ -60,7 +60,7 @@ module Facter::Manufacturer
 
   def self.prtdiag_sparc_find_system_info()
     # Parses prtdiag for a SPARC architecture string, won't work with Solaris x86
-    output = Facter::Core::Execution.exec('/usr/sbin/prtdiag 2>/dev/null | head -n 10')
+    output = Facter::Core::Execution.exec('/usr/sbin/prtdiag 2>/dev/null | /usr/bin/head -n 10')
 
     # System Configuration:  Sun Microsystems  sun4u Sun SPARC Enterprise M3000 Server
     if output and output =~ /^System Configuration:\s+(.+?)\s+(sun\d+\S+)\s+(.+)/


### PR DESCRIPTION
prtdiag is used to determine manufacturer and productname on Solaris.

If you run it on a big box like a SPARC T5 it produces a lot of output,
and might take some time, this produces timeouts leading to missing facts.

The simple addition of a pipe to head avoid prtdiag to produce it full output.

The first lines should always contain the product information.

See https://tickets.puppetlabs.com/browse/FACT-547
