### PR TITLE
(FACT-904) Fix external fact load ordering.

### DIFF
--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -337,4 +337,25 @@ SCENARIO("using the fact collection") {
             REQUIRE(value->value() == "overridden");
         }
     }
+    GIVEN("two external fact directories to search") {
+        facts.add_external_facts({
+            LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/ordering/foo",
+            LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/ordering/bar"
+        });
+        THEN("it should have the fact value from the last file loaded") {
+            REQUIRE(facts.size() == 1);
+            REQUIRE(facts.get<string_value>("foo"));
+            REQUIRE(facts.get<string_value>("foo")->value() == "set in bar/foo.yaml");
+        }
+        facts.clear();
+        facts.add_external_facts({
+            LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/ordering/bar",
+            LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/ordering/foo"
+        });
+        THEN("it should have the fact value from the last file loaded") {
+            REQUIRE(facts.size() == 1);
+            REQUIRE(facts.get<string_value>("foo"));
+            REQUIRE(facts.get<string_value>("foo")->value() == "set in foo/foo.yaml");
+        }
+    }
 }

--- a/lib/tests/fixtures/facts/external/ordering/bar/foo.yaml
+++ b/lib/tests/fixtures/facts/external/ordering/bar/foo.yaml
@@ -1,0 +1,1 @@
+foo: set in bar/foo.yaml

--- a/lib/tests/fixtures/facts/external/ordering/foo/foo.yaml
+++ b/lib/tests/fixtures/facts/external/ordering/foo/foo.yaml
@@ -1,0 +1,1 @@
+foo: set in foo/foo.yaml

--- a/lib/tests/util/directory.cc
+++ b/lib/tests/util/directory.cc
@@ -55,12 +55,13 @@ SCENARIO("listing directories in a directory") {
         });
         sort(subdirectories.begin(), subdirectories.end());
         THEN("all directories are returned") {
-            REQUIRE(subdirectories.size() == 5);
+            REQUIRE(subdirectories.size() == 6);
             REQUIRE(subdirectories[0] == "json");
-            REQUIRE(subdirectories[1] == "posix");
-            REQUIRE(subdirectories[2] == "text");
-            REQUIRE(subdirectories[3] == "windows");
-            REQUIRE(subdirectories[4] == "yaml");
+            REQUIRE(subdirectories[1] == "ordering");
+            REQUIRE(subdirectories[2] == "posix");
+            REQUIRE(subdirectories[3] == "text");
+            REQUIRE(subdirectories[4] == "windows");
+            REQUIRE(subdirectories[5] == "yaml");
         }
     }
     GIVEN("a directory pattern") {


### PR DESCRIPTION
Previously, libfacter was searching for external fact files to load and
mapping those files to the resolvers that can handle them.  This mapping
was done with a std::map, which resulted in a lexographical ordering
based on the path of the file when the loading was performed.  Users
expect facter to load external facts based on the order the external
directories were specified.

Therefore, this commit removes the unnecessary mapping and simply loads
an external fact file when it is found.