### PR TITLE
Ticket/facter 2/fact 484 virtual avoid permission warnings

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -167,9 +167,9 @@ module Facter::Util::Virtual
   #
   # @api public
   #
-  # @return [String] or nil if the path does not exist
+  # @return [String] or nil if the path does not exist or is unreadable
   def self.read_sysfs_dmi_entries(path="/sys/firmware/dmi/entries/1-0/raw")
-    if File.exists?(path)
+    if File.readable?(path)
       Facter::Util::FileRead.read_binary(path)
     end
   end


### PR DESCRIPTION
Retrieving the virtual fact without root privileges would yield
warning messages due to missing permissions on
/sys/firmware/dmi/entries/1-0/raw (at least on certain versions of Debian).

The readable? query makes more sense than exists? at this point, anyway.
