### PR TITLE
(FACT-894) Update per-user external facts location

### DIFF
--- a/lib/src/facts/posix/collection.cc
+++ b/lib/src/facts/posix/collection.cc
@@ -22,7 +22,7 @@ namespace facter { namespace facts {
         if (getuid()) {
             string home;
             if (environment::get("HOME", home)) {
-                directories.emplace_back(home + "/.facter/facts.d");
+                directories.emplace_back(home + "/.puppetlabs/opt/facter/facts.d");
             }
         } else {
             directories.emplace_back("/opt/puppetlabs/facter/facts.d");


### PR DESCRIPTION
Changes from ~/.facter/facts.d to ~/.puppetlabs/opt/facter/facts.d, as
per the puppet-specification.