### PR TITLE
(FACT-825) Increase prtdiag timeout for Solaris virtual fact

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -73,7 +73,7 @@ end
 Facter.add("virtual") do
   confine :kernel => 'SunOS'
   has_weight 10
-  self.timeout = 6
+  self.timeout = 20
 
   setcode do
     next "zone" if Facter::Util::Virtual.zone?


### PR DESCRIPTION
This commit bumps up the default timeout for the virtual fact in
Solaris to 20 seconds. `prtdiag` on large Solaris systems can often
take upwards of 10 seconds, so 20 seconds is a reasonably safe timeout.

This fix was previously merged (d82f695a0) and then lost in the
Facter-2 / master branch merge.