### PR TITLE
(FACT-656) facter generates error on Solaris kernel zone due to prtdiag

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -78,7 +78,7 @@ Facter.add("virtual") do
   setcode do
     next "zone" if Facter::Util::Virtual.zone?
 
-    output = Facter::Core::Execution.exec('prtdiag')
+    output = Facter::Core::Execution.exec('prtdiag 2>/dev/null')
     if output
       lines = output.split("\n")
       next "parallels"  if lines.any? {|l| l =~ /Parallels/ }

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -251,7 +251,7 @@ describe "Virtual fact" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Core::Execution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Core::Execution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
-      Facter::Core::Execution.stubs(:exec).with('prtdiag').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
+      Facter::Core::Execution.stubs(:exec).with('prtdiag 2>/dev/null').returns("System Configuration: VMware, Inc. VMware Virtual Platform")
       Facter.fact(:virtual).value.should == "vmware"
     end
 
@@ -259,7 +259,7 @@ describe "Virtual fact" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Core::Execution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Core::Execution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
-      Facter::Core::Execution.stubs(:exec).with('prtdiag').returns("System Configuration: Parallels Virtual Platform")
+      Facter::Core::Execution.stubs(:exec).with('prtdiag 2>/dev/null').returns("System Configuration: Parallels Virtual Platform")
       Facter.fact(:virtual).value.should == "parallels"
     end
 
@@ -267,7 +267,7 @@ describe "Virtual fact" do
       Facter.fact(:hardwaremodel).stubs(:value).returns(nil)
       Facter::Core::Execution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
       Facter::Core::Execution.stubs(:exec).with('dmidecode 2> /dev/null').returns(nil)
-      Facter::Core::Execution.stubs(:exec).with('prtdiag').returns("System Configuration: innotek GmbH VirtualBox")
+      Facter::Core::Execution.stubs(:exec).with('prtdiag 2>/dev/null').returns("System Configuration: innotek GmbH VirtualBox")
       Facter.fact(:virtual).value.should == "virtualbox"
     end
   end


### PR DESCRIPTION
facter on kernel zone no longer generates and error to stderr.  
bundle exec rspec tests now pass
