### PR TITLE
(FACT-893) prefer /etc/centos-release over /etc/redhat-release

### DIFF
--- a/lib/facter/operatingsystem/linux.rb
+++ b/lib/facter/operatingsystem/linux.rb
@@ -273,6 +273,8 @@ module Facter
             else
               operatingsystem = "OEL"
             end
+          elsif FileTest.exists?("/etc/centos-release")
+            operatingsystem = get_centos_operatingsystem_name
           elsif FileTest.exists?("/etc/redhat-release")
             operatingsystem = get_redhat_operatingsystem_name
           elsif FileTest.exists?("/etc/SuSE-release")
@@ -285,6 +287,19 @@ module Facter
         operatingsystem
       end
 
+      # Uses a regex search on /etc/centos-release to determine OS
+      #
+      # @return [String]
+      def get_centos_operatingsystem_name
+        txt = File.read("/etc/centos-release")
+        matches = {
+          "CentOS"     => "centos",
+        }
+        match = regex_search_release_file_for_operatingsystem(matches, txt)
+        match = "CentOS" if match == nil
+
+        match
+      end
       # Uses a regex search on /etc/redhat-release to determine OS
       #
       # @return [String]
@@ -381,7 +396,13 @@ module Facter
 
       def get_redhatish_release_with_release_file
         case get_operatingsystem
-        when "CentOS", "RedHat", "Scientific", "SLC", "Ascendos", "CloudLinux", "PSBM", "XenServer"
+        when "CentOS"
+          releasefile = if File.exists?('/etc/centos-release')
+            "/etc/centos-release"
+          else
+            "/etc/redhat-release"
+          end
+        when "RedHat", "Scientific", "SLC", "Ascendos", "CloudLinux", "PSBM", "XenServer"
           releasefile = "/etc/redhat-release"
         when "Fedora"
           releasefile = "/etc/fedora-release"

--- a/spec/unit/operatingsystem/linux_spec.rb
+++ b/spec/unit/operatingsystem/linux_spec.rb
@@ -58,6 +58,24 @@ describe Facter::Operatingsystem::Linux do
       end
     end
 
+    describe "on distributions that rely on the contents of /etc/centos-release" do
+      before :each do
+        subject.expects(:get_lsbdistid).returns(nil)
+      end
+      {
+        "CentOS"     => "CentOS Linux release 7.1.1503 (Core)",
+      }.each_pair do |operatingsystem, string|
+        it "should be #{operatingsystem} based on /etc/centos-release contents #{string}" do
+          FileTest.expects(:exists?).at_least_once.returns false
+          FileTest.expects(:exists?).with("/etc/enterprise-release").returns false
+          FileTest.expects(:exists?).with("/etc/centos-release").returns true
+          FileTest.expects(:exists?).with("/etc/redhat-release").never
+          File.expects(:read).with("/etc/centos-release").at_least_once.returns string
+          os = subject.get_operatingsystem
+          expect(os).to eq operatingsystem
+        end
+      end
+    end
     describe "on distributions that rely on the contents of /etc/redhat-release" do
       before :each do
         subject.expects(:get_lsbdistid).returns(nil)
@@ -237,6 +255,15 @@ describe Facter::Operatingsystem::Linux do
           Facter::Util::FileRead.expects(:read).with(file).at_least_once
           release = subject.get_operatingsystemrelease
         end
+      end
+    end
+    describe "with operatingsystem reported as centos (new way)" do
+      it "should read /etc/centos-release" do
+        subject.expects(:get_operatingsystem).at_least_once.returns('CentOS')
+        File.expects(:exists?).with('/etc/centos-release').at_least_once.returns(true)
+        Facter::Util::FileRead.expects(:read).with('/etc/centos-release').at_least_once
+        Facter::Util::FileRead.expects(:read).with('/etc/redhat-release').never
+        release = subject.get_operatingsystemrelease
       end
     end
 


### PR DESCRIPTION
CentOS decided to change the format of /etc/redhat-release within
a minor release, which affected correct detection of CentOS systems
on a 7.1.1503 release.
This patch prefers /etc/centos-release over /etc/redhat-release if
present.
/etc/centos-release has already been present on EL6 and actually
/etc/redhat-release used to be a symlink on /etc/centos-release.
From CentOS 7.1.1503 on /etc/redhat-release id not anymore a
symlink, but comes with its own not (yet) parseable content.
Given that the CentOS project prefers /etc/centos-release over
/etc/redhat-release facter should also prefer that.

More background: http://lists.centos.org/pipermail/centos-devel/2015-February/012873.html

Parsing /etc/os-release might be the more forward looking change,
however this would require much more changes to facter, than such
a emergency hot-fix would justify.