### PR TITLE
(FACT-649) Cherry-pick acceptance setup fix for RedHat / Fedora back into master

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -4,7 +4,7 @@ module Puppet
   module Acceptance
     module InstallUtils
       PLATFORM_PATTERNS = {
-        :redhat  => /fedora|el|centos/,
+        :redhat  => /fedora|fc|el|centos/,
         :debian  => /debian|ubuntu/,
         :solaris => /solaris/,
         :windows => /windows/,


### PR DESCRIPTION
This commit cherry-picks work done on the install_utils acceptance setup
back into master, which was lost during the facter-2 / master merge.

Original commit (eeb4065):
(maint) Recognize `fc` as a type of redhat platform in acceptance setup

The beaker config file for fedora 18 in this project has a platform
starting with `fc` instead of `fedora`.
