### PR TITLE
Ensure only major and minor versions are returned for CentOS 7.

### DIFF
--- a/lib/facter/operatingsystemrelease.rb
+++ b/lib/facter/operatingsystemrelease.rb
@@ -42,6 +42,8 @@ Facter.add(:operatingsystemrelease) do
       line = release.split("\n").first.chomp
       if match = /\(Rawhide\)$/.match(line)
         "Rawhide"
+      elsif match = /release (\d.\d)(\.(\d))/.match(line)
+        match[1]
       elsif match = /release (\d[\d.]*)/.match(line)
         match[1]
       end


### PR DESCRIPTION
CentOS now includes major, minor and release version values in /etc/redhat-release.
