### PR TITLE
(FACT-868) Fix YAML output for short IPv6 addresses

### DIFF
--- a/lib/src/util/string.cc
+++ b/lib/src/util/string.cc
@@ -114,6 +114,11 @@ namespace facter { namespace util {
             return true;
         }
 
+        // Check that it doesn't start with the ':' special character. This interferes with parsing.
+        if (str[0] == ':') {
+            return true;
+        }
+
         // Poor man's check for a numerical string
         // May start with - or +
         // May contain at most one . or ,


### PR DESCRIPTION
The IPv6 address ::1 isn't quoted in Facter's YAML output, but parsing
it with Ruby YAML strips one of the ':' characters and is not read as a
valid IP address.

Update Facter to quote strings starting with ':'.