### PR TITLE
(FACT-900) Fix external facts path for non-Administrator

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -124,8 +124,10 @@ if (WIN32)
         "src/ruby/windows/api.cc"
         "src/util/windows/dynamic_library.cc"
         "src/util/windows/environment.cc"
+        "src/util/windows/process.cc"
         "src/util/windows/registry.cc"
         "src/util/windows/system_error.cc"
+        "src/util/windows/user.cc"
         "src/util/windows/wmi.cc"
         "src/util/windows/wsa.cc"
     )

--- a/lib/inc/internal/util/windows/process.hpp
+++ b/lib/inc/internal/util/windows/process.hpp
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * Declares utility functions for querying process properties
+ */
+#pragma once
+
+namespace facter { namespace util { namespace windows { namespace process {
+
+    /**
+     * Returns whether or not the OS has the ability to set elevated token information.
+     * @return True on Windows Vista or later, otherwise false.
+     */
+    bool supports_elevated_security();
+
+    /**
+     * Returns whether or not the owner of the current process is running with elevated security privileges.
+     * Only supported on Windows Vista or later.
+     * @return True if elevated, otherwise false.
+     */
+    bool has_elevated_security();
+
+}}}}  // namespace facter::util::windows::process

--- a/lib/inc/internal/util/windows/user.hpp
+++ b/lib/inc/internal/util/windows/user.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Declares utility functions for querying user properties
+ */
+#pragma once
+
+#include <string>
+
+namespace facter { namespace util { namespace windows { namespace user {
+
+    /**
+     * Determines whether the current process has Administrator privileges and can be expected to succeed at
+     * tasks restricted to Administrators.
+     * @return True if the current process has Administrator privileges, otherwise false.
+     */
+    bool is_admin();
+
+    /**
+     * Query token membership to determine whether the current user is a member of the Administrators group.
+     * @return True if user is an Administrator, otherwise false.
+     */
+    bool check_token_membership();
+
+    /**
+     * Finds the user's home directory in a Ruby-compatible way.
+     * @return The home directory, trying %HOME% > %HOMEDRIVE%%HOMEPATH% > %USERPROFILE%
+     */
+    std::string home_dir();
+
+}}}}  // namespace facter::util::windows::user

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -1,0 +1,45 @@
+#include <internal/util/windows/system_error.hpp>
+#include <internal/util/windows/windows.hpp>
+#include <facter/util/scoped_resource.hpp>
+#include <leatherman/logging/logging.hpp>
+
+using namespace std;
+
+namespace facter { namespace util { namespace windows { namespace process {
+
+    bool supports_elevated_security()
+    {
+        // In the future this can use IsWindowsVistaOrGreater, but as of the initial work versionhelpers.h is only in
+        // the master branch of MinGW-w64.
+        OSVERSIONINFOEXW vi = {sizeof(vi), HIBYTE(_WIN32_WINNT_VISTA), LOBYTE(_WIN32_WINNT_VISTA), 0, 0, {0}, 0};
+
+        return VerifyVersionInfoW(&vi, VER_MAJORVERSION|VER_MINORVERSION|VER_SERVICEPACKMAJOR,
+            VerSetConditionMask(VerSetConditionMask(VerSetConditionMask(0,
+                VER_MAJORVERSION, VER_GREATER_EQUAL),
+                VER_MINORVERSION, VER_GREATER_EQUAL),
+                VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL));
+    }
+
+    bool has_elevated_security()
+    {
+        HANDLE temp_token;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &temp_token)) {
+            // pre-Vista will return ERROR_NO_SUCH_PRIVILEGE
+            if (GetLastError() != ERROR_NO_SUCH_PRIVILEGE) {
+                LOG_DEBUG("OpenProcessToken call failed: %1%", system_error());
+            }
+            return false;
+        }
+        scoped_resource<HANDLE> token(move(temp_token), CloseHandle);
+
+        TOKEN_ELEVATION token_elevation;
+        DWORD token_elevation_length;
+        if (!GetTokenInformation(token, TokenElevation, &token_elevation, sizeof(TOKEN_ELEVATION), &token_elevation_length)) {
+            LOG_DEBUG("GetTokenInformation call failed: %1%", system_error());
+            return false;
+        }
+
+        return token_elevation.TokenIsElevated;
+    }
+
+}}}}

--- a/lib/src/util/windows/user.cc
+++ b/lib/src/util/windows/user.cc
@@ -1,0 +1,58 @@
+#include <internal/util/windows/user.hpp>
+#include <internal/util/windows/process.hpp>
+#include <internal/util/windows/system_error.hpp>
+#include <internal/util/windows/windows.hpp>
+#include <facter/util/environment.hpp>
+#include <leatherman/logging/logging.hpp>
+
+using namespace std;
+
+namespace facter { namespace util { namespace windows { namespace user {
+
+    bool is_admin()
+    {
+        if (process::supports_elevated_security()) {
+            return process::has_elevated_security();
+        }
+
+        return check_token_membership();
+    }
+
+    bool check_token_membership()
+    {
+        DWORD sid_size = SECURITY_MAX_SID_SIZE;
+        unsigned char sid_buffer[SECURITY_MAX_SID_SIZE];
+        auto sid = static_cast<PSID>(&sid_buffer);
+        if (!CreateWellKnownSid(WinBuiltinAdministratorsSid, nullptr, sid, &sid_size)) {
+            LOG_DEBUG("Failed to create administrators SID: %1%", system_error());
+            return false;
+        }
+
+        if (!IsValidSid(sid)) {
+            LOG_DEBUG("Invalid SID");
+            return false;
+        }
+
+        BOOL is_member;
+        if (!CheckTokenMembership(nullptr, sid, &is_member)) {
+            LOG_DEBUG("Failed to check membership: %1%", system_error());
+            return false;
+        }
+
+        return is_member;
+    }
+
+    string home_dir()
+    {
+        string home, alt;
+        if (environment::get("HOME", home)) {
+            return home;
+        } else if (environment::get("HOMEDRIVE", home) && environment::get("HOMEPATH", alt)) {
+            return home + alt;
+        } else if (environment::get("USERPROFILE", home)) {
+            return home;
+        }
+        return {};
+    }
+
+}}}}


### PR DESCRIPTION
The external facts path for non-Administrator users was incorrect, it used
COMMON_APPDATA when the puppet specification states it should use
~/.puppetlabs/opt/facter/facts.d. One reason for this location is that
facts in COMMON_APPDATA may not be executable by non-Administrators.

Determine whether Facter is running with Administrator privileges; if not,
use the location in the HOME directory instead of COMMON_APPDATA.