### PR TITLE
(FACT-643) Cherry-pick lost Rackspace fact back into master

### DIFF
--- a/lib/facter/rackspace.rb
+++ b/lib/facter/rackspace.rb
@@ -1,0 +1,34 @@
+# Purpose: Determine information about Rackspace cloud instances
+#
+# Resolution:
+#   If this is a Rackspace Cloud instance, populates rsc_ facts
+#
+# Caveats:
+#   Depends on Xenstore
+#
+
+Facter.add(:is_rsc) do
+  setcode do
+    result = Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/provider")
+    if result == "Rackspace"
+      "true"
+    end
+  end
+end
+
+Facter.add(:rsc_region) do
+  confine :is_rsc => "true"
+  setcode do
+    Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/region")
+  end
+end
+
+Facter.add(:rsc_instance_id) do
+  confine :is_rsc => "true"
+  setcode do
+    result = Facter::Util::Resolution.exec("/usr/bin/xenstore-read name")
+    if result and (match = result.match(/instance-(.*)/))
+      match[1]
+    end
+  end
+end

--- a/spec/unit/rackspace_spec.rb
+++ b/spec/unit/rackspace_spec.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+
+require 'spec_helper'
+require 'facter'
+
+describe "rackspace facts" do
+  describe "on Rackspace Cloud" do
+    before :each do
+      Facter.collection.internal_loader.load(:rackspace)
+    end
+
+    it "should set is_rsc to true" do
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider").returns("Rackspace")
+      Facter.fact(:is_rsc).value.should == "true"
+    end
+
+    it "should set the region to dfw" do
+      Facter.fact(:is_rsc).stubs(:value).returns("true")
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/region").returns("dfw")
+      Facter.fact(:rsc_region).value.should == "dfw"
+    end
+
+    it "should get the instance id" do
+      Facter.fact(:is_rsc).stubs(:value).returns("true")
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read name").returns("instance-75a96685-85d6-44c6-aed8-41ef0fb2cfcc")
+      Facter.fact(:rsc_instance_id).value.should == "75a96685-85d6-44c6-aed8-41ef0fb2cfcc"
+    end
+  end
+
+  describe "not on Rackspace Cloud" do
+    before do
+      Facter.collection.internal_loader.load(:rackspace)
+    end
+
+    it "shouldn't set is_rsc" do
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider").returns("other")
+      Facter.fact(:is_rsc).value.should == nil
+    end
+  end
+end


### PR DESCRIPTION
This commit cherry-picks work done on the rackspace fact which
was lost during the facter-2 / master merge.

Original commit (a6bc494d4):
Add initial functionality for exposing Rackspace Cloud data

Rackspace Cloud doesn't expose the metadata service provided
by OpenStack.  You can get some basic information about region
and what the instance id is from xenstore, though
