### PR TITLE
(maint) Move misplaced confine statement in dhcp_servers fact

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -17,8 +17,8 @@ require 'facter/util/dhcp_servers'
 
 
 Facter.add(:dhcp_servers) do
+  confine :kernel => :linux
   confine do
-    confine :kernel => :linux
     Facter::Core::Execution.which('nmcli')
   end
 


### PR DESCRIPTION
Previously, one confine statement was nested within another, meaning
that every time we invoked the suitable method, we changed the number of
confines.
