### PR TITLE
(PUP-3479) Update ffi to ~1.9.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ mingw = [:mingw]
 mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 
 platform(*mingw) do
-  gem 'ffi', '~> 1.9.3', :require => false
+  gem 'ffi', '~> 1.9.5', :require => false
   gem 'win32-dir', '~> 0.4.8', :require => false
   gem 'win32-security', '~> 0.2.5', :require => false
 end

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -19,13 +19,13 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2.6'
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.3'
+      ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.8'
       win32-security: '~> 0.2.5'
       win32console: '~> 1.3.2'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.3'
+      ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.8'
       win32-security: '~> 0.2.5'
 bundle_platforms:


### PR DESCRIPTION
Ruby 2.1.x on Windows requires ffi 1.9.5+. Update the ffi dependency to
1.9.5.
