### PR TITLE
(maint) Add validation of the facter schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem 'rspec', "~> 2.11.0"
   gem 'mocha', "~> 0.10.5"
   gem 'json', "~> 1.7", :platforms => :ruby
+  gem 'json-schema', :platforms => :ruby
   gem 'puppetlabs_spec_helper'
 end
 

--- a/acceptance/tests/facter_json_output_validates.rb
+++ b/acceptance/tests/facter_json_output_validates.rb
@@ -6,7 +6,8 @@ test_name "Running facter --json should validate against the schema"
 agents.each do |agent|
   step "Agent #{agent}: run 'facter --json' and validate"
   on(agent, facter('--json')) do
-    schema = JSON.parse(File.read("../schema/facter.json"))
-    fail_test "facter --json was invalid" unless JSON::Validator.validate!(schema, stdout)
+    # Validate that the output facts match the facter schema
+    FACTER_SCHEMA    = JSON.parse(File.read('../schema/facter.json'))
+    fail_test "facter --json was invalid" unless JSON::Validator.validate!(FACTER_SCHEMA, stdout)
   end
 end

--- a/schema/json-meta-schema.json
+++ b/schema/json-meta-schema.json
@@ -1,0 +1,150 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/schema/validate.rb
+++ b/schema/validate.rb
@@ -3,14 +3,24 @@
 require 'json'
 require 'json-schema'
 
-facts  = `bundle exec facter --json`
-schema = JSON.parse(File.read("schema/facter.json"))
-errors =  JSON::Validator.fully_validate(schema, facts)
-if errors.empty?
-  puts "Passed validation!"
-  exit 0
-else
-  puts errors
-  puts "Failed validation."
-  exit 1
+def validate(schema, data, name)
+  errors =  JSON::Validator.fully_validate(schema, data)
+  if errors.empty?
+    puts "#{name} passed validation!"
+  else
+    puts errors
+    puts "#{name} failed validation."
+    exit 1
+  end
 end
+
+# Read in both the json meta-schema and the facter schema
+JSON_META_SCHEMA = JSON.parse(File.read('schema/json-meta-schema.json'))
+FACTER_SCHEMA    = JSON.parse(File.read("schema/facter.json"))
+
+# Validate that the facter schema itself is valid json
+validate(JSON_META_SCHEMA, FACTER_SCHEMA, "facter schema")
+
+# Validate that the output facts match the facter schema
+facts  = `bundle exec facter --json`
+validate(FACTER_SCHEMA, facts, "facts")

--- a/spec/schema/validate_facter_schema.rb
+++ b/spec/schema/validate_facter_schema.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'facter/util/config'
+
+if !Facter::Util::Config.is_windows?
+  require 'json'
+  require 'json-schema'
+
+  describe 'facter.json schema' do
+    it 'should be valid' do
+      # Read in both the json meta-schema and the facter schema
+      JSON_META_SCHEMA = JSON.parse(File.read('schema/json-meta-schema.json'))
+      FACTER_SCHEMA    = JSON.parse(File.read('schema/facter.json'))
+
+      # Validate that the facter schema itself is valid json
+      JSON::Validator.validate!(JSON_META_SCHEMA, FACTER_SCHEMA)
+    end
+  end
+end


### PR DESCRIPTION
Previously we've had validation that the facts output by facter
conform to the facter schema, but no catch if the schema itself
was invalid.

This commit adds that additional validation step to both the
acceptance test and the one-off validate.rb script.
