### PR TITLE
(FACT-706) Fixing xenstore-read errors in rackspace.rb

### DIFF
--- a/lib/facter/rackspace.rb
+++ b/lib/facter/rackspace.rb
@@ -12,7 +12,7 @@
 
 Facter.add(:is_rsc) do
   setcode do
-    result = Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/provider")
+    result = Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/provider 2> /dev/null")
     if result == "Rackspace"
       "true"
     end
@@ -22,7 +22,7 @@ end
 Facter.add(:rsc_region) do
   confine :is_rsc => "true"
   setcode do
-    Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/region")
+    Facter::Util::Resolution.exec("/usr/bin/xenstore-read vm-data/provider_data/region 2> /dev/null")
   end
 end
 

--- a/spec/unit/rackspace_spec.rb
+++ b/spec/unit/rackspace_spec.rb
@@ -10,13 +10,13 @@ describe "rackspace facts" do
     end
 
     it "should set is_rsc to true" do
-      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider").returns("Rackspace")
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider 2> /dev/null").returns("Rackspace")
       Facter.fact(:is_rsc).value.should == "true"
     end
 
     it "should set the region to dfw" do
       Facter.fact(:is_rsc).stubs(:value).returns("true")
-      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/region").returns("dfw")
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/region 2> /dev/null").returns("dfw")
       Facter.fact(:rsc_region).value.should == "dfw"
     end
 
@@ -33,7 +33,7 @@ describe "rackspace facts" do
     end
 
     it "shouldn't set is_rsc" do
-      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider").returns("other")
+      Facter::Util::Resolution.stubs(:exec).with("/usr/bin/xenstore-read vm-data/provider_data/provider 2> /dev/null").returns("other")
       Facter.fact(:is_rsc).value.should == nil
     end
   end


### PR DESCRIPTION
If a vm has the xen-tools installed, but is not running from
rackspace, the following error would crop up at every interactive
run:

/usr/bin/xenstore-read:
couldn't read path vm-data/provider_data/provider

Redirecting stderr to /dev/null (similar to domain.rb, virtual.rb,
etc) alleviates this while still returning relevant results when
applicable.
