### PR TITLE
(FACT-889) Update locale handling

### DIFF
--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -1,5 +1,7 @@
 #include <facter/logging/logging.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 namespace lm = leatherman::logging;
@@ -22,6 +24,9 @@ namespace facter { namespace logging {
 
     void setup_logging(ostream& os)
     {
+        // Initialize boost filesystem's locale to a UTF-8 default.
+        // Logging gets setup the same way via the default 2nd argument.
+        boost::filesystem::path::imbue(leatherman::locale::get_locale());
         lm::setup_logging(os);
     }
 


### PR DESCRIPTION
An update to Leatherman removes setting global locale settings, and
introduces the get_locale helper method to get a UTF-8 system default
locale (important on Windows, where the default locale is not UTF-8).
Leatherman now provides an argument to set the locale when setting up
logging, that only affects the logging sink.

The change to setup_logging uses a UTF-8 default, so we don't change
calls to it. However boost::filesystem is no longer initialized in
Leatherman, so we initialize it locally as part of logging setup. We
specifically ensure boost::filesystem is imbued in the libfacter
library, in case boost is statically linked.