### PR TITLE
(FACT-601) Format plaintext output for non-string values

### DIFF
--- a/lib/facter/util/formatter.rb
+++ b/lib/facter/util/formatter.rb
@@ -23,10 +23,11 @@ module Facter
         # name and separated by "=>"
         if hash.length == 1
           if value = hash.values.first
-            output = value
+            output = value.is_a?(String) ? value : value.inspect
           end
         else
           hash.sort_by { |(name, value)| name }.each do |name,value|
+            value = value.is_a?(String) ? value : value.inspect
             output << "#{name} => #{value}\n"
           end
         end

--- a/spec/unit/util/formatter_spec.rb
+++ b/spec/unit/util/formatter_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'facter/util/formatter'
+
+describe Facter::Util::Formatter do
+  describe "formatting as json" do
+    it "formats the text as json when json is available", :if => Facter.json? do
+      JSON.expects(:pretty_generate).with({"hello" => "world"}).returns(%Q({"hello": "world"}))
+      expect(described_class.format_json({"hello" => "world"})).to eq %Q({"hello": "world"})
+    end
+
+    it "raises an error when JSON is not available" do
+      Facter.stubs(:json?).returns false
+      expect {
+        described_class.format_json({"hello" => "world"})
+      }.to raise_error(/'json' library is not present/)
+    end
+  end
+
+  describe "formatting as yaml" do
+    it "dumps the text as YAML" do
+      expect(described_class.format_yaml({"hello" => "world"})).to match(/hello: world/)
+    end
+  end
+
+  describe "formatting as plaintext" do
+    it "formats a single string value without quotes" do
+      expect(described_class.format_plaintext({"foo" => "bar"})).to eq "bar"
+    end
+
+    it "formats a structured value with #inspect" do
+      value = ["bar"]
+      value.expects(:inspect).returns %Q(["bar"])
+      hash = {"foo" => value, "baz" => "quux"}
+      expect(described_class.format_plaintext(hash)).to match(%Q([bar]))
+    end
+    it "formats multiple string values as key/value pairs" do
+      hash = {"foo" => "bar", "baz" => "quux"}
+      expect(described_class.format_plaintext(hash)).to match(/foo => bar/)
+      expect(described_class.format_plaintext(hash)).to match(/baz => quux/)
+    end
+
+    it "formats multiple structured values with #inspect" do
+      value = ["bar"]
+      value.expects(:inspect).twice.returns %Q(["bar"])
+      hash = {"foo" => value, "baz" => "quux"}
+      expect(described_class.format_plaintext(hash)).to match(/foo => \["bar"\]/)
+      expect(described_class.format_plaintext(hash)).to match(/baz => quux/)
+    end
+  end
+end


### PR DESCRIPTION
Without this commit, structured facts outputted as plaintext are
printed using `#to_s`, which is useless on ruby 1.8.7:

```
$ facter partitions
sda1mount/bootsize1024000uuid7de786a9-be75-4711-b782-fb26aec963d4sda2size975747072sda3size2047
```

This commit changes the outputting to format non-string values using
`#inspect` which produces much more usable values:

```
$ facter partitions
{"sda1"=>{"uuid"=>"7de786a9-be75-4711-b782-fb26aec963d4", "size"=>"1024000", "mount"=>"/boot"}, "sda2"=>{"size"=>"975747072"}, "sda3"=>{"size"=>"2047"}}
```
