### PR TITLE
(CFACT-258) Add a timeout option to Facter::Core::Execution#execute.

### DIFF
--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -117,7 +117,7 @@ namespace facter { namespace ruby {
 
         // Helper functions
         static module* from_self(VALUE self);
-        static VALUE execute_command(std::string const& command, VALUE failure_default, bool raise);
+        static VALUE execute_command(std::string const& command, VALUE failure_default, bool raise, uint32_t timeout = 0);
 
         void initialize_search_paths(std::vector<std::string> const& paths);
         VALUE load_fact(VALUE value);

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -386,6 +386,12 @@ namespace facter { namespace execution {
                 return count != 0;
             }
 
+            if (GetLastError() == ERROR_BROKEN_PIPE) {
+                // Treat a broken pipe as nothing left to read
+                buffer.resize(0);
+                return false;
+            }
+
             // Check to see if it's a pending operation
             if (GetLastError() != ERROR_IO_PENDING) {
                 LOG_ERROR("failed to read child output: %1%.", system_error());

--- a/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
+++ b/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
@@ -1,0 +1,1 @@
+Facter::Core::Execution.execute('not a command', :on_fail => :raise)

--- a/lib/tests/fixtures/ruby/execute_on_fail_value.rb
+++ b/lib/tests/fixtures/ruby/execute_on_fail_value.rb
@@ -1,0 +1,5 @@
+Facter.add(:foo) do
+    setcode do
+        Facter::Core::Execution.execute('not a command', :on_fail => 'default')
+    end
+end

--- a/lib/tests/fixtures/ruby/execute_timeout.rb
+++ b/lib/tests/fixtures/ruby/execute_timeout.rb
@@ -1,0 +1,1 @@
+Facter::Core::Execution.execute("ruby -e 'sleep 15'", :timeout => 1)

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -520,6 +520,26 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar baz\"");
         }
     }
+    GIVEN("Facter::Core::Execution#execute with on_fail => :raise") {
+        core->set_filter(log_level_attr >= log_level::error);
+        REQUIRE_FALSE(load_custom_fact("execute_on_fail_raise.rb", facts));
+        THEN("an error is logged") {
+            REQUIRE(has_message(*appender, "ERROR", "execution of command \"not a command\" failed"));
+        }
+    }
+    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with a default value") {
+        REQUIRE(load_custom_fact("execute_on_fail_value.rb", facts));
+        THEN("value should be in the collection") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"default\"");
+        }
+    }
+    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with a timeout") {
+        core->set_filter(log_level_attr >= log_level::error);
+        REQUIRE_FALSE(load_custom_fact("execute_timeout.rb", facts));
+        THEN("an error is logged") {
+            REQUIRE(has_message(*appender, "ERROR", "command timed out after 1 seconds."));
+        }
+    }
     GIVEN("a fact that uses timeout") {
         core->set_filter(log_level_attr >= log_level::warning);
         REQUIRE(load_custom_fact("timeout.rb", facts));


### PR DESCRIPTION
This adds support in the Ruby Facter API to pass a timeout option to
Facter::Core::Execution#execute.  If the timeout elapses, a
Facter::Core::Execution::ExecutionFailure is raised.

The timeout option is given in seconds.

Example:
```ruby
Facter::Core::Execution.execute('foo', timeout: 5)
```