### PR TITLE
(maint) Remove old comment

### DIFF
--- a/lib/src/facts/windows/virtualization_resolver.cc
+++ b/lib/src/facts/windows/virtualization_resolver.cc
@@ -22,9 +22,6 @@ namespace facter { namespace facts { namespace windows {
 
     string virtualization_resolver::get_hypervisor(collection& facts)
     {
-        // TODO: This is probably not equivalent to line 194 of
-        // https://github.com/puppetlabs/facter/blob/master/lib/facter/virtual.rb
-        // Explore whether it can work, or if we need another wmi query
         static vector<tuple<string, string>> vms = {
             make_tuple("VirtualBox",        string(vm::virtualbox)),
             make_tuple("VMware",            string(vm::vmware)),


### PR DESCRIPTION
The comment about Windows virtualization approach not matching Facter
2.x was before it used WMI calls. The current behavior is equivalent to
Facter's 2.x behavior querying WMI, so the comment can be removed.