### PR TITLE
(FACT-656) facter generates error on Solaris kernel zone due to prtdiag

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -78,7 +78,7 @@ Facter.add("virtual") do
   setcode do
     next "zone" if Facter::Util::Virtual.zone?
 
-    output = Facter::Core::Execution.exec('prtdiag')
+    output = Facter::Core::Execution.exec('/usr/sbin/prtdiag 2> /dev/null')
     if output
       lines = output.split("\n")
       next "parallels"  if lines.any? {|l| l =~ /Parallels/ }


### PR DESCRIPTION
Verified that with this change the message

prtdiag: failed to open SMBIOS: System does not export an SMBIOS table

is no longer outputed in a Solaris Kernel Zone
