### PR TITLE
(FACT-719) Fix invalid argument warning when reading raw dmi data

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -184,7 +184,10 @@ module Facter::Util::Virtual
   # @return [String] or nil if the path does not exist or is unreadable
   def self.read_sysfs_dmi_entries(path="/sys/firmware/dmi/entries/1-0/raw")
     if File.readable?(path)
-      Facter::Util::FileRead.read_binary(path)
+      begin
+        Facter::Util::FileRead.read_binary(path)
+      rescue Errno::EINVAL
+      end
     end
   end
 end


### PR DESCRIPTION
Even when /sys/firmware/dmi/entries/1-0/raw is readable according to
its permissions, the actual reading can still fail with EINVAL.  This
patch catches that exception and treats it as if the file had not been
marked readable in the first place.

To be on the safe side, only EINVAL is muted, so other error
conditions will still come through.
