### PR TITLE
(FACT-640) Cherry-pick lost gid fact back into master

### DIFF
--- a/lib/facter/gid.rb
+++ b/lib/facter/gid.rb
@@ -1,0 +1,15 @@
+# Fact: gid
+#
+# Purpose: Return the gid of the user running Puppet
+#
+# Resolution:
+#
+# Caveats:
+# Not supported in windows yet.
+
+Facter.add(:gid) do
+  confine do
+    Facter::Core::Execution.which('id')
+  end
+  setcode { Facter::Core::Execution.exec('id -ng') }
+end

--- a/spec/unit/gid_spec.rb
+++ b/spec/unit/gid_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe "gid fact" do
+
+  describe "on systems with id" do
+    it "should return the current group" do
+      Facter::Core::Execution.expects(:which).with('id').returns(true)
+      Facter::Core::Execution.expects(:exec).once.with('id -ng').returns 'bar'
+
+      Facter.fact(:gid).value.should == 'bar'
+    end
+  end
+
+  describe "on systems without id" do
+    it "is not supported" do
+      Facter::Core::Execution.expects(:which).with('id').returns(false)
+
+      Facter.fact(:gid).value.should == nil
+    end
+  end
+
+end


### PR DESCRIPTION
This commit cherry-picks the gid fact back into master,
which was lost during the facter-2 / master merge.

Original commit (abb477df):
(#22143) Add 'gid' fact to resolve users primary group.
A very simple fact to fetch the primary group.  I've only tested
this on Linux/OSX/FreeBSD but id -ng seems to be global.  I even
got a user to test it on Hurd and it worked.
