### PR TITLE
(FACT-855) Restore ci:acceptance Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,9 @@
 RAKE_ROOT = File.expand_path(File.dirname(__FILE__))
 
+$LOAD_PATH << File.join(RAKE_ROOT, 'tasks')
+require 'rake'
+Dir['tasks/**/*.rake'].each { |t| load t }
+
 build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
 if File.exist?(build_defs_file)
   begin

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -1,0 +1,22 @@
+require 'yaml'
+require 'time'
+
+namespace "ci" do
+ desc "Tar up the acceptance/ directory so that package test runs have tests to run against."
+  task :acceptance_artifacts => :tag_creator do
+    rm_f "acceptance/acceptance-artifacts.tar.gz"
+    sh "tar -czv --exclude acceptance/.bundle -f acceptance-artifacts.tar.gz acceptance"
+  end
+
+  task :tag_creator do
+    Dir.chdir("acceptance") do
+      File.open('creator.txt', 'w') do |fh|
+        YAML.dump({
+          'creator_id' => ENV['CREATOR'] || ENV['BUILD_URL'] || 'unknown',
+          'created_on' => Time.now.iso8601,
+          'commit' => (`git log -1 --oneline` rescue "unknown: #{$!}")
+        }, fh)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Acceptance jobs rely on a packaging Rake task in the project to package
up acceptance tests, tag them, and pass them on. That task was removed
during the native facter move.

Restore the Rake task for use in Jenkins CI.