### PR TITLE
(CFACT-258) Fix Facter::Core::Execution#execute not raising by default.

### DIFF
--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -295,6 +295,10 @@ namespace facter {  namespace ruby {
         /**
          * See MRI documentation.
          */
+        VALUE (* const rb_hash_lookup2)(VALUE, VALUE, VALUE);
+        /**
+         * See MRI documentation.
+         */
         VALUE (* const rb_obj_freeze)(VALUE);
         /**
          * See MRI documentation.
@@ -395,6 +399,13 @@ namespace facter {  namespace ruby {
          * @return Returns the Ruby value as a string.
          */
         std::string to_string(VALUE v) const;
+
+        /**
+         * Converts the given string to a Ruby symbol.
+         * @param s The string to convert to a symbol.
+         * @return Returns the symbol.
+         */
+        VALUE to_symbol(std::string const& s) const;
 
         /**
          * Converts a C string to a Ruby UTF-8 encoded string value.

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -73,6 +73,7 @@ namespace facter { namespace ruby {
         LOAD_SYMBOL(rb_hash_new),
         LOAD_SYMBOL(rb_hash_aset),
         LOAD_SYMBOL(rb_hash_lookup),
+        LOAD_SYMBOL(rb_hash_lookup2),
         LOAD_SYMBOL(rb_obj_freeze),
         LOAD_SYMBOL(rb_sym_to_s),
         LOAD_SYMBOL(rb_to_id),
@@ -231,6 +232,11 @@ namespace facter { namespace ruby {
         v = rb_funcall(v, rb_intern("to_s"), 0);
         size_t size = static_cast<size_t>(rb_num2ulong(rb_funcall(v, rb_intern("bytesize"), 0)));
         return string(rb_string_value_ptr(&v), size);
+    }
+
+    VALUE api::to_symbol(string const& s) const
+    {
+        return rb_funcall(utf8_value(s), rb_intern("to_sym"), 0);
     }
 
     VALUE api::utf8_value(char const* s, size_t len) const

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -383,11 +383,7 @@ namespace facter { namespace ruby {
         volatile VALUE name = ruby.nil_value();
         VALUE options = argc == 2 ? argv[1] : ruby.nil_value();
         if (!ruby.is_nil(options)) {
-            name = ruby.rb_funcall(
-                    options,
-                    ruby.rb_intern("delete"),
-                    1,
-                    ruby.rb_funcall(ruby.utf8_value("name"), ruby.rb_intern("to_sym"), 0));
+            name = ruby.rb_funcall(options, ruby.rb_intern("delete"), 1, ruby.to_symbol("name"));
         }
 
         ruby.to_native<fact>(fact_self)->define_resolution(name, options);
@@ -696,15 +692,16 @@ namespace facter { namespace ruby {
 
         // Unfortunately we have to call to_sym rather than using ID2SYM, which is Ruby version dependent
         uint32_t timeout = 0;
-        volatile VALUE timeout_option = ruby.rb_hash_lookup(argv[1], ruby.rb_funcall(ruby.utf8_value("timeout"), ruby.rb_intern("to_sym"), 0));
+        volatile VALUE timeout_option = ruby.rb_hash_lookup(argv[1], ruby.to_symbol("timeout"));
         if (ruby.is_fixednum(timeout_option)) {
             timeout = static_cast<uint32_t>(ruby.rb_num2ulong(timeout_option));
         }
 
-        // Get the on_fail option
+        // Get the on_fail option (defaults to :raise)
         bool raise = false;
-        volatile VALUE fail_option = ruby.rb_hash_lookup(argv[1], ruby.rb_funcall(ruby.utf8_value("on_fail"), ruby.rb_intern("to_sym"), 0));
-        if (ruby.is_symbol(fail_option) && ruby.to_string(fail_option) == "raise") {
+        volatile VALUE raise_value = ruby.to_symbol("raise");
+        volatile VALUE fail_option = ruby.rb_hash_lookup2(argv[1], ruby.to_symbol("on_fail"), raise_value);
+        if (ruby.equals(fail_option, raise_value)) {
             raise = true;
             fail_option = ruby.nil_value();
         }
@@ -937,7 +934,7 @@ namespace facter { namespace ruby {
         if (!name) {
             ruby.rb_raise(*ruby.rb_eArgError, "invalid log level specified.", 0);
         }
-        return ruby.rb_funcall(ruby.utf8_value(name), ruby.rb_intern("to_sym"), 0);
+        return ruby.to_symbol(name);
     }
 
 }}  // namespace facter::ruby

--- a/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
+++ b/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
@@ -1,1 +1,17 @@
+# Should raise by default
+begin
+    Facter::Core::Execution.execute('not a command')
+    raise 'did not raise'
+rescue Facter::Core::Execution::ExecutionFailure
+end
+
+# Should raise if given an option hash that does not contain :on_fail
+begin
+    Facter::Core::Execution.execute('not a command', {})
+    raise 'did not raise'
+rescue Facter::Core::Execution::ExecutionFailure
+end
+
+# Should raise if directly given the option
 Facter::Core::Execution.execute('not a command', :on_fail => :raise)
+raise 'did not raise'


### PR DESCRIPTION
If an options hash was passed to Facter::Core::Execution#execute and the
options hash did not contain an :on_fail key, we were not properly
defaulting the value to :raise to raise an error.

This fix calls rb_hash_lookup2 to supply :raise if the lookup fails,
resulting in raising an exception if the :on_fail key is not present in
the options hash.