### PR TITLE
(CFACT-268) Don't resolve custom facts when --no-custom-facts is used

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
         // Add the environment facts
         facts.add_environment_facts();
 
-        if (ruby) {
+        if (ruby && !vm.count("no-custom-facts")) {
             facter::ruby::load_custom_facts(facts, custom_directories);
         }
 


### PR DESCRIPTION
This commit fixes a regression around the --no-custom-facts
command-line option. Currently, the option is not being honored,
and so custom facts will be resolved even if the option is used.
This commit ensures that custom facts will not be resolved if either
this option is passed or if Ruby is not present.