### PR TITLE
(FACT-755) Fix unprivileged Xen detection when /proc/xen is not present. 

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -131,7 +131,7 @@ Facter.add("virtual") do
 
     if Facter::Util::Virtual.xen?
       next "xen0" if FileTest.exists?("/dev/xen/evtchn")
-      next "xenu" if FileTest.exists?("/proc/xen")
+      next "xenu" if FileTest.exists?("/proc/xen") || FileTest.exists?("/dev/xvda1")
     end
 
     next "virtualbox" if Facter::Util::Virtual.virtualbox?

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -147,6 +147,15 @@ describe "Virtual fact" do
       Facter.fact(:virtual).value.should == "xenu"
     end
 
+    it "should be xenu with xvda1 device in /dev" do
+      Facter.fact(:hardwaremodel).stubs(:value).returns("i386")
+      Facter::Util::Virtual.expects(:xen?).returns(true)
+      FileTest.expects(:exists?).with("/dev/xen/evtchn").returns(false)
+      FileTest.expects(:exists?).with("/proc/xen").returns(false)
+      FileTest.expects(:exists?).with("/dev/xvda1").returns(true)
+      Facter.fact(:virtual).value.should == "xenu"
+    end
+
     it "should be xenhvm with Xen HVM vendor name from lspci 2>/dev/null" do
       Facter::Core::Execution.stubs(:exec).with('lspci 2>/dev/null').returns("00:03.0 Unassigned class [ff80]: XenSource, Inc. Xen Platform Device (rev 01)")
       Facter.fact(:virtual).value.should == "xenhvm"


### PR DESCRIPTION
...is a xen

I had problems on some xen virtual hosts, that /dev/xen/\* or /proc/xen was not present. But /dev/xvda1 (partition) was always present.
