### PR TITLE
(maint) Fix boost::optional usage for Boost 1.58.

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -42,12 +42,12 @@ namespace facter { namespace facts { namespace linux {
         scoped_descriptor sock(socket(AF_INET, SOCK_DGRAM, 0));
         if (static_cast<int>(sock) < 0) {
             LOG_WARNING("socket failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
-            return {};
+            return boost::none;
         }
 
         if (ioctl(sock, SIOCGIFMTU, &req) == -1) {
             LOG_WARNING("ioctl failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
-            return {};
+            return boost::none;
         }
         return req.ifr_mtu;
     }

--- a/lib/src/facts/osx/networking_resolver.cc
+++ b/lib/src/facts/osx/networking_resolver.cc
@@ -32,7 +32,7 @@ namespace facter { namespace facts { namespace osx {
     boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
     {
         if (!data) {
-            return {};
+            return boost::none;
         }
         return reinterpret_cast<if_data const*>(data)->ifi_mtu;
     }

--- a/lib/src/facts/posix/load_average_resolver.cc
+++ b/lib/src/facts/posix/load_average_resolver.cc
@@ -17,7 +17,7 @@ namespace facter { namespace facts { namespace posix {
         array<double, 3> averages;
         if (getloadavg(averages.data(), averages.size()) == -1) {
             LOG_DEBUG("failed to retrieve load averages: %1% (%2%).", strerror(errno), errno);
-            return nullptr;
+            return boost::none;
         }
         return make_tuple(averages[0], averages[1], averages[2]);
     }


### PR DESCRIPTION
Boost 1.58 stops treating nullptr_t as a substitute for boost::none, so
remove instances where nullptr was used.  Also changing a few places
where the default initialization syntax was used; let's stick to using
boost::none as it's more semantically clear.