### PR TITLE
(FACT-612) Add structured uptime fact

### DIFF
--- a/lib/facter/system_uptime.rb
+++ b/lib/facter/system_uptime.rb
@@ -1,0 +1,42 @@
+# Fact: system_uptime
+#
+# Purpose:
+#   Return the system uptime in a hash in the forms of
+#   seconds, minutes, hours, days and a general, human
+#   readable uptime.
+#
+# Resolution:
+#   Does basic math on the get_uptime_seconds utility
+#   to calculate seconds, minutes, hours and days.
+#
+# Caveats:
+#
+
+require 'facter/util/uptime'
+
+Facter.add(:system_uptime) do
+  setcode do
+    system_uptime = {}
+    if Facter.value(:kernel) == 'windows'
+      seconds = Facter::Util::Uptime.get_uptime_seconds_win
+    else
+      seconds = Facter::Util::Uptime.get_uptime_seconds_unix
+    end
+
+    if seconds
+      system_uptime['seconds'] = seconds
+      minutes                  = seconds / 60 % 60
+      system_uptime['hours']   = seconds / (60 * 60)
+      system_uptime['days']    = system_uptime['hours'] / 24
+
+      case system_uptime['days']
+      when 0 then system_uptime['uptime'] = "#{system_uptime['hours']}:#{"%02d" % minutes} hours"
+      when 1 then system_uptime['uptime'] = "1 day"
+      else system_uptime['uptime']        = "#{system_uptime['days']} days"
+      end
+    else
+      system_uptime['uptime']  = 'unknown'
+    end
+    system_uptime
+  end
+end

--- a/lib/facter/uptime.rb
+++ b/lib/facter/uptime.rb
@@ -3,32 +3,14 @@
 # Purpose: return the system uptime in a human readable format.
 #
 # Resolution:
-#   Does basic maths on the "uptime_seconds" fact to return a count of
-#   days, hours and minutes of uptime
+#   Uses the structured "uptime_hash" fact, which does basic maths
+#   on the number of seconds of uptime to return a count of days,
+#   hours and minutes of uptime
 #
 # Caveats:
 #
 
-require 'facter/util/uptime'
-
 Facter.add(:uptime) do
-  setcode do
-    seconds = Facter.fact(:uptime_seconds).value
-
-    unless seconds
-      "unknown"
-    else
-      days    = seconds / (60 * 60 * 24)
-      hours   = seconds / (60 * 60) % 24
-      minutes = seconds / 60 % 60
-
-      case days
-      when 0 then "#{hours}:#{"%02d" % minutes} hours"
-      when 1 then '1 day'
-      else "#{days} days"
-      end
-    end
-
-  end
+  setcode { Facter.value(:system_uptime)['uptime'] }
 end
 

--- a/lib/facter/uptime_days.rb
+++ b/lib/facter/uptime_days.rb
@@ -1,15 +1,13 @@
 # Fact: uptime_days
 #
 # Purpose: Return purely number of days of uptime.
-#
-# Resolution: Divides uptime_hours fact by 24.
+
+# Resolution: Uses the 'days' key of the uptime_hash fact, which divides
+# its own 'hours' key by 24
 #
 # Caveats:
 #
 
 Facter.add(:uptime_days) do
-  setcode do
-    hours = Facter.value(:uptime_hours)
-    hours && hours / 24 # hours in day
-  end
+  setcode { Facter.value(:system_uptime)['days'] }
 end

--- a/lib/facter/uptime_hours.rb
+++ b/lib/facter/uptime_hours.rb
@@ -2,14 +2,12 @@
 #
 # Purpose: Return purely number of hours of uptime.
 #
-# Resolution: Divides uptime_seconds fact by 3600.
+# Resolution: Uses the 'hours' key of the uptime_hash fact, which divides
+# its own 'seconds' key by 3600
 #
 # Caveats:
 #
 
 Facter.add(:uptime_hours) do
-  setcode do
-    seconds = Facter.value(:uptime_seconds)
-    seconds && seconds / (60 * 60) # seconds in hour
-  end
+  setcode { Facter.value(:system_uptime)['hours'] }
 end

--- a/lib/facter/uptime_seconds.rb
+++ b/lib/facter/uptime_seconds.rb
@@ -3,7 +3,8 @@
 # Purpose: Return purely number of seconds of uptime.
 #
 # Resolution:
-#   Using the 'facter/util/uptime.rb' module, try a verity of methods to acquire
+#   Acquires the uptime in seconds via the 'seconds' key of the uptime_hash fact,
+#   which uses the 'facter/util/uptime.rb' module to try a variety of methods to acquire
 #   the uptime on Unix.
 #
 #   On Windows, the module calculates the uptime by the "LastBootupTime" Windows
@@ -15,10 +16,5 @@
 require 'facter/util/uptime'
 
 Facter.add(:uptime_seconds) do
-  setcode { Facter::Util::Uptime.get_uptime_seconds_unix }
-end
-
-Facter.add(:uptime_seconds) do
-  confine :kernel => :windows
-  setcode { Facter::Util::Uptime.get_uptime_seconds_win }
+  setcode { Facter.value(:system_uptime)['seconds'] }
 end

--- a/schema/facter.json
+++ b/schema/facter.json
@@ -146,6 +146,16 @@
         "swapfree_mb" : { "type": "string" },
         "swapsize" : { "type": "string" },
         "swapsize_mb" : { "type": "string" },
+        "system_uptime" : { "type": "object",
+          "properties" : {
+            "seconds" : { "type": "integer" },
+            "minutes" : { "type": "integer" },
+            "hours" : { "type": "integer" },
+            "days" : { "type": "integer" },
+            "uptime" : { "type": "string" }
+          },
+          "required" : ["seconds", "minutes", "hours", "days", "uptime"]
+        },
         "timezone" : { "type": "string" },
         "totalprocessorcount" : { "type": "string" },
         "type" : { "type": "string" },

--- a/spec/unit/system_uptime_spec.rb
+++ b/spec/unit/system_uptime_spec.rb
@@ -1,0 +1,80 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+require 'facter/util/uptime'
+
+describe "system_uptime:" do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  describe "When uptime information is available" do
+    describe "uptime" do
+      test_cases = [
+        [60 * 60 * 24 * 3,      '3 days'],
+        [60 * 60 * 24 * 3 + 25, '3 days'],
+        [60 * 60 * 24 * 1,      '1 day'],
+        [60 * 60 * 24 * 1 + 25, '1 day'],
+        [60 * (60 * 3 + 45),    '3:45 hours'],
+        [60 * (60 * 3 + 4),     '3:04 hours'],
+        [60 * 60,               '1:00 hours'],
+        [60 * 35,               '0:35 hours']
+      ]
+
+      test_cases.each do |seconds, expected|
+        it "should return #{expected.inspect} for #{seconds} seconds in Linux" do
+          Facter.fact(:kernel).stubs(:value).returns("linux")
+          Facter::Util::Uptime.stubs(:get_uptime_seconds_unix).returns(seconds)
+          Facter.fact(:system_uptime).value['uptime'].should eq expected
+        end
+
+        it "should return #{expected.inspect} for #{seconds} seconds in Windows" do
+          Facter.fact(:kernel).stubs(:value).returns("windows")
+          Facter::Util::Uptime.stubs(:get_uptime_seconds_win).returns(seconds)
+          Facter.fact(:system_uptime).value['uptime'].should eq expected
+        end
+      end
+    end
+  end
+
+  describe "when uptime information is available" do
+    before do
+      Facter::Util::Uptime.stubs(:get_uptime_seconds_unix).returns(60 * 60 * 24 + 23)
+      Facter::Util::Uptime.stubs(:get_uptime_seconds_win).returns(60 * 60 * 24 + 23)
+    end
+
+    it "should include a key for seconds" do
+      Facter.fact(:system_uptime).value['seconds'].should eq 60 * 60 * 24 + 23
+    end
+
+     it "should include a key for hours" do
+      Facter.fact(:system_uptime).value['hours'].should eq 24
+    end
+
+    it "should include a key for days" do
+      Facter.fact(:system_uptime).value['days'].should eq 1
+    end
+  end
+
+  describe "when uptime information is not available" do
+    before do
+      Facter::Util::Uptime.stubs(:get_uptime_seconds_unix).returns(nil)
+      Facter::Util::Uptime.stubs(:get_uptime_seconds_win).returns(nil)
+    end
+
+    it "should have an 'uptime' key with value 'unknown'" do
+      Facter.fact(:system_uptime).value['uptime'].should eq "unknown"
+    end
+
+    it "should have a 'seconds' key with value nil" do
+      Facter.fact(:system_uptime).value['seconds'].should eq nil
+    end
+
+    it "should have a 'hours' key with value nil" do
+      Facter.fact(:system_uptime).value['hours'].should eq nil
+    end
+
+    it "should have a 'days' key with value nil" do
+      Facter.fact(:system_uptime).value['days'].should eq nil
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new 'system_uptime' structured fact, which
includes keys for seconds, minutes, hours, days and uptime. Also,
the existing uptime facts have been modified to use this hash rather
than calling out to Facter::Util::Uptime utilities to generate their
values.
