### PR TITLE
(CPR-5, FACT-467) Move dmidecode from dependency to recommends

### DIFF
--- a/ext/debian/control
+++ b/ext/debian/control
@@ -7,9 +7,9 @@ Standards-Version: 3.9.1
 Homepage: http://www.puppetlabs.com
 
 Package: facter
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, dmidecode [i386 amd64 ia64], virt-what, pciutils
-Recommends: lsb-release
+Architecture: all
+Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter, virt-what, pciutils
+Recommends: lsb-release, dmidecode
 Description: Ruby module for collecting simple facts about a host operating system
  Some of the facts are preconfigured, such as the hostname and the operating
  system. Additional facts can be added through simple Ruby scripts.


### PR DESCRIPTION
Previously facter had a hard dependency on dmidecode. This made the
debian package uninstallable on ARM based devices such as raspberry pi.
This commit moves dmidecode from dependency to recommends. In nearly all
cases dmidecode will still be pulled in, unless it can't be (as in the
ARM case). This also moves the package from all (meaning any arch it can
be built for) to any (meaning noarch).

Note this is a packaging change only.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
