### PR TITLE
(FACT-865) Split stdout and stderr handling in execution.

### DIFF
--- a/lib/inc/facter/util/option_set.hpp
+++ b/lib/inc/facter/util/option_set.hpp
@@ -60,9 +60,10 @@ namespace facter { namespace util {
         }
 
         /**
-         * Cast operator to value_type.
+         * Gets the underlying value of the set.
+         * @return Returns the underlying value of the set.
          */
-        operator value_type() const
+        value_type value() const
         {
             return _value;
         }
@@ -198,7 +199,7 @@ namespace facter { namespace util {
     template<typename T>
     option_set<T> operator &(option_set<T> const& lhs, option_set<T> const& rhs)
     {
-        return option_set<T>(static_cast<typename option_set<T>::value_type>(lhs) & static_cast<typename option_set<T>::value_type>(rhs));
+        return option_set<T>(lhs.value() & rhs.value());
     }
 
     /**
@@ -210,7 +211,7 @@ namespace facter { namespace util {
     template<typename T>
     option_set<T> operator |(option_set<T> const& lhs, option_set<T> const& rhs)
     {
-        return option_set<T>(static_cast<typename option_set<T>::value_type>(lhs) | static_cast<typename option_set<T>::value_type>(rhs));
+        return option_set<T>(lhs.value() | rhs.value());
     }
 
     /**
@@ -222,7 +223,7 @@ namespace facter { namespace util {
     template<typename T>
     option_set<T> operator ^(option_set<T> const& lhs, option_set<T> const& rhs)
     {
-        return option_set<T>(static_cast<typename option_set<T>::value_type>(lhs) ^ static_cast<typename option_set<T>::value_type>(rhs));
+        return option_set<T>(lhs.value() ^ rhs.value());
     }
 
 }}  // namespace facter::util

--- a/lib/inc/internal/execution/execution.hpp
+++ b/lib/inc/internal/execution/execution.hpp
@@ -10,14 +10,17 @@
 namespace facter { namespace execution {
 
     /**
-     * Reads from a stream closure until there is no more data to read.
-     * If a callback is supplied, buffers each line and passes it to the callback.
-     * Otherwise, returns the concatenation of the stream.
-     * @param trim_output True if output should be trimmed or false if not.
-     * @param callback The callback that is called with each line of output.
-     * @param yield_input The input stream closure; it expects a mutable string buffer, and returns whether the closure should be invoked again for more input.
-     * @return Returns the stream results concatenated together, or an empty string if callback is not null.
+     * Processes stdout and stderror streams of a child process.
+     * @param trim True if output should be trimmed or false if not.
+     * @param stdout_callback The callback to use when a line is read for stdout.
+     * @param stderr_callback The callback to use when a line is read for stdout.
+     * @param read_streams The callback that is called to read stdout and stderr streams.
+     * @return Returns a tuple of stdout and stderr output.  If stdout_callback or stderr_callback is given, it will return empty strings.
      */
-    std::string process_stream(bool trim_output, std::function<bool(std::string&)> callback, std::function<bool(std::string&)> yield_input);
+    std::tuple<std::string, std::string> process_streams(
+        bool trim,
+        std::function<bool(std::string&)> const& stdout_callback,
+        std::function<bool(std::string&)> const& stderr_callback,
+        std::function<void(std::function<bool(std::string const&)>, std::function<bool(std::string const&)>)> const& read_streams);
 
 }}  // namespace facter::execution

--- a/lib/src/facts/external/execution_resolver.cc
+++ b/lib/src/facts/external/execution_resolver.cc
@@ -28,18 +28,39 @@ namespace facter { namespace facts { namespace external {
 
         try
         {
-            execution::each_line(path, [&facts](string const& line) {
-                auto pos = line.find('=');
-                if (pos == string::npos) {
-                    LOG_DEBUG("ignoring line in output: %1%", line);
+            string error;
+            execution::each_line(
+                path,
+                [&](string const& line) {
+                    auto pos = line.find('=');
+                    if (pos == string::npos) {
+                        LOG_DEBUG("ignoring line in output: %1%", line);
+                        return true;
+                    }
+                    // Add as a string fact
+                    string fact = line.substr(0, pos);
+                    boost::to_lower(fact);
+                    facts.add(move(fact), make_value<string_value>(line.substr(pos+1)));
                     return true;
-                }
-                // Add as a string fact
-                string fact = line.substr(0, pos);
-                boost::to_lower(fact);
-                facts.add(move(fact), make_value<string_value>(line.substr(pos+1)));
-                return true;
-            }, { execution_options::defaults, execution_options::throw_on_failure });
+                },
+                [&](string const& line) {
+                    if (!error.empty()) {
+                        error += "\n";
+                    }
+                    error += line;
+                    return true;
+                },
+                0,
+                {
+                    execution_options::trim_output,
+                    execution_options::merge_environment,
+                    execution_options::throw_on_failure
+                });
+
+            // Log a warning if there is error output from the command
+            if (!error.empty()) {
+                LOG_WARNING("external fact file \"%1%\" had output on stderr: %2%", path, error);
+            }
         }
         catch (execution_exception& ex) {
             throw external_fact_exception(ex.what());

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -224,9 +224,11 @@ namespace facter { namespace facts { namespace linux {
 
         // For VMware ESX, execute the vmware tool
         if (value.empty() && name == os::vmware_esx) {
-            auto result = execute("vmware", { "-v" });
-            if (result.first) {
-                re_search(result.second, boost::regex("VMware ESX .*?(\\d.*)"), &value);
+            bool success;
+            string output, none;
+            tie(success, output, none) = execute("vmware", { "-v" });
+            if (success) {
+                re_search(output, boost::regex("VMware ESX .*?(\\d.*)"), &value);
             }
         }
 

--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -170,12 +170,14 @@ namespace facter { namespace facts { namespace linux {
 
     string virtualization_resolver::get_vmware_vm()
     {
-        auto result = execute("vmware", { "-v" });
-        if (!result.first) {
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute("vmware", { "-v" });
+        if (!success) {
             return {};
         }
         vector<string> parts;
-        boost::split(parts, result.second, boost::is_space(), boost::token_compress_on);
+        boost::split(parts, output, boost::is_space(), boost::token_compress_on);
         if (parts.size() < 2) {
             return {};
         }

--- a/lib/src/facts/osx/networking_resolver.cc
+++ b/lib/src/facts/osx/networking_resolver.cc
@@ -61,11 +61,13 @@ namespace facter { namespace facts { namespace osx {
     string networking_resolver::find_dhcp_server(string const& interface) const
     {
         // Use ipconfig to get the server identifier
-        auto result = execute("ipconfig", { "getoption", interface, "server_identifier" });
-        if (!result.first) {
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute("ipconfig", { "getoption", interface, "server_identifier" });
+        if (!success) {
             return {};
         }
-        return result.second;
+        return output;
     }
 
 }}}  // namespace facter::facts::osx

--- a/lib/src/facts/posix/processor_resolver.cc
+++ b/lib/src/facts/posix/processor_resolver.cc
@@ -12,9 +12,11 @@ namespace facter { namespace facts { namespace posix {
         data result;
 
         // Unfortunately there's no corresponding member in utsname for "processor", so we need to spawn
-        auto output = execute("uname", { "-p" });
-        if (output.first) {
-            result.isa = output.second;
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute("uname", { "-p" });
+        if (success) {
+            result.isa = output;
         }
         return result;
     }

--- a/lib/src/facts/posix/uptime_resolver.cc
+++ b/lib/src/facts/posix/uptime_resolver.cc
@@ -43,11 +43,13 @@ namespace facter { namespace facts { namespace posix {
 
     int64_t uptime_resolver::get_uptime()
     {
-        auto result = execute("uptime");
-        if (!result.first || result.second.empty()) {
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute("uptime");
+        if (!success) {
             return -1;
         }
-        return parse_uptime(result.second);
+        return parse_uptime(output);
     }
 
 }}}  // namespace facter::facts::posix

--- a/lib/src/facts/solaris/dmi_resolver.cc
+++ b/lib/src/facts/solaris/dmi_resolver.cc
@@ -74,9 +74,11 @@ namespace facter { namespace facts { namespace solaris {
                 }
                 return true;
             });
-            auto output = execution::execute("/usr/sbin/uname", {"-a"});
-            if (output.first) {
-                re_search(output.second, boost::regex(".* sun\\d[vu] sparc SUNW,(.*)"), &result.product_name);
+            bool success;
+            string output, none;
+            tie(success, output, none) = execution::execute("/usr/sbin/uname", {"-a"});
+            if (success) {
+                re_search(output, boost::regex(".* sun\\d[vu] sparc SUNW,(.*)"), &result.product_name);
             }
         }
         return result;

--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -185,11 +185,13 @@ namespace facter { namespace facts { namespace solaris {
 
     string networking_resolver::find_dhcp_server(string const& interface) const
     {
-        auto result = execute("dhcpinfo", { "-i", interface, "ServerID" });
-        if (!result.first) {
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute("dhcpinfo", { "-i", interface, "ServerID" });
+        if (!success) {
             return {};
         }
-        return result.second;
+        return output;
     }
 
 }}}  // namespace facter::facts::solaris

--- a/lib/src/facts/solaris/virtualization_resolver.cc
+++ b/lib/src/facts/solaris/virtualization_resolver.cc
@@ -18,8 +18,10 @@ namespace facter { namespace facts { namespace solaris {
     string virtualization_resolver::get_hypervisor(collection& facts)
     {
         // works for both x86 & sparc.
-        auto result = execution::execute("/usr/bin/zonename");
-        if (result.first && result.second != "global") {
+        bool success;
+        string output, none;
+        tie(success, output, none) = execution::execute("/usr/bin/zonename");
+        if (success && output != "global") {
             return vm::zone;
         }
 

--- a/lib/src/facts/solaris/zone_resolver.cc
+++ b/lib/src/facts/solaris/zone_resolver.cc
@@ -14,7 +14,7 @@ namespace facter { namespace facts { namespace solaris {
     zone_resolver::data zone_resolver::collect_data(collection& facts)
     {
         data result;
-        result.current_zone_name = execution::execute("/bin/zonename").second;
+        result.current_zone_name = get<1>(execution::execute("/bin/zonename"));
 
         static boost::regex zone_pattern("(\\d+):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*)");
 

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -486,20 +486,21 @@ namespace facter { namespace ruby {
         }
         LOG_DEBUG("ruby was found at \"%1%\".", ruby);
 
-        auto result = execute(ruby, { "-e", "print File.join(RbConfig::CONFIG['"+libruby_configdir()+"'], RbConfig::CONFIG['LIBRUBY_SO'])" },
-            option_set<execution_options>{ execution_options::defaults, execution_options::redirect_stderr });
-        if (!result.first) {
-            LOG_WARNING("ruby failed to run: %1%", result.second);
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute(ruby, { "-e", "print File.join(RbConfig::CONFIG['"+libruby_configdir()+"'], RbConfig::CONFIG['LIBRUBY_SO'])" });
+        if (!success) {
+            LOG_WARNING("ruby failed to run: %1%", output);
             return library;
         }
 
         boost::system::error_code ec;
-        if (!exists(result.second, ec) || is_directory(result.second, ec)) {
-            LOG_DEBUG("ruby library \"%1%\" was not found: ensure ruby was built with the --enable-shared configuration option.", result.second);
+        if (!exists(output, ec) || is_directory(output, ec)) {
+            LOG_DEBUG("ruby library \"%1%\" was not found: ensure ruby was built with the --enable-shared configuration option.", output);
             return library;
         }
 
-        library.load(result.second);
+        library.load(output);
         return library;
     }
 

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -732,14 +732,22 @@ namespace facter { namespace ruby {
 
         // Block to ensure that result is destructed before raising.
         try {
-            auto result = execution::execute(execution::command_shell,
-                {execution::command_args, expand_command(command)},
-                option_set<execution_options> {
-                    execution_options::defaults,
-                    execution_options::redirect_stderr
-                }, timeout);
-            if (result.first) {
-                return ruby.utf8_value(result.second);
+            bool success;
+            string output, none;
+            tie(success, output, none) = execution::execute(
+                execution::command_shell,
+                {
+                    execution::command_args,
+                    expand_command(command)
+                },
+                timeout,
+                {
+                    execution_options::trim_output,
+                    execution_options::merge_environment,
+                    execution_options::redirect_stderr_to_stdout
+                });
+            if (success) {
+                return ruby.utf8_value(output);
             }
         } catch (timeout_exception const& ex) {
             // Always raise for timeouts

--- a/lib/src/ruby/simple_resolution.cc
+++ b/lib/src/ruby/simple_resolution.cc
@@ -63,16 +63,24 @@ namespace facter { namespace ruby {
         }
 
         // Otherwise, we were given a command so execute it
-        auto result = execute(command_shell,
-            {command_args, expand_command(_command)},
-            option_set<execution_options> {
-                execution_options::defaults,
-                execution_options::redirect_stderr
+        bool success;
+        string output, none;
+        tie(success, output, none) = execute(
+            command_shell,
+            {
+                command_args,
+                expand_command(_command)
+            },
+            0,
+            {
+                execution_options::trim_output,
+                execution_options::merge_environment,
+                execution_options::redirect_stderr_to_stdout
             });
-        if (!result.first) {
+        if (!success) {
             return ruby.nil_value();
         }
-        return ruby.utf8_value(result.second);
+        return ruby.utf8_value(output);
     }
 
     VALUE simple_resolution::alloc(VALUE klass)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "facts/schema.cc"
     "facts/string_value.cc"
     "logging/logging.cc"
+    "log_capture.cc"
     "main.cc"
     "util/directory.cc"
     "util/environment.cc"

--- a/lib/tests/execution/posix/execution.cc
+++ b/lib/tests/execution/posix/execution.cc
@@ -2,7 +2,9 @@
 #include <facter/execution/execution.hpp>
 #include <facter/util/string.hpp>
 #include <boost/algorithm/string.hpp>
+#include <internal/util/regex.hpp>
 #include "../../fixtures.hpp"
+#include "../../log_capture.hpp"
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -10,6 +12,7 @@
 using namespace std;
 using namespace facter::util;
 using namespace facter::execution;
+using namespace facter::logging;
 using namespace facter::testing;
 
 SCENARIO("searching for programs with execution::which") {
@@ -128,18 +131,20 @@ SCENARIO("executing commands with execution::execute") {
         });
         return variables;
     };
+    bool success;
+    string output, error;
     GIVEN("a command that succeeds") {
         THEN("the output should be returned") {
-            auto result = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file3.txt" });
-            REQUIRE(result.first);
-            REQUIRE(result.second == "file3");
+            tie(success, output, error) = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file3.txt" });
+            REQUIRE(success);
+            REQUIRE(output == "file3");
         }
         WHEN("requested to merge the environment") {
             setenv("TEST_INHERITED_VARIABLE", "TEST_INHERITED_VALUE", 1);
-            auto result = execute("env", {}, { {"TEST_VARIABLE1", "TEST_VALUE1" }, {"TEST_VARIABLE2", "TEST_VALUE2" } });
+            tie(success, output, error) = execute("env", {}, { {"TEST_VARIABLE1", "TEST_VALUE1" }, {"TEST_VARIABLE2", "TEST_VALUE2" } });
             unsetenv("TEST_INHERITED_VARIABLE");
-            REQUIRE(result.first);
-            auto variables = get_variables(result.second);
+            REQUIRE(success);
+            auto variables = get_variables(output);
             THEN("the child environment should contain the given variables") {
                 REQUIRE(variables.size() > 4);
                 REQUIRE(variables.count("TEST_VARIABLE1") == 1);
@@ -155,13 +160,11 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
         WHEN("requested to override the environment") {
-            option_set<execution_options> options = { execution_options::defaults };
-            options.clear(execution_options::merge_environment);
             setenv("TEST_INHERITED_VARIABLE", "TEST_INHERITED_VALUE", 1);
-            auto result = execute("env", {}, { {"TEST_VARIABLE1", "TEST_VALUE1" }, {"TEST_VARIABLE2", "TEST_VALUE2" }}, options);
+            tie(success, output, error) = execute("env", {}, { {"TEST_VARIABLE1", "TEST_VALUE1" }, {"TEST_VARIABLE2", "TEST_VALUE2" }}, 0, { execution_options::trim_output });
             unsetenv("TEST_INHERITED_VARIABLE");
-            REQUIRE(result.first);
-            auto variables = get_variables(result.second);
+            REQUIRE(success);
+            auto variables = get_variables(output);
             THEN("the child environment should only contain the given variables") {
                 REQUIRE(variables.size() == 4);
                 REQUIRE(variables.count("TEST_VARIABLE1") == 1);
@@ -177,9 +180,9 @@ SCENARIO("executing commands with execution::execute") {
             }
         }
         WHEN("requested to override LC_ALL or LANG") {
-            auto result = execute("env", {}, { {"LANG", "FOO" }, { "LC_ALL", "BAR" } });
-            REQUIRE(result.first);
-            auto variables = get_variables(result.second);
+            tie(success, output, error) = execute("env", {}, { {"LANG", "FOO" }, { "LC_ALL", "BAR" } });
+            REQUIRE(success);
+            auto variables = get_variables(output);
             THEN("the values should be passed to the child process") {
                 REQUIRE(variables.count("LC_ALL") == 1);
                 REQUIRE(variables["LC_ALL"] == "BAR");
@@ -190,51 +193,58 @@ SCENARIO("executing commands with execution::execute") {
     }
     GIVEN("a command that fails") {
         WHEN("default options are used") {
-            auto result = execute("ls", { "does_not_exist" });
+            tie(success, output, error) = execute("ls", { "does_not_exist" });
             THEN("no output is returned") {
-                REQUIRE_FALSE(result.first);
-                REQUIRE(result.second == "");
+                REQUIRE_FALSE(success);
+                REQUIRE(output == "");
+                REQUIRE(error == "");
             }
         }
-        WHEN("the redirect STDERR option is used") {
-            auto result = execute("ls", { "does_not_exist" }, option_set<execution_options>({ execution_options::defaults, execution_options::redirect_stderr }));
+        WHEN("the redirect stderr option is used") {
+            tie(success, output, error) = execute("ls", { "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::redirect_stderr_to_stdout });
             THEN("error output is returned") {
-                REQUIRE_FALSE(result.first);
-                REQUIRE(boost::ends_with(result.second, "No such file or directory"));
+                REQUIRE_FALSE(success);
+                REQUIRE(boost::ends_with(output, "No such file or directory"));
+                REQUIRE(error == "");
+            }
+        }
+        WHEN("not redirecting stderr to null") {
+            tie(success, output, error) = execute("ls", { "does_not_exist" }, 0, { execution_options::trim_output, execution_options::merge_environment });
+            THEN("error output is returned") {
+                REQUIRE_FALSE(success);
+                REQUIRE(output == "");
+                REQUIRE(boost::ends_with(error, "No such file or directory"));
             }
         }
         WHEN("the 'throw on non-zero exit' option is used") {
             THEN("a child exit exception is thrown") {
-                REQUIRE_THROWS_AS(execute("ls", {"does_not_exist"}, option_set<execution_options>({execution_options::defaults, execution_options::throw_on_nonzero_exit})), child_exit_exception);
+                REQUIRE_THROWS_AS(execute("ls", {"does_not_exist"}, 0, {execution_options::trim_output, execution_options::merge_environment, execution_options::throw_on_nonzero_exit}), child_exit_exception);
             }
         }
         WHEN("the 'throw on signal' option is used") {
             THEN("a child signal exception is thrown") {
-                REQUIRE_THROWS_AS(execute("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/selfkill.sh" }, option_set<execution_options>({ execution_options::defaults, execution_options::throw_on_signal })), child_signal_exception);
+                REQUIRE_THROWS_AS(execute("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/selfkill.sh" }, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::throw_on_signal }), child_signal_exception);
             }
         }
     }
     GIVEN("a command that outputs leading/trailing whitespace") {
         THEN("whitespace should be trimmed by default") {
-            auto result = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file1.txt" });
-            REQUIRE(result.first);
-            REQUIRE(result.second == "this is a test of trimming");
+            tie(success, output, error) = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file1.txt" });
+            REQUIRE(success);
+            REQUIRE(output == "this is a test of trimming");
         }
         WHEN("the 'trim whitespace' option is not used") {
-            option_set<execution_options> options = { execution_options::defaults };
-            options.clear(execution_options::trim_output);
-            auto result = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file1.txt" }, options);
+            tie(success, output, error) = execute("cat", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/ls/file1.txt" }, 0, { execution_options::merge_environment });
             THEN("whitespace should not be trimmed") {
-                REQUIRE(result.second == "   this is a test of trimming   ");
+                REQUIRE(output == "   this is a test of trimming   ");
             }
         }
     }
     GIVEN("a long-running command") {
         WHEN("given a timeout") {
             THEN("a timeout exception should be thrown") {
-                option_set<execution_options> options = { execution_options::defaults };
                 try {
-                    execute("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, options, 1);
+                    execute("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, 1);
                     FAIL("did not throw timeout exception");
                 } catch (timeout_exception const& ex) {
                     // Verify the process group was killed by waiting for it
@@ -244,6 +254,32 @@ SCENARIO("executing commands with execution::execute") {
                 } catch (exception const&) {
                     FAIL("unexpected exception thrown");
                 }
+            }
+        }
+    }
+    GIVEN("stderr is redirected to null") {
+        WHEN("using a debug log level") {
+            log_capture capture(level::debug);
+            tie(success, output, error) = execute(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/error_message");
+            REQUIRE(success);
+            REQUIRE(output == "foo=bar");
+            REQUIRE(error.empty());
+            THEN("stderr is logged") {
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE(re_search(output, boost::regex("DEBUG !!! - error message!")));
+            }
+        }
+        WHEN("not using a debug log level") {
+            log_capture capture(level::warning);
+            tie(success, output, error) = execute(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/error_message");
+            REQUIRE(success);
+            REQUIRE(output == "foo=bar");
+            REQUIRE(error.empty());
+            THEN("stderr is not logged") {
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE_FALSE(re_search(output, boost::regex("DEBUG !!! - error message!")));
             }
         }
     }
@@ -303,19 +339,29 @@ SCENARIO("executing commands with execution::each_line") {
             }
         }
         WHEN("requested to override the environment") {
-            option_set<execution_options> options = { execution_options::defaults };
-            options.clear(execution_options::merge_environment);
             setenv("TEST_INHERITED_VARIABLE", "TEST_INHERITED_VALUE", 1);
             map<string, string> variables;
-            bool success = each_line("env", {}, { {"TEST_VARIABLE1", "TEST_VALUE1" }, {"TEST_VARIABLE2", "TEST_VALUE2" } }, [&](string& line) {
-                vector<string> parts;
-                boost::split(parts, line, boost::is_any_of("="), boost::token_compress_off);
-                if (parts.size() != 2) {
+            bool success = each_line(
+                "env",
+                {},
+                {
+                    {"TEST_VARIABLE1", "TEST_VALUE1" },
+                    {"TEST_VARIABLE2", "TEST_VALUE2" }
+                },
+                [&](string& line) {
+                    vector<string> parts;
+                    boost::split(parts, line, boost::is_any_of("="), boost::token_compress_off);
+                    if (parts.size() != 2) {
+                        return true;
+                    }
+                    variables.emplace(make_pair(move(parts[0]), move(parts[1])));
                     return true;
-                }
-                variables.emplace(make_pair(move(parts[0]), move(parts[1])));
-                return true;
-            }, options);
+                },
+                nullptr,
+                0,
+                {
+                    execution_options::trim_output
+                });
             unsetenv("TEST_INHERITED_VARIABLE");
             REQUIRE(success);
             THEN("the child environment should only contain the given variables") {
@@ -362,28 +408,94 @@ SCENARIO("executing commands with execution::each_line") {
                 REQUIRE_FALSE(success);
             }
         }
-        WHEN("the redirect STDERR option is used") {
+        WHEN("the redirect stderr option is used") {
             string output;
-            auto result = each_line("ls", { "does_not_exist" }, [&](string& line) {
-                if (!output.empty()) {
-                    output += "\n";
-                }
-                output += line;
-                return true;
-            }, option_set<execution_options>({ execution_options::defaults, execution_options::redirect_stderr }));
+            auto result = each_line(
+                "ls",
+                {
+                    "does_not_exist"
+                },
+                [&](string& line) {
+                    if (!output.empty()) {
+                        output += "\n";
+                    }
+                    output += line;
+                    return true;
+                },
+                nullptr,
+                0,
+                {
+                    execution_options::trim_output,
+                    execution_options::merge_environment,
+                    execution_options::redirect_stderr_to_stdout
+                });
             THEN("error output is returned") {
                 REQUIRE_FALSE(result);
                 REQUIRE(boost::ends_with(output, "No such file or directory"));
             }
         }
+        WHEN("not redirecting stderr to null") {
+            string output;
+            string error;
+            auto result = each_line(
+                "ls",
+                {
+                    "does_not_exist"
+                },
+                [&](string& line) {
+                    if (!output.empty()) {
+                        output += "\n";
+                    }
+                    output += line;
+                    return true;
+                },
+                [&](string& line) {
+                    if (!error.empty()) {
+                        error += "\n";
+                    }
+                    error += line;
+                    return true;
+                });
+            THEN("error output is returned") {
+                REQUIRE_FALSE(result);
+                REQUIRE(output == "");
+                REQUIRE(boost::ends_with(error, "No such file or directory"));
+            }
+        }
+        WHEN("redirecting stderr to null") {
+            string error;
+            auto result = each_line(
+                "ls",
+                {
+                    "does_not_exist"
+                },
+                nullptr,
+                [&](string& line) {
+                    if (!error.empty()) {
+                        error += "\n";
+                    }
+                    error += line;
+                    return true;
+                },
+                0,
+                {
+                    execution_options::trim_output,
+                    execution_options::merge_environment,
+                    execution_options::redirect_stderr_to_null
+                });
+            THEN("no error output is returned") {
+                REQUIRE_FALSE(result);
+                REQUIRE(error == "");
+            }
+        }
         WHEN("the 'throw on non-zero exit' option is used") {
             THEN("a child exit exception is thrown") {
-                REQUIRE_THROWS_AS(each_line("ls", {"does_not_exist"}, [](string& line) { return true; }, option_set<execution_options>({execution_options::defaults, execution_options::throw_on_nonzero_exit})), child_exit_exception);
+                REQUIRE_THROWS_AS(each_line("ls", {"does_not_exist"}, nullptr, nullptr, 0, {execution_options::trim_output, execution_options::merge_environment, execution_options::throw_on_nonzero_exit}), child_exit_exception);
             }
         }
         WHEN("the 'throw on signal' option is used") {
             THEN("a child signal exception is thrown") {
-                REQUIRE_THROWS_AS(each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/selfkill.sh" }, [](string& line) { return true; }, option_set<execution_options>({ execution_options::defaults, execution_options::throw_on_signal })), child_signal_exception);
+                REQUIRE_THROWS_AS(each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/selfkill.sh" }, nullptr, nullptr, 0, { execution_options::trim_output, execution_options::merge_environment, execution_options::throw_on_signal }), child_signal_exception);
             }
         }
     }
@@ -391,8 +503,7 @@ SCENARIO("executing commands with execution::each_line") {
         WHEN("given a timeout") {
             THEN("a timeout exception should be thrown") {
                 try {
-                    option_set<execution_options> options = { execution_options::defaults };
-                    each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, [](string& line) { return true; }, options, 1);
+                    each_line("sh", { LIBFACTER_TESTS_DIRECTORY "/fixtures/execution/sleep.sh" }, nullptr, nullptr, 1);
                     FAIL("did not throw timeout exception");
                 } catch (timeout_exception const& ex) {
                     // Verify the process group was killed by waiting for it
@@ -402,6 +513,26 @@ SCENARIO("executing commands with execution::each_line") {
                 } catch (exception const&) {
                     FAIL("unexpected exception thrown");
                 }
+            }
+        }
+    }
+    GIVEN("stderr is redirected to null") {
+        WHEN("using a debug log level") {
+            log_capture capture(level::debug);
+            REQUIRE(facter::execution::each_line(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/error_message", nullptr));
+            THEN("stderr is logged") {
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE(re_search(output, boost::regex("DEBUG !!! - error message!")));
+            }
+        }
+        WHEN("not using a debug log level") {
+            log_capture capture(level::warning);
+            REQUIRE(facter::execution::each_line(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/error_message", nullptr));
+            THEN("stderr is not logged") {
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE_FALSE(re_search(output, boost::regex("DEBUG !!! - error message!")));
             }
         }
     }

--- a/lib/tests/facts/external/posix/execution_resolver.cc
+++ b/lib/tests/facts/external/posix/execution_resolver.cc
@@ -3,12 +3,15 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/util/string.hpp>
+#include <internal/util/regex.hpp>
 #include "../../../fixtures.hpp"
+#include "../../../log_capture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::facts::external;
+using namespace facter::logging;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts") {
@@ -38,6 +41,18 @@ SCENARIO("resolving external executable facts") {
                 REQUIRE(facts.get<string_value>("exe_fact4"));
                 REQUIRE_FALSE(facts.get<string_value>("EXE_fact4"));
                 REQUIRE(facts.get<string_value>("exe_fact4")->value() == "value2");
+            }
+        }
+        WHEN("messages are logged to stderr") {
+            THEN("a warning is generated") {
+                log_capture capture(level::warning);
+                resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/error_message", facts);
+                REQUIRE(facts.size() == 1);
+                REQUIRE(facts.get<string_value>("foo"));
+                REQUIRE(facts.get<string_value>("foo")->value() == "bar");
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE(re_search(output, boost::regex("WARN  puppetlabs\\.facter - external fact file \".*/error_message\" had output on stderr: error message!")));
             }
         }
         THEN("the file can be resolved") {

--- a/lib/tests/facts/external/windows/execution_resolver.cc
+++ b/lib/tests/facts/external/windows/execution_resolver.cc
@@ -3,12 +3,15 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/util/string.hpp>
+#include <internal/util/regex.hpp>
 #include "../../../fixtures.hpp"
+#include "../../../log_capture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
 using namespace facter::facts::external;
+using namespace facter::logging;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts") {
@@ -39,6 +42,18 @@ SCENARIO("resolving external executable facts") {
                 REQUIRE(facts.get<string_value>("exe_fact4"));
                 REQUIRE_FALSE(facts.get<string_value>("EXE_fact4"));
                 REQUIRE(facts.get<string_value>("exe_fact4")->value() == "value2");
+            }
+        }
+        WHEN("messages are logged to stderr") {
+            THEN("a warning is generated") {
+                log_capture capture(level::warning);
+                resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/error_message.bat", facts);
+                REQUIRE(facts.size() == 1);
+                REQUIRE(facts.get<string_value>("foo"));
+                REQUIRE(facts.get<string_value>("foo")->value() == "bar");
+                auto output = capture.result();
+                CAPTURE(output);
+                REQUIRE(re_search(output, boost::regex("WARN  puppetlabs\\.facter - external fact file \".*error_message.bat\" had output on stderr: error message!")));
             }
         }
         THEN("the file can be resolved") {

--- a/lib/tests/facts/posix/collection.cc
+++ b/lib/tests/facts/posix/collection.cc
@@ -19,11 +19,12 @@ SCENARIO("resolving external executable facts into a collection") {
             LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution",
         });
         THEN("facts should resolve") {
-            REQUIRE(facts.size() == 3);
+            REQUIRE(facts.size() == 4);
             REQUIRE(facts.get<string_value>("exe_fact1"));
             REQUIRE(facts.get<string_value>("exe_fact2"));
             REQUIRE_FALSE(facts.get<string_value>("exe_fact3"));
             REQUIRE(facts.get<string_value>("exe_fact4"));
+            REQUIRE(facts.get<string_value>("foo"));
         }
     }
     GIVEN("a relative path") {

--- a/lib/tests/facts/windows/collection.cc
+++ b/lib/tests/facts/windows/collection.cc
@@ -20,7 +20,7 @@ SCENARIO("resolving external executable facts into a collection") {
             LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/powershell",
         });
         THEN("facts should resolve") {
-            REQUIRE(facts.size() == 6);
+            REQUIRE(facts.size() == 7);
             REQUIRE(facts.get<string_value>("exe_fact1"));
             REQUIRE(facts.get<string_value>("exe_fact2"));
             REQUIRE_FALSE(facts.get<string_value>("exe_fact3"));

--- a/lib/tests/fixtures/facts/external/posix/execution/error_message
+++ b/lib/tests/fixtures/facts/external/posix/execution/error_message
@@ -1,0 +1,4 @@
+#! /usr/bin/env sh
+echo error message! >&2
+echo foo=bar
+

--- a/lib/tests/fixtures/facts/external/windows/execution/error_message.bat
+++ b/lib/tests/fixtures/facts/external/windows/execution/error_message.bat
@@ -1,0 +1,4 @@
+@echo off
+echo error message! >&2
+echo foo=bar
+exit /b 0

--- a/lib/tests/fixtures/facts/external/windows/powershell/error_message.ps1
+++ b/lib/tests/fixtures/facts/external/windows/powershell/error_message.ps1
@@ -1,0 +1,3 @@
+[Console]::Error.WriteLine('error message!')
+Write 'foo=bar'
+exit 0

--- a/lib/tests/log_capture.cc
+++ b/lib/tests/log_capture.cc
@@ -1,0 +1,29 @@
+#include "log_capture.hpp"
+#include <boost/nowide/iostream.hpp>
+
+using namespace std;
+using namespace facter::logging;
+
+namespace facter { namespace testing {
+
+    log_capture::log_capture(facter::logging::level level)
+    {
+        // Setup logging for capturing
+        setup_logging(_stream);
+        set_level(level);
+    }
+
+    log_capture::~log_capture()
+    {
+        // Cleanup
+        setup_logging(boost::nowide::cout);
+        set_level(level::none);
+        clear_logged_errors();
+    }
+
+    string log_capture::result() const
+    {
+        return _stream.str();
+    }
+
+}}  // namespace facter::testing

--- a/lib/tests/log_capture.hpp
+++ b/lib/tests/log_capture.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <facter/logging/logging.hpp>
+
+namespace facter { namespace testing {
+
+    /**
+     * Utility class for capturing facter log output.
+     */
+    struct log_capture
+    {
+        /**
+         * Constructs the log capture and starts capturing log output.
+         * @param level The log level to capture.
+         */
+        explicit log_capture(facter::logging::level level);
+
+        /**
+         * Destructs the log capture and stops capturing log output.
+         */
+        ~log_capture();
+
+        /**
+         * Gets the captured log.
+         * @return Returns the captured log as a single string.
+         */
+        std::string result() const;
+
+     private:
+        std::ostringstream _stream;
+    };
+
+}}  // namespace facter::testing

--- a/lib/tests/logging/logging.cc
+++ b/lib/tests/logging/logging.cc
@@ -1,116 +1,69 @@
 #include <catch.hpp>
 #include <facter/logging/logging.hpp>
-#include <leatherman/logging/logging.hpp>
-#include <boost/log/sinks/sync_frontend.hpp>
-#include <boost/log/sinks/basic_sink_backend.hpp>
-#include <boost/nowide/convert.hpp>
+#include <internal/util/regex.hpp>
+#include "../log_capture.hpp"
 
 using namespace std;
 using namespace facter::logging;
-namespace sinks = boost::log::sinks;
-
-struct custom_log_appender :
-    sinks::basic_formatted_sink_backend<char, sinks::synchronized_feeding>
-{
-    void consume(boost::log::record_view const& rec, string_type const& message)
-    {
-        stringstream s;
-        for (auto const& attr : rec.attribute_values()) {
-            if (attr.first == "Severity") {
-                s << attr.second.extract<leatherman::logging::log_level>();
-            }
-        }
-        _level = s.str();
-        _message = message;
-    }
-
-    string _level;
-    string _message;
-};
-
-struct logging_test_context
-{
-    using sink_t = sinks::synchronous_sink<custom_log_appender>;
-
-    logging_test_context()
-    {
-        set_level(level::trace);
-        clear_logged_errors();
-
-        _appender.reset(new custom_log_appender());
-        _sink.reset(new sink_t(_appender));
-
-        auto core = boost::log::core::get();
-        core->add_sink(_sink);
-    }
-
-    ~logging_test_context()
-    {
-        set_level(level::none);
-        clear_logged_errors();
-
-        auto core = boost::log::core::get();
-        core->reset_filter();
-        core->remove_sink(_sink);
-
-        _sink.reset();
-        _appender.reset();
-    }
-
-    boost::shared_ptr<custom_log_appender> _appender;
-    boost::shared_ptr<sink_t> _sink;
-};
+using namespace facter::util;
+using namespace facter::testing;
 
 SCENARIO("logging with a TRACE level") {
-    logging_test_context context;
+    log_capture capture(level::trace);
     REQUIRE(is_enabled(level::trace));
     log(level::trace, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "TRACE");
-    REQUIRE(context._appender->_message == string(colorize(level::trace)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("TRACE puppetlabs\\.facter - testing 1 2 3$")));
     REQUIRE_FALSE(error_logged());
 }
 
 SCENARIO("logging with a DEBUG level") {
-    logging_test_context context;
+    log_capture capture(level::debug);
     REQUIRE(is_enabled(level::debug));
     log(level::debug, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "DEBUG");
-    REQUIRE(context._appender->_message == string(colorize(level::debug)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("DEBUG puppetlabs\\.facter - testing 1 2 3$")));
     REQUIRE_FALSE(error_logged());
 }
 
 SCENARIO("logging with an INFO level") {
-    logging_test_context context;
+    log_capture capture(level::info);
     REQUIRE(is_enabled(level::info));
     log(level::info, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "INFO");
-    REQUIRE(context._appender->_message == string(colorize(level::info)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("INFO  puppetlabs\\.facter - testing 1 2 3$")));
     REQUIRE_FALSE(error_logged());
 }
 
 SCENARIO("logging with a WARNING level") {
-    logging_test_context context;
+    log_capture capture(level::warning);
     REQUIRE(is_enabled(level::warning));
     log(level::warning, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "WARN");
-    REQUIRE(context._appender->_message == string(colorize(level::warning)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("WARN  puppetlabs\\.facter - testing 1 2 3")));
     REQUIRE_FALSE(error_logged());
 }
 
 SCENARIO("logging with an ERROR level") {
-    logging_test_context context;
+    log_capture capture(level::error);
     REQUIRE(is_enabled(level::error));
     log(level::error, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "ERROR");
-    REQUIRE(context._appender->_message == string(colorize(level::error)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - testing 1 2 3$")));
     REQUIRE(error_logged());
 }
 
 SCENARIO("logging with a FATAL level") {
-    logging_test_context context;
+    log_capture capture(level::fatal);
     REQUIRE(is_enabled(level::fatal));
     log(level::fatal, "testing %1% %2% %3%", 1, "2", 3.0);
-    REQUIRE(context._appender->_level == "FATAL");
-    REQUIRE(context._appender->_message == string(colorize(level::fatal)) + "testing 1 2 3" + colorize());
+    auto output = capture.result();
+    CAPTURE(output);
+    REQUIRE(re_search(output, boost::regex("FATAL puppetlabs\\.facter - testing 1 2 3$")));
     REQUIRE(error_logged());
 }

--- a/lib/tests/main.cc
+++ b/lib/tests/main.cc
@@ -10,11 +10,8 @@ using namespace facter::logging;
 int main(int argc, char **argv)
 {
     // Disable logging for tests
+    setup_logging(boost::nowide::cout);
     set_level(level::none);
-
-    // Uncomment this to get debug output during a test run
-    // setup_logging(cout);
-    // set_level(level::debug);
 
     // Before running tests, initialize Ruby
     facter::ruby::initialize();


### PR DESCRIPTION
This implements a new pipe for reading stderr in addition to stdout from
child processes.  Previously, stderr was optionally redirected to
stdout or to the null device if not merging the two streams.  This change
allows child process execution to treat stdout and stderr as two
separate streams, enabling the ability to process stdout while logging
stderr messages (e.g. external executable facts).

The execute functions now return a tuple of both the stdout and stderr
contents.  The each_line functions now take an additional function
object to call when a line of stderr is read.
