### PR TITLE
(FACT-888) Properly detect KVM when CPU type is not qemu32/qemu64

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -164,6 +164,7 @@ Facter.add("virtual") do
       next "rhev"       if lines.any? {|l| l =~ /Product Name: RHEV Hypervisor/ }
       next "ovirt"      if lines.any? {|l| l =~ /Product Name: oVirt Node/ }
       next "bochs"      if lines.any? {|l| l =~ /Bochs/ }
+      next "kvm"        if lines.any? {|l| l =~ /Manufacturer: QEMU/ }
     end
 
     # Default to 'physical'

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -193,6 +193,13 @@ describe "Virtual fact" do
       Facter.fact(:virtual).value.should == "ovirt"
     end
 
+    it "should be kvm with KVM Node manufacturer name from dmidecode" do
+      Facter.fact(:kernel).stubs(:value).returns("Linux")
+      Facter::Core::Execution.stubs(:exec).with('lspci 2>/dev/null').returns(nil)
+      Facter::Core::Execution.stubs(:exec).with('dmidecode 2> /dev/null').returns("Manufacturer: QEMU")
+      Facter.fact(:virtual).value.should == "kvm"
+    end
+
     it "is gce based on DMI info" do
       Facter.fact(:kernel).stubs(:value).returns("Linux")
       Facter::Util::Virtual.stubs(:gce?).returns(true)


### PR DESCRIPTION
If CPU type is not set to a qemu type, /proc/cpuinfo will not contain
'QEMU'; in this case we have to look at dmidecode data to detect
kvm/qemu.