### PR TITLE
(do not merge) FACT-707-improve-acceptance-pre-suite

### DIFF
--- a/acceptance/config/git/options.rb
+++ b/acceptance/config/git/options.rb
@@ -1,4 +1,8 @@
 {
+  :type => 'git',
+  :install => [
+    'facter',
+  ],
   :pre_suite => [
     'setup/common/00_EnvSetup.rb',
     'setup/git/pre-suite/01_TestSetup.rb',

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -9,7 +9,8 @@ module Puppet
         :redhat        => /fedora|el|centos/,
         :debian        => /debian|ubuntu/,
         :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
-        :solaris       => /solaris/,
+        :solaris11     => /solaris-11/,
+        :solaris10     => /solaris-10/,
         :windows       => /windows/,
       }.freeze
 

--- a/acceptance/setup/common/00_EnvSetup.rb
+++ b/acceptance/setup/common/00_EnvSetup.rb
@@ -22,8 +22,16 @@ PACKAGES = {
   :debian_ruby18 => [
     'libjson-ruby',
   ],
-  :solaris => [
-    ['git', 'developer/versioning/git'],
+  :solaris10 => [
+    ['git',         'git'],
+    ['ruby',        'ruby18'],
+    ['ruby-dev',    'ruby18_dev'],
+    ['gcc',         'gcc4core'],
+    ['ruby18_gcc4', 'ruby18_dev'],
+    ['ruby-json',   'rb18_json_1_5_3'],
+  ],
+  :solaris11 => [
+    ['git',  'developer/versioning/git'],
     ['ruby', 'runtime/ruby-18'],
     # there isn't a package for json, so it is installed later via gems
   ],
@@ -32,6 +40,19 @@ PACKAGES = {
     # there isn't a need for json on windows because it is bundled in ruby 1.9
   ],
 }
+
+hosts.each do |host|
+  case host['platform']
+  when  /solaris-11/
+    on host, 'if ((`pkg publisher | wc -l` < 2)); then pkg set-publisher -P -g http://pkg.oracle.com/solaris/release/ solaris; fi'
+  when  /solaris-10/
+    on host, 'mkdir -p /var/lib'
+    on host, 'ln -s /opt/csw/bin/pkgutil /usr/bin/pkgutil'
+    on host, 'ln -s /opt/csw/bin/gem18 /usr/bin/gem'
+    on host, 'ln -s /opt/csw/bin/git /usr/bin/git'
+    on host, 'ln -s /opt/csw/bin/ruby18 /usr/bin/ruby'
+  end
+end
 
 install_packages_on(hosts, PACKAGES, :check_if_exists => true)
 
@@ -57,7 +78,7 @@ hosts.each do |host|
     on host, 'cd /; icacls bin /reset /T'
     on host, 'ruby --version'
     on host, 'cmd /c gem list'
-  when /solaris/
+  when /solaris-11/
     step "#{host} Install json from rubygems"
     on host, 'gem install json'
   end

--- a/acceptance/setup/git/pre-suite/01_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/01_TestSetup.rb
@@ -1,3 +1,8 @@
+begin
+  require 'puppet/acceptance/git_utils'
+  extend Puppet::Acceptance::GitUtils
+end
+
 test_name "Install packages and repositories on target machines..." do
   extend Beaker::DSL::InstallUtils
 
@@ -7,8 +12,15 @@ test_name "Install packages and repositories on target machines..." do
 
   tmp_repositories = []
   options[:install].each do |uri|
-    raise(ArgumentError, "#{uri} is not recognized.") unless(uri =~ GitURI)
-    tmp_repositories << extract_repo_info_from(uri)
+    if uri !~ GitURI
+      # Build up project git urls based on git server and fork env variables or defaults
+      project = uri.split('#')
+      newURI = "#{build_giturl(project[0])}#{newURI}##{project[1]}"
+      tmp_repositories << extract_repo_info_from(newURI)
+    else
+      raise(ArgumentError, "#{uri} is not recognized.") unless(uri =~ GitURI)
+      tmp_repositories << extract_repo_info_from(uri)
+    end
   end
 
   repositories = order_packages(tmp_repositories)


### PR DESCRIPTION
don't merge this.  still need to cherry-pick items from puppet pre-suite into here.
fix git install options
fix packages for solaris10 and unknown publisher for solaris11
workaround beaker env-issue by symlinking to required binaries out of PATH

gets facter acceptance running on sol10
makes it easier to spin up machines for manual testing or writing tests