### PR TITLE
(CFACT-140) Add acceptance tests for Facter executable

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -1,0 +1,47 @@
+module Facter
+  module Acceptance
+    module UserFactUtils
+
+      # Determine paths for testing custom and external facts.
+      # Paths vary by platform.
+
+      # Retreive the path of a non-standard directory for custom or external facts.
+      #
+      def get_user_fact_dir(platform, version)
+        if platform =~ /windows/
+          if version < 6.0
+            'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+          else
+            'C:/ProgramData/PuppetLabs/facter/custom'
+          end
+        else
+          '/opt/puppetlabs/facter/custom'
+        end
+      end
+
+      # Retreive the path of the standard facts.d directory.
+      #
+      def get_factsd_dir(platform, version)
+        if platform =~ /windows/
+          if version < 6.0
+            'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/facts.d'
+          else
+            'C:/ProgramData/PuppetLabs/facter/facts.d'
+          end
+        else
+          '/opt/puppetlabs/facter/facts.d'
+        end
+      end
+
+      # Retreive the extension to use for an external fact script.
+      # Windows uses '.bat' and everything else uses '.sh'
+      def get_external_fact_script_extension(platform)
+        if platform =~ /windows/
+          '.bat'
+        else
+          '.sh'
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -21,7 +21,7 @@ EOM
 
 agents.each do |agent|
 
-  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")
@@ -34,12 +34,12 @@ agents.each do |agent|
   end
 
   step "--no-custom-facts option should disable custom facts"
-  on(agent, "FACTERLIB=#{custom_dir} cfacter --no-custom-facts custom_fact") do
+  on(agent, "FACTERLIB=#{custom_dir} facter --no-custom-facts custom_fact") do
     assert_equal("", stdout.chomp, "Expected custom fact to be disabled, but it resolved as #{stdout.chomp}")
   end
 
   step "--custom-dir option should allow custom facts to be resolved from a specific directory"
-  on(agent, "cfacter --custom-dir #{custom_dir} custom_fact") do
+  on(agent, "facter --custom-dir #{custom_dir} custom_fact") do
     assert_equal("testvalue", stdout.chomp, "Custom fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -1,5 +1,16 @@
 test_name "custom fact commandline options (--no-custom-facts and --custom-dir)"
 
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# These tests are intended to ensure both custom fact related command-line options
+# work properly. The first step tests that an existing custom fact in Facter's
+# custom fact load path will not execute when the `--no-custom-facts` option is passed.
+# The second step checks that a custom fact in a directory specified by the `--custom-dir`
+# option is found by Facter and resolved.
+#
+
 content = <<EOM
 Facter.add('custom_fact') do
   setcode do
@@ -9,15 +20,8 @@ end
 EOM
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
-    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
-      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
-    else
-      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
-    end
-  else
-    custom_dir  = '/opt/puppetlabs/facter/custom'
-  end
+
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -1,0 +1,41 @@
+test_name "custom fact commandline options (--no-custom-facts and --custom-dir)"
+
+content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
+      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+    else
+      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
+    end
+  else
+    custom_dir  = '/opt/puppetlabs/facter/custom'
+  end
+
+  step "Agent #{agent}: create custom fact directory and executable custom fact"
+  on(agent, "mkdir -p '#{custom_dir}'")
+  custom_fact = "#{custom_dir}/custom_fact.rb"
+  create_remote_file(agent, custom_fact, content)
+  on(agent, "chmod +x #{custom_fact}")
+
+  teardown do
+    on(agent, "rm -f '#{custom_fact}'")
+  end
+
+  step "--no-custom-facts option should disable custom facts"
+  on(agent, "FACTERLIB=#{custom_dir} cfacter --no-custom-facts custom_fact") do
+    assert_equal("", stdout.chomp, "Expected custom fact to be disabled, but it resolved as #{stdout.chomp}")
+  end
+
+  step "--custom-dir option should allow custom facts to be resolved from a specific directory"
+  on(agent, "cfacter --custom-dir #{custom_dir} custom_fact") do
+    assert_equal("testvalue", stdout.chomp, "Custom fact output does not match expected output")
+  end
+end

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -7,7 +7,7 @@ test_name "--debug command-line option prints debugging information to stderr"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve debug info from stderr using --debug option"
-  on(agent, "cfacter --debug") do
+  on(agent, "facter --debug") do
     assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
   end
 end

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -1,5 +1,10 @@
 test_name "--debug command-line option prints debugging information to stderr"
 
+#
+# This test is intended to ensure that the --debug command-line option works
+# properly. This option prints debugging information to stderr.
+#
+
 agents.each do |agent|
   step "Agent #{agent}: retrieve debug info from stderr using --debug option"
   on(agent, "cfacter --debug") do

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -1,0 +1,8 @@
+test_name "--debug command-line option prints debugging information to stderr"
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve debug info from stderr using --debug option"
+  on(agent, "cfacter --debug") do
+    assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
+  end
+end

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -21,7 +21,7 @@ echo "external_fact=testvalue"
 EOM
 
 agents.each do |agent|
-  os_version = on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f
+  os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
   factsd = get_factsd_dir(agent['platform'], os_version)
   custom_external_dir = get_user_fact_dir(agent['platform'], os_version)
   ext = get_external_fact_script_extension(agent['platform'])
@@ -48,12 +48,12 @@ agents.each do |agent|
   end
 
   step "--no-external-facts option should disable external facts"
-  on(agent, "cfacter --no-external-facts external_fact") do
+  on(agent, "facter --no-external-facts external_fact") do
     assert_equal("", stdout.chomp, "Expected external fact to be disabled, but it resolved as #{stdout.chomp}")
   end
 
   step "--external-dir option should allow external facts to be resolved from a specific directory"
-  on(agent, "cfacter --external-dir #{custom_external_dir} external_fact") do
+  on(agent, "facter --external-dir #{custom_external_dir} external_fact") do
     assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -1,0 +1,54 @@
+test_name "external fact commandline options (--no-external-facts and --external-dir)"
+
+unix_content = <<EOM
+#!/bin/sh
+echo "external_fact=testvalue"
+EOM
+
+win_content = <<EOM
+echo "external_fact=testvalue"
+EOM
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
+      factsd = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/puppet/facts.d'
+      custom_external_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+    else
+      factsd = 'C:/ProgramData/PuppetLabs/puppet/facts.d'
+      custom_external_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
+    end
+    ext = '.bat'
+    content = win_content
+  else
+    factsd = '/opt/puppetlabs/facter/facts.d'
+    custom_external_dir = '/opt/puppetlabs/facter/custom'
+    ext = '.sh'
+    content = unix_content
+  end
+
+  step "Agent #{agent}: setup facts.d and custom external fact directories"
+  on(agent, "mkdir -p '#{factsd}'")
+  on(agent, "mkdir -p '#{custom_external_dir}'")
+
+  step "Agent #{agent}: create executable external facts in facts.d and custom external fact dir"
+  ext_fact_factsd     = "#{factsd}/external_fact#{ext}"
+  ext_fact_custom_dir = "#{custom_external_dir}/external_fact#{ext}"
+  create_remote_file(agent, ext_fact_factsd, content)
+  create_remote_file(agent, ext_fact_custom_dir, content)
+  on(agent, "chmod +x #{ext_fact_factsd} #{ext_fact_custom_dir}")
+
+  teardown do
+    on(agent, "rm -f '#{ext_fact_factsd} #{ext_fact_custom_dir}'")
+  end
+
+  step "--no-external-facts option should disable external facts"
+  on(agent, "cfacter --no-external-facts external_fact") do
+    assert_equal("", stdout.chomp, "Expected external fact to be disabled, but it resolved as #{stdout.chomp}")
+  end
+
+  step "--external-dir option should allow external facts to be resolved from a specific directory"
+  on(agent, "cfacter --external-dir #{custom_external_dir} external_fact") do
+    assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
+  end
+end

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -1,5 +1,11 @@
 test_name "--help command-line option prints usage information to stdout"
 
+#
+# This test is intended to ensure that the --help command-line option works
+# properly. This option prints usage information and available command-line
+# options.
+#
+
 agents.each do |agent|
   step "Agent #{agent}: retrieve usage info from stdout using --help option"
   on(agent, "cfacter --help") do

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -1,0 +1,8 @@
+test_name "--help command-line option prints usage information to stdout"
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve usage info from stdout using --help option"
+  on(agent, "cfacter --help") do
+    assert_match(/cfacter \[options\] \[query\] \[query\] \[...\]/, stdout, "Expected stdout to contain usage information")
+  end
+end

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -8,7 +8,7 @@ test_name "--help command-line option prints usage information to stdout"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve usage info from stdout using --help option"
-  on(agent, "cfacter --help") do
-    assert_match(/cfacter \[options\] \[query\] \[query\] \[...\]/, stdout, "Expected stdout to contain usage information")
+  on(agent, "facter --help") do
+    assert_match(/facter \[options\] \[query\] \[query\] \[...\]/, stdout, "Expected stdout to contain usage information")
   end
 end

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -1,0 +1,43 @@
+require 'json'
+
+test_name "--json command-line option results in valid JSON output"
+
+content = <<EOM
+Facter.add('structured_fact') do
+  setcode do
+    { "foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }
+  end
+end
+EOM
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
+      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+    else
+      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
+    end
+  else
+    custom_dir  = '/opt/puppetlabs/facter/custom'
+  end
+
+  step "Agent #{agent}: create a structured custom fact"
+  custom_fact = "#{custom_dir}/custom_fact.rb"
+  on(agent, "mkdir -p '#{custom_dir}'")
+  create_remote_file(agent, custom_fact, content)
+  on(agent, "chmod +x #{custom_fact}")
+
+  teardown do
+    on(agent, "rm -f '#{custom_fact}'")
+  end
+
+  step "Agent #{agent}: retrieve output using the --json option"
+  on(agent, "FACTERLIB=#{custom_dir} cfacter structured_fact --json") do
+    begin
+      expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3"}})
+      assert_equal(expected, stdout.chomp, "JSON output does not match expected output")
+    rescue
+      fail_test "Couldn't parse output as JSON"
+    end
+  end
+end

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -1,6 +1,15 @@
-require 'json'
-
 test_name "--json command-line option results in valid JSON output"
+
+require 'json'
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# This test is intended to ensure that the --json command-line option works
+# properly. This option causes Facter to output facts in JSON format.
+# A custom fact is used to test for parity between Facter's output and
+# the expected JSON output.
+#
 
 content = <<EOM
 Facter.add('structured_fact') do
@@ -11,15 +20,7 @@ end
 EOM
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
-    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
-      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
-    else
-      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
-    end
-  else
-    custom_dir  = '/opt/puppetlabs/facter/custom'
-  end
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
   custom_fact = "#{custom_dir}/custom_fact.rb"

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -20,7 +20,7 @@ end
 EOM
 
 agents.each do |agent|
-  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
   custom_fact = "#{custom_dir}/custom_fact.rb"
@@ -33,7 +33,7 @@ agents.each do |agent|
   end
 
   step "Agent #{agent}: retrieve output using the --json option"
-  on(agent, "FACTERLIB=#{custom_dir} cfacter structured_fact --json") do
+  on(agent, "FACTERLIB=#{custom_dir} facter structured_fact --json") do
     begin
       expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3"}})
       assert_equal(expected, stdout.chomp, "JSON output does not match expected output")

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -7,7 +7,7 @@ test_name "--log-level command-line option can be used to specify logging level"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option"
-  on(agent, "cfacter --log-level debug") do
+  on(agent, "facter --log-level debug") do
     assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
   end
 end

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -1,0 +1,13 @@
+test_name "--log-level command-line option can be used to specify logging level"
+#
+# This test is intended to ensure that the --log-level command-line option works
+# properly. This option can be used with an argument to specify the level of logging
+# which will present in Facter's output.
+#
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option"
+  on(agent, "cfacter --log-level debug") do
+    assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
+  end
+end

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -1,5 +1,14 @@
 test_name "--trace command-line option enables backtraces for custom facts"
 
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# This test is intended to ensure that the --trace command-line option works
+# properly. This option provides backtraces for erroring custom Ruby facts.
+# To test, we try to resolve an erroneous custom fact and catch the backtrace.
+#
+
 content = <<EOM
 Facter.add('custom_fact') do
   setcode do
@@ -9,15 +18,7 @@ end
 EOM
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
-    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
-      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
-    else
-      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
-    end
-  else
-    custom_dir  = '/opt/puppetlabs/facter/custom'
-  end
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -1,0 +1,38 @@
+test_name "--trace command-line option enables backtraces for custom facts"
+
+content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    non_existent_value
+  end
+end
+EOM
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
+      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+    else
+      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
+    end
+  else
+    custom_dir  = '/opt/puppetlabs/facter/custom'
+  end
+
+  step "Agent #{agent}: create custom fact directory and executable custom fact"
+  on(agent, "mkdir -p '#{custom_dir}'")
+  custom_fact = "#{custom_dir}/custom_fact.rb"
+  create_remote_file(agent, custom_fact, content)
+  on(agent, "chmod +x #{custom_fact}")
+
+  teardown do
+    on(agent, "rm -f '#{custom_fact}'")
+  end
+
+  step "--trace option should provide a backtrace for a custom fact with errors"
+  begin
+    on(agent, "FACTERLIB=#{custom_dir} cfacter --trace custom_fact")
+  rescue Exception => e
+    assert_match(/backtrace:\s+#{custom_fact}/, e.message, "Expected a backtrace for erroneous custom fact")
+  end
+end

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -18,7 +18,7 @@ end
 EOM
 
 agents.each do |agent|
-  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")
@@ -32,7 +32,7 @@ agents.each do |agent|
 
   step "--trace option should provide a backtrace for a custom fact with errors"
   begin
-    on(agent, "FACTERLIB=#{custom_dir} cfacter --trace custom_fact")
+    on(agent, "FACTERLIB=#{custom_dir} facter --trace custom_fact")
   rescue Exception => e
     assert_match(/backtrace:\s+#{custom_fact}/, e.message, "Expected a backtrace for erroneous custom fact")
   end

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -1,0 +1,8 @@
+test_name "--verbose command-line option prints verbose information to stderr"
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve verbose info from stderr using --verbose option"
+  on(agent, "cfacter --verbose") do
+    assert_match(/INFO  puppetlabs.facter - executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
+  end
+end

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -1,5 +1,10 @@
 test_name "--verbose command-line option prints verbose information to stderr"
 
+#
+# This test is intended to ensure that the --verbose command-line option
+# works properly. This option provides verbose (INFO) output to stderr.
+#
+
 agents.each do |agent|
   step "Agent #{agent}: retrieve verbose info from stderr using --verbose option"
   on(agent, "cfacter --verbose") do

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -7,7 +7,7 @@ test_name "--verbose command-line option prints verbose information to stderr"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve verbose info from stderr using --verbose option"
-  on(agent, "cfacter --verbose") do
+  on(agent, "facter --verbose") do
     assert_match(/INFO  puppetlabs.facter - executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
   end
 end

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -1,0 +1,8 @@
+test_name "--version command-line option returns the version string"
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve version info using the --version option"
+  on(agent, "cfacter --version") do
+    assert_match(/\d+\.\d+\.\d+/, stdout, "Output #{stdout} is not a recognized version string")
+  end
+end

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -1,5 +1,10 @@
 test_name "--version command-line option returns the version string"
 
+#
+# This test is intended to ensure that the --version command-line option works
+# properly. This option outputs the current Facter version.
+#
+
 agents.each do |agent|
   step "Agent #{agent}: retrieve version info using the --version option"
   on(agent, "cfacter --version") do

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -7,7 +7,7 @@ test_name "--version command-line option returns the version string"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve version info using the --version option"
-  on(agent, "cfacter --version") do
+  on(agent, "facter --version") do
     assert_match(/\d+\.\d+\.\d+/, stdout, "Output #{stdout} is not a recognized version string")
   end
 end

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -1,7 +1,15 @@
-require 'yaml'
-
 test_name "--yaml command-line option results in valid YAML output"
 
+require 'yaml'
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# This test is intended to ensure that the --yaml command-line option works
+# properly. This option causes Facter to output facts in YAML format.
+# A custom fact is used to test for parity between Facter's output and
+# the expected YAML output.
+#
 content = <<EOM
 Facter.add('structured_fact') do
   setcode do
@@ -11,15 +19,7 @@ end
 EOM
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
-    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
-      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
-    else
-      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
-    end
-  else
-    custom_dir  = '/opt/puppetlabs/facter/custom'
-  end
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
   custom_fact = "#{custom_dir}/custom_fact.rb"

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -19,7 +19,7 @@ end
 EOM
 
 agents.each do |agent|
-  custom_dir = get_user_fact_dir(agent['platform'], on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f)
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
   custom_fact = "#{custom_dir}/custom_fact.rb"
@@ -32,7 +32,7 @@ agents.each do |agent|
   end
 
   step "Agent #{agent}: retrieve output using the --yaml option"
-  on(agent, "FACTERLIB=#{custom_dir} cfacter structured_fact --yaml") do
+  on(agent, "FACTERLIB=#{custom_dir} facter structured_fact --yaml") do
     begin
       expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}.to_yaml.gsub("---\n", '')
       assert_equal(expected, stdout, "YAML output does not match expected output")

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -1,0 +1,43 @@
+require 'yaml'
+
+test_name "--yaml command-line option results in valid YAML output"
+
+content = <<EOM
+Facter.add('structured_fact') do
+  setcode do
+    { "foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }
+  end
+end
+EOM
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    if on(agent, cfacter('kernelmajversion')).stdout.chomp.to_f < 6.0
+      custom_dir = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+    else
+      custom_dir = 'C:/ProgramData/PuppetLabs/facter/custom'
+    end
+  else
+    custom_dir  = '/opt/puppetlabs/facter/custom'
+  end
+
+  step "Agent #{agent}: create a structured custom fact"
+  custom_fact = "#{custom_dir}/custom_fact.rb"
+  on(agent, "mkdir -p '#{custom_dir}'")
+  create_remote_file(agent, custom_fact, content)
+  on(agent, "chmod +x #{custom_fact}")
+
+  teardown do
+    on(agent, "rm -f '#{custom_fact}'")
+  end
+
+  step "Agent #{agent}: retrieve output using the --yaml option"
+  on(agent, "FACTERLIB=#{custom_dir} cfacter structured_fact --yaml") do
+    begin
+      expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}.to_yaml.gsub("---\n", '')
+      assert_equal(expected, stdout, "YAML output does not match expected output")
+    rescue
+      fail_test "Couldn't parse output as YAML"
+    end
+  end
+end

--- a/acceptance/tests/runs_external_facts_once.rb
+++ b/acceptance/tests/runs_external_facts_once.rb
@@ -1,25 +1,21 @@
 test_name "#22944: Facter executes external executable facts many times"
 
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
 agents.each do |agent|
   step "Agent #{agent}: create external executable fact"
 
   outfile = agent.tmpfile('mark_calls')
+  factsd = get_factsd_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+  ext = get_external_fact_script_extension(agent['platform'])
 
-  # assume we're running as root
   if agent['platform'] =~ /windows/
-    if on(agent, facter('kernelmajversion')).stdout.chomp.to_f < 6.0
-      factsd = 'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/facts.d'
-    else
-      factsd = 'C:/ProgramData/PuppetLabs/facter/facts.d'
-    end
-    ext = '.bat'
     content = <<EOM
 echo "SCRIPT CALLED" >> #{outfile}
 echo "test=value"
 EOM
   else
-    factsd = '/opt/puppetlabs/facter/facts.d'
-    ext = '.sh'
     content = <<EOM
 #!/bin/sh
 echo "SCRIPT CALLED" >> #{outfile}


### PR DESCRIPTION
This commit adds a new suite of tests around the Facter executable.
Specifically, new tests are added for each of Facter's command-line
options.