### PR TITLE
(FACT-914) Avoid locale on Solaris with GCC

### DIFF
--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -26,7 +26,10 @@ namespace facter { namespace logging {
     {
         // Initialize boost filesystem's locale to a UTF-8 default.
         // Logging gets setup the same way via the default 2nd argument.
+#if !defined(__sun) || !defined(__GNUC__)
+        // Locale support in GCC on Solaris is busted, so skip it.
         boost::filesystem::path::imbue(leatherman::locale::get_locale());
+#endif
         lm::setup_logging(os);
     }
 


### PR DESCRIPTION
On Solaris when using GCC, std::locale is broken.
https://gcc.gnu.org/ml/gcc/2012-08/msg00284.html

Disable using std::locale on Solaris. The defaults support UTF-8.