### PR TITLE
(docs) Update submodule instructions to work after clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Pre-Build
 
 All of the following examples start by assuming the current directory is the root of the repo.
 
-Note the use of git submodules, so use `git clone --recursive` to ensure the submodules are populated.
+Note the use of git submodules, so use `git submodule update --init` to ensure the submodules are populated.
 
 On Windows, add `-G "MinGW Makefiles" -DCMAKE_PREFIX_PATH=\<binary install path\> -DBOOST_STATIC=ON` to the `cmake` invocation.
 


### PR DESCRIPTION
Users often clone the repo before reading build instructions; or they
may clone, then checkout a branch, and want to ensure the submodules are
updated for that branch.

Change `git clone --recursive` to `git submodule update --init` to
ensure submodules are updated for the current branch, and provide
instructions that work after cloning.