### PR TITLE
(FACT-685) Add processors['speed'] for OpenBSD

### DIFF
--- a/lib/facter/processors/os.rb
+++ b/lib/facter/processors/os.rb
@@ -177,6 +177,16 @@ module Facter
       def get_physical_processor_count
         Facter::Util::POSIX.sysctl("hw.ncpufound").to_i
       end
+
+      def get_processor_speed
+        speed = Facter::Util::POSIX.sysctl("hw.cpuspeed").to_i
+        if speed < 1000
+          "#{speed} MHz"
+        else
+          speed = speed.to_f / 1000
+          "#{(speed * 100).round.to_f / 100.0} GHz"
+        end
+      end
     end
 
     class SunOS < Base

--- a/spec/unit/processors/os_spec.rb
+++ b/spec/unit/processors/os_spec.rb
@@ -368,6 +368,20 @@ describe Facter::Processors::OpenBSD do
       expect(count).to eq 2
     end
   end
+
+  describe "getting the processor speed" do
+    it "should delegate to the sysctl utility (GHz)" do
+      Facter::Util::POSIX.expects(:sysctl).with("hw.cpuspeed").once.returns("2501")
+      speed = subject.get_processor_speed
+      expect(speed).to eq "2.5 GHz"
+    end
+
+    it "should delegate to the sysctl utility (MHz)" do
+      Facter::Util::POSIX.expects(:sysctl).with("hw.cpuspeed").once.returns("123")
+      speed = subject.get_processor_speed
+      expect(speed).to eq "123 MHz"
+    end
+  end
 end
 
 describe Facter::Processors::SunOS do


### PR DESCRIPTION
What is the preferred format for the `speed` fact? Currently it's reported in mHz (without `mHz` or any unit appended to the output) on OpenBSD.
