### PR TITLE
(FACT-822) Prioritize AIO binaries over PATH

### DIFF
--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -64,4 +64,22 @@ module Facter::Util::Config
   end
 
   setup_default_ext_facts_dirs
+
+  def self.override_binary_dir=(dir)
+    @override_binary_dir = dir
+  end
+
+  def self.override_binary_dir
+    @override_binary_dir
+  end
+
+  def self.setup_default_override_binary_dir
+    if Facter::Util::Config.is_windows?
+      @override_binary_dir = nil
+    else
+      @override_binary_dir = "/opt/puppetlabs/puppet/bin"
+    end
+  end
+
+  setup_default_override_binary_dir
 end

--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -13,9 +13,17 @@ module Facter::Util::Virtual
   # and later versions of virt-what may emit this message on stderr. This
   # method ensures stderr is redirected and that error messages are stripped
   # from stdout.
-  def self.virt_what(command = "virt-what")
-    command = Facter::Core::Execution.which(command)
-    return unless command
+  def self.virt_what(cmd = "virt-what")
+    if bindir = Facter::Util::Config.override_binary_dir
+      command = Facter::Core::Execution.which(File.join(bindir, cmd))
+    else
+      command = nil
+    end
+
+    if !command
+      command = Facter::Core::Execution.which(cmd)
+      return unless command
+    end
 
     if Facter.value(:kernel) == 'windows'
       redirected_cmd = "#{command} 2>NUL"

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -94,4 +94,26 @@ describe Facter::Util::Config do
     end
 
   end
+
+  describe "override_binary_dir" do
+    it "should return the default value for linux" do
+      Facter::Util::Config.stubs(:is_windows?).returns(false)
+      Facter::Util::Config.setup_default_override_binary_dir
+      Facter::Util::Config.override_binary_dir.should == "/opt/puppetlabs/puppet/bin"
+    end
+
+    it "should return nil for windows" do
+      Facter::Util::Config.stubs(:is_windows?).returns(true)
+      Facter::Util::Config.setup_default_override_binary_dir
+      Facter::Util::Config.override_binary_dir.should == nil
+    end
+
+    it "should output new values when explicitly set" do
+      Facter::Util::Config.setup_default_override_binary_dir
+      new_value = '/usr/share/newdir'
+      Facter::Util::Config.override_binary_dir = new_value
+      Facter::Util::Config.override_binary_dir.should == new_value
+    end
+  end
+
 end


### PR DESCRIPTION
Without this change, facter in the AIO agent may use system binaries
instead of AIO package binaries.

Prefix the search path with the AIO binary location so we will use AIO
binaries when they're available.