### PR TITLE
(FACT-596) Update selinux_config_policy fact

### DIFF
--- a/lib/facter/selinux.rb
+++ b/lib/facter/selinux.rb
@@ -148,7 +148,7 @@ Facter.add("selinux_config_policy") do
   setcode do
     result = 'unknown'
     mode = Facter::Core::Execution.exec(sestatus_cmd)
-    mode.each_line { |l| result = $1 if l =~ /^Policy from config file\:\s+(\w+)$/i }
+    mode.each_line { |l| result = $2 if l =~ /^(Policy from config file|Loaded policy name)\:\s+(\w+)$/i }
     result.chomp
   end
 end

--- a/spec/fixtures/unit/selinux/selinux_sestatus2
+++ b/spec/fixtures/unit/selinux/selinux_sestatus2
@@ -1,0 +1,9 @@
+SELinux status: enabled
+SELinuxfs mount: /sys/fs/selinux
+SELinux root directory: /etc/selinux
+Loaded policy name: default
+Current mode: enforcing
+Mode from config file: permissive
+Policy MLS status: enabled
+Policy deny_unknown status: denied
+Max kernel policy version: 29

--- a/spec/unit/selinux_spec.rb
+++ b/spec/unit/selinux_spec.rb
@@ -96,6 +96,11 @@ describe "SELinux facts" do
 
       Facter.fact(:selinux_config_policy).value.should == "targeted"
     end
+    it "should return the loaded SELinux policy" do
+      sestatus_is(my_fixture_read("selinux_sestatus2"))
+
+      Facter.fact(:selinux_config_policy).value.should == "default"
+    end
   end
 
   def sestatus_is(status)


### PR DESCRIPTION
The newer version of selinux use the term "Loaded policy name" in lieu
of "Policy from config file".

This updated version matches on both for backard compatibility reasons

Also added a fixture containing an example run from the newer output
for selinux on centos 7/debian/rhel 7.