### PR TITLE
(FACT-658) facter doesn't parse gnu uptime output

### DIFF
--- a/lib/facter/util/uptime.rb
+++ b/lib/facter/util/uptime.rb
@@ -77,6 +77,6 @@ module Facter::Util::Uptime
   end
 
   def self.uptime_executable_cmd
-    "uptime"
+    "/usr/bin/uptime"
   end
 end

--- a/spec/unit/util/uptime_spec.rb
+++ b/spec/unit/util/uptime_spec.rb
@@ -98,14 +98,14 @@ describe Facter::Util::Uptime do
 
           test_cases.each do |uptime, expected|
             it "should return #{expected} for #{uptime}" do
-              Facter::Core::Execution.stubs(:execute).with('uptime 2>/dev/null', {:on_fail => nil}).returns(uptime)
+              Facter::Core::Execution.stubs(:execute).with('/usr/bin/uptime 2>/dev/null', {:on_fail => nil}).returns(uptime)
               Facter.fact(:uptime_seconds).value.should == expected
             end
           end
 
           describe "nor is 'uptime' command" do
             before :each do
-              Facter::Core::Execution.stubs(:execute).with('uptime 2>/dev/null', {:on_fail => nil}).returns(nil)
+              Facter::Core::Execution.stubs(:execute).with('/usr/bin/uptime 2>/dev/null', {:on_fail => nil}).returns(nil)
             end
 
             it "should return nil" do


### PR DESCRIPTION
Changed uptime to /usr/bin/uptime so that gnu version of uptime will not be used.
