### PR TITLE
Display facts for aliases in *BSD

### DIFF
--- a/lib/facter/interfaces.rb
+++ b/lib/facter/interfaces.rb
@@ -47,3 +47,16 @@ Facter::Util::IP.get_interfaces.each do |interface|
     end
   end
 end
+
+# Get aliases on *BSD 
+Facter::Util::IP.get_interfaces.each do |interface|
+  %w{ipaddress ipaddress6 netmask}.each do |label|
+    (0..Facter::Util::IP.get_alias_no(interface, label)).each do |a|
+      Facter.add(label + "_" + Facter::Util::IP.alphafy(interface) + "_alias#{a}") do
+        setcode do
+          Facter::Util::IP.get_interface_value(interface, label, a)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- interfaces.rb - aliases on *BSD are iterated over up to their actual count - slightly modified Michelle Sullivan's version
- util/ip.rb - added get_alias_no method to return alias count; method get_interface_value modified by Michelle Sullivan to allow obtaining values for specific aliases

Originated here:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=190796
