### PR TITLE
(FACT-947) Use GetUserProfileDirectory

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -217,13 +217,14 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     # The GetPerformanceInfo symbol has moved around a lot between Windows versions;
     # these options tie it to the backwards-compatible version.
     set(LIBFACTER_PLATFORM_LIBRARIES
-        "Psapi.lib"
-        "Version.lib"
-        "Wbemuuid.lib"
-        "Secur32.lib"
-        "Ws2_32.lib"
-        "iphlpapi.lib"
-        "userenv.lib")
+        Psapi.lib
+        Version.lib
+        Wbemuuid.lib
+        Secur32.lib
+        Ws2_32.lib
+        iphlpapi.lib
+        userenv.lib
+    )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPSAPI_VERSION=1")
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -222,7 +222,8 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         "Wbemuuid.lib"
         "Secur32.lib"
         "Ws2_32.lib"
-        "iphlpapi.lib")
+        "iphlpapi.lib"
+        "userenv.lib")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPSAPI_VERSION=1")
 endif()
 

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -487,8 +487,8 @@ namespace facter { namespace execution {
         stdOutWr.release();
         stdErrWr.release();
 
-        scoped_resource<HANDLE> hProcess(move(procInfo.hProcess), CloseHandle);
-        scoped_resource<HANDLE> hThread(move(procInfo.hThread), CloseHandle);
+        scoped_resource<HANDLE> hProcess(procInfo.hProcess, CloseHandle);
+        scoped_resource<HANDLE> hThread(procInfo.hThread, CloseHandle);
 
         // Use a Job Object to group any child processes spawned by the CreateProcess invocation, so we can
         // easily stop them in case of a timeout.

--- a/lib/src/util/windows/dynamic_library.cc
+++ b/lib/src/util/windows/dynamic_library.cc
@@ -26,7 +26,7 @@ namespace facter { namespace util {
             LOG_DEBUG("library matching pattern %1% not found, CreateToolhelp32Snapshot failed: %2%.", pattern.c_str(), system_error());
             return library;
         }
-        scoped_resource<HANDLE> hModSnap(std::move(hModuleSnap), CloseHandle);
+        scoped_resource<HANDLE> hModSnap(hModuleSnap, CloseHandle);
 
         MODULEENTRY32 me32 = {};
         me32.dwSize = sizeof(MODULEENTRY32);

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -22,7 +22,7 @@ namespace facter { namespace util { namespace windows { namespace process {
 
     bool has_elevated_security()
     {
-        HANDLE temp_token;
+        HANDLE temp_token = INVALID_HANDLE_VALUE;
         if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &temp_token)) {
             // pre-Vista will return ERROR_NO_SUCH_PRIVILEGE
             if (GetLastError() != ERROR_NO_SUCH_PRIVILEGE) {
@@ -30,7 +30,7 @@ namespace facter { namespace util { namespace windows { namespace process {
             }
             return false;
         }
-        scoped_resource<HANDLE> token(move(temp_token), CloseHandle);
+        scoped_resource<HANDLE> token(temp_token, CloseHandle);
 
         TOKEN_ELEVATION token_elevation;
         DWORD token_elevation_length;

--- a/lib/src/util/windows/process.cc
+++ b/lib/src/util/windows/process.cc
@@ -24,10 +24,7 @@ namespace facter { namespace util { namespace windows { namespace process {
     {
         HANDLE temp_token = INVALID_HANDLE_VALUE;
         if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &temp_token)) {
-            // pre-Vista will return ERROR_NO_SUCH_PRIVILEGE
-            if (GetLastError() != ERROR_NO_SUCH_PRIVILEGE) {
-                LOG_DEBUG("OpenProcessToken call failed: %1%", system_error());
-            }
+            LOG_DEBUG("OpenProcessToken call failed: %1%", system_error());
             return false;
         }
         scoped_resource<HANDLE> token(temp_token, CloseHandle);

--- a/lib/src/util/windows/wmi.cc
+++ b/lib/src/util/windows/wmi.cc
@@ -49,7 +49,7 @@ namespace facter { namespace util { namespace windows {
         if (FAILED(hres)) {
             throw wmi_exception(format_hresult("failed to create IWbemLocator object", hres));
         }
-        _pLoc = scoped_resource<IWbemLocator *>(move(pLoc),
+        _pLoc = scoped_resource<IWbemLocator *>(pLoc,
             [](IWbemLocator *loc) { if (loc) loc->Release(); });
 
         IWbemServices *pSvc;
@@ -57,7 +57,7 @@ namespace facter { namespace util { namespace windows {
         if (FAILED(hres)) {
             throw wmi_exception(format_hresult("could not connect to WMI server", hres));
         }
-        _pSvc = scoped_resource<IWbemServices *>(move(pSvc),
+        _pSvc = scoped_resource<IWbemServices *>(pSvc,
             [](IWbemServices *svc) { if (svc) svc->Release(); });
 
         hres = CoSetProxyBlanket(_pSvc, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, NULL,
@@ -111,7 +111,7 @@ namespace facter { namespace util { namespace windows {
             LOG_DEBUG("query %1% failed", qry);
             return {};
         }
-        scoped_resource<IEnumWbemClassObject *> pEnum(move(_pEnum),
+        scoped_resource<IEnumWbemClassObject *> pEnum(_pEnum,
             [](IEnumWbemClassObject *rsc) { if (rsc) rsc->Release(); });
 
         imaps array_of_vals;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ if (WIN32)
         Secur32.lib
         Ws2_32.lib
         iphlpapi.lib
+        userenv.lib
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_TESTS_PLATFORM_LIBRARIES

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -68,8 +68,12 @@ if (UNIX)
         set(LIBFACTER_TESTS_CATEGORY_SOURCES ${LIBFACTER_TESTS_CATEGORY_SOURCES} "util/posix/scoped_bio.cc")
     endif()
 
-     set(POSIX_LIBRARIES pthread dl)
+     set(POSIX_TESTS_LIBRARIES ${POSIX_LIBRARIES})
 endif()
+
+set(LIBFACTER_TESTS_PLATFORM_LIBRARIES
+    ${LIBFACTER_PLATFORM_LIBRARIES}
+)
 
 if (WIN32)
     set(LIBFACTER_TESTS_CATEGORY_SOURCES
@@ -79,26 +83,6 @@ if (WIN32)
         "facts/external/windows/execution_resolver.cc"
         "facts/external/windows/powershell_resolver.cc"
         "util/windows/environment.cc"
-    )
-    set(LIBFACTER_TESTS_PLATFORM_LIBRARIES
-        Psapi.lib
-        Version.lib
-        Wbemuuid.lib
-        Secur32.lib
-        Ws2_32.lib
-        iphlpapi.lib
-        userenv.lib
-    )
-elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-    set(LIBFACTER_TESTS_PLATFORM_LIBRARIES
-        ${BLKID_LIBRARIES}
-        rt
-    )
-elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
-    set(LIBFACTER_TESTS_PLATFORM_LIBRARIES
-        kstat
-        socket
-        nsl
     )
 endif()
 
@@ -124,7 +108,7 @@ include_directories(
 add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc> ${LIBFACTER_TESTS_COMMON_SOURCES} ${LIBFACTER_TESTS_PLATFORM_SOURCES} ${LIBFACTER_TESTS_CATEGORY_SOURCES})
 set_target_properties(libfacter_test PROPERTIES COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY" COTIRE_ENABLE_PRECOMPILED_HEADER ${PRECOMPILED_HEADERS} COTIRE_ADD_UNITY_BUILD FALSE)
 target_link_libraries(libfacter_test
-    ${POSIX_LIBRARIES}
+    ${POSIX_TESTS_LIBRARIES}
     ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
     ${YAMLCPP_LIBRARIES}
     ${Boost_LIBRARIES}


### PR DESCRIPTION
Previously, we queried environment variables to find the User's profile
directory. This followed logic used in Puppet to do the same. That was
more error-prone and required querying multiple environment variables.

Use GetUserProfileDirectory to get the path instead, which should work on
all platforms. In particular this will be better supported in future
Windows versions.