### PR TITLE
(FACT-826) Use /opt/puppetlabs/facter/facts.d

### DIFF
--- a/acceptance/tests/runs_external_facts_once.rb
+++ b/acceptance/tests/runs_external_facts_once.rb
@@ -24,7 +24,7 @@ agents.each do |agent|
     ext = '.bat'
     content = win_content
   else
-    factsd = '/opt/puppetlabs/agent/facts.d'
+    factsd = '/opt/puppetlabs/facter/facts.d'
     ext = '.sh'
     content = unix_content
   end

--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -41,9 +41,9 @@ module Facter::Util::Config
     if Facter::Util::Root.root?
       windows_dir = windows_data_dir
       if windows_dir.nil? then
-        # Note: Beginning with Facter 3, /opt/puppetlabs/agent/facts.d will be the only
+        # Note: Beginning with Facter 3, /opt/puppetlabs/facter/facts.d will be the only
         # default external fact directory.
-        @external_facts_dirs = ["/opt/puppetlabs/agent/facts.d",
+        @external_facts_dirs = ["/opt/puppetlabs/facter/facts.d",
                                 "/etc/facter/facts.d",
                                 "/etc/puppetlabs/facter/facts.d"]
       else

--- a/lib/facter/util/directory_loader.rb
+++ b/lib/facter/util/directory_loader.rb
@@ -1,9 +1,9 @@
 # A Facter plugin that loads external facts.
 #
 # Default Unix Directories:
-# /opt/puppetlabs/agent/facts.d, /etc/facter/facts.d, /etc/puppetlabs/facter/facts.d
+# /opt/puppetlabs/facter/facts.d, /etc/facter/facts.d, /etc/puppetlabs/facter/facts.d
 #
-# Beginning with Facter 3, only /opt/puppetlabs/agent/facts.d will be a default external fact
+# Beginning with Facter 3, only /opt/puppetlabs/facter/facts.d will be a default external fact
 # directory in Unix.
 #
 # Default Windows Direcotires:

--- a/spec/unit/util/config_spec.rb
+++ b/spec/unit/util/config_spec.rb
@@ -55,7 +55,7 @@ describe Facter::Util::Config do
       Facter::Util::Config.stubs(:is_windows?).returns(false)
       Facter::Util::Config.stubs(:windows_data_dir).returns(nil)
       Facter::Util::Config.setup_default_ext_facts_dirs
-      Facter::Util::Config.external_facts_dirs.should == ["/opt/puppetlabs/agent/facts.d", "/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
+      Facter::Util::Config.external_facts_dirs.should == ["/opt/puppetlabs/facter/facts.d", "/etc/facter/facts.d", "/etc/puppetlabs/facter/facts.d"]
     end
 
     it "should return the default value for windows 2008" do


### PR DESCRIPTION
Previously, facter would load external facts from
`/opt/puppetlabs/agent/facts.d`, but this was wrong for two reasons. The
`agent` directory was renamed to `puppet` in AIO. Also, it was
conflating facter's `facts.d` directory, with puppet's `facts.d`
directory. Puppet pluginsyncs external facts in modules to the latter
directory, which defaults to `$vardir/facts.d`

This updates facter to use `/opt/puppetlabs/facter/facts.d`. This
directory is private to facter.