### PR TITLE
(FACT-797) Fix KVM detection on Linux

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -149,7 +149,7 @@ Facter.add("virtual") do
       next "xenhvm"     if lines.any? {|l| l =~ /XenSource/ }
       next "hyperv"     if lines.any? {|l| l =~ /Microsoft Corporation Hyper-V/ }
       next "gce"        if lines.any? {|l| l =~ /Class 8007: Google, Inc/ }
-      next "kvm"        if lines.any? {|l| l =~ /virtio/ }
+      next "kvm"        if lines.any? {|l| l =~ /virtio/i }
     end
 
     # Parse dmidecode

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -210,6 +210,11 @@ describe "Virtual fact" do
       Facter.fact(:virtual).value.should == "hyperv"
     end
 
+    it "should be kvm with virtio device lspci 2>/dev/null" do
+      Facter::Util::Virtual.expects(:lspci).returns("00:03.0 Ethernet controller: Red Hat, Inc Virtio network device")
+      Facter.fact(:virtual).value.should == "kvm"
+    end
+
     context "In a Linux Container (LXC)" do
       before :each do
         Facter.fact(:kernel).stubs(:value).returns("Linux")


### PR DESCRIPTION
Non-root users must rely on output of lspci command
to detect virtualization. However, PCI devices have
"Virtio" in its description, so we need case-insensitive
match (as I'm not aware how the output on other platforms
look like). Added rspec to improve test coverage.