### PR TITLE
(FACT-600) Don't hardcode location of `sysctl`

### DIFF
--- a/lib/facter/util/posix.rb
+++ b/lib/facter/util/posix.rb
@@ -7,7 +7,7 @@ module POSIX
   #
   # @api private
   def sysctl(mib)
-    Facter::Util::Resolution.exec("/sbin/sysctl -n #{mib} 2>/dev/null")
+    Facter::Util::Resolution.exec("sysctl -n #{mib} 2>/dev/null")
   end
 
   module_function :sysctl

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'facter/util/posix'
+
+describe Facter::Util::POSIX do
+  describe "retrieving values via sysctl" do
+    it "returns the result of the sysctl command" do
+      Facter::Util::Resolution.expects(:exec).with("sysctl -n hw.pagesize 2>/dev/null").returns("somevalue")
+      expect(described_class.sysctl("hw.pagesize")).to eq "somevalue"
+    end
+  end
+end


### PR DESCRIPTION
`sysctl` is found in `/sbin` on OpenBSD but is in `/usr/bin` on OSX.
Because we can't assume the location it's easier to allow
`Facter::Core::Execution.which` to locate the executable to invoke.
