### PR TITLE
(FACT-641) Cherry-pick lost Solaris 10 zfs_version fix back into master

### DIFF
--- a/lib/facter/zfs_version.rb
+++ b/lib/facter/zfs_version.rb
@@ -3,8 +3,12 @@ require 'facter'
 Facter.add('zfs_version') do
   setcode do
     if Facter::Core::Execution.which('zfs')
-      zfs_v = Facter::Core::Execution.exec('zfs upgrade -v')
-      zfs_version = zfs_v.scan(/^\s+(\d+)\s+/m).flatten.last unless zfs_v.empty?
+      zfs_help = Facter::Core::Execution.exec('zfs -? 2> /dev/null')
+      zfs_has_upgrade = zfs_help.match(/\A.*upgrade.*\z/m) unless zfs_help.nil?
+      if zfs_has_upgrade
+        zfs_v = Facter::Core::Execution.exec('zfs upgrade -v')
+        zfs_version = zfs_v.scan(/^\s+(\d+)\s+/m).flatten.last unless zfs_v.nil?
+      end
     end
   end
 end

--- a/spec/fixtures/unit/zfs_version/zfs_new
+++ b/spec/fixtures/unit/zfs_version/zfs_new
@@ -1,0 +1,61 @@
+usage: zfs command args ...
+where 'command' is one of the following:
+
+        create [-p] [-o property=value] ... <filesystem>
+        create [-ps] [-b blocksize] [-o property=value] ... -V <size> <volume>
+        destroy [-rRf] <filesystem|volume>
+        destroy [-rRd] <snapshot>
+
+        snapshot [-r] [-o property=value] ... <filesystem@snapname|volume@snapname>
+        rollback [-rRf] <snapshot>
+        clone [-p] [-o property=value] ... <snapshot> <filesystem|volume>
+        promote <clone-filesystem>
+        rename <filesystem|volume|snapshot> <filesystem|volume|snapshot>
+        rename -p <filesystem|volume> <filesystem|volume>
+        rename -r <snapshot> <snapshot>
+        list [-rH][-d max] [-o property[,...]] [-t type[,...]] [-s property] ...
+            [-S property] ... [filesystem|volume|snapshot] ...
+
+        set <property=value> <filesystem|volume|snapshot> ...
+        get [-rHp] [-d max] [-o "all" | field[,...]] [-s source[,...]]
+            <"all" | property[,...]> [filesystem|volume|snapshot] ...
+        inherit [-rS] <property> <filesystem|volume|snapshot> ...
+        upgrade [-v]
+        upgrade [-r] [-V version] <-a | filesystem ...>
+        userspace [-hniHp] [-o field[,...]] [-sS field] ... [-t type[,...]]
+            <filesystem|snapshot>
+        groupspace [-hniHpU] [-o field[,...]] [-sS field] ... [-t type[,...]]
+            <filesystem|snapshot>
+
+        mount
+        mount [-vO] [-o opts] <-a | filesystem>
+        unmount [-f] <-a | filesystem|mountpoint>
+        share <-a | filesystem>
+        unshare <-a | filesystem|mountpoint>
+
+        send [-RDp] [-[iI] snapshot] <snapshot>
+        receive [-vnFu] <filesystem|volume|snapshot>
+        receive [-vnFu] [-d | -e] <filesystem>
+
+        allow <filesystem|volume>
+        allow [-ldug] <"everyone"|user|group>[,...] <perm|@setname>[,...]
+            <filesystem|volume>
+        allow [-ld] -e <perm|@setname>[,...] <filesystem|volume>
+        allow -c <perm|@setname>[,...] <filesystem|volume>
+        allow -s @setname <perm|@setname>[,...] <filesystem|volume>
+
+        unallow [-rldug] <"everyone"|user|group>[,...]
+            [<perm|@setname>[,...]] <filesystem|volume>
+        unallow [-rld] -e [<perm|@setname>[,...]] <filesystem|volume>
+        unallow [-r] -c [<perm|@setname>[,...]] <filesystem|volume>
+        unallow [-r] -s @setname [<perm|@setname>[,...]] <filesystem|volume>
+
+        hold [-r] <tag> <snapshot> ...
+        holds [-r] <snapshot> ...
+        release [-r] <tag> <snapshot> ...
+
+Each dataset is of the form: pool/[dataset/]*dataset[@name]
+
+For the property list, run: zfs set|get
+
+For the delegated permission list, run: zfs allow|unallow

--- a/spec/fixtures/unit/zfs_version/zfs_old
+++ b/spec/fixtures/unit/zfs_version/zfs_old
@@ -1,0 +1,43 @@
+usage: zfs command args ...
+where 'command' is one of the following:
+
+        create [[-o property=value] ... ] <filesystem>
+        create [-s] [-b blocksize] [[-o property=value] ...]
+            -V <size> <volume>
+        destroy [-rRf] <filesystem|volume|snapshot>
+
+        snapshot [-r] <filesystem@name|volume@name>
+        rollback [-rRf] <snapshot>
+        clone <snapshot> <filesystem|volume>
+        promote <clone filesystem>
+        rename <filesystem|volume|snapshot> <filesystem|volume|snapshot>
+
+        list [-rH] [-o property[,property]...] [-t type[,type]...]
+            [-s property [-s property]...] [-S property [-S property]...]
+            [filesystem|volume|snapshot] ...
+
+        set <property=value> <filesystem|volume> ...
+        get [-rHp] [-o field[,field]...] [-s source[,source]...]
+            <all | property[,property]...> [filesystem|volume|snapshot] ...
+        inherit [-r] <property> <filesystem|volume> ...
+
+        mount
+        mount [-o opts] [-O] -a
+        mount [-o opts] [-O] <filesystem>
+
+        unmount [-f] -a
+        unmount [-f] <filesystem|mountpoint>
+
+        share -a
+        share <filesystem>
+
+        unshare [-f] -a
+        unshare [-f] <filesystem|mountpoint>
+
+        send [-i <snapshot>] <snapshot>
+        receive [-vnF] <filesystem|volume|snapshot>
+        receive [-vnF] -d <filesystem>
+
+Each dataset is of the form: pool/[dataset/]*dataset[@name]
+
+For the property list, run: zfs set|get

--- a/spec/unit/zfs_version_spec.rb
+++ b/spec/unit/zfs_version_spec.rb
@@ -18,27 +18,37 @@ describe "zfs_version fact" do
     Facter::Core::Execution.stubs(:which).with("zfs").returns("/usr/bin/zfs")
   end
 
+  it "should return nil on old versions of Solaris 10" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_old'))
+    Facter.fact(:zfs_version).value.should == nil
+  end
+
   it "should return correct version on Solaris 10" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_10'))
     Facter.fact(:zfs_version).value.should == "3"
   end
 
   it "should return correct version on Solaris 11" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('solaris_11'))
     Facter.fact(:zfs_version).value.should == "5"
   end
 
   it "should return correct version on FreeBSD 8.2" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_8.2'))
     Facter.fact(:zfs_version).value.should == "4"
   end
 
   it "should return correct version on FreeBSD 9.0" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('freebsd_9.0'))
     Facter.fact(:zfs_version).value.should == "5"
   end
 
   it "should return correct version on Linux with ZFS-fuse" do
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
     Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))
     Facter.fact(:zfs_version).value.should == "4"
   end
@@ -50,20 +60,16 @@ describe "zfs_version fact" do
   end
 
   it "should return nil if zfs fails to run" do
-    Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns('')
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(nil)
     Facter.fact(:zfs_version).value.should == nil
   end
 
   it "handles the zfs command becoming available at a later point in time" do
     # Simulate Puppet configuring the zfs tools from a persistent daemon by
     # simulating three sequential responses to which('zfs').
-    Facter::Core::Execution.stubs(:which).
-      with("zfs").
-      returns(nil,nil,"/usr/bin/zfs")
-    Facter::Core::Execution.stubs(:exec).
-      with("zfs upgrade -v").
-      returns(my_fixture_read('linux-fuse_0.6.9'))
-
+    Facter::Core::Execution.stubs(:which).with("zfs").returns(nil,nil,"/usr/bin/zfs")
+    Facter::Core::Execution.stubs(:exec).with("zfs -? 2> /dev/null").returns(my_fixture_read('zfs_new'))
+    Facter::Core::Execution.stubs(:exec).with("zfs upgrade -v").returns(my_fixture_read('linux-fuse_0.6.9'))
     fact = Facter.fact(:zfs_version)
 
     # zfs is not present the first two times the fact is resolved.


### PR DESCRIPTION
This commit cherry-picks work done on the zfs_version fact
for Solaris 10, which was lost during the facter-2 / master merge.

Original commits (2a3b5f4, 5672d00, afc66f4, 64b854d):
Fix zfs_version on old versions of Solaris 10
The zfs upgrade command used by zfs_version does not exist on some older versions of Solaris 10.

This checks for the existence of the command before trying to run it.
