### PR TITLE
(FACT-647) Cherry-pick lost SELinux exception handling back into master

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -88,8 +88,11 @@ Facter.add("selinux") do
     result = "false"
     if FileTest.exists?("#{selinux_mount_point}/enforce")
       if FileTest.exists?("/proc/self/attr/current")
-        if (File.read("/proc/self/attr/current") != "kernel\0")
-          result = "true"
+        begin
+          if (File.read("/proc/self/attr/current") != "kernel\0")
+            result = "true"
+          end
+        rescue
         end
       end
     end


### PR DESCRIPTION
This commit cherry-picks work done on the selinux facts
back into master, which was lost during the facter-2 / master merge.

Original commit(40603c9):
Catch exceptions when detecting SELinux status
