### PR TITLE
(FACT-629) Don't use proxy in `reachable?` method of ec2 facts

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -21,7 +21,7 @@ module Facter
 
         begin
           Timeout.timeout(timeout) do
-            open(@baseurl).read
+            open(@baseurl, :proxy => nil).read
           end
           able_to_connect = true
         rescue OpenURI::HTTPError => e

--- a/spec/unit/ec2/rest_spec.rb
+++ b/spec/unit/ec2/rest_spec.rb
@@ -15,7 +15,7 @@ shared_examples_for "an ec2 rest querier" do
     end
 
     it "is false if the given uri returns a 404" do
-      subject.expects(:open).with(anything).once.raises(OpenURI::HTTPError.new("404 Not Found", StringIO.new("woo")))
+      subject.expects(:open).with(anything, :proxy => nil).once.raises(OpenURI::HTTPError.new("404 Not Found", StringIO.new("woo")))
       expect(subject).to_not be_reachable
     end
 


### PR DESCRIPTION
This commit fixes an issue in which ec2 facts could not be
resolved with a proxy because the `reachable?` method did not
set `:proxy => nil` by default, causing the facts to be considered
unsuitable.
