### PR TITLE
(FACT-595) Unbreak {is_,}virtual fact for OpenBSD when running on KVM.

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -174,6 +174,7 @@ module Facter::Util::Virtual
       return "virtualbox" if lines.any? {|l| l =~ /VirtualBox/ }
       return "xenhvm"     if lines.any? {|l| l =~ /HVM domU/ }
       return "ovirt"      if lines.any? {|l| l =~ /oVirt Node/ }
+      return "kvm"        if lines.any? {|l| l =~ /KVM/ }
     end
   end
 

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -314,6 +314,11 @@ describe "Virtual fact" do
       Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("oVirt Node")
       Facter.fact(:virtual).value.should == "ovirt"
     end
+
+    it "should be kvm with KVM product name from sysctl" do
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("KVM")
+      Facter.fact(:virtual).value.should == "kvm"
+    end
   end
 
   describe "on Windows" do


### PR DESCRIPTION
It turned out the `parse_virtualization` method didn't account for KVM therefore at least OpenBSD wouldn't correctly set the virtual facts when running on KVM.
