### PR TITLE
(maint) Replace deprecated .exists? with .exist?

### DIFF
--- a/lib/facter/system32.rb
+++ b/lib/facter/system32.rb
@@ -12,7 +12,7 @@
 Facter.add(:system32) do
   confine :kernel => :windows
   setcode do
-    if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative")
+    if File.exist?("#{ENV['SYSTEMROOT']}\\sysnative")
       "#{ENV['SYSTEMROOT']}\\sysnative"
     else
       "#{ENV['SYSTEMROOT']}\\system32"

--- a/spec/unit/system32_spec.rb
+++ b/spec/unit/system32_spec.rb
@@ -12,7 +12,7 @@ describe "system32 fact" do
 
   describe "when running in 32-bit ruby" do
     it "resolves to sysnative" do
-      File.expects(:exists?).with(sysnative).returns(true)
+      File.expects(:exist?).with(sysnative).returns(true)
 
       expect(Facter.fact(:system32).value).to eq(sysnative)
     end
@@ -20,7 +20,7 @@ describe "system32 fact" do
 
   describe "when running in 64-bit ruby" do
     it "resolves to system32" do
-      File.expects(:exists?).with(sysnative).returns(false)
+      File.expects(:exist?).with(sysnative).returns(false)
 
       expect(Facter.fact(:system32).value).to eq(system32)
     end


### PR DESCRIPTION
`File.exists?` is deprecated and should be upgraded to the correct format
