### PR TITLE
(FACT-592) Unbreak swapfree/swapsize facts on OpenBSD

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -186,8 +186,8 @@ module Facter::Memory
         0
       end
     when /OpenBSD/i
-      if line =~ /^total: (\d+)k bytes allocated = \d+k used, (\d+)k available$/
-        (is_size) ? $1.to_i : $2.to_i
+      if line =~ /^total: (\d+) (\d+)-blocks allocated, (\d+) used, (\d+) available$/
+        (is_size) ? ($1.to_i * $2.to_i) : ($4.to_i * $2.to_i)
       else
         0
       end
@@ -214,8 +214,10 @@ module Facter::Memory
 
   def self.scale_swap_value(value, kernel)
     case kernel
-    when /OpenBSD/i, /FreeBSD/i
+    when /FreeBSD/i
       value.to_f / 1024.0
+    when /OpenBSD/i
+      value.to_f / 1024.0 / 1024.0
     when /SunOS/i
       value.to_f / 2 / 1024.0
     else

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -178,7 +178,7 @@ describe "Memory facts" do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
 
-      swapusage = "total: 148342k bytes allocated = 0k used, 148342k available"
+      swapusage = "total: 4080510 512-blocks allocated, 461832 used, 3618678 available"
       Facter::Core::Execution.stubs(:exec).with('swapctl -s').returns(swapusage)
 
       Facter::Core::Execution.stubs(:exec).with('vmstat').returns(my_fixture_read('openbsd-vmstat'))
@@ -193,11 +193,11 @@ describe "Memory facts" do
     end
 
     it "should return the current swap free in MB" do
-      Facter.fact(:swapfree_mb).value.should == "144.87"
+      Facter.fact(:swapfree_mb).value.should == "1766.93"
     end
 
     it "should return the current swap size in MB" do
-      Facter.fact(:swapsize_mb).value.should == "144.87"
+      Facter.fact(:swapsize_mb).value.should == "1992.44"
     end
 
     it "should return the current memory free in MB" do


### PR DESCRIPTION
On OpenBSD the "swapctl -s" output also reports the blocksize which
must be taken into account. Also the scaler was incorrectly reporting
terabytes of swap instead of gigabytes.

The spec tests were updated accordingly which were passing, eventhough they didn't quite match the actual output of `swapctl -s` on a real system.
