### PR TITLE
(FACT-828) puppetversion: speed boost for standalone Facter

### DIFF
--- a/lib/facter/puppetversion.rb
+++ b/lib/facter/puppetversion.rb
@@ -11,8 +11,8 @@
 Facter.add(:puppetversion) do
   setcode do
     begin
-      require 'puppet'
-      Puppet::PUPPETVERSION.to_s
+      require 'puppet/version'
+      Puppet.version.to_s
     rescue LoadError
       nil
     end


### PR DESCRIPTION
This gives the "puppetversion" fact a massive speed boost, execution time for that single fact goes down from 2-400ms to 10-20ms on different test nodes.
