### PR TITLE
Catching a timeout exception

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -90,6 +90,9 @@ module Facter
       rescue *CONNECTION_ERRORS => e
         Facter.log_exception(e, "Failed to fetch ec2 uri #{uri}: #{e.message}")
         return nil
+      rescue Timeout::Error => e
+        Facter.log_exception(e, "Failed to fetch ec2 uri #{uri}: #{e.message}")
+        return nil
       end
 
       private


### PR DESCRIPTION
A very trivial patch.

This exception can bubble up and cause confusion in places like: https://github.com/puppetlabs/facter/blob/master/lib/facter/core/resolvable.rb#L68
Where it throws "Timed out after #{limit} seconds while resolving #{qualified_name}" even if it timed out for a different reason after a different amount of time.

It looks best to catch it here with the other connection errors.