### PR TITLE
(FACT-642) Cherry-pick lost zpool_version fix into master

### DIFF
--- a/lib/facter/zpool_version.rb
+++ b/lib/facter/zpool_version.rb
@@ -4,7 +4,7 @@ Facter.add('zpool_version') do
   setcode do
     if Facter::Core::Execution.which('zpool')
       zpool_v = Facter::Core::Execution.exec('zpool upgrade -v')
-      zpool_version = zpool_v.match(/ZFS pool version (\d+)./).captures.first unless zpool_v.empty?
+      zpool_version = zpool_v.scan(/^\s+(\d+)\s+/m).flatten.last unless zpool_v.nil?
     end
   end
 end

--- a/spec/fixtures/unit/zfs_version/zfsonlinux_0.6.1
+++ b/spec/fixtures/unit/zfs_version/zfsonlinux_0.6.1
@@ -1,0 +1,13 @@
+The following filesystem versions are supported:
+
+VER  DESCRIPTION
+---  --------------------------------------------------------
+ 1   Initial ZFS filesystem version
+ 2   Enhanced directory entries
+ 3   Case insensitive and filesystem user identifier (FUID)
+ 4   userquota, groupquota properties
+ 5   System attributes
+
+For more information on a particular version, including supported releases,
+see the ZFS Administration Guide.
+

--- a/spec/fixtures/unit/zpool_version/zfsonlinux_0.6.1
+++ b/spec/fixtures/unit/zpool_version/zfsonlinux_0.6.1
@@ -1,0 +1,48 @@
+This system supports ZFS pool feature flags.
+
+The following features are supported:
+
+FEAT DESCRIPTION
+-------------------------------------------------------------
+async_destroy                         (read-only compatible)
+     Destroy filesystems asynchronously.
+empty_bpobj                           (read-only compatible)
+     Snapshots use less space.
+lz4_compress                         
+     LZ4 compression algorithm support.
+
+The following legacy versions are also supported:
+
+VER  DESCRIPTION
+---  --------------------------------------------------------
+ 1   Initial ZFS version
+ 2   Ditto blocks (replicated metadata)
+ 3   Hot spares and double parity RAID-Z
+ 4   zpool history
+ 5   Compression using the gzip algorithm
+ 6   bootfs pool property
+ 7   Separate intent log devices
+ 8   Delegated administration
+ 9   refquota and refreservation properties
+ 10  Cache devices
+ 11  Improved scrub performance
+ 12  Snapshot properties
+ 13  snapused property
+ 14  passthrough-x aclinherit
+ 15  user/group space accounting
+ 16  stmf property support
+ 17  Triple-parity RAID-Z
+ 18  Snapshot user holds
+ 19  Log device removal
+ 20  Compression using zle (zero-length encoding)
+ 21  Deduplication
+ 22  Received properties
+ 23  Slim ZIL
+ 24  System attributes
+ 25  Improved scrub stats
+ 26  Improved snapshot deletion performance
+ 27  Improved snapshot creation performance
+ 28  Multiple vdev replacements
+
+For more information on a particular version, including supported releases,
+see the ZFS Administration Guide.

--- a/spec/unit/zfs_version_spec.rb
+++ b/spec/unit/zfs_version_spec.rb
@@ -43,6 +43,11 @@ describe "zfs_version fact" do
     Facter.fact(:zfs_version).value.should == "4"
   end
 
+  it "should return correct version on Linux with zfsonlinux" do
+    Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('zfsonlinux_0.6.1'))
+    Facter.fact(:zfs_version).value.should == "5"
+  end
+
   it "should return nil if zfs command is not available" do
     Facter::Core::Execution.stubs(:which).with("zfs").returns(nil)
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))

--- a/spec/unit/zpool_version_spec.rb
+++ b/spec/unit/zpool_version_spec.rb
@@ -43,6 +43,11 @@ describe "zpool_version fact" do
     Facter.fact(:zpool_version).value.should == "23"
   end
 
+  it "should return correct version on Linux with zfsonlinux" do
+    Facter::Core::Execution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('zfsonlinux_0.6.1'))
+    Facter.fact(:zpool_version).value.should == "28"
+  end
+
   it "should return nil if zpool is not available" do
     Facter::Core::Execution.stubs(:which).with("zpool").returns(nil)
     Facter::Core::Execution.stubs(:exec).with("zpool upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))


### PR DESCRIPTION
This commit cherry-picks work done on the zpool_version fact,
which was lost during the facter-2 / master merge.

Original commit (363191011):
(#20617) add support for zfsonlinux + fixtures

"zpool upgrade -v" has a "FEAT DESCRIPTION" section that other ZFS
implementations don't have. The regex in the zpool_version fact choked
on this difference. It was replaced by same one used in the zfs_version
fact.

Thanks to Trey Dockendorf for his helpful bugreport!
