### PR TITLE
(maint) add yarjuf to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ platforms :ruby do
 end
 
 group :development, :test do
+  gem 'yarjuf', "~> 1.0"
   gem 'rake', "~> 10.1.0"
   gem 'rspec', "~> 2.11.0"
   gem 'mocha', "~> 0.10.5"


### PR DESCRIPTION
There's a ci:spec task that requires the yarjuf gem, but there's no yarjuf gem in the Gemfile. This fixes that.