### PR TITLE
Fix unnecessary NetworkManager stderr output.

### DIFF
--- a/lib/facter/util/dhcp_servers.rb
+++ b/lib/facter/util/dhcp_servers.rb
@@ -16,8 +16,8 @@ module Facter::Util::DHCPServers
   end
 
   def self.devices
-    if Facter::Core::Execution.which('nmcli')
-      Facter::Core::Execution.exec("nmcli d").split("\n").select {|d| d =~ /\sconnected/i }.collect{ |line| line.split[0] }
+    if Facter::Core::Execution.which('nmcli') and Facter::Core::Execution.exec("nmcli -t --fields RUNNING g status").strip() != "not running"
+      Facter::Core::Execution.exec("nmcli d 2>/dev/null").split("\n").select {|d| d =~ /\sconnected/i }.collect{ |line| line.split[0] }
     else
       []
     end


### PR DESCRIPTION
If `nmcli` exists but NetworkManager is not running (or not being used to manage networking), then the `dhcp_servers` fact generates the stderr output `Error: NetworkManager is not running.` on each run of Facter/Puppet, generating unnecessary stderr output, cron emails, and/or puppet report output.
