### PR TITLE
(FACT-855) Package schema for future acceptance test

### DIFF
--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -5,7 +5,7 @@ namespace "ci" do
  desc "Tar up the acceptance/ directory so that package test runs have tests to run against."
   task :acceptance_artifacts => :tag_creator do
     rm_f "acceptance/acceptance-artifacts.tar.gz"
-    sh "tar -czv --exclude acceptance/.bundle -f acceptance-artifacts.tar.gz acceptance"
+    sh "tar -czv --exclude acceptance/.bundle -f acceptance-artifacts.tar.gz acceptance lib/schema"
   end
 
   task :tag_creator do


### PR DESCRIPTION
Without this commit, future acceptance tests will not be have access to
the fact schema. Package the schema as part of the acceptance artifacts
so they can be used for acceptance tests.