### PR TITLE
(maint) Fail hard if building native facter throws errors

### DIFF
--- a/contrib/facter.ps1
+++ b/contrib/facter.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = 'Stop'
+
 ### Set variables from command line
 # $arch => Choose 32 or 64-bit build
 # $cores => Set the number of cores to use for parallel builds


### PR DESCRIPTION
We are currently running into some errors where building native facter
will throw errors, but the script will continue to run. This isn't good,
especially because it means we ship an incomplete archive. This commit
is an attempt at having the native facter build script fail in a
consistent way when things go wrong.