### PR TITLE
(maint) doc fix - there is no Facter::Util::Execution

### DIFF
--- a/lib/facter/util/resolution.rb
+++ b/lib/facter/util/resolution.rb
@@ -25,7 +25,7 @@ class Facter::Util::Resolution
 
   class << self
     # Expose command execution methods that were extracted into
-    # Facter::Util::Execution from Facter::Util::Resolution in Facter 2.0.0 for
+    # Facter::Core::Execution from Facter::Util::Resolution in Facter 2.0.0 for
     # compatibility.
     #
     # @deprecated


### PR DESCRIPTION
Yard docs had a reference to `Facter::Util::Execution` (does not exist) instead of `Facter::Core::Execution`
