### PR TITLE
(FACT-720) Memoize WMI query results

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -196,6 +196,7 @@ module Facter
   # @api public
   def self.reset
     @collection = nil
+    Facter::Util::WMI.reset
     reset_search_path!
   end
 

--- a/lib/facter/util/wmi.rb
+++ b/lib/facter/util/wmi.rb
@@ -10,7 +10,13 @@ module Facter::Util::WMI
     end
 
     def execquery(query)
-      connect().execquery(query)
+      @results ||= {}
+      @results[query] ||= connect().execquery(query)
+      @results[query]
+    end
+
+    def reset
+      @results = nil
     end
   end
 end

--- a/spec/unit/util/wmi_spec.rb
+++ b/spec/unit/util/wmi_spec.rb
@@ -16,4 +16,14 @@ describe Facter::Util::WMI do
 
     Facter::Util::WMI.execquery("select * from Win32_OperatingSystem")
   end
+
+  it "re-queries WMI after facter is reset" do
+    query = "select FreePhysicalMemory from Win32_OperatingSystem"
+    Facter::Util::WMI.stubs(:connect).returns(connection)
+    connection.expects(:execquery).with(query).returns("1048640").twice
+
+    Facter::Util::WMI.execquery(query)
+    Facter.reset
+    Facter::Util::WMI.execquery(query)
+  end
 end


### PR DESCRIPTION
Previously, facter would execute the same WMI queries repeatedly, which is
very slow, as in facter takes nearly 10 seconds to execute.

This commit memoizes the WMI query results, resulting in facter executing in
less than 4 seconds.

Note the IP related facts still query for their specific property on the
adapter, e.g. select IPAddress FROM Win32_NetworkAdapterConfiguration,
select IPSubnet, select MACAddress, etc. Additional speedup could be attained
by reworking the ip related facts to return all necessary properties in
one query, but is too much work to justify the gain.
