### PR TITLE
(FACT-184) Facter can't detect long interface names

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -80,7 +80,10 @@ module Facter::Util::IP
 
   def self.get_all_interface_output
     case Facter.value(:kernel)
-    when 'Linux', 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly', 'AIX'
+    when 'Linux'
+      output = Facter::Util::IP.exec_ip(["link"])
+      output.gsub!(/^\d+:\s*/, "")				# delete leading number
+    when 'OpenBSD', 'NetBSD', 'FreeBSD', 'Darwin', 'GNU/kFreeBSD', 'DragonFly', 'AIX'
       output = Facter::Util::IP.exec_ifconfig(["-a","2>/dev/null"])
     when 'SunOS'
       output = Facter::Util::IP.exec_ifconfig(["-a"])
@@ -97,6 +100,13 @@ module Facter::Util::IP
     output
   end
 
+  ##
+  # exec_ip uses the Linux ip command
+  #
+  # @return [String] the output of `ip #{arguments} 2>/dev/null` or nil
+  def self.exec_ip(additional_arguments=[])
+    Facter::Core::Execution.exec("/bin/ip #{additional_arguments.join(' ')}")
+  end
 
   ##
   # exec_ifconfig uses the ifconfig command


### PR DESCRIPTION
The current way how to detect interface names is using the "ifconfig"
but this command shortened the long interface names. As Facter reads
"ifconfig" output with a shortened interface names puppet is not
able to work with them anymore. There is a patch that uses "ip link"
instead of "ifconfig" to retrieve interface names because "ip link"
provides the full interface names.