### PR TITLE
(FACT-697) properly skip fact if NetworkManager is not running.

### DIFF
--- a/lib/facter/dhcp_servers.rb
+++ b/lib/facter/dhcp_servers.rb
@@ -24,7 +24,8 @@ Facter.add(:dhcp_servers) do
     Facter::Core::Execution.which('nmcli')
   end
   confine do
-    Facter::Util::DHCPServers.network_manager_state != 'unknown'
+    s = Facter::Util::DHCPServers.network_manager_state
+    !s.empty? && (s != 'unknown')
   end
 
   setcode do

--- a/spec/unit/dhcp_servers_spec.rb
+++ b/spec/unit/dhcp_servers_spec.rb
@@ -175,6 +175,28 @@ describe "DHCP server facts" do
           Facter.fact(:dhcp_servers).value.should be_nil
         end
       end
+      describe 'with nmcli version >= 0.9.9 available but printing an error to STDERR' do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE g 2>/dev/null').returns("\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.9.0')
+        end
+
+        it 'should not produce a dhcp_servers fact' do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+
+      describe 'with nmcli version <= 0.9.8 available but printing an error to STDERR' do
+        before :each do
+          Facter::Core::Execution.stubs(:exec).with('nmcli -t -f STATE nm 2>/dev/null').returns("\n")
+          Facter::Core::Execution.stubs(:exec).with('nmcli --version').returns('nmcli tool, version 0.9.7.0')
+        end
+
+        it 'should not produce a dhcp_servers fact' do
+          Facter.fact(:dhcp_servers).value.should be_nil
+        end
+      end
+
     end
 
     describe "without nmcli available" do


### PR DESCRIPTION
On my CentOS 7 nmcli printed an error to STDERR if NetworkManager
is not running, however this was redirected to /dev/null
This had effect that the confine didn't work and facter tried to
exectue `nmcli d`, which then printed the same error to STDERR,
having the mesage "Error: NetworkManager is not running." on each
facter/puppet run.

We now properly check if something at all was returned and
otherwise assume that nmcli won't work anyways.