### PR TITLE
(FACT-705) Improve documentation of structured facts

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -5,6 +5,8 @@
 #   If the interface that is the default gateway is DHCP assigned, there
 #   will also be a `"system"` entry in the hash.
 #
+#   This fact is structured. Values are returned as a group of key-value pairs.
+#
 # Resolution:
 #   Parses the output of `nmcli` to find the DHCP server for the interface if available.
 #

--- a/lib/facter/operatingsystemmajrelease.rb
+++ b/lib/facter/operatingsystemmajrelease.rb
@@ -3,11 +3,14 @@
 # Purpose: Returns the major release of the operating system.
 #
 # Resolution:
-#   Uses the releasemajor key of the os structured fact, which itself
-#   splits down its operatingsystemrelease key at decimal point for
-#   osfamily RedHat derivatives and Debian.
-#   Uses operatingsystemrelease key to the first non decimal
-#   character for operatingsystem Solaris.
+#   Uses the release['major'] entry of the os structured fact, which itself
+#   attempts to use its own release['full'] entry to determine the major release value.
+#   In RedHat osfamily derivatives and Debian, splits down the release string for a decimal point
+#   and uses the first non-decimal character.
+#   In Solaris, uses the first non-decimal character of the release string.
+#   In Ubuntu, uses the characters before and after the first decimal point, as in '14.04'.
+#   In Windows, uses the full release string in the case of server releases, such as '2012 R2',
+#   and uses the first non-decimal character in the cases of releases such as '8.1'.
 #
 #   This should be the same as lsbmajdistrelease, but on minimal systems there
 #   are too many dependencies to use LSB
@@ -16,7 +19,7 @@
 #   "Alpine" "Amazon" "Archlinux" "Ascendos" "Bluewhite64" "CentOS" "CloudLinux" 
 #   "Debian" "Fedora" "Gentoo" "Mandrake" "Mandriva" "MeeGo" "OEL" "OpenSuSE" 
 #   "OracleLinux" "OVS" "PSBM" "RedHat" "Scientific" "Slackware" "Slamd64" "SLC"
-#   "SLED" "SLES" "SuSE" "Ubuntu" "VMWareESX"
+#   "SLED" "SLES" "Solaris" "SuSE" "Ubuntu" "VMWareESX"
 #
 
 Facter.add(:operatingsystemmajrelease) do

--- a/lib/facter/os.rb
+++ b/lib/facter/os.rb
@@ -1,29 +1,58 @@
 # Fact: os
 #
 # Purpose:
-#   Return various facts related to the machine's operating system.
+#   Return various facts related to the machine's operating system, including:
+#   Name: The name of the operating system.
+#   Family: A mapping of the operating system to an operating system family.
+#   Release: The release version of the operating system. Includes entries for the
+#   major and minor release versions, as well as the full release string.
+#   Lsb: Linux Standard Base information for the system.
+#
+#   This fact is structured. These values are returned as a group of key-value pairs.
 #
 # Resolution:
-#   For operatingsystem, if the kernel is a Linux kernel, check for the
-#   existence of a selection of files in `/etc` to find the specific flavor.
+#   For the name entry, if the kernel is a Linux kernel, check for the existence of a 
+#   selection of files in `/etc` to find the specific flavor.
 #   On SunOS based kernels, attempt to determine the flavor, otherwise return Solaris.
 #   On systems other than Linux, use the kernel value.
 #
-#   For operatingsystemrelease, on RedHat derivatives, we return their `/etc/<varient>-release` file.
+#   For the family entry, map operating systems to operating system families, such
+#   as linux distribution derivatives. Adds mappings from specific operating systems
+#   to kernels in the case that it is relevant.
+#
+#   For the release entry, on RedHat derivatives, returns `/etc/<variant>-release` file.
 #   On Debian, returns `/etc/debian_version`.
 #   On Ubuntu, parses `/etc/lsb-release` for the release version
-#   On Suse and derivatives, parses `/etc/SuSE-release` for a selection of version information.
+#   On Suse and derivatives, parses `/etc/SuSE-release` for a selection of version
+#   information.
 #   On Slackware, parses `/etc/slackware-version`.
 #   On Amazon Linux, returns the lsbdistrelease fact's value.
 #   On Mageia, parses `/etc/mageia-release` for the release version.
 #   On all remaining systems, returns the kernelrelease fact's value.
 #
-#   For the lsb facts, uses the `lsb_release` system command.
+#   For the major version, uses the value of the full release string to determine the major
+#   release version.
+#   In RedHat osfamily derivatives and Debian, splits down the release string for a decimal point
+#   and uses the first non-decimal character.
+#   In Solaris, uses the first non-decimal character of the release string.
+#   In Ubuntu, uses the characters before and after the first decimal point, as in '14.04'.
+#   In Windows, uses the full release string in the case of server releases, such as '2012 R2',
+#   and uses the first non-decimal character in the cases of releases such as '8.1'.
+#
+#   For the minor version, attempts to split the full release version string and return
+#   the value of the character after the first decimal.
+#
+#   For the lsb entries, uses the `lsb_release` system command.
 #
 # Caveats:
-#   Lsb facts only work on Linux (and the kfreebsd derivative) systems.
-#   Requires the `lsb_release` program, which may not be installed by default.
-#   It is only as accurate as the ourput of lsb_release.
+#   The family entry is completely reliant on the name key, and no heuristics are used.
+#
+#   The major and minor release sub-facts of the release entry are not currenty
+#   supported on all platforms.
+#
+#   The lsb entries only work on Linux (and the kfreebsd derivative) systems. Requires
+#   the `lsb_release` program, which may not be installed by default. It is only as 
+#   accurate as the output of `lsb_release`.
 #
 
 require 'facter/operatingsystem/implementation'

--- a/lib/facter/partitions.rb
+++ b/lib/facter/partitions.rb
@@ -3,6 +3,8 @@
 # Purpose:
 #   Return the details of the disk partitions.
 #
+#   This fact is structured. Values are returned as a group of key-value pairs.
+#
 # Resolution:
 #   Parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes).
 #

--- a/lib/facter/processors.rb
+++ b/lib/facter/processors.rb
@@ -1,18 +1,24 @@
 # Fact: processors
 #
 # Purpose:
-#   Additional facts about the machine's CPU's, including
-#   processor lists, models, counts, and speeds.
+#   Provide additional facts about the machine's CPUs, including:
+#   Models: A list of processors present on the system.
+#   Count:  The number of hardware threads.
+#   Physicalcount: The number of physical processors.
+#   Speed: The speed of the processors on the system.
+#
+#   This fact is structured. These values are returned as a group of key-value pairs.
 #
 # Resolution:
-#   Each kernel utilizes its own implementation object to collect
-#   processor data. Linux and kFreeBSD parse `/proc/cpuinfo` for each
-#   processor. AIX parses the output of `lsdev` for its processor section.
-#   For Solaris, we parse the output of `kstat` for each processor. OpenBSD uses
-#   the sysctl variables 'hw.model' and 'hw.ncpu' for the CPU model and 
-#   the CPU count respectively. Darwin utilizes the system profiler to collect
-#   the physical CPU count and speed.
+#   Linux and kFreeBSD parse `/proc/cpuinfo` for each processor.
+#   AIX parses the output of `lsdev` for its processor section.
+#   Solaris parses the output of `kstat` for each processor.
+#   OpenBSD uses the sysctl variables `hw.model` and `hw.ncpu` for the CPU model
+#   and the CPU count respectively.
+#   Darwin utilizes the system profiler to collect the physical CPU count and speed.
 #
+# Caveats:
+#   The 'speed' sub-fact is not currently supported on all platforms.
 
 require 'facter/processors/os'
 

--- a/lib/facter/system_uptime.rb
+++ b/lib/facter/system_uptime.rb
@@ -5,6 +5,8 @@
 #   seconds, hours, days and a general, human
 #   readable uptime.
 #
+#   This fact is structured. These values are returned as a group of key-value pairs.
+#
 # Resolution:
 #   Does basic math on the get_uptime_seconds utility
 #   to calculate seconds, hours and days.


### PR DESCRIPTION
Prior to this commit, the Facter core documentation did not
specify which facts were structured. In addition, the documentation
for several structured facts did not adequately describe the contents
of the fact.

This commit improves the header comments for several structured facts,
which are used to auto-generate the Facter core docs. Formatting was
used in accordance with the tool used to generate our core docs, which
can be found here: https://github.com/holguinj/extracter.
