### PR TITLE
Only load ec2 rest once to avoid double loading warnings

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -15,7 +15,7 @@
 #   Directly queries the EC2 metadata endpoint.
 #
 
-require 'facter/ec2/rest'
+require 'facter/ec2/rest' unless defined?(Facter::EC2)
 
 Facter.define_fact(:ec2_metadata) do
   define_resolution(:rest) do


### PR DESCRIPTION
When implementing custom facter module, I usually require external dependencies. But when requiring 'facter/ec2',  I get the following warning:

```
Already evaluated rest at true, reevaluating anyways
Already evaluated rest at true, reevaluating anyways
```

This PR ensure the `facter/ec2/rest.rb` is only loaded once when I require 'facter/ec2' module. 

Singed CLA. 

