### PR TITLE
Add Ubuntu to operatingsystemmajrelease confine like doc says !

### DIFF
--- a/lib/facter/operatingsystemmajrelease.rb
+++ b/lib/facter/operatingsystemmajrelease.rb
@@ -28,6 +28,7 @@ Facter.add(:operatingsystemmajrelease) do
     :OracleLinux,
     :OVS,
     :RedHat,
+    :Ubuntu,
     :Scientific,
     :SLC,
     :CumulusLinux


### PR DESCRIPTION
Supports the following operating systems: SuSE" "Ubuntu" "VMWareESX"

But no Ubuntu in Confine !!
