### PR TITLE
(FACT-955) Fix hardwaremodel/architecture fact for WOW64.

### DIFF
--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -20,54 +20,27 @@ namespace facter { namespace facts { namespace windows {
 
     static string get_hardware()
     {
-        // IsWow64Process is not available on all supported versions of Windows.
-        // Use GetModuleHandle to get a handle to the DLL that contains the function
-        // and GetProcAddress to get a pointer to the function if available.
-        typedef BOOL (WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
-
-        BOOL isWow64 = FALSE;
-        LPFN_ISWOW64PROCESS fnIsWow64Process = (LPFN_ISWOW64PROCESS)
-                GetProcAddress(GetModuleHandleW(L"kernel32"), "IsWow64Process");
-        if (nullptr != fnIsWow64Process) {
-            if (!fnIsWow64Process(GetCurrentProcess(), &isWow64)) {
-                LOG_DEBUG("failure determining whether current process is WOW64, defaulting to false"
-                        ": %1%", system_error());
-            }
-        }
-
         SYSTEM_INFO sysInfo;
         GetNativeSystemInfo(&sysInfo);
 
-        // The cryptic windows cpu architecture models are documented in these places:
-        //   http://source.winehq.org/source/include/winnt.h#L568
-        //   http://msdn.microsoft.com/en-us/library/windows/desktop/aa394373(v=vs.85).aspx
-        //   http://msdn.microsoft.com/en-us/library/windows/desktop/windows.system.processorarchitecture.aspx
-        //   http://linux.derkeiler.com/Mailing-Lists/Kernel/2008-05/msg12924.html (anything over 6 is still i686)
-        // Also, arm and neutral are included because they are valid for the upcoming
-        // windows 8 release.  --jeffweiss 23 May 2012
-        auto archLevel = (sysInfo.wProcessorLevel > 5) ? 6 : sysInfo.wProcessorLevel;
         switch (sysInfo.wProcessorArchitecture) {
-            case PROCESSOR_ARCHITECTURE_NEUTRAL:        return "neutral";
-            case PROCESSOR_ARCHITECTURE_IA32_ON_WIN64:  return "i686";
-            case PROCESSOR_ARCHITECTURE_AMD64:          return isWow64 ? "i" + to_string(archLevel) + "86" : "x64";
-            case PROCESSOR_ARCHITECTURE_MSIL:           return "msil";
-            case PROCESSOR_ARCHITECTURE_ALPHA64:        return "alpha64";
-            case PROCESSOR_ARCHITECTURE_IA64:           return "ia64";
-            case PROCESSOR_ARCHITECTURE_ARM:            return "arm";
-            case PROCESSOR_ARCHITECTURE_SHX:            return "shx";
-            case PROCESSOR_ARCHITECTURE_PPC:            return "powerpc";
-            case PROCESSOR_ARCHITECTURE_ALPHA:          return "alpha";
-            case PROCESSOR_ARCHITECTURE_MIPS:           return "mips";
-            case PROCESSOR_ARCHITECTURE_INTEL:          return "i" + to_string(archLevel) + "86";
-            default: return "unknown";  // PROCESSOR_ARCHITECTURE_UNKNOWN
+            case PROCESSOR_ARCHITECTURE_AMD64:
+                return "x64";
+            case PROCESSOR_ARCHITECTURE_ARM:
+                return "arm";
+            case PROCESSOR_ARCHITECTURE_IA64:
+                return "ia64";
+            case PROCESSOR_ARCHITECTURE_INTEL:
+                return "i" + to_string((sysInfo.wProcessorLevel > 5) ? 6 : sysInfo.wProcessorLevel) + "86";
+            default:
+                return "unknown";
         }
     }
 
     static string get_architecture(string const& hardware)
     {
-        // For most, the architecture is the same as the model.
-        // For others /(i[3456]86|pentium)/, use x86
-        if (re_search(hardware, boost::regex("i[3456]86|pentium"))) {
+        // Use "x86" for 32-bit systems
+        if (re_search(hardware, boost::regex("i[3456]86"))) {
             return "x86";
         }
         return hardware;


### PR DESCRIPTION
On 64-bit Windows, facter was reporting "i686" for the hardwaremodel and
architecture facts when running under WOW64 (i.e. facter itself was
32-bit).  There was an incorrect check in Facter for WOW64 that was
reporting the architecture of Facter and not the operating system.

This fix removes that check.  Additionally, removing architectures that
are no longer supported (Windows only supports x86, x64, ia64, and ARM).