### PR TITLE
(FACT-926) Provide meaningful operatingsystem fact values for Arista EOS

### DIFF
--- a/lib/inc/facter/facts/os.hpp
+++ b/lib/inc/facter/facts/os.hpp
@@ -177,6 +177,10 @@ namespace facter { namespace facts {
          * The Windows operating system.
          */
         constexpr static char const* windows = "windows";
+        /**
+         * The AristaEOS operating system.
+         */
+        constexpr static char const* arista_eos = "AristaEOS";
     };
 
 }}

--- a/lib/inc/internal/facts/linux/release_file.hpp
+++ b/lib/inc/internal/facts/linux/release_file.hpp
@@ -102,6 +102,10 @@ namespace facter { namespace facts { namespace linux {
          * Release file for Mint Linux.
          */
         constexpr static char const* linux_mint_info = "/etc/linuxmint/info";
+        /**
+         * Release file for AristaEOS.
+         */
+        constexpr static char const* arista_eos = "/etc/Eos-release";
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -140,6 +140,7 @@ namespace facter { namespace facts { namespace linux {
                 { string(os::oracle_linux),             string(release_file::oracle_linux) },
                 { string(os::oracle_enterprise_linux),  string(release_file::oracle_enterprise_linux) },
                 { string(os::oracle_vm_linux),          string(release_file::oracle_vm_linux) },
+                { string(os::arista_eos),               string(release_file::arista_eos) },
         };
 
         string value;
@@ -215,6 +216,9 @@ namespace facter { namespace facts { namespace linux {
             } else if (name == os::openwrt) {
                 file = release_file::openwrt_version;
                 pattern = "(?m)^(\\d+\\.\\d+.*)";
+            } else if (name == os::arista_eos) {
+                file = release_file::arista_eos;
+                pattern = "Arista Networks EOS (\\d+\\.\\d+\\.\\d+[A-M]?)";
             }
             if (file) {
                 string contents = file::read(file);
@@ -361,6 +365,7 @@ namespace facter { namespace facts { namespace linux {
             make_tuple(string(release_file::alpine),         string(os::alpine)),
             make_tuple(string(release_file::mageia),         string(os::mageia)),
             make_tuple(string(release_file::amazon),         string(os::amazon)),
+            make_tuple(string(release_file::arista_eos),     string(os::arista_eos)),
         };
 
         for (auto const& file : files) {


### PR DESCRIPTION
This commit adds support for Arista EOS within the operating system
set of facts. This includes the `os` structured fact and the legacy
operatingsystem facts.