### PR TITLE
(FACT-644) Cherry-pick lost XCP operatingsystem fact fix back into master

### DIFF
--- a/lib/facter/operatingsystem.rb
+++ b/lib/facter/operatingsystem.rb
@@ -98,6 +98,8 @@ Facter.add(:operatingsystem) do
         "Ascendos"
       elsif txt =~ /^XenServer/i
         "XenServer"
+      elsif txt =~ /XCP/
+        "XCP"
       else
         "RedHat"
       end

--- a/spec/unit/operatingsystem_spec.rb
+++ b/spec/unit/operatingsystem_spec.rb
@@ -109,6 +109,7 @@ describe "Operating System fact" do
       "Ascendos"   => "Ascendos release 6.0 (Nameless)",
       "CloudLinux" => "CloudLinux Server release 5.5",
       "XenServer"  => "XenServer release 5.6.0-31188p (xenenterprise)",
+      "XCP"        => "XCP release 1.6.10-61809c",
     }.each_pair do |operatingsystem, string|
       it "should be #{operatingsystem} based on /etc/redhat-release contents #{string}" do
         FileTest.expects(:exists?).with("/etc/redhat-release").returns true


### PR DESCRIPTION
This commit cherry-picks work done on the operatingsystem fact that
was lost during the facter-2 / master merge.

Original commit (ed28b9382):
Ticket #18175 Wrong operatingsystem reported for Xen Cloud Platform

Facter will now return XCP for the fact operatingsystem when
/etc/redhat-release contains the XCP version string.
