### PR TITLE
(FACT-865) Work around missing stderr output in tests

### DIFF
--- a/acceptance/tests/runs_external_facts_once.rb
+++ b/acceptance/tests/runs_external_facts_once.rb
@@ -1,18 +1,9 @@
 test_name "#22944: Facter executes external executable facts many times"
 
-unix_content = <<EOM
-#!/bin/sh
-echo "SCRIPT CALLED" >&2
-echo "test=value"
-EOM
-
-win_content = <<EOM
-echo "SCRIPT CALLED" >&2
-echo "test=value"
-EOM
-
 agents.each do |agent|
   step "Agent #{agent}: create external executable fact"
+
+  outfile = agent.tmpfile('mark_calls')
 
   # assume we're running as root
   if agent['platform'] =~ /windows/
@@ -22,17 +13,22 @@ agents.each do |agent|
       factsd = 'C:/ProgramData/PuppetLabs/facter/facts.d'
     end
     ext = '.bat'
-    content = win_content
+    content = <<EOM
+echo "SCRIPT CALLED" >> #{outfile}
+echo "test=value"
+EOM
   else
     factsd = '/opt/puppetlabs/facter/facts.d'
     ext = '.sh'
-    content = unix_content
+    content = <<EOM
+#!/bin/sh
+echo "SCRIPT CALLED" >> #{outfile}
+echo "test=value"
+EOM
   end
-
 
   step "Agent #{agent}: create facts.d directory"
   on(agent, "mkdir -p '#{factsd}'")
-
 
   step "Agent #{agent}: create external fact"
   ext_fact = "#{factsd}/external_fact#{ext}"
@@ -47,13 +43,14 @@ agents.each do |agent|
   on(agent, "chmod +x '#{ext_fact}'")
 
   step "Agent #{agent}: ensure it only executes once"
-  on(agent, facter) do
-    lines = stderr.split('\n')
+  on(agent, facter)
+  on(agent, "cat #{outfile}") do
+    lines = stdout.split('\n')
     times = lines.count { |line| line =~ /SCRIPT CALLED/ }
     if times == 1
       step "External executable fact executed once"
     else
-      fail_test "External fact executed #{times} times, expected once: #{stderr}"
+      fail_test "External fact executed #{times} times, expected once: #{stdout}"
     end
   end
 end


### PR DESCRIPTION
FACT-865 documents a bug where stderr written by an external fact isn't
reproduced in facter output. Preserve the behavior of an existing
acceptance test that relied on that behavior by writing to a file
instead.