### PR TITLE
(maint) Ensure AIO pre-suite uses PC1 repository

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -151,7 +151,7 @@ module Puppet
               platform_configs_dir
             )
 
-            link = "http://%s/%s/%s/repos/%s/%s%s/products/%s/" % [
+            link = "http://%s/%s/%s/repos/%s/%s%s/PC1/%s/" % [
               tld,
               project,
               sha,
@@ -160,6 +160,18 @@ module Puppet
               version,
               arch
             ]
+
+            if not link_exists?(link)
+              link = "http://%s/%s/%s/repos/%s/%s%s/products/%s/" % [
+                tld,
+                project,
+                sha,
+                variant,
+                fedora_prefix,
+                version,
+                arch
+              ]
+            end
 
             if not link_exists?(link)
               link = "http://%s/%s/%s/repos/%s/%s%s/devel/%s/" % [
@@ -172,6 +184,7 @@ module Puppet
                 arch
               ]
             end
+
             if not link_exists?(link)
               raise "Unable to reach a repo directory at #{link}"
             end
@@ -216,8 +229,14 @@ module Puppet
             scp_to host, list, repo_loc
             scp_to host, repo_dir, repo_loc
 
+            pc1_check = on(host,
+                           "[[ -d /root/#{project}/#{version}/pool/PC1 ]]",
+                           :acceptable_exit_codes => [0,1])
+
+            repo_name =  pc1_check.exit_code == 0 ? 'PC1' : 'main'
+
             on host, "cp #{repo_loc}/*.list /etc/apt/sources.list.d"
-            on host, "find /etc/apt/sources.list.d/ -name \"*.list\" -exec sed -i \"s/deb\\s\\+http:\\/\\/#{tld}.*$/deb file:\\/\\/\\/root\\/#{project}\\/#{version} #{version} main/\" {} \\;"
+            on host, "find /etc/apt/sources.list.d/ -name \"*.list\" -exec sed -i \"s/deb\\s\\+http:\\/\\/#{tld}.*$/deb file:\\/\\/\\/root\\/#{project}\\/#{version} #{version} #{repo_name}/\" {} \\;"
             on host, "dpkg -i --force-all #{repo_loc}/*.deb"
             on host, "apt-get update"
           else


### PR DESCRIPTION
Prior to this we were installing repositories for products/devel or main
(for rpms and debs respectively).

Now AIO packages will be in a repository called PC1. This adds checks to
the repository set up steps so that PC1 will be tried first. Once
packaging is fully switched over will need to remove references to older
repositories.