### PR TITLE
(FACT-607) Include facter man pages in the package for OSX.

### DIFF
--- a/ext/osx/file_mapping.yaml
+++ b/ext/osx/file_mapping.yaml
@@ -19,6 +19,11 @@ directories:
     owner: 'root'
     group: 'wheel'
     perms: '0644'
+  man/man8:
+    path: 'usr/share/man/man8'
+    owner: 'root'
+    group: 'wheel'
+    perms: '0755'
 files:
   '[A-Z]*':
     path: 'usr/share/doc/facter'


### PR DESCRIPTION
Without this commit, the facter man page is not included in the package for OSX.

This commit adds the appropriate directives to ext/osx/file_mapping.yaml
to include facter man pages in the package for OSX.
