### PR TITLE
(FACT-595) Unbreak {is_,}virtual fact for OpenBSD when running on KVM.

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -106,6 +106,7 @@ Facter.add("virtual") do
       next "virtualbox" if lines.any? {|l| l =~ /VirtualBox/ }
       next "xenhvm"     if lines.any? {|l| l =~ /HVM domU/ }
       next "ovirt"      if lines.any? {|l| l =~ /oVirt Node/ }
+      next "kvm"        if lines.any? {|l| l =~ /KVM/ }
     end
   end
 end

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -303,6 +303,11 @@ describe "Virtual fact" do
       Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("oVirt Node")
       Facter.fact(:virtual).value.should == "ovirt"
     end
+
+    it "should be kvm with KVM product name from sysctl" do
+      Facter::Util::POSIX.stubs(:sysctl).with('hw.product').returns("KVM")
+      Facter.fact(:virtual).value.should == "kvm"
+    end
   end
 
   describe "on Windows" do


### PR DESCRIPTION
Picking up where #701 left off, now rebased onto `facter-2`.
