### PR TITLE
(FACT-603) Allow acceptance to use github mirror

### DIFF
--- a/acceptance/lib/puppet/acceptance/git_utils.rb
+++ b/acceptance/lib/puppet/acceptance/git_utils.rb
@@ -1,0 +1,19 @@
+module Puppet
+  module Acceptance
+    module GitUtils
+      def lookup_in_env(env_variable_name, project_name, default)
+        project_specific_name = "#{project_name.upcase.gsub("-","_")}_#{env_variable_name}"
+        ENV[project_specific_name] || ENV[env_variable_name] || default
+      end
+
+      def build_giturl(project_name, git_fork = nil, git_server = nil)
+        git_fork ||= lookup_in_env('FORK', project_name, 'puppetlabs')
+        git_server ||= lookup_in_env('GIT_SERVER', project_name, 'github.com')
+        repo = (git_server == 'github.com') ?
+          "#{git_fork}/#{project_name}.git" :
+          "#{git_fork}-#{project_name}.git"
+        "git://#{git_server}/#{repo}"
+      end
+    end
+  end
+end

--- a/acceptance/setup/common/00_EnvSetup.rb
+++ b/acceptance/setup/common/00_EnvSetup.rb
@@ -4,6 +4,8 @@ step "Ensure Git and Ruby"
 
 require 'puppet/acceptance/install_utils'
 extend Puppet::Acceptance::InstallUtils
+require 'puppet/acceptance/git_utils'
+extend Puppet::Acceptance::GitUtils
 require 'beaker/dsl/install_utils'
 extend Beaker::DSL::InstallUtils
 
@@ -34,7 +36,11 @@ hosts.each do |host|
   case host['platform']
   when /windows/
     step "#{host} Install ruby from git"
-    install_from_git(host, "/opt/puppet-git-repos", :name => 'puppet-win32-ruby', :path => 'git://github.com/puppetlabs/puppet-win32-ruby', :rev  => '1.9.3-x86')
+    revision = '1.9.3-x86'
+    install_from_git(host, "/opt/puppet-git-repos",
+                    :name => 'puppet-win32-ruby',
+                    :path => build_giturl('puppet-win32-ruby'),
+                    :rev  => revision)
     on host, 'cd /opt/puppet-git-repos/puppet-win32-ruby; cp -r ruby/* /'
     on host, 'cd /lib; icacls ruby /grant "Everyone:(OI)(CI)(RX)"'
     on host, 'cd /lib; icacls ruby /reset /T'


### PR DESCRIPTION
This provides the necessary bits to allow facter to use github mirrors during
acceptance runs.
