### PR TITLE
Properly detect KVM when CPU type is not qemu32/qemu64

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -164,6 +164,7 @@ Facter.add("virtual") do
       next "rhev"       if lines.any? {|l| l =~ /Product Name: RHEV Hypervisor/ }
       next "ovirt"      if lines.any? {|l| l =~ /Product Name: oVirt Node/ }
       next "bochs"      if lines.any? {|l| l =~ /Bochs/ }
+      next "kvm"        if lines.any? {|l| l =~ /Manufacturer: QEMU/ }
     end
 
     # Default to 'physical'


### PR DESCRIPTION
kvm detection code in util/virtual.rb examines cpuid data and looks for 'QEMU' string. However, if KVM CPU emulation is not set to qemu32 or qemu64 then this does not work. For example, if CPU type is set to 'host' then /proc/cpuinfo simply passes through the underlying host CPU details.

If a QEMU cpu is not found, kvm can be detected by looking at dmidecode data.
