### PR TITLE
(FACT-951) Make Boost.Chrono dependency explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - wget https://s3.amazonaws.com/kylo-pl-bucket/doxygen_install.tar.bz2
   - sudo tar xjvf doxygen_install.tar.bz2 --strip 1 -C /usr/local
   # Install dependencies of facter
-  - sudo apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev
+  - sudo apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev libboost-chrono1.55-dev
   - wget https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1_install.tar.bz2
   - sudo tar xjvf yaml-cpp-0.5.1_install.tar.bz2 --strip 1 -C /usr/local
   # Install libblkid-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ include(options)
 
 # We use system, filesystem, regex, and log directly. Log depends on system, filesystem, datetime, and thread.
 # For Windows, we've added locale to correctly generate a UTF-8 compatible default locale.
-set(BOOST_PKGS program_options system filesystem date_time thread regex log)
+set(BOOST_PKGS program_options system filesystem date_time thread regex log chrono)
 if (WIN32)
     list(APPEND BOOST_PKGS locale)
 endif()

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For the remaining tasks, build commands can be executed in the shell from Start 
 * build [Boost](http://sourceforge.net/projects/boost/files/latest/download)
 
         .\bootstrap mingw
-        .\b2 toolset=gcc --build-type=minimal install --prefix=$install --with-program_options --with-system --with-filesystem --with-date_time --with-thread --with-regex --with-log --with-locale boost.locale.iconv=off
+        .\b2 toolset=gcc --build-type=minimal install --prefix=$install --with-program_options --with-system --with-filesystem --with-date_time --with-thread --with-regex --with-log --with-locale --with-chrono boost.locale.iconv=off
 
 * build [yaml-cpp](https://code.google.com/p/yaml-cpp/downloads)
 
@@ -84,7 +84,7 @@ In Powershell:
     7za x boost_1_54_0.7z
     pushd boost_1_54_0
     .\bootstrap mingw
-    .\b2 toolset=gcc --build-type=minimal install --prefix=$install --with-program_options --with-system --with-filesystem --with-date_time --with-thread --with-regex --with-log --with-locale boost.locale.iconv=off
+    .\b2 toolset=gcc --build-type=minimal install --prefix=$install --with-program_options --with-system --with-filesystem --with-date_time --with-thread --with-regex --with-log --with-locale --with-chrono boost.locale.iconv=off
     popd
 
     (New-Object Net.WebClient).DownloadFile("https://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz", "$pwd/yaml-cpp-0.5.1.tar.gz")

--- a/contrib/dockerfiles/travis-facter-builder/Dockerfile
+++ b/contrib/dockerfiles/travis-facter-builder/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Michael Smith <michael.smith@puppetlabs.com>
 RUN apt-get -y install libssl-dev
 RUN apt-get -y install libcurl4-openssl-dev
 RUN apt-get -y install libblkid-dev
-RUN apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev
+RUN apt-get -y install libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-regex1.55-dev libboost-date-time1.55-dev libboost-thread1.55-dev libboost-log1.55-dev libboost-locale1.55-dev libboost-chrono1.55-dev
 
 # Build and install yaml-cpp
 RUN wget https://yaml-cpp.googlecode.com/files/yaml-cpp-0.5.1.tar.gz -O yaml-cpp-0.5.1.tgz && \


### PR DESCRIPTION
LTH-5 makes the Boost.Chrono dependency explicit. Make updates to
documentation, CI, and submodules to incorporate that fix.