### PR TITLE
(FACT-612) Fix issue with missing POSIX requirement for system_uptime

### DIFF
--- a/lib/facter/util/uptime.rb
+++ b/lib/facter/util/uptime.rb
@@ -28,6 +28,7 @@ module Facter::Util::Uptime
   end
 
   def self.uptime_sysctl
+    require 'facter/util/posix'
     output = Facter::Util::POSIX.sysctl(uptime_sysctl_variable)
     if output
       compute_uptime(Time.at(output.match(/\d+/)[0].to_i))


### PR DESCRIPTION
This commit fixes an issue where in OSX, system_uptime
would fail due to a missing requirement of 'facter/util/posix'
in uptime's utility file.
