### PR TITLE
(FACT-596) Update selinux_config_policy fact

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -148,7 +148,7 @@ Facter.add("selinux_config_policy") do
   setcode do
     result = 'unknown'
     mode = Facter::Core::Execution.exec(sestatus_cmd)
-    mode.each_line { |l| result = $1 if l =~ /^Policy from config file\:\s+(\w+)$/i }
+    mode.each_line { |l| result = $2 if l =~ /^(Policy from config file|Loaded policy name)\:\s+(\w+)$/i }    
     result.chomp
   end
 end


### PR DESCRIPTION
The newer version of selinux use the term "Loaded policy name"
in lieu of "Policy from config file".

This updated version matches on both for backard compatibility
reasons.

This should fix FACT-756 as well.