### PR TITLE
(FACT-775) do not replace dot by underscore in interface name

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -43,7 +43,7 @@ module Facter::Util::IP
 
   # Convert an interface name into purely alphanumeric characters.
   def self.alphafy(interface)
-    interface.gsub(/[^a-z0-9_]/i, '_')
+    interface.gsub(/[^a-z0-9_\.]/i, '_')
   end
 
   def self.convert_from_hex?(kernel)


### PR DESCRIPTION
because facter should return eth0.100 vlan interface instead of eth0_100