### PR TITLE
(FACT-710) Prefer 64-bit powershell

### DIFF
--- a/lib/facter/util/parser.rb
+++ b/lib/facter/util/parser.rb
@@ -139,8 +139,18 @@ module Facter::Util::Parser
   class PowershellParser < Base
     # Returns a hash of facts from powershell output
     def parse_results
-      shell_command = "powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -File \"#{filename}\""
-      KeyValuePairOutputFormat.parse Facter::Core::Execution.exec(shell_command)
+      powershell =
+        if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")
+          "#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe"
+        elsif File.exists?("#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe")
+          "#{ENV['SYSTEMROOT']}\\system32\\WindowsPowershell\\v1.0\\powershell.exe"
+        else
+          'powershell.exe'
+        end
+
+      shell_command = "\"#{powershell}\" -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -File \"#{filename}\""
+      output = Facter::Core::Execution.exec(shell_command)
+      KeyValuePairOutputFormat.parse(output)
     end
   end
 


### PR DESCRIPTION
Previously, facter would execute 'powershell.exe' for external powershell
based facts. However, when running in 32-bit ruby, this executes 32-bit
powershell, which behaves very differently than 64-bit powershell due to
them having different PSModulePaths. As a result, there are many times where
a user could execute the powershell script from the command line, but the
same script would fail when executed by facter.

This commit changes the powershell parser to prefer the 64-bit powershell
using the sysnative alias. If that doesn't exist, we fall back to the system32
directory (in case powershell is not in the PATH), and finally fall back to
an unqualified 'powershell.exe'. This follows the convention adopted in the
powershell module[1]

[1] https://github.com/puppetlabs/puppetlabs-powershell/blob/1.0.3/lib/puppet/provider/exec/powershell.rb#L6-L13
