### PR TITLE
Detect KVM even when generic CPU Model Name is used.

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -29,7 +29,15 @@ module Facter::Util::Virtual
   ##
   # lspci is a delegating helper method intended to make it easier to stub the
   # system call without affecting other calls to Facter::Core::Execution.exec
-  def self.lspci(command = "lspci 2>/dev/null")
+  def self.lspci(command = nil)
+    if command.nil?
+      if ["FreeBSD", "OpenBSD"].include? Facter.value(:kernel)
+        command = "pciconf -lv 2>/dev/null"
+      else
+        command = "lspci 2>/dev/null"
+      end
+    end
+
     Facter::Core::Execution.exec command
   end
 

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -149,6 +149,7 @@ Facter.add("virtual") do
       next "xenhvm"     if lines.any? {|l| l =~ /XenSource/ }
       next "hyperv"     if lines.any? {|l| l =~ /Microsoft Corporation Hyper-V/ }
       next "gce"        if lines.any? {|l| l =~ /Class 8007: Google, Inc/ }
+      next "kvm"        if lines.any? {|l| l =~ /virtio/ }
     end
 
     # Parse dmidecode
@@ -162,6 +163,7 @@ Facter.add("virtual") do
       next "hyperv"     if lines.any? {|l| l =~ /Product Name: Virtual Machine/ }
       next "rhev"       if lines.any? {|l| l =~ /Product Name: RHEV Hypervisor/ }
       next "ovirt"      if lines.any? {|l| l =~ /Product Name: oVirt Node/ }
+      next "bochs"      if lines.any? {|l| l =~ /Bochs/ }
     end
 
     # Default to 'physical'

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -73,6 +73,26 @@ describe "Virtual fact" do
     end
   end
 
+  describe "on FreeBSD" do
+    before(:each) do
+      Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
+      Facter.fact(:operatingsystem).stubs(:value).returns("FreeBSD")
+    end
+
+    it "should be kvm with virtio device pciconf -lv 2>/dev/null" do
+      Facter::Core::Execution.stubs(:exec).with('/sbin/sysctl -n security.jail.jailed').returns('0')
+      Facter::Util::Virtual.stubs(:lspci).returns("virtio_pci4@pci0:0:8:0:	class=0x020000 card=0x00011af4 chip=0x10001af4 rev=0x00 hdr=0x00")
+      Facter.fact(:virtual).value.should == "kvm"
+    end
+
+    it "should be bochs with Bochs vendor name from dmidecode" do
+      Facter::Core::Execution.stubs(:exec).with('/sbin/sysctl -n security.jail.jailed').returns('0')
+      Facter::Core::Execution.stubs(:exec).with('pciconf -lv 2>/dev/null').returns(nil)
+      Facter::Core::Execution.stubs(:exec).with('dmidecode 2> /dev/null').returns("Manufacturer: Bochs")
+      Facter.fact(:virtual).value.should == "bochs"
+    end
+  end
+
   describe "on Linux" do
     before(:each) do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
@@ -521,6 +541,12 @@ describe "is_virtual fact" do
   it "should be true when running in docker" do
     Facter.fact(:kernel).stubs(:value).returns("Linux")
     Facter.fact(:virtual).stubs(:value).returns("docker")
+    Facter.fact(:is_virtual).value.should == "true"
+  end
+
+  it "should be true when running in bochs" do
+    Facter.fact(:kernel).stubs(:value).returns("Linux")
+    Facter.fact(:virtual).stubs(:value).returns("bochs")
     Facter.fact(:is_virtual).value.should == "true"
   end
 end


### PR DESCRIPTION
We recently changed our VPS's CPU models from "QEMU Virtual CPU version 1.7.1"
to "Westmere E56xx/L56xx/X56xx (Nehalem-C)". This led to facter
errorenously detecting a physical environment rather than a virtualized one.

This commit checks both pciconf and dmidecode for any signs of a virtualized.
environment. KVM relies on bochs for emulating its BIOS. But if there's no
virtio device and no telling CPU Model Name there is no way to distinct
between plain Bochs and Bochs used together with KVM (at least not that I'm
aware of). Therefore, I added an extra virtual type called 'bochs'. At least
it will result either way in is_virtual=true.
