### PR TITLE
(FACT-680) Correctly detect ipv6 link-local addresses

### DIFF
--- a/lib/facter/ipaddress6.rb
+++ b/lib/facter/ipaddress6.rb
@@ -28,7 +28,7 @@ def get_address_after_token(output, token, return_first=false)
 
   String(output).scan(/#{token}\s?((?>[0-9,a-f,A-F]*\:{1,2})+[0-9,a-f,A-F]{0,4})/).each do |match|
     match = match.first
-    unless match =~ /fe80.*/ or match == "::1"
+    unless match =~ /^fe80.*/ or match == "::1"
       ip = match
       break if return_first
     end

--- a/spec/fixtures/ifconfig/linux_ifconfig_all_with_multiple_interfaces_and_fe80
+++ b/spec/fixtures/ifconfig/linux_ifconfig_all_with_multiple_interfaces_and_fe80
@@ -1,0 +1,19 @@
+eth0      Link encap:Ethernet  HWaddr 00:12:3f:be:22:01  
+          inet addr:131.252.209.153  Bcast:131.252.209.255  Mask:255.255.255.0
+          inet6 addr: 2610:10:20:209:212:3fff:fe80:2201/64 Scope:Global
+          inet6 addr: fe80::212:3fff:febe:2201/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:20793317 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:19583281 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:1723593481 (1.7 GB)  TX bytes:283377282 (283.3 MB)
+          Interrupt:16 
+
+lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+          RX packets:31809 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:31809 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0 
+          RX bytes:2075836 (2.0 MB)  TX bytes:2075836 (2.0 MB)

--- a/spec/fixtures/ifconfig/linux_ifconfig_all_with_multiple_interfaces_and_no_public_ipv6
+++ b/spec/fixtures/ifconfig/linux_ifconfig_all_with_multiple_interfaces_and_no_public_ipv6
@@ -1,0 +1,18 @@
+eth0      Link encap:Ethernet  HWaddr 00:12:3f:be:22:01  
+          inet addr:131.252.209.153  Bcast:131.252.209.255  Mask:255.255.255.0
+          inet6 addr: fe80::212:3fff:febe:2201/64 Scope:Link
+          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
+          RX packets:20793317 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:19583281 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:1723593481 (1.7 GB)  TX bytes:283377282 (283.3 MB)
+          Interrupt:16 
+
+lo        Link encap:Local Loopback  
+          inet addr:127.0.0.1  Mask:255.0.0.0
+          inet6 addr: ::1/128 Scope:Host
+          UP LOOPBACK RUNNING  MTU:16436  Metric:1
+          RX packets:31809 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:31809 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:0 
+          RX bytes:2075836 (2.0 MB)  TX bytes:2075836 (2.0 MB)

--- a/spec/unit/ipaddress6_spec.rb
+++ b/spec/unit/ipaddress6_spec.rb
@@ -33,13 +33,31 @@ describe "The IPv6 address fact" do
   end
 
   it "should return ipaddress6 information for Linux with recent net-tools" do
-      Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
-      Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
-      Facter::Util::IP.stubs(:exec_ifconfig).with(["2>/dev/null"]).
-        returns(ifconfig_fixture('ifconfig_net_tools_1.60.txt'))
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["2>/dev/null"]).
+      returns(ifconfig_fixture('ifconfig_net_tools_1.60.txt'))
 
-      Facter.value(:ipaddress6).should == "2610:10:20:209:212:3fff:febe:2201"
-    end
+    Facter.value(:ipaddress6).should == "2610:10:20:209:212:3fff:febe:2201"
+  end
+
+  it "should return ipaddress6 with fe80 in any other octet than the first for Linux" do
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["2>/dev/null"]).
+      returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces_and_fe80'))
+
+    Facter.value(:ipaddress6).should == "2610:10:20:209:212:3fff:fe80:2201"
+  end
+
+  it "should not return ipaddress6 link-local address for Linux" do
+    Facter::Core::Execution.stubs(:exec).with('uname -s').returns('Linux')
+    Facter::Util::IP.stubs(:get_ifconfig).returns("/sbin/ifconfig")
+    Facter::Util::IP.stubs(:exec_ifconfig).with(["2>/dev/null"]).
+      returns(ifconfig_fixture('linux_ifconfig_all_with_multiple_interfaces_and_no_public_ipv6'))
+
+    Facter.value(:ipaddress6).should be_false
+  end
 
   it "should return ipaddress6 information for Solaris" do
     Facter::Core::Execution.stubs(:exec).with('uname -s').returns('SunOS')


### PR DESCRIPTION
The regex in lib/facter/ipaddress6.rb will incorrectly detect all
addresses with 'fe80' in them and identify them as link-local addresses.

Should only occur when addresses start with fe80:

Modified existing tests to include an address with fe80 in it.
