### PR TITLE
(FACT-651) added KVM detection for SunOS

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -95,8 +95,10 @@ module Facter::Util::Virtual
        File.read("/proc/cpuinfo")
      elsif ["FreeBSD", "OpenBSD"].include? Facter.value(:kernel)
        Facter::Util::POSIX.sysctl("hw.model")
+     elsif Facter.value(:kernel) == "SunOS" and FileTest.exists?("/usr/sbin/prtconf")
+       Facter::Core::Execution.exec("/usr/sbin/prtconf -v")
      end
-     (txt =~ /QEMU Virtual CPU/) ? true : false
+     (txt =~ /QEMU Virtual (CPU|Machine)/i) ? true : false
   end
 
   def self.virtualbox?

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -223,6 +223,14 @@ describe Facter::Util::Virtual do
     Facter::Util::Virtual.should be_kvm
   end
 
+  it "should detect kvm on SunOS" do
+    FileTest.stubs(:exists?).with("/proc/cpuinfo").returns(false)
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    FileTest.stubs(:exists?).with("/usr/sbin/prtconf").returns(true)
+    Facter::Core::Execution.stubs(:exec).with("/usr/sbin/prtconf -v").returns("Qemu virtual machine")
+    Facter::Util::Virtual.should be_kvm
+  end
+
   it "should identify FreeBSD jail when in jail" do
     Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
     Facter::Core::Execution.stubs(:exec).with("/sbin/sysctl -n security.jail.jailed").returns("1")


### PR DESCRIPTION
On one of my few KVM-virtualized Solaris instances, I noticed the detection of being virtual or not wasn't working properly. Note: I'm running OpenIndiana, and possibly on Solaris itself the path to prtconf could be different.
