### PR TITLE
(Review) (FACT-648) Cherry-pick lost Xen 4.0 command support back into master

### DIFF
--- a/lib/facter/util/xendomains.rb
+++ b/lib/facter/util/xendomains.rb
@@ -1,10 +1,19 @@
 # A module to gather running Xen Domains
 #
 module Facter::Util::Xendomains
+  XEN_COMMANDS = ['/usr/sbin/xl', '/usr/sbin/xm']
+
+  def self.xen_command
+    XEN_COMMANDS.find { |cmd| Facter::Util::Resolution.which(cmd) }
+  end
+
   def self.get_domains
-    if xm_list = Facter::Core::Execution.exec('/usr/sbin/xm list 2>/dev/null')
-      domains = xm_list.split("\n").reject { |line| line =~ /^(Name|Domain-0)/ }
-      domains.map { |line| line.split(/\s/)[0] }.join(',')
+    command = self.xen_command
+    if command
+      if domains_list = Facter::Util::Resolution.exec("#{command} list 2>/dev/null")
+        domains = domains_list.split("\n").reject { |line| line =~ /^(Name|Domain-0)/ }
+        domains.map { |line| line.split(/\s/)[0] }.join(',')
+      end
     end
   end
 end

--- a/spec/unit/util/xendomains_spec.rb
+++ b/spec/unit/util/xendomains_spec.rb
@@ -4,18 +4,63 @@ require 'spec_helper'
 require 'facter/util/xendomains'
 
 describe Facter::Util::Xendomains do
-  describe ".get_domains" do
-    it "should return a list of running Xen Domains on Xen0" do
-      xen0_domains = my_fixture_read("xendomains")
-      Facter::Core::Execution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(xen0_domains)
-      Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
+
+  let(:xen0_domains) { my_fixture_read("xendomains") }
+
+  describe "when the xl command is present" do
+    before do
+      Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns('/usr/sbin/xl')
     end
 
-    describe "when xm list isn't executable" do
-      it "should be nil" do
-        Facter::Core::Execution.stubs(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(nil)
-        Facter::Util::Xendomains.get_domains.should == nil
+    describe "and the xm command is not present" do
+
+      before do
+        Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns(nil)
+        Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xm list 2>/dev/null').never
       end
+
+      it "lists the domains running on Xen0 with the 'xl' command" do
+        Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xl list 2>/dev/null').returns(xen0_domains)
+        Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
+      end
+    end
+
+    describe "and the xm command is also present" do
+      before do
+        Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/bin/xm')
+        Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xm list 2>/dev/null').never
+      end
+
+      it "prefers xl over xm" do
+        Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xl list 2>/dev/null').returns(xen0_domains)
+        Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
+      end
+    end
+  end
+
+  describe "when xl is not present" do
+    before do
+      Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
+      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xl list 2>/dev/null').never
+    end
+
+    describe "and the xm command is present" do
+      before do
+        Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns('/usr/sbin/xm')
+      end
+
+      it "lists the domains running on Xen0 with the 'xm' command" do
+        Facter::Util::Resolution.expects(:exec).with('/usr/sbin/xm list 2>/dev/null').returns(xen0_domains)
+        Facter::Util::Xendomains.get_domains.should == %{web01,mailserver}
+      end
+    end
+  end
+
+  describe "neither xl or xm are present" do
+    it "returns nil" do
+      Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xl').returns(nil)
+      Facter::Util::Resolution.stubs(:which).with('/usr/sbin/xm').returns(nil)
+      Facter::Util::Xendomains.get_domains.should == nil
     end
   end
 end


### PR DESCRIPTION
This commit cherry-picks work done on the xendomains fact
back into master, which was lost during the facter-2 / master merge.

Original commit(a1dd388c4):
Support xen 4.0 command invocation

As of Xen 4.0, querying for xen domains is done with `/usr/bin/xl`
while earlier versions used `/usr/bin/xm`. This commit checks over the
preferred command (xl) and then falls back to old command (xm) to detect
the correct command to run.

Conflicts:
    lib/facter/util/xendomains.rb
    spec/unit/util/xendomains_spec.rb
