### PR TITLE
(FACT-646) Cherry-pick updated debian control file back into master

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -9,6 +9,7 @@ Homepage: http://www.puppetlabs.com
 Package: facter
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, dmidecode [i386 amd64 ia64], virt-what, pciutils
+Recommends: lsb-release
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.


### PR DESCRIPTION
This commit cherry-picks work done on Facter's Debian/control file
back into master, which was lost during the facter-2 / master merge.

Original commit(b444b32328):
debian/control: Recommend lsb-release.

Recommending lsb-release should be enough to have it pulled in by
default on most Debian distributions solving the issue where the lsb*
facts and those depending on them weren't working.
