### PR TITLE
(FACT-627) Print `false` when outputting a single fact value

### DIFF
--- a/lib/facter/util/formatter.rb
+++ b/lib/facter/util/formatter.rb
@@ -22,7 +22,7 @@ module Facter
         # Print the value of a single fact, otherwise print a list sorted by fact
         # name and separated by "=>"
         if hash.length == 1
-          if value = hash.values.first
+          if !(value = hash.values.first).nil?
             output = value.is_a?(String) ? value : value.inspect
           end
         else

--- a/spec/unit/util/formatter_spec.rb
+++ b/spec/unit/util/formatter_spec.rb
@@ -27,12 +27,17 @@ describe Facter::Util::Formatter do
       expect(described_class.format_plaintext({"foo" => "bar"})).to eq "bar"
     end
 
+    it "can return false:FalseClass as a single fact value" do
+      expect(described_class.format_plaintext({"foo" => false})).to eq "false"
+    end
+
     it "formats a structured value with #inspect" do
       value = ["bar"]
       value.expects(:inspect).returns %Q(["bar"])
       hash = {"foo" => value, "baz" => "quux"}
       expect(described_class.format_plaintext(hash)).to match(%Q([bar]))
     end
+
     it "formats multiple string values as key/value pairs" do
       hash = {"foo" => "bar", "baz" => "quux"}
       expect(described_class.format_plaintext(hash)).to match(/foo => bar/)


### PR DESCRIPTION
Before this commit the plaintext formatter did a naive `if value` which
is false when `value` is either nil or false. While we don't want to
print nil facts, facts that are false are valid but the previous
behavior would treat them as undefined as well. This commit ensures that
the fact value is not nil, and if the fact is defined then it is
printed.

Thanks to RI Pienaar and Robin Bowes for finding and reporting this
issue.
