### PR TITLE
(FACT-567) Restore windows dependencies during gem packaging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ platform(*mingw) do
   gem 'ffi', '~> 1.9.3'
   gem 'win32-dir', '~> 0.4.8'
   gem 'windows-pr', '~> 1.2'
-  gem 'win32-security', '>= 0.2.0'
+  gem 'win32-security', '~> 0.2.5'
 end
 
 gem 'facter', ">= 1.0.0", :path => File.expand_path("..", __FILE__)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -22,14 +22,14 @@ gem_platform_dependencies:
       ffi: '~> 1.9.3'
       win32-dir: '~> 0.4.8'
       windows-pr: '~> 1.2'
-      win32-security: '>= 0.2.0'
+      win32-security: '~> 0.2.5'
       win32console: '~> 1.3.2'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.3'
       win32-dir: '~> 0.4.8'
       windows-pr: '~> 1.2'
-      win32-security: '>= 0.2.0'
+      win32-security: '~> 0.2.5'
 bundle_platforms:
   universal-darwin: ruby
   x86-mingw32: mingw


### PR DESCRIPTION
Restored windows dependencies during gem packaging. With this change, the gem spec contains the correct info for both x86 and x64:
## x86

<pre>
$ gem specification --ruby pkg/facter-2.0.2.134-x86-mingw32.gem
...
   if s.respond_to? :specification_version then
    s.specification_version = 4

    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
      s.add_runtime_dependency(%q&lt;ffi>, ["~> 1.9.3"])
      s.add_runtime_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
      s.add_runtime_dependency(%q&lt;windows-pr>, ["~> 1.2"])
      s.add_runtime_dependency(%q&lt;win32-security>, [">= 0.2.0"])
      s.add_runtime_dependency(%q&lt;win32console>, ["~> 1.3.2"])
    else
      s.add_dependency(%q&lt;ffi>, ["~> 1.9.3"])
      s.add_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
      s.add_dependency(%q&lt;windows-pr>, ["~> 1.2"])
      s.add_dependency(%q&lt;win32-security>, [">= 0.2.0"])
      s.add_dependency(%q&lt;win32console>, ["~> 1.3.2"])
    end
  else
    s.add_dependency(%q&lt;ffi>, ["~> 1.9.3"])
    s.add_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
    s.add_dependency(%q&lt;windows-pr>, ["~> 1.2"])
    s.add_dependency(%q&lt;win32-security>, [">= 0.2.0"])
    s.add_dependency(%q&lt;win32console>, ["~> 1.3.2"])
  end
</pre>

## x64

<pre>
$ gem specification --ruby pkg/facter-2.0.2.134-x64-mingw32.gem
...
  if s.respond_to? :specification_version then
    s.specification_version = 4

    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
      s.add_runtime_dependency(%q&lt;ffi>, ["~> 1.9.3"])
      s.add_runtime_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
      s.add_runtime_dependency(%q&lt;windows-pr>, ["~> 1.2"])
      s.add_runtime_dependency(%q&lt;win32-security>, [">= 0.2.0"])
    else
      s.add_dependency(%q&lt;ffi>, ["~> 1.9.3"])
      s.add_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
      s.add_dependency(%q&lt;windows-pr>, ["~> 1.2"])
      s.add_dependency(%q&lt;win32-security>, [">= 0.2.0"])
    end
  else
    s.add_dependency(%q&lt;ffi>, ["~> 1.9.3"])
    s.add_dependency(%q&lt;win32-dir>, ["~> 0.4.8"])
    s.add_dependency(%q&lt;windows-pr>, ["~> 1.2"])
    s.add_dependency(%q&lt;win32-security>, [">= 0.2.0"])
  end
</pre>


 Note how win32console is only a dependency for the x86 gem, but not x64.
