### PR TITLE
(FACT-779) Fix issue with Facter failing silently with --puppet option on Puppet 4

### DIFF
--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -187,7 +187,7 @@ OPTIONS
 
     def self.load_puppet
       require 'puppet'
-      Puppet.parse_config
+      Puppet.initialize_settings
 
       # If you've set 'vardir' but not 'libdir' in your
       # puppet.conf, then the hook to add libdir to $:


### PR DESCRIPTION
In commit a5363dd0 in Puppet, the deprecated parse_config class method
was removed from Puppet. Until now, Facter still called this method
when the --puppet flag was invoked, and was failing silently. This
commit updates that call to the newer Puppet.initialize_settings method.