### PR TITLE
(FACT-728) Update Windows OS release resolution for > 6.2.x kernels

### DIFF
--- a/lib/facter/operatingsystem/windows.rb
+++ b/lib/facter/operatingsystem/windows.rb
@@ -9,6 +9,13 @@ module Facter
         Facter::Util::WMI.execquery("SELECT version, producttype FROM Win32_OperatingSystem").each do |os|
           result =
             case os.version
+            when /^6\.4/
+              # As of October 2014, there are no Win server releases with kernel 6.4.x.
+              # This case prevents future releases from resolving to nil before we
+              # can update the fact regexes.
+              os.producttype == 1 ? "10" : Facter[:kernelrelease].value
+            when /^6\.3/
+              os.producttype == 1 ? "8.1" : "2012 R2"
             when /^6\.2/
               os.producttype == 1 ? "8" : "2012"
             when /^6\.1/

--- a/spec/unit/operatingsystem/windows_spec.rb
+++ b/spec/unit/operatingsystem/windows_spec.rb
@@ -21,8 +21,29 @@ describe Facter::Operatingsystem::Windows do
       ['6.2.9200', 1] => "8",
       ['6.2.9200', 2] => "2012",
       ['6.2.9200', 3] => "2012",
+      ['6.3.9600', 1] => "8.1",
+      ['6.3.9600', 2] => "2012 R2",
+      ['6.3.9600', 3] => "2012 R2",
+      ['6.4.9841', 1] => "10",     # Kernel version for Windows 10 preview. Subject to change.
     }.each do |os_values, expected_output|
       it "should be #{expected_output}  with Version #{os_values[0]}  and ProductType #{os_values[1]}" do
+        os = mock('os', :version => os_values[0], :producttype => os_values[1])
+        Facter::Util::WMI.expects(:execquery).returns([os])
+        release = subject.get_operatingsystemrelease
+        expect(release).to eq expected_output
+      end
+    end
+
+    {
+      # Note: this is the kernel version for the Windows 10 technical preview,
+      # which is subject to change. These tests cover any future Windows server
+      # releases with a kernel version of 6.4.x, none of which have been released
+      # as of October 2014.
+      ['6.4.9841', 2] => "6.4.9841",
+      ['6.4.9841', 3] => "6.4.9841",
+    }.each do |os_values, expected_output|
+      it "should be the kernel release for unknown future server releases" do
+        Facter.fact(:kernelrelease).stubs(:value).returns("6.4.9841")
         os = mock('os', :version => os_values[0], :producttype => os_values[1])
         Facter::Util::WMI.expects(:execquery).returns([os])
         release = subject.get_operatingsystemrelease


### PR DESCRIPTION
Currently, Facter only knows how to deal with Windows kernels
up to 6.2.x for parsing out the operating system release value.
Windows 8.1 and 10 use kernel versions 6.3.x and 6.4.x
respectively, which cause Facter to fall back to reporting the
kernel version as the operating system release, instead of the
strings "8" or "10" as it should.

This commit adds a check for kernel versions starting with "6.3"
or "6.4" to resolve this issue.
