### PR TITLE
Updated comment docs formatting

### DIFF
--- a/lib/facter/Cfkey.rb
+++ b/lib/facter/Cfkey.rb
@@ -3,7 +3,7 @@
 # Purpose: Return the public key(s) for CFengine.
 #
 # Resolution:
-#   Tries each file of standard localhost.pub & cfkey.pub locations,
+#   Tries each file of standard localhost.pub and cfkey.pub locations,
 #   checks if they appear to be a public key, and then join them all together.
 #
 # Caveats:

--- a/lib/facter/architecture.rb
+++ b/lib/facter/architecture.rb
@@ -4,8 +4,8 @@
 #   Return the CPU hardware architecture.
 #
 # Resolution:
-#   On non-AIX IBM, OpenBSD, Linux and Debian's kfreebsd, use the hardwaremodel fact.
-#   On AIX get the arch value from lsattr -El proc0 -a type
+#   On non-AIX IBM, OpenBSD, Linux, and Debian's kfreebsd, use the hardwaremodel fact.
+#   On AIX get the arch value from `lsattr -El proc0 -a type`.
 #   Gentoo and Debian call "x86_86" "amd64".
 #   Gentoo also calls "i386" "x86".
 #

--- a/lib/facter/augeasversion.rb
+++ b/lib/facter/augeasversion.rb
@@ -1,9 +1,9 @@
 # Fact: augeasversion
 #
-# Purpose: Report the version of the Augeas library
+# Purpose: Report the version of the Augeas library.
 #
 # Resolution:
-#   Loads ruby-augeas and reports the value of /augeas/version, the version of
+#   Loads ruby-augeas and reports the value of `/augeas/version`, the version of
 #   the underlying Augeas library.
 #
 # Caveats:

--- a/lib/facter/blockdevices.rb
+++ b/lib/facter/blockdevices.rb
@@ -4,10 +4,10 @@
 #   Return the size of a block device in bytes
 #
 # Resolution:
-#   Parse the contents of /sys/block/<device>/size to receive the size (multiplying by 512 to correct for blocks-to-bytes)
+#   Parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes).
 #
 # Caveats:
-#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs.
 #
 
 # Fact: blockdevice_<devicename>_vendor
@@ -16,10 +16,10 @@
 #   Return the vendor name of block devices attached to the system
 #
 # Resolution:
-#   Parse the contents of /sys/block/<device>/device/vendor to retrieve the vendor for a device
+#   Parse the contents of `/sys/block/<device>/device/vendor` to retrieve the vendor for a device.
 #
 # Caveats:
-#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs.
 #
 
 # Fact: blockdevice_<devicename>_model
@@ -28,20 +28,20 @@
 #   Return the model name of block devices attached to the system
 #
 # Resolution:
-#   Parse the contents of /sys/block/<device>/device/model to retrieve the model name/number for a device
+#   Parse the contents of `/sys/block/<device>/device/model` to retrieve the model name/number for a device.
 #
 # Caveats:
-#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs.
 #
 
 
 # Fact: blockdevices
 #
 # Purpose:
-#   Return a comma seperated list of block devices
+#   Return a comma separated list of block devices.
 #
 # Resolution:
-#   Retrieve the block devices that were identified and iterated over in the creation of the blockdevice_ facts
+#   Retrieve the block devices that were identified and iterated over in the creation of the blockdevice_ facts.
 #
 # Caveats:
 #   Block devices must have been identified using sysfs information

--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -3,13 +3,13 @@
 # Purpose:
 #   Return the DHCP server addresses for all interfaces as a hash.
 #   If the interface that is the default gateway is dhcp assigned, there
-#   will also be a 'system' entry in the hash.
+#   will also be a `system` entry in the hash.
 #
 # Resolution:
-#   Parses the output of nmcli to find the DHCP server for the interface if available
+#   Parses the output of `nmcli` to find the DHCP server for the interface if available.
 #
 # Caveats:
-#   Requires nmcli to be available and the interface must use network-manager.
+#   Requires `nmcli` to be available and the interface must use network-manager.
 #
 
 require 'facter'

--- a/lib/facter/domain.rb
+++ b/lib/facter/domain.rb
@@ -5,14 +5,14 @@
 #
 # Resolution:
 #   On UNIX (excluding Darwin), first try and use the hostname fact,
-#   which uses the hostname system command, and then parse the output
+#   which uses the `hostname` system command, and then parse the output
 #   of that.
-#   Failing that it tries the dnsdomainname system command.
-#   Failing that it uses /etc/resolv.conf and takes the domain from that, or as
+#   Failing that it tries the `dnsdomainname` system command.
+#   Failing that it uses `/etc/resolv.conf` and takes the domain from that, or as
 #   a final resort, the search from that.
-#   Otherwise returns nil.
+#   Otherwise returns `nil`.
 #
-#   On Windows uses the win32ole gem and winmgmts to get the DNSDomain value
+#   On Windows uses the `win32ole` gem and `winmgmts` to get the DNSDomain value
 #   from the Win32 networking stack.
 #
 # Caveats:

--- a/lib/facter/facterversion.rb
+++ b/lib/facter/facterversion.rb
@@ -1,8 +1,8 @@
 # Fact: facterversion
 #
-# Purpose: returns the version of the facter module.
+# Purpose: Returns the version of the facter module.
 #
-# Resolution: Uses the Facter.version method.
+# Resolution: Uses the `Facter.version` method.
 #
 # Caveats:
 #

--- a/lib/facter/filesystems.rb
+++ b/lib/facter/filesystems.rb
@@ -1,9 +1,16 @@
+# Fact: filesystems
 #
-# filesystems.rb
+# Purpose:
+#   This fact provides an alphabetic list of usable file systems that can
+#   be used for block devices like hard drives, media cards, etc.
 #
-# This fact provides an alphabetic list of usable file systems that can
-# be used for block devices like hard drives, media cards and so on ...
+# Resolution:
+#   Checks `/proc/filesystems`.
 #
+# Caveats:
+#   Only supports Linux.
+#
+
 Facter.add('filesystems') do
   confine :kernel => :linux
   setcode do

--- a/lib/facter/fqdn.rb
+++ b/lib/facter/fqdn.rb
@@ -1,6 +1,6 @@
 # Fact: fqdn
 #
-# Purpose: Returns the fully qualified domain name of the host.
+# Purpose: Returns the fully-qualified domain name of the host.
 #
 # Resolution: Simply joins the hostname fact with the domain name fact.
 #

--- a/lib/facter/hardwareisa.rb
+++ b/lib/facter/hardwareisa.rb
@@ -4,11 +4,11 @@
 #   Returns hardware processor type.
 #
 # Resolution:
-#   On Solaris, AIX, Linux and the BSDs simply uses the output of "uname -p"
-#   On HP-UX, "uname -m" gives us the same information.
+#   On Solaris, AIX, Linux and the BSDs simply uses the output of `uname -p`
+#   On HP-UX, `uname -m` gives us the same information.
 #
 # Caveats:
-#   Some linuxes return unknown to uname -p with relative ease.
+#   Some Linuxes return unknown to `uname -p` with relative ease.
 #
 
 Facter.add(:hardwareisa) do

--- a/lib/facter/hardwaremodel.rb
+++ b/lib/facter/hardwaremodel.rb
@@ -4,9 +4,9 @@
 #   Returns the hardware model of the system.
 #
 # Resolution:
-#   Uses purely "uname -m" on all platforms other than AIX and Windows.
-#   On AIX uses the parsed "modelname" output of "lsattr -El sys0 -a modelname".
-#   On Windows uses the 'host_cpu' pulled out of Ruby's config.
+#   Uses purely `uname -m` on all platforms other than AIX and Windows.
+#   On AIX uses the parsed `modelname` output of `lsattr -El sys0 -a modelname`.
+#   On Windows uses the `host_cpu` pulled out of Ruby's config.
 #
 # Caveats:
 #

--- a/lib/facter/id.rb
+++ b/lib/facter/id.rb
@@ -4,9 +4,9 @@
 # running user id.
 #
 # Resolution:
-#   On all Unixes bar Solaris, just returns "whoami".
-#   On Solaris, parses the output of the "id" command to grab the username, as
-#   Solaris doesn't have the whoami command.
+#   On all Unixes bar Solaris, just returns `whoami`.
+#   On Solaris, parses the output of the `id` command to grab the username,
+#   as Solaris doesn't have the `whoami` command.
 #
 # Caveats:
 #

--- a/lib/facter/interfaces.rb
+++ b/lib/facter/interfaces.rb
@@ -1,11 +1,14 @@
 # Fact: interfaces
 #
 # Purpose:
+#   Generates the following facts on supported platforms: `<interface>_ipaddress`,
+#   `<interface>_ipaddress6`, `<interface>_macaddress`, `<interface>_netmask`,
+#   and `<interface>_mtu`.
 #
 # Resolution:
 #
 # Caveats:
-#
+#   
 
 # interfaces.rb
 # Try to get additional Facts about the machine's network interfaces

--- a/lib/facter/ipaddress6.rb
+++ b/lib/facter/ipaddress6.rb
@@ -3,15 +3,15 @@
 # Purpose: Returns the "main" IPv6 IP address of a system.
 #
 # Resolution:
-#  OS dependant code that parses the output of various networking
-#  tools and currently not very intelligent. Returns the first
-#  non-loopback and non-linklocal address found in the ouput unless
-#  a default route can be mapped to a routeable interface. Guessing
-#  an interface is currently only possible with BSD type systems
-#  to many assumptions have to be made on other platforms to make
-#  this work with the current code. Most code ported or modeled
-#  after the ipaddress fact for the sake of similar functionality
-#  and familiar mechanics.
+#   OS dependant code that parses the output of various networking
+#   tools and currently not very intelligent. Returns the first
+#   non-loopback and non-linklocal address found in the ouput unless
+#   a default route can be mapped to a routeable interface. Guessing
+#   an interface is currently only possible with BSD type systems
+#   to many assumptions have to be made on other platforms to make
+#   this work with the current code. Most code ported or modeled
+#   after the ipaddress fact for the sake of similar functionality
+#   and familiar mechanics.
 #
 # Caveats:
 #

--- a/lib/facter/kernel.rb
+++ b/lib/facter/kernel.rb
@@ -3,8 +3,8 @@
 # Purpose: Returns the operating system's name.
 #
 # Resolution:
-#   Uses Ruby's rbconfig to find host_os, if that is a Windows derivative, the
-#   returns 'windows', otherwise returns "uname -s" verbatim.
+#   Uses Ruby's rbconfig to find host_os, if that is a Windows derivative, then
+#   returns 'windows', otherwise returns the output of `uname -s` verbatim.
 #
 # Caveats:
 #

--- a/lib/facter/kernelmajversion.rb
+++ b/lib/facter/kernelmajversion.rb
@@ -4,7 +4,7 @@
 #
 # Resolution:
 #   Takes the first 2 elements of the kernel version as delimited by periods.
-#   Takes the first element of the kernel version on FreeBSD
+#   Takes the first element of the kernel version on FreeBSD.
 #
 # Caveats:
 #

--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -3,10 +3,10 @@
 # Purpose: Return the operating system's release number.
 #
 # Resolution:
-#   On AIX returns the output from the "oslevel -s" system command.
+#   On AIX returns the output from the `oslevel -s` system command.
 #   On Windows based systems, uses the win32ole gem to query Windows Management
-#   for the 'Win32_OperatingSystem' value.
-#   Otherwise uses the output of "uname -r" system command.
+#   for the `Win32_OperatingSystem` value.
+#   Otherwise uses the output of `uname -r` system command.
 #
 # Caveats:
 #

--- a/lib/facter/kernelversion.rb
+++ b/lib/facter/kernelversion.rb
@@ -3,9 +3,9 @@
 # Purpose: Return the operating system's kernel version.
 #
 # Resolution:
-#   On Solaris and SunOS based machines, returns the output of "uname -v".
-#   Otherwise returns the 'kernerlversion' fact up to the first '-'. This may be
-#   the entire 'kernelversion' fact in many cases.
+#   On Solaris and SunOS based machines, returns the output of `uname -v`.
+#   Otherwise returns the kernerlversion fact up to the first `-`. This may be
+#   the entire kernelversion fact in many cases.
 #
 # Caveats:
 #

--- a/lib/facter/lsbdistcodename.rb
+++ b/lib/facter/lsbdistcodename.rb
@@ -3,12 +3,13 @@
 # Purpose: Return Linux Standard Base information for the host.
 #
 # Resolution:
-#   Uses the lsb_release system command
+#   Uses the lsb_release system command.
 #
 # Caveats:
 #   Only works on Linux (and the kfreebsd derivative) systems.
 #   Requires the lsb_release program, which may not be installed by default.
-#   Also is as only as accurate as that program outputs.
+#   Is only as accurate as the output of lsb_release.
+#
 
 Facter.add(:lsbdistcodename) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]

--- a/lib/facter/lsbdistdescription.rb
+++ b/lib/facter/lsbdistdescription.rb
@@ -3,12 +3,13 @@
 # Purpose: Return Linux Standard Base information for the host.
 #
 # Resolution:
-#   Uses the lsb_release system command
+#   Uses the lsb_release system command.
 #
 # Caveats:
 #   Only works on Linux (and the kfreebsd derivative) systems.
 #   Requires the lsb_release program, which may not be installed by default.
-#   Also is as only as accurate as that program outputs.
+#   Is only as accurate as the output of lsb_release.
+#
 
 Facter.add(:lsbdistdescription) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]

--- a/lib/facter/lsbdistid.rb
+++ b/lib/facter/lsbdistid.rb
@@ -3,12 +3,13 @@
 # Purpose: Return Linux Standard Base information for the host.
 #
 # Resolution:
-#   Uses the lsb_release system command
+#   Uses the lsb_release system command.
 #
 # Caveats:
 #   Only works on Linux (and the kfreebsd derivative) systems.
 #   Requires the lsb_release program, which may not be installed by default.
-#   Also is as only as accurate as that program outputs.
+#   Is only as accurate as the output of lsb_release.
+#
 
 Facter.add(:lsbdistid) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]

--- a/lib/facter/lsbdistrelease.rb
+++ b/lib/facter/lsbdistrelease.rb
@@ -3,12 +3,13 @@
 # Purpose: Return Linux Standard Base information for the host.
 #
 # Resolution:
-#   Uses the lsb_release system command
+#   Uses the lsb_release system command.
 #
 # Caveats:
 #   Only works on Linux (and the kfreebsd derivative) systems.
 #   Requires the lsb_release program, which may not be installed by default.
-#   Also is as only as accurate as that program outputs.
+#   Is only as accurate as the output of lsb_release.
+#
 
 Facter.add(:lsbdistrelease) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]

--- a/lib/facter/lsbmajdistrelease.rb
+++ b/lib/facter/lsbmajdistrelease.rb
@@ -1,7 +1,8 @@
 # Fact: lsbmajdistrelease
 #
-# Purpose: Returns the major version of the operation system version as gleaned
-# from the lsbdistrelease fact.
+# Purpose:
+#   Returns the major version of the operation system version as gleaned
+#   from the lsbdistrelease fact.
 #
 # Resolution:
 #   Parses the lsbdistrelease fact for numbers followed by a period and

--- a/lib/facter/lsbrelease.rb
+++ b/lib/facter/lsbrelease.rb
@@ -3,12 +3,13 @@
 # Purpose: Return Linux Standard Base information for the host.
 #
 # Resolution:
-#   Uses the lsb_release system command
+#   Uses the lsb_release system command.
 #
 # Caveats:
 #   Only works on Linux (and the kfreebsd derivative) systems.
 #   Requires the lsb_release program, which may not be installed by default.
-#   Also is as only as accurate as that program outputs.
+#   Is only as accurate as the output of lsb_release.
+#
 
 Facter.add(:lsbrelease) do
   confine :kernel => [ :linux, :"gnu/kfreebsd" ]

--- a/lib/facter/macaddress.rb
+++ b/lib/facter/macaddress.rb
@@ -1,6 +1,7 @@
 # Fact: macaddress
 #
 # Purpose:
+#   Returns the MAC address of the primary network interface.
 #
 # Resolution:
 #

--- a/lib/facter/macosx.rb
+++ b/lib/facter/macosx.rb
@@ -6,7 +6,7 @@
 #
 # Resolution:
 #   Uses util/macosx.rb to do the fact reconnaissance, then outputs them
-#   preceded by 'sp_'
+#   preceded by `sp_`
 #
 # Caveats:
 #

--- a/lib/facter/manufacturer.rb
+++ b/lib/facter/manufacturer.rb
@@ -3,10 +3,10 @@
 # Purpose: Return the hardware manufacturer information about the hardware.
 #
 # Resolution:
-#   On OpenBSD, queries sysctl values, via a util class.
-#   On SunOS Sparc, uses prtdiag via a util class.
+#   On OpenBSD, queries `sysctl` values, via a util class.
+#   On SunOS Sparc, uses `prtdiag` via a util class.
 #   On Windows, queries the system via a util class.
-#   Uses the 'util/manufacturer.rb' for fallback parsing.
+#   Uses `util/manufacturer.rb` for fallback parsing.
 #
 # Caveats:
 #

--- a/lib/facter/memory.rb
+++ b/lib/facter/memory.rb
@@ -3,15 +3,15 @@
 # Purpose: Return information about memory and swap usage.
 #
 # Resolution:
-#   On Linuxes, uses Facter::Memory.meminfo_number from
-#   'facter/util/memory.rb'
-#   On AIX, parses "swap -l" for swap values only.
-#   On OpenBSD, it parses "swapctl -l" for swap values, vmstat via a module for
-#   free memory, and "sysctl hw.physmem" for maximum memory.
-#   On FreeBSD, it parses "swapinfo -k" for swap values, and parses sysctl for
+#   On Linuxes, uses `Facter::Memory.meminfo_number` from
+#   `facter/util/memory.rb`
+#   On AIX, parses `swap -l` for swap values only.
+#   On OpenBSD, it parses `swapctl -l` for swap values, `vmstat` via a module for
+#   free memory, and `sysctl hw.physmem` for maximum memory.
+#   On FreeBSD, it parses `swapinfo -k` for swap values, and parses `sysctl` for
 #   maximum memory.
-#   On Solaris, use "swap -l" for swap values, and parsing prtconf for maximum
-#   memory, and again, the vmstat module for free memory.
+#   On Solaris, use `swap -l` for swap values, and parsing `prtconf` for maximum
+#   memory, and again, the `vmstat` module for free memory.
 #
 # Caveats:
 #   Some BSD platforms aren't covered at all. AIX is missing memory values.

--- a/lib/facter/netmask.rb
+++ b/lib/facter/netmask.rb
@@ -2,10 +2,11 @@
 #
 # Purpose: Returns the netmask for the main interfaces.
 #
-# Resolution: Uses the facter/util/netmask library routines.
+# Resolution: Uses the `facter/util/netmask` library routines.
 #
 # Caveats:
 #
+
 # netmask.rb
 # Find the netmask of the primary ipaddress
 # Copyright (C) 2007 David Schmitt <david@schmitt.edv-bus.at>

--- a/lib/facter/network.rb
+++ b/lib/facter/network.rb
@@ -1,11 +1,11 @@
 # Fact: network
 #
 # Purpose:
-# Get IP, network and netmask information for available network
-# interfacs.
+#   Get IP, network and netmask information for available network
+#   interfacs.
 #
 # Resolution:
-#  Uses 'facter/util/ip' to enumerate interfaces and return their information.
+#   Uses `facter/util/ip` to enumerate interfaces and return their information.
 #
 # Caveats:
 #

--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -4,8 +4,8 @@
 #
 # Resolution:
 #   If the kernel is a Linux kernel, check for the existence of a selection of
-#   files in /etc/ to find the specific flavour.
-#   On SunOS based kernels, attempt to determine the flavour, otherwise return Solaris.
+#   files in `/etc/` to find the specific flavor.
+#   On SunOS based kernels, attempt to determine the flavor, otherwise return Solaris.
 #   On systems other than Linux, use the kernel value.
 #
 # Caveats:

--- a/lib/facter/operatingsystemmajrelease.rb
+++ b/lib/facter/operatingsystemmajrelease.rb
@@ -6,16 +6,16 @@
 #   Splits down the operatingsystemrelease fact at decimal point for
 #   osfamily RedHat derivatives and Debian.
 #   Uses operatingsystemrelease to the first non decimal character for
-#   operatingsystem Solaris
+#   operatingsystem Solaris. This should be the same as lsbmajdistrelease,
+#   but on minimal systems there are too many dependencies to use LSB
 #
-# This should be the same as lsbmajdistrelease, but on minimal systems there
-# are too many dependencies to use LSB
+# Caveats:
+#   Supports the following operating systems: "Alpine" "Amazon" "Archlinux"
+#   "Ascendos" "Bluewhite64" "CentOS" "CloudLinux" 
+#   "Debian" "Fedora" "Gentoo" "Mandrake" "Mandriva" "MeeGo" "OEL" "OpenSuSE" 
+#   "OracleLinux" "OVS" "PSBM" "RedHat" "Scientific" "Slackware" "Slamd64" "SLC"
+#   "SLED" "SLES" "SuSE" "Ubuntu" "VMWareESX"
 #
-# List of operatingsystems at time of writing:
-#"Alpine" "Amazon" "Archlinux" "Ascendos" "Bluewhite64" "CentOS" "CloudLinux" 
-#"Debian" "Fedora" "Gentoo" "Mandrake" "Mandriva" "MeeGo" "OEL" "OpenSuSE" 
-#"OracleLinux" "OVS" "PSBM" "RedHat" "Scientific" "Slackware" "Slamd64" "SLC"
-#"SLED" "SLES" "SuSE" "Ubuntu" "VMWareESX"
 
 Facter.add(:operatingsystemmajrelease) do
   confine :operatingsystem => [

--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -3,16 +3,15 @@
 # Purpose: Returns the release of the operating system.
 #
 # Resolution:
-#   On RedHat derivatives, returns their '/etc/<variant>-release' file.
-#   On Debian, returns '/etc/debian_version'.
-#   On Ubuntu, parses '/etc/lsb-release' for the release version.
-#   On Suse, derivatives, parses '/etc/SuSE-release' for a selection of version
+#   On RedHat derivatives, returns their `/etc/<variant>-release` file.
+#   On Debian, returns `/etc/debian_version`.
+#   On Ubuntu, parses `/etc/lsb-release` for the release version.
+#   On Suse, derivatives, parses `/etc/SuSE-release` for a selection of version
 #   information.
-#   On Slackware, parses '/etc/slackware-version'.
-#   On Amazon Linux, returns the 'lsbdistrelease' value.
-#   On Mageia, parses '/etc/mageia-release' for the release version.
-#
-#   On all remaining systems, returns the 'kernelrelease' value.
+#   On Slackware, parses `/etc/slackware-version`.
+#   On Amazon Linux, returns the lsbdistrelease fact's value.
+#   On Mageia, parses `/etc/mageia-release` for the release version.
+#   On all remaining systems, returns the kernelrelease fact's value.
 #
 # Caveats:
 #

--- a/lib/facter/osfamily.rb
+++ b/lib/facter/osfamily.rb
@@ -3,13 +3,13 @@
 # Purpose: Returns the operating system
 #
 # Resolution:
-#   Maps operating systems to operating system families, such as linux
+#   Maps operating systems to operating system families, such as Linux
 #   distribution derivatives. Adds mappings from specific operating systems
 #   to kernels in the case that it is relevant.
 #
 # Caveats:
 #   This fact is completely reliant on the operatingsystem fact, and no
-#   heuristics are used
+#   heuristics are used.
 #
 
 Facter.add(:osfamily) do

--- a/lib/facter/partitions.rb
+++ b/lib/facter/partitions.rb
@@ -1,14 +1,15 @@
 # Fact: partitions
 #
 # Purpose:
-#   Return the details of the disk partitions
+#   Return the details of the disk partitions.
 #
 # Resolution:
-#   Parse the contents of /sys/block/<device>/size to receive the size (multiplying by 512 to correct for blocks-to-bytes)
+#   Parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes).
 #
 # Caveats:
-#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs
+#   Only supports Linux 2.6+ at this time, due to the reliance on sysfs.
 #
+
 # Author: Chris Portman <chris@portman.net.au>
 
 require 'facter'

--- a/lib/facter/path.rb
+++ b/lib/facter/path.rb
@@ -1,8 +1,8 @@
 # Fact: path
 #
-# Purpose: Returns the $PATH variable.
+# Purpose: Returns the `$PATH` variable.
 #
-# Resolution: Gets $PATH from the environment.
+# Resolution: Gets `$PATH` from the environment.
 #
 # Caveats:
 #

--- a/lib/facter/physicalprocessorcount.rb
+++ b/lib/facter/physicalprocessorcount.rb
@@ -3,9 +3,8 @@
 # Purpose: Return the number of physical processors.
 #
 # Resolution:
-#
 #   Attempts to use sysfs to get the physical IDs of the processors. Falls
-#   back to /proc/cpuinfo and "physical id" if sysfs is not available.
+#   back to `/proc/cpuinfo` and `physical id` if sysfs is not available.
 #
 # Caveats:
 #

--- a/lib/facter/processor.rb
+++ b/lib/facter/processor.rb
@@ -4,10 +4,10 @@
 #   Additional Facts about the machine's CPUs.
 #
 # Resolution:
-#   On Linux and kFreeBSD, parse '/proc/cpuinfo' for each processor.
-#   On AIX, parse the output of 'lsdev' for its processor section.
-#   On Solaris, parse the output of 'kstat' for each processor.
-#   On OpenBSD, use the sysctl variables 'hw.model' and 'hw.ncpu'
+#   On Linux and kFreeBSD, parse `/proc/cpuinfo` for each processor.
+#   On AIX, parse the output of `lsdev` for its processor section.
+#   On Solaris, parse the output of `kstat` for each processor.
+#   On OpenBSD, use the sysctl variables `hw.model` and`'hw.ncpu'`  
 #   for the CPU model and the CPU count respectively.
 #
 # Caveats:

--- a/lib/facter/ps.rb
+++ b/lib/facter/ps.rb
@@ -1,11 +1,12 @@
 # Fact: ps
 #
-# Purpose: Internal fact for what to use to list all processes. Used by
-# Service{} type in Puppet.
+# Purpose: 
+#   Internal fact for what to use to list all processes. Used by
+#   the Service type in Puppet.
 #
 # Resolution:
-#   Assumes "ps -ef" for all operating systems other than BSD derivatives, where
-#   it uses "ps auxwww"
+#   Assumes `ps -ef` for all operating systems other than BSD derivatives, where
+#   it uses `ps auxwww`
 #
 # Caveats:
 #

--- a/lib/facter/rubysitedir.rb
+++ b/lib/facter/rubysitedir.rb
@@ -2,6 +2,9 @@
 #
 # Purpose: Returns Ruby's site library directory.
 #
+# Resolution:
+#   Uses the RbConfig module.
+#
 
 require 'rbconfig'
 

--- a/lib/facter/rubyversion.rb
+++ b/lib/facter/rubyversion.rb
@@ -2,7 +2,7 @@
 #
 # Purpose: Returns the version of Ruby facter is running under.
 #
-# Resolution: Returns RUBY_VERSION.
+# Resolution: Returns `RUBY_VERSION`.
 #
 # Caveats:
 #

--- a/lib/facter/timezone.rb
+++ b/lib/facter/timezone.rb
@@ -2,7 +2,7 @@
 #
 # Purpose: Return the machine's time zone.
 #
-# Resolution: Uses's Ruby's Time module's Time.new call.
+# Resolution: Usess Ruby's Time module's `Time.new`.
 #
 # Caveats:
 #

--- a/lib/facter/uptime.rb
+++ b/lib/facter/uptime.rb
@@ -1,10 +1,10 @@
 # Fact: uptime
 #
-# Purpose: return the system uptime in a human readable format.
+# Purpose: Return the system uptime in a human-readable format.
 #
 # Resolution:
-#   Does basic maths on the "uptime_seconds" fact to return a count of
-#   days, hours and minutes of uptime
+#   Does basic math on the uptime_seconds fact to return a count of
+#   days, hours, and minutes of uptime.
 #
 # Caveats:
 #

--- a/lib/facter/uptime_days.rb
+++ b/lib/facter/uptime_days.rb
@@ -1,8 +1,8 @@
 # Fact: uptime_days
 #
-# Purpose: Return purely number of days of uptime.
+# Purpose: Return just the number of days of uptime.
 #
-# Resolution: Divides uptime_hours fact by 24.
+# Resolution: Divides the uptime_hours fact by 24.
 #
 # Caveats:
 #

--- a/lib/facter/uptime_hours.rb
+++ b/lib/facter/uptime_hours.rb
@@ -1,8 +1,8 @@
 # Fact: uptime_hours
 #
-# Purpose: Return purely number of hours of uptime.
+# Purpose: Return just the number of hours of uptime.
 #
-# Resolution: Divides uptime_seconds fact by 3600.
+# Resolution: Divides the uptime_seconds fact by 3600.
 #
 # Caveats:
 #

--- a/lib/facter/uptime_seconds.rb
+++ b/lib/facter/uptime_seconds.rb
@@ -1,12 +1,12 @@
 # Fact: uptime_seconds
 #
-# Purpose: Return purely number of seconds of uptime.
+# Purpose: Return just the number of seconds of uptime.
 #
 # Resolution:
-#   Using the 'facter/util/uptime.rb' module, try a verity of methods to acquire
+#   Using the `facter/util/uptime.rb` module, try a variety of methods to acquire
 #   the uptime on Unix.
 #
-#   On Windows, the module calculates the uptime by the "LastBootupTime" Windows
+#   On Windows, the module calculates the uptime by the `LastBootupTime` Windows
 #   management value.
 #
 # Caveats:

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -1,29 +1,40 @@
 # Fact: virtual
 #
-# Purpose: Determine if the system's hardware is real or virtualised.
+# Purpose: Determine if the system's hardware is real or virtualized.
 #
 # Resolution:
 #   Assumes physical unless proven otherwise.
 #
-#   On Darwin, use the macosx util module to acquire the SPHardwareDataType and
-#   SPEthernetDataType, from which it is possible to determine if the host is a
-#   VMware, Parallels, or VirtualBox.  This previously used SPDisplaysDataType
+#   On Darwin, use the macosx util module to acquire the SPHardwareDataType
+#   and SPEthernetDataType, from which it is possible to determine if the host is
+#   a VMware, Parallels, or VirtualBox.  This previously used SPDisplaysDataType,
 #   which was not reliable if running headless, and also caused lagging issues
 #   on actual Macs.
 #
-#   On Linux, BSD, Solaris and HPUX:
-#   Much of the logic here is obscured behind util/virtual.rb, which rather
-#   than document here, which would encourage drift, just refer to it.
-#   The Xen tests in here rely on /sys and /proc, and check for the presence and
+#   On Linux, BSD, Solaris and HPUX: Much of the logic here is obscured behind
+#   `util/virtual.rb`, which you can consult directly for more detailed resolution
+#   information.
+#   The Xen tests in here rely on `/sys` and `/proc,` and check for the presence and
 #   contents of files in there.
-#   If after all the other tests, it's still seen as physical, then it tries to
-#   parse the output of the "lspci", "dmidecode" and "prtdiag" and parses them
+#   If after all the other tests it's still seen as physical, then it tries to
+#   parse the output of the `lspci`, `dmidecode`, and `prtdiag` and parses them
 #   for obvious signs of being under VMware, Parallels or VirtualBox.
-#   Finally it checks for the existence of vmware-vmx, which would hint it's
-#   VMware.
+#   Finally, it checks for the existence of `vmware-vmx`, which would hint that
+#   it's VMware.
 #
 # Caveats:
 #   Many checks rely purely on existence of files.
+#
+
+# Fact: is_virtual
+#
+# Purpose: Return `true` or `false` depending on whether a machine is virtualized or not.
+#
+# Resolution: Hypervisors and the like may be detected as a virtual type, but
+#   are not actual virtual machines, or should not be treated as such. This
+#   determines if the host is actually virtualized.
+#
+# Caveats:
 #
 
 require 'facter/util/virtual'
@@ -285,17 +296,6 @@ Facter.add("virtual") do
     "gce" if Facter::Util::Virtual.gce?
   end
 end
-
-# Fact: is_virtual
-#
-# Purpose: returning true or false for if a machine is virtualised or not.
-#
-# Resolution: Hypervisors and the like may be detected as a virtual type, but
-# are not actual virtual machines, or should not be treated as such. This
-# determines if the host is actually virtualized.
-#
-# Caveats:
-#
 
 Facter.add("is_virtual") do
   confine :kernel => %w{Linux FreeBSD OpenBSD SunOS HP-UX Darwin GNU/kFreeBSD windows}

--- a/lib/facter/vlans.rb
+++ b/lib/facter/vlans.rb
@@ -2,7 +2,7 @@
 #
 # Purpose: On Linux, return a list of all the VLANs on the system.
 #
-# Resolution: On Linux only, checks for and reads /proc/net/vlan/config and
+# Resolution: On Linux only, checks for and reads `/proc/net/vlan/config` and
 # parses it.
 #
 # Caveats:

--- a/lib/facter/xendomains.rb
+++ b/lib/facter/xendomains.rb
@@ -3,7 +3,7 @@
 # Purpose: Return the list of Xen domains on the Dom0.
 #
 # Resolution:
-#   On a Xen Dom0 host, return a list of Xen domains using the 'util/xendomains'
+#   On a Xen Dom0 host, return a list of Xen domains using the `util/xendomains`
 #   library.
 #
 # Caveats:

--- a/lib/facter/zones.rb
+++ b/lib/facter/zones.rb
@@ -2,15 +2,16 @@
 #
 # Purpose:
 #   Return the list of zones on the system and add one zones_ fact
-#   for each zone with its state e.g. running, incomplete or installed.
+#   for each zone with its state e.g. running, incomplete, or installed.
 #
 # Resolution:
-#   Uses 'usr/sbin/zoneadm list -cp' to get the list of zones in separate parsable
-#   lines with delimeter being ':' which is used to split the line string and get
+#   Uses `usr/sbin/zoneadm list -cp` to get the list of zones in separate parsable
+#   lines with delimeter being `:` which is used to split the line string and get
 #   the zone details.
 #
 # Caveats:
-#   We dont support below s10 where zones are not available.
+#   Only supported on Solaris 10 and up.
+#
 require 'facter/util/solaris_zones'
 if Facter.value(:kernel) == 'SunOS'
   Facter::Util::SolarisZones.add_facts


### PR DESCRIPTION
The docs team can now automatically extract comment docs from facts, but
that means that the comment docs have to be formatted just a bit more
consistently now. I've reformatted the ones that needed it. There are no
changes to actual code. There's some information about the formatting
standard I'm using in the README at github.com/holguinj/extracter.

I couldn't resist doing some copy-editing while I was in there, but that wasn't the main purpose.
