### PR TITLE
(FACT-753) Update default external fact directories for unified agent layout

### DIFF
--- a/acceptance/tests/runs_external_facts_once.rb
+++ b/acceptance/tests/runs_external_facts_once.rb
@@ -24,7 +24,7 @@ agents.each do |agent|
     ext = '.bat'
     content = win_content
   else
-    factsd = '/etc/facter/facts.d'
+    factsd = '/opt/puppetlabs/agent/facts.d'
     ext = '.sh'
     content = unix_content
   end

--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -41,7 +41,11 @@ module Facter::Util::Config
     if Facter::Util::Root.root?
       windows_dir = windows_data_dir
       if windows_dir.nil? then
-        @external_facts_dirs = ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+        # Note: Beginning with Facter 3, /opt/puppetlabs/agent/facts.d will be the only
+        # default external fact directory.
+        @external_facts_dirs = ["/opt/puppetlabs/agent/facts.d",
+                                "/etc/facter/facts.d",
+                                "/etc/puppetlabs/facter/facts.d"]
       else
         @external_facts_dirs = [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
       end

--- a/lib/facter/util/directory_loader.rb
+++ b/lib/facter/util/directory_loader.rb
@@ -1,7 +1,10 @@
 # A Facter plugin that loads external facts.
 #
 # Default Unix Directories:
-# /etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"
+# /opt/puppetlabs/agent/facts.d, /etc/facter/facts.d, /etc/puppetlabs/facter/facts.d
+#
+# Beginning with Facter 3, only /opt/puppetlabs/agent/facts.d will be a default external fact
+# directory in Unix.
 #
 # Default Windows Direcotires:
 # C:\ProgramData\Puppetlabs\facter\facts.d (2008)

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -55,7 +55,7 @@ describe Facter::Util::Config do
       Facter::Util::Config.stubs(:is_windows?).returns(false)
       Facter::Util::Config.stubs(:windows_data_dir).returns(nil)
       Facter::Util::Config.setup_default_ext_facts_dirs
-      Facter::Util::Config.external_facts_dirs.should == ["/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+      Facter::Util::Config.external_facts_dirs.should == ["/opt/puppetlabs/agent/facts.d", "/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
     end
 
     it "should return the default value for windows 2008" do


### PR DESCRIPTION
This commit updates the default search directories for external facts.
We now look in `/opt/puppetlabs/agent/facts.d` for both open source and
PE versions of Facter. When Facter 3 ships, we will default to only
searching in this directory, but to facilitate a smoother transition
Facter 2.4 will look in both old and new external fact search paths.

Note that this change only affects Unix agents, as Windows paths are
staying the same.

This change is part of the unified agent effort.