### PR TITLE
(FACT-951) Build Boost.Chrono in Windows packaging

### DIFF
--- a/contrib/facter.ps1
+++ b/contrib/facter.ps1
@@ -127,6 +127,7 @@ if ($buildSource) {
     "--with-regex",
     "--with-log",
     "--with-locale",
+    "--with-chrono",
     "--prefix=`"$toolsDir\$boostPkg`"",
     "boost.locale.iconv=off"
     "-j$cores"


### PR DESCRIPTION
Prior commits updated Facter to explicitly depend on Boost Chrono.
Update Windows packaging to be explicit about building it as well.