### PR TITLE
(FACT-772) Remove print statment while loading external facts

### DIFF
--- a/lib/facter/util/directory_loader.rb
+++ b/lib/facter/util/directory_loader.rb
@@ -66,7 +66,7 @@ class Facter::Util::DirectoryLoader
       elsif data == {} or data == nil
         Facter.warn "Fact file #{file} was parsed but returned an empty data set"
       else
-        data.each { |p,v| collection.add(p, :value => v) { p(weight); has_weight(weight) } }
+        data.each { |p,v| collection.add(p, :value => v) { has_weight(weight) } }
       end
     end
   end


### PR DESCRIPTION
This commit removes an unneccessary print statment added in commit 99a00658
which was firing off every time an external fact was loaded.
