### PR TITLE
(FACT-727) Add meaningful operatingsystem fact values for Arista EOS

### DIFF
--- a/lib/facter/operatingsystem/linux.rb
+++ b/lib/facter/operatingsystem/linux.rb
@@ -46,6 +46,8 @@ module Facter
           get_alpine_release_with_release_file
         when "Amazon"
           get_amazon_release_with_lsb
+        when "AristaEOS"
+          get_arista_release_with_release_file
         when "BlueWhite64"
           get_bluewhite_release_with_release_file
         when "CentOS", "RedHat", "Scientific", "SLC", "Ascendos", "CloudLinux", "PSBM",
@@ -239,6 +241,7 @@ module Facter
       def get_operatingsystem_with_release_files
         operatingsystem = nil
         release_files = {
+          "AristaEOS"   => "/etc/Eos-release",
           "Debian"      => "/etc/debian_version",
           "Gentoo"      => "/etc/gentoo-release",
           "Fedora"      => "/etc/fedora-release",
@@ -343,6 +346,14 @@ module Facter
         if release = Facter::Util::FileRead.read('/etc/alpine-release')
           release.sub!(/\s*$/, '')
           release
+        end
+      end
+
+      def get_arista_release_with_release_file
+        if release = Facter::Util::FileRead.read('/etc/Eos-release')
+          if match = /\d+\.\d+(:?\.\d+)?[A-M]?$/.match(release)
+            match[0]
+          end
         end
       end
 

--- a/spec/unit/operatingsystem/linux_spec.rb
+++ b/spec/unit/operatingsystem/linux_spec.rb
@@ -29,6 +29,7 @@ describe Facter::Operatingsystem::Linux do
 
     describe "When lsbdistid is not available" do
      {
+        "AristaEOS"   => "/etc/Eos-release",
         "Debian"      => "/etc/debian_version",
         "Gentoo"      => "/etc/gentoo-release",
         "Fedora"      => "/etc/fedora-release",
@@ -193,6 +194,7 @@ describe Facter::Operatingsystem::Linux do
       'Slamd64',
       'Slackware',
       'Alpine',
+      'AristaEOS',
     ].each do |os|
       it "should return the kernel fact on operatingsystem #{os}" do
         Facter.expects(:value).with("kernel").returns "Linux"
@@ -212,17 +214,18 @@ describe Facter::Operatingsystem::Linux do
 
   describe "Operatingsystemrelease fact" do
     test_cases = {
-      "OpenWrt"    => "/etc/openwrt_version",
-      "CentOS"    => "/etc/redhat-release",
-      "RedHat"    => "/etc/redhat-release",
+      "AristaEOS"   => "/etc/Eos-release",
+      "OpenWrt"     => "/etc/openwrt_version",
+      "CentOS"      => "/etc/redhat-release",
+      "RedHat"      => "/etc/redhat-release",
       "LinuxMint"   => "/etc/linuxmint/info",
       "Scientific"  => "/etc/redhat-release",
-      "Fedora"    => "/etc/fedora-release",
-      "MeeGo"     => "/etc/meego-release",
-      "OEL"     => "/etc/enterprise-release",
-      "oel"     => "/etc/enterprise-release",
-      "OVS"     => "/etc/ovs-release",
-      "ovs"     => "/etc/ovs-release",
+      "Fedora"      => "/etc/fedora-release",
+      "MeeGo"       => "/etc/meego-release",
+      "OEL"         => "/etc/enterprise-release",
+      "oel"         => "/etc/enterprise-release",
+      "OVS"         => "/etc/ovs-release",
+      "ovs"         => "/etc/ovs-release",
       "OracleLinux" => "/etc/oracle-release",
       "Ascendos"    => "/etc/redhat-release",
     }
@@ -260,6 +263,13 @@ describe Facter::Operatingsystem::Linux do
       expect(release).to eq "foo"
     end
 
+    it "should use the contents of /etc/Eos-release in AristaEOS" do
+      subject.expects(:get_operatingsystem).returns("AristaEOS")
+      File.expects(:read).with("/etc/Eos-release").returns("Arista Networks EOS 4.13.7M")
+      release = subject.get_operatingsystemrelease
+      expect(release).to eq "4.13.7M"
+    end
+
     it "should fall back to parsing /etc/system-release if lsb facts are not available in Amazon" do
       subject.expects(:get_operatingsystem).returns("Amazon")
       subject.expects(:get_lsbdistrelease).returns(nil)
@@ -288,7 +298,7 @@ describe Facter::Operatingsystem::Linux do
   end
 
   describe "Operatingsystemmajrelease key" do
-    ['Amazon','CentOS','CloudLinux','Debian','Fedora','OEL','OracleLinux','OVS','RedHat','Scientific','SLC','CumulusLinux'].each do |operatingsystem|
+    ['Amazon' 'AristaEOS', 'CentOS','CloudLinux','Debian','Fedora','OEL','OracleLinux','OVS','RedHat','Scientific','SLC','CumulusLinux'].each do |operatingsystem|
       describe "on #{operatingsystem} operatingsystems" do
         it "should be derived from operatingsystemrelease" do
           subject.stubs(:get_operatingsystem).returns(operatingsystem)


### PR DESCRIPTION
This commit adds support for Arista EOS within the operating system
set of facts. This includes the `os`, `operatingsystem`, `osfamily`
`operatingsystemmajrelease`, and `operatingsystemrelease` facts.
