### PR TITLE
(FACT-353) Set LC_ALL environment variable to "C" for child processes.

### DIFF
--- a/lib/facter/core/execution/base.rb
+++ b/lib/facter/core/execution/base.rb
@@ -31,9 +31,9 @@ class Facter::Core::Execution::Base
 
     on_fail = options.fetch(:on_fail, :raise)
 
-    ## Set LANG to force i18n to C for the duration of this exec; this ensures that any code that parses the
-    ## output of the command can expect it to be in a consistent / predictable format / locale
-    with_env "LANG" => "C" do
+    # Set LC_ALL and LANG to force i18n to C for the duration of this exec; this ensures that any code that parses the
+    # output of the command can expect it to be in a consistent / predictable format / locale
+    with_env 'LC_ALL' => 'C', 'LANG' => 'C' do
 
       expanded_command = expand_command(command)
 

--- a/spec/unit/core/execution/base_spec.rb
+++ b/spec/unit/core/execution/base_spec.rb
@@ -5,7 +5,7 @@ describe Facter::Core::Execution::Base do
 
   describe "#with_env" do
     it "should execute the caller's block with the specified env vars" do
-      test_env = { "LANG" => "C", "FOO" => "BAR" }
+      test_env = { 'LANG' => 'C', 'LC_ALL' => 'C', 'FOO' => 'BAR' }
       subject.with_env test_env do
         test_env.keys.each do |key|
           ENV[key].should == test_env[key]
@@ -64,12 +64,10 @@ describe Facter::Core::Execution::Base do
 
   describe "#execute" do
 
-    it "switches LANG to C when executing the command" do
-      subject.expects(:with_env).with('LANG' => 'C')
+    it "switches LANG and LC_ALL to C when executing the command" do
+      subject.expects(:with_env).with('LC_ALL' => 'C', 'LANG' => 'C')
       subject.execute('foo')
     end
-
-    it "switches LC_ALL to C when executing the command"
 
     it "expands the command before running it" do
       subject.stubs(:`).returns ''


### PR DESCRIPTION
Adding LC_ALL => C for the with_env call in execute.  This will ensure
that child processes that do not check LANG will output using a C
locale if they respect LC_ALL instead.
