### PR TITLE
(FACT-898) Fix schema test to accept integer as a valid double

### DIFF
--- a/acceptance/tests/verify_facts.rb
+++ b/acceptance/tests/verify_facts.rb
@@ -23,7 +23,10 @@ def validate_fact(node, fact_value, hidden)
             when 'integer'
               fact_value.is_a? Integer
             when 'double'
-              fact_value.is_a? Float
+              # http://www.yaml.org/spec/1.2/spec.html#id2804092 states the form of a double in YAML
+              # If a type isn't explicit, it's reasonable to output a single integer value for a double,
+              # as in 0 and 1, instead of 0.0 or 1.0.
+              fact_value.is_a? Float or fact_value.to_s =~ /^([0-9]|\.inf|\.nan|-\.inf)$/
             when 'string'
               fact_value.is_a? String
             when 'ip'


### PR DESCRIPTION
The schema acceptance test parses YAML output using Ruby's YAML parser,
and validates it against our YAML schema. The YAML output from facter
will drop the '.' if the value is a whole number, such as '0' - which
happened in the load_averages fact, causing an acceptance test failure.
This is valid YAML output for a floating point type, as defined at
http://www.yaml.org/spec/1.2/spec.html#id2804092.

Update the test to recognize all YAML floating point formats for a fact
expected to output a double.