### PR TITLE
(FACT-659) Fix Linux partition fact's filesystem regex.

### DIFF
--- a/lib/facter/util/partitions/linux.rb
+++ b/lib/facter/util/partitions/linux.rb
@@ -51,7 +51,7 @@ module Facter::Util::Partitions
 
     def self.filesystem(partition)
       if Facter::Core::Execution.which('blkid')
-        Facter::Core::Execution.exec("blkid #{File.join('/dev', partition)}").scan(/TYPE="(.+)"/).flatten.first
+        Facter::Core::Execution.exec("blkid #{File.join('/dev', partition)}").scan(/TYPE="([^"]*)"/).flatten.first
       end
     end
     


### PR DESCRIPTION
The regex for extracting the filesystem from blkid does not properly
handle quoted values.  Currently it is matching all characters between
two double quotes, including a double quote character.

The fix is to match all characters except for a double quote between two
double quotes.  This prevents us from greedily matching more than the intended
value.
