### PR TITLE
(FACT-868) Add unit tests for output quoting

### DIFF
--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -567,7 +567,7 @@ void validate_fact(YAML::Node const& node, value const* fact_value, bool require
     } else if ((svalue = dynamic_cast<string_value const*>(fact_value))) {
         type = "string";
 
-        // Check for special string types
+        // Check for special string types; sourced from http://stackoverflow.com/a/17871737
         static boost::regex ip_pattern("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
         static boost::regex ip6_pattern("^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$");
         static boost::regex mac_pattern("^(([0-9a-fA-F]){2}\\:){5}([0-9a-fA-F]){2}$");

--- a/lib/tests/facts/string_value.cc
+++ b/lib/tests/facts/string_value.cc
@@ -26,7 +26,8 @@ SCENARIO("using a string fact value") {
             REQUIRE(value.value() == "hello world");
         }
     }
-    GIVEN("a value") {
+
+    GIVEN("a simple string value") {
         string_value value("foobar");
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
@@ -49,13 +50,115 @@ SCENARIO("using a string fact value") {
                 ostringstream stream;
                 value.write(stream);
                 REQUIRE(stream.str() == "\"foobar\"");
+                }
             }
-        }
         WHEN("serialized to text without quotes") {
             THEN("it should not be quoted") {
                 ostringstream stream;
                 value.write(stream, false);
                 REQUIRE(stream.str() == "foobar");
+            }
+        }
+    }
+
+    GIVEN("an ipv6 address string value ending with ':'") {
+        string_value value("fe80::");
+        WHEN("serialized to JSON") {
+            THEN("it should have the same value") {
+                rapidjson::Value json_value;
+                MemoryPoolAllocator<> allocator;
+                value.to_json(allocator, json_value);
+                REQUIRE(json_value.IsString());
+                REQUIRE(json_value.GetString() == string("fe80::"));
+            }
+        }
+        WHEN("serialized to YAML") {
+            THEN("it should be quoted") {
+                Emitter emitter;
+                value.write(emitter);
+                REQUIRE(string(emitter.c_str()) == "\"fe80::\"");
+            }
+        }
+        WHEN("serialized to text with quotes") {
+            THEN("it should be quoted") {
+                ostringstream stream;
+                value.write(stream);
+                REQUIRE(stream.str() == "\"fe80::\"");
+                }
+            }
+        WHEN("serialized to text without quotes") {
+            THEN("it should not be quoted") {
+                ostringstream stream;
+                value.write(stream, false);
+                REQUIRE(stream.str() == "fe80::");
+            }
+        }
+    }
+
+    GIVEN("an ipv4 address string value") {
+        string_value value("127.254.3.0");
+        WHEN("serialized to JSON") {
+            THEN("it should have the same value") {
+                rapidjson::Value json_value;
+                MemoryPoolAllocator<> allocator;
+                value.to_json(allocator, json_value);
+                REQUIRE(json_value.IsString());
+                REQUIRE(json_value.GetString() == string("127.254.3.0"));
+            }
+        }
+        WHEN("serialized to YAML") {
+            THEN("it should have the same value") {
+                Emitter emitter;
+                value.write(emitter);
+                REQUIRE(string(emitter.c_str()) == "127.254.3.0");
+            }
+        }
+        WHEN("serialized to text with quotes") {
+            THEN("it should be quoted") {
+                ostringstream stream;
+                value.write(stream);
+                REQUIRE(stream.str() == "\"127.254.3.0\"");
+                }
+            }
+        WHEN("serialized to text without quotes") {
+            THEN("it should not be quoted") {
+                ostringstream stream;
+                value.write(stream, false);
+                REQUIRE(stream.str() == "127.254.3.0");
+            }
+        }
+    }
+
+    GIVEN("a ':' prefixed string value") {
+        string_value value("::1");
+        WHEN("serialized to JSON") {
+            THEN("it should have the same value") {
+                rapidjson::Value json_value;
+                MemoryPoolAllocator<> allocator;
+                value.to_json(allocator, json_value);
+                REQUIRE(json_value.IsString());
+                REQUIRE(json_value.GetString() == string("::1"));
+            }
+        }
+        WHEN("serialized to YAML") {
+            THEN("it should be quoted") {
+                Emitter emitter;
+                value.write(emitter);
+                REQUIRE(string(emitter.c_str()) == "\"::1\"");
+            }
+        }
+        WHEN("serialized to text with quotes") {
+            THEN("it should be quoted") {
+                ostringstream stream;
+                value.write(stream);
+                REQUIRE(stream.str() == "\"::1\"");
+                }
+            }
+        WHEN("serialized to text without quotes") {
+            THEN("it should not be quoted") {
+                ostringstream stream;
+                value.write(stream, false);
+                REQUIRE(stream.str() == "::1");
             }
         }
     }


### PR DESCRIPTION
Facter selectively quotes output for JSON, YAML, and text. Add tests to
confirm some of the quoting behavior.