### PR TITLE
(FACT-617) Facter README.md should express semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,28 @@ Further Information
 -------------------
 
 See http://www.puppetlabs.com/puppet/related-projects/facter for more details.
+
+Support
+-------
+Please log tickets and issues at our [JIRA tracker](http://tickets.puppetlabs.com).  A [mailing
+list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
+available for asking questions and getting help from others. In addition there
+is an active #puppet channel on Freenode.
+
+We use semantic version numbers for our releases, and recommend that users stay
+as up-to-date as possible by upgrading to patch releases and minor releases as
+they become available.
+
+Bugfixes and ongoing development will occur in minor releases for the current
+major version. Security fixes will be backported to a previous major version on
+a best-effort basis, until the previous major version is no longer maintained.
+
+
+For example: If a security vulnerability is discovered in Facter 2.1.0, we
+would fix it in the 2 series, most likely as 2.1.1. Maintainers would then make
+a best effort to backport that fix onto the latest Facter 1.7 release.
+
+Long-term support, including security patches and bug fixes, is available for
+commercial customers. Please see the following page for more details:
+
+[Puppet Enterprise Support Lifecycle](http://puppetlabs.com/misc/puppet-enterprise-lifecycle)


### PR DESCRIPTION
The puppet readme (https://github.com/puppetlabs/puppet/blob/master/README.md)
explains the maintenance we have for versions of puppet and that it is
semantically versioned. We recently encountered an issue with Facter where
users were surprised that we did not ship a security release for a previous
major version of facter. The previous assumption may have been that the puppet
README was sufficient for all of our FOSS projects, but this is probably not
the case. We should update the README.md in facter with the same verbage as
puppet so our intended release lifecycle is clear.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
