### PR TITLE
(FACT-697) Add confine to dhcp_servers for nmcli

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -23,6 +23,9 @@ Facter.add(:dhcp_servers) do
   confine do
     Facter::Core::Execution.which('nmcli')
   end
+  confine do
+    Facter::Core::Execution.exec('nmcli -t -f STATE g').strip != 'unknown'
+  end
 
   setcode do
     gwdev   = Facter::Util::DHCPServers.gateway_device

--- a/spec/unit/dhcp_servers_spec.rb
+++ b/spec/unit/dhcp_servers_spec.rb
@@ -18,6 +18,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
@@ -30,6 +31,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -43,6 +45,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -55,6 +58,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -65,6 +69,7 @@ describe "DHCP server facts" do
       describe "with no CONNECTED devices" do
         before :each do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("disconnected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -84,6 +89,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
@@ -96,6 +102,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -109,6 +116,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -121,6 +129,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -131,11 +140,23 @@ describe "DHCP server facts" do
       describe "with no CONNECTED devices" do
         before :each do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("disconnected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
           Facter.fact(:dhcp_servers).value.should be_nil
         end
+      end
+    end
+
+    describe "without NetworkManager running" do
+      before :each do
+        Facter::Core::Execution.stubs(:exec).with("nmcli d").returns("Error: NetworkManager is not running\n")
+        Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+      end
+
+      it "should not produce a dhcp_servers fact" do
+        Facter.fact(:dhcp_servers).value.should be_nil
       end
     end
 


### PR DESCRIPTION
This patch adds a confine on dhcp_servers to ensure that, not only is
nmcli present, but actually is connected to NetworkManager.

This fixes the issue where facter is throwing an error of
'NetworkManager is not running' at each run of facter.

Closes: FACT-697
