### PR TITLE
(FACT-697) Fix nmcli command line usage for versions < 0.9.9.

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -24,7 +24,7 @@ Facter.add(:dhcp_servers) do
     Facter::Core::Execution.which('nmcli')
   end
   confine do
-    Facter::Core::Execution.exec('nmcli -t -f STATE g').strip != 'unknown'
+    Facter::Util::DHCPServers.network_manager_state != 'unknown'
   end
 
   setcode do

--- a/lib/facter/util/dhcp_servers.rb
+++ b/lib/facter/util/dhcp_servers.rb
@@ -25,9 +25,8 @@ module Facter::Util::DHCPServers
 
   def self.device_dhcp_server(device)
     if Facter::Core::Execution.which('nmcli')
-      version = self.nmcli_version
       # If the version is >= 0.9.9, use show instead of list
-      if version && version[0] > 0 || version[1] > 9 || (version[1] == 9 && version[2] >= 9)
+      if is_newer_nmcli?
         Facter::Core::Execution.exec("nmcli -f all d show #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
       else
         Facter::Core::Execution.exec("nmcli -f all d list iface #{device}").scan(/dhcp_server_identifier.*?(\d+\.\d+\.\d+\.\d+)$/).flatten.first
@@ -35,9 +34,25 @@ module Facter::Util::DHCPServers
     end
   end
 
+  def self.network_manager_state
+    # If the version is >= 0.9.9, use g instead of nm
+    if is_newer_nmcli?
+      output = Facter::Core::Execution.exec('nmcli -t -f STATE g 2>/dev/null')
+    else
+      output = Facter::Core::Execution.exec('nmcli -t -f STATE nm 2>/dev/null')
+    end
+    return nil unless output
+    output.strip
+  end
+
   def self.nmcli_version
     if version = Facter::Core::Execution.exec("nmcli --version")
       version.scan(/version\s(\d+)\.?(\d+)?\.?(\d+)?\.?(\d+)?/).flatten.map(&:to_i)
     end
+  end
+
+  def self.is_newer_nmcli?
+    version = nmcli_version
+    version && (version[0] > 0 || version[1] > 9 || (version[1] == 9 && version[2] >= 9))
   end
 end

--- a/spec/unit/dhcp_servers_spec.rb
+++ b/spec/unit/dhcp_servers_spec.rb
@@ -18,7 +18,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("connected\n")
         end
 
         it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
@@ -31,7 +31,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -45,7 +45,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -58,7 +58,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d list iface wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("connected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -69,7 +69,7 @@ describe "DHCP server facts" do
       describe "with no CONNECTED devices" do
         before :each do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("disconnected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("disconnected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -89,7 +89,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("connected\n")
         end
 
         it "should produce a dhcp_servers fact that includes values for 'system' as well as each dhcp enabled interface" do
@@ -102,7 +102,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -116,7 +116,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_dhcp"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_dhcp"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("connected\n")
         end
 
         it "should a dhcp_servers fact that includes values for each dhcp enables interface and NO 'system' value" do
@@ -129,7 +129,7 @@ describe "DHCP server facts" do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show eth0").returns(my_fixture_read("nmcli_eth0_static"))
           Facter::Core::Execution.stubs(:exec).with("nmcli -f all d show wlan0").returns(my_fixture_read("nmcli_wlan0_static"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("connected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -140,7 +140,7 @@ describe "DHCP server facts" do
       describe "with no CONNECTED devices" do
         before :each do
           Facter::Core::Execution.stubs(:exec).with("nmcli d").returns(my_fixture_read("nmcli_devices_disconnected"))
-          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("disconnected\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("disconnected\n")
         end
 
         it "should not produce a dhcp_servers fact" do
@@ -149,14 +149,31 @@ describe "DHCP server facts" do
       end
     end
 
-    describe "without NetworkManager running" do
+    describe 'without NetworkManager running' do
       before :each do
-        Facter::Core::Execution.stubs(:exec).with("nmcli d").returns("Error: NetworkManager is not running\n")
-        Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g').returns("connected\n")
+        Facter::Core::Execution.stubs(:which).with('nmcli').returns('/usr/bin/nmcli')
       end
 
-      it "should not produce a dhcp_servers fact" do
-        Facter.fact(:dhcp_servers).value.should be_nil
+      describe 'with nmcli version >= 0.9.9 available' do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("unknown\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.9.0')
+        end
+
+        it 'should not produce a dhcp_servers fact' do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+
+      describe 'with nmcli version <= 0.9.8 available' do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("unknown\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.7.0')
+        end
+
+        it 'should not produce a dhcp_servers fact' do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
       end
     end
 


### PR DESCRIPTION
The code to confine the dhcp_servers fact to when NetworkManager's
status is not "unknown" used a command line syntax that is only
available in nmcli versions >= 0.9.9.

This commit uses the older command line syntax when the nmcli version is
less than 0.9.9.
