### PR TITLE
(FACT-654) Don't try to resolve Ldom facts on non-SPARC systems

### DIFF
--- a/lib/facter/ldom.rb
+++ b/lib/facter/ldom.rb
@@ -9,7 +9,10 @@
 #   Uses the output of `virtinfo -ap`.
 #
 
-if Facter.value(:kernel) == 'SunOS' and Facter::Core::Execution.which('virtinfo')
+if Facter.value(:kernel) == 'SunOS' &&
+   Facter.value(:hardwareisa) == 'sparc' &&
+   Facter::Core::Execution.which('virtinfo')
+
   virtinfo = Facter::Core::Execution.exec('virtinfo -ap')
 
   # Convert virtinfo parseable output format to array of arrays.

--- a/spec/unit/ldom_spec.rb
+++ b/spec/unit/ldom_spec.rb
@@ -15,6 +15,7 @@ describe "ldom fact" do
     before :each do
       # For virtinfo documentation:
       # http://docs.oracle.com/cd/E23824_01/html/821-1462/virtinfo-1m.html
+      Facter.fact(:hardwareisa).stubs(:value).returns("sparc")
       Facter::Core::Execution.stubs(:which).with("virtinfo").returns 'virtinfo'
       Facter::Core::Execution.stubs(:exec).with("virtinfo -ap").
         returns(ldom_fixtures('ldom_v1'))
@@ -64,11 +65,23 @@ describe "ldom fact" do
 
   describe "when running on non ldom hardware" do
     before :each do
+      Facter.fact(:hardwareisa).stubs(:value).returns("sparc")
       Facter::Core::Execution.stubs(:which).with("virtinfo").returns(nil)
       Facter.collection.internal_loader.load(:ldom)
     end
 
     it "should return correct virtual" do
+      Facter.fact(:ldom_domainrole_impl).should == nil
+    end
+  end
+
+  describe "when running on non-sparc hardware" do
+    before :each do
+      Facter.fact(:hardwareisa).stubs(:value).returns("i386")
+      Facter::Core::Execution.stubs(:which).with("virtinfo").returns 'virtinfo'
+    end
+
+    it "should not try to resolve the ldom facts" do
       Facter.fact(:ldom_domainrole_impl).should == nil
     end
   end


### PR DESCRIPTION
In Solaris 11.2, Oracle introduced a rewrite of virtinfo which
supports both x86 and SPARC, whereas the old version only supported
SPARC. Since Ldoms are a SPARC-only feature, we now need to confine
the ldom facts to only resolve on SPARC based platforms.

Note that this information comes from community member Kristina Tripp,
who provided the necessary details on the new virtinfo implementation.
