### PR TITLE
(FACT-683) Use XPG4 variant of `id` in Solaris to determine GID

### DIFF
--- a/lib/facter/gid.rb
+++ b/lib/facter/gid.rb
@@ -10,7 +10,16 @@
 
 Facter.add(:gid) do
   confine do
-    Facter::Core::Execution.which('id')
+    Facter::Core::Execution.which('id') && Facter.value(:kernel) != "SunOS"
   end
   setcode { Facter::Core::Execution.exec('id -ng') }
+end
+
+Facter.add(:gid) do
+  confine :kernel => :SunOS
+  setcode do
+    if File.exist? '/usr/xpg4/bin/id'
+      Facter::Core::Execution.exec('/usr/xpg4/bin/id -ng')
+    end
+  end
 end

--- a/spec/unit/gid_spec.rb
+++ b/spec/unit/gid_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe "gid fact" do
 
-  describe "on systems with id" do
+  describe "on non-SunOS systems with id" do
     it "should return the current group" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter::Core::Execution.expects(:which).with('id').returns(true)
       Facter::Core::Execution.expects(:exec).once.with('id -ng').returns 'bar'
 
@@ -11,12 +12,31 @@ describe "gid fact" do
     end
   end
 
-  describe "on systems without id" do
+  describe "on non-SunOS systems without id" do
     it "is not supported" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter::Core::Execution.expects(:which).with('id').returns(false)
 
       Facter.fact(:gid).value.should == nil
     end
   end
 
+  describe "on SunOS systems with /usr/xpg4/bin/id" do
+    it "should return the current group" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      File.expects(:exist?).with('/usr/xpg4/bin/id').returns true
+      Facter::Core::Execution.expects(:exec).with('/usr/xpg4/bin/id -ng').returns 'bar'
+
+      Facter.fact(:gid).value.should == 'bar'
+    end
+  end
+
+  describe "on SunOS systems without /usr/xpg4/bin/id" do
+    it "is not supported" do
+      Facter.fact(:kernel).stubs(:value).returns("SunOS")
+      File.expects(:exist?).with('/usr/xpg4/bin/id').returns false
+
+      Facter.fact(:gid).value.should == nil
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, the GID fact would attempt to invoke the `/usr/bin/id`
variant of the `id` command in Solaris, which does not include the necessary flags to
determine the user GID in Solaris 10.

This commit updates the fact to instead use the more advanced `/usr/xpg4/bin/id`
for Solaris instead.
