### PR TITLE
(maint) Update beaker pin and allow env var override

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,12 +1,22 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.2.0"
+def location_for(place, fake_version = nil)
+  if place =~ /^(git:[^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place, { :require => false }]
+  end
+end
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#master')
 gem 'rake', "~> 10.1.0"
 
 # json-schema does not support windows, so use the 'ruby' platform to exclude it on windows
 platforms :ruby do
   # json-schema uses multi_json, but chokes with multi_json 1.7.9, so prefer 1.7.7
-  gem "multi_json", "1.7.7", :require => false
+  gem "multi_json", "~> 1.10", :require => false
   gem "json-schema", "2.1.1", :require => false
 end
 


### PR DESCRIPTION
This adds support for BEAKER_VERSION as was added in puppet at commit:

puppetlabs/puppet@072891f

However, the beaker pin is to master, since it has updated AIO paths.

This change also updates the multi-json gem version - this was pinned to 1.7.7
over a year ago to avoid a bug since fixed, so we can return to normal
pessimistic versioning. This is necessary because newer beakers pick up a
requirement for a newer version of multi-json via a transitive dependency.
