### PR TITLE
(maint) Fix submodule init in Windows packaging

### DIFF
--- a/contrib/facter.ps1
+++ b/contrib/facter.ps1
@@ -95,9 +95,10 @@ echo $env:PATH
 cd $sourceDir
 
 ## Download facter and setup build directories
-git clone --recursive $facterFork facter
+git clone $facterFork facter
 cd facter
 git checkout $facterRef
+git submodule update --init --recursive
 mkdir -Force release
 cd release
 $buildDir=$pwd


### PR DESCRIPTION
Without this change, packaging on Windows initializes the submodules on
the master branch, no matter what ref is requested.

Do submodule init and update after changing to the requested branch, to
ensure the correct submodules are initialized and at the right ref.