### PR TITLE
(FACT-610) Make hardwaremodel fact on x64 Windows consistent.

### DIFF
--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -25,7 +25,7 @@ namespace facter { namespace facts { namespace windows {
 
         switch (sysInfo.wProcessorArchitecture) {
             case PROCESSOR_ARCHITECTURE_AMD64:
-                return "x64";
+                return "x86_64";
             case PROCESSOR_ARCHITECTURE_ARM:
                 return "arm";
             case PROCESSOR_ARCHITECTURE_IA64:
@@ -42,6 +42,8 @@ namespace facter { namespace facts { namespace windows {
         // Use "x86" for 32-bit systems
         if (re_search(hardware, boost::regex("i[3456]86"))) {
             return "x86";
+        } else if (hardware == "x86_64") {
+            return "x64";
         }
         return hardware;
     }


### PR DESCRIPTION
Most platforms use "x86_64" as the hardware model for 64-bit platforms.
Windows was using "x64" instead.  To make Windows consistent with other
platforms, the "hardwaremodel" will use the "x86_64" identifier, but
will keep "architecture" as x64, since Windows uses "x64" in its nomenclature in
favor of "amd64" and "x86_64".