### PR TITLE
(FACT-895) Include loadavg.h on Solaris

### DIFF
--- a/lib/src/facts/posix/load_average_resolver.cc
+++ b/lib/src/facts/posix/load_average_resolver.cc
@@ -4,6 +4,10 @@
 #include <boost/optional.hpp>
 #include <leatherman/logging/logging.hpp>
 
+#ifdef __sun
+#include <sys/loadavg.h>
+#endif
+
 using namespace std;
 
 namespace facter { namespace facts { namespace posix {


### PR DESCRIPTION
getloadavg is not defined in the POSIX standard, though it's present on
all POSIX systems we support. On Solaris, it's not present in stdlib.h,
so compilation fails.

On Solaris, include sys/loadavg.h to resolve getloadavg.