### PR TITLE
(FACT-692) Fix issue with Solaris resolution of operatingsystemmajrelease

### DIFF
--- a/lib/facter/operatingsystem/sunos.rb
+++ b/lib/facter/operatingsystem/sunos.rb
@@ -42,7 +42,7 @@ module Facter
         end
       end
 
-      def get_operatingsystemmajrelease
+      def get_operatingsystemmajorrelease
         if get_operatingsystem == "Solaris"
           if match = get_operatingsystemrelease.match(/^(\d+)/)
             match.captures[0]

--- a/spec/unit/operatingsystem/sunos_spec.rb
+++ b/spec/unit/operatingsystem/sunos_spec.rb
@@ -125,19 +125,19 @@ describe Facter::Operatingsystem::SunOS do
 
     it "should correctly derive from operatingsystemrelease on solaris 10" do
       subject.expects(:get_operatingsystemrelease).returns("10_u8")
-      release = subject.get_operatingsystemmajrelease
+      release = subject.get_operatingsystemmajorrelease
       expect(release).to eq "10"
     end
 
     it "should correctly derive from operatingsystemrelease on solaris 11 (old version scheme)" do
       subject.expects(:get_operatingsystemrelease).returns("11 11/11")
-      release = subject.get_operatingsystemmajrelease
+      release = subject.get_operatingsystemmajorrelease
       expect(release).to eq "11"
     end
 
     it "should correctly derive from operatingsystemrelease on solaris 11 (new version scheme)" do
       subject.expects(:get_operatingsystemrelease).returns("11.1")
-      release = subject.get_operatingsystemmajrelease
+      release = subject.get_operatingsystemmajorrelease
       expect(release).to eq "11"
     end
   end


### PR DESCRIPTION
This commit corrects the naming of the method responsible for
determining the major release of SunOS systems, allowing Solaris 10
systems to correctly resolve the operatingsystemmajrelease fact.

With the addition of the structured operatingsystem fact, a new
class structure was created which includes a base class with
several platform specific children. The method within these
classes which is responsible for determining the operatingsystem
major release is named 'get_operatingsystemmajorrelease'. The
method was, however, misnamed in the SunOS class as
'get_operatingsystemmajrelease', which is never called, causing
the fact to fall back to the base class implementation.

This commit fixes this regression which was introduced in Facter 2.2.0
at commit 793b258.
