### PR TITLE
(FACT-942) Add acceptance test for external fact directory

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -10,12 +10,12 @@ module Facter
       def get_user_fact_dir(platform, version)
         if platform =~ /windows/
           if version < 6.0
-            'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/custom'
+            File.join('C:', 'Documents and Settings', 'All Users', 'Application Data', 'PuppetLabs', 'facter', 'custom')
           else
-            'C:/ProgramData/PuppetLabs/facter/custom'
+            File.join('C:', 'ProgramData', 'PuppetLabs', 'facter', 'custom')
           end
         else
-          '/opt/puppetlabs/facter/custom'
+          File.join('/', 'opt', 'puppetlabs', 'facter', 'custom')
         end
       end
 
@@ -24,12 +24,12 @@ module Facter
       def get_factsd_dir(platform, version)
         if platform =~ /windows/
           if version < 6.0
-            'C:/Documents and Settings/All Users/Application Data/PuppetLabs/facter/facts.d'
+            File.join('C:', 'Documents and Settings', 'All Users', 'Application Data', 'PuppetLabs', 'facter', 'facts.d')
           else
-            'C:/ProgramData/PuppetLabs/facter/facts.d'
+            File.join('C:', 'ProgramData', 'PuppetLabs', 'facter', 'facts.d')
           end
         else
-          '/opt/puppetlabs/facter/facts.d'
+          File.join('/', 'opt', 'puppetlabs', 'facter', 'facts.d')
         end
       end
 

--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -1,0 +1,47 @@
+test_name "Root default external facts directory (facts.d) is searched for facts"
+
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# This test is intended to ensure that executable external facts placed into the
+# default facts.d directory are properly found and resolved by Facter when run
+# as root.
+#
+
+unix_content = <<EOM
+#!/bin/sh
+echo "external_fact=testvalue"
+EOM
+
+win_content = <<EOM
+@echo off
+echo external_fact=testvalue
+EOM
+
+agents.each do |agent|
+  os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+  factsd = get_factsd_dir(agent['platform'], os_version)
+  ext = get_external_fact_script_extension(agent['platform'])
+
+  if agent['platform'] =~ /windows/
+    content = win_content
+  else
+    content = unix_content
+  end
+
+  step "Agent #{agent}: setup default external facts directory (facts.d)"
+  on(agent, "mkdir -p '#{factsd}'")
+
+  step "Agent #{agent}: create an executable external fact in default facts.d"
+  ext_fact = File.join(factsd, "external_fact#{ext}")
+  create_remote_file(agent, ext_fact, content)
+  on(agent, "chmod +x #{ext_fact}")
+
+  teardown do
+    on(agent, "rm -f '#{ext_fact}'")
+  end
+
+  step "Agent #{agent}: the external fact should resolve"
+  assert_equal("testvalue", fact_on(agent, "external_fact"))
+end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -34,12 +34,12 @@ agents.each do |agent|
   end
 
   step "--no-custom-facts option should disable custom facts"
-  on(agent, "FACTERLIB=#{custom_dir} facter --no-custom-facts custom_fact") do
+  on(agent, facter("--no-custom-facts custom_fact")) do
     assert_equal("", stdout.chomp, "Expected custom fact to be disabled, but it resolved as #{stdout.chomp}")
   end
 
   step "--custom-dir option should allow custom facts to be resolved from a specific directory"
-  on(agent, "facter --custom-dir #{custom_dir} custom_fact") do
+  on(agent, facter("--custom-dir #{custom_dir} custom_fact")) do
     assert_equal("testvalue", stdout.chomp, "Custom fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -25,7 +25,7 @@ agents.each do |agent|
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")
-  custom_fact = "#{custom_dir}/custom_fact.rb"
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
   create_remote_file(agent, custom_fact, content)
   on(agent, "chmod +x #{custom_fact}")
 

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -7,7 +7,7 @@ test_name "--debug command-line option prints debugging information to stderr"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve debug info from stderr using --debug option"
-  on(agent, "facter --debug") do
+  on(agent, facter('--debug')) do
     assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
   end
 end

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -37,8 +37,8 @@ agents.each do |agent|
   on(agent, "mkdir -p '#{custom_external_dir}'")
 
   step "Agent #{agent}: create executable external facts in facts.d and custom external fact dir"
-  ext_fact_factsd     = "#{factsd}/external_fact#{ext}"
-  ext_fact_custom_dir = "#{custom_external_dir}/external_fact#{ext}"
+  ext_fact_factsd     = File.join(factsd, "external_fact#{ext}")
+  ext_fact_custom_dir = File.join(custom_external_dir, "external_fact#{ext}")
   create_remote_file(agent, ext_fact_factsd, content)
   create_remote_file(agent, ext_fact_custom_dir, content)
   on(agent, "chmod +x #{ext_fact_factsd} #{ext_fact_custom_dir}")

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -17,7 +17,8 @@ echo "external_fact=testvalue"
 EOM
 
 win_content = <<EOM
-echo "external_fact=testvalue"
+@echo off
+echo external_fact=testvalue
 EOM
 
 agents.each do |agent|
@@ -48,12 +49,12 @@ agents.each do |agent|
   end
 
   step "--no-external-facts option should disable external facts"
-  on(agent, "facter --no-external-facts external_fact") do
+  on(agent, facter("--no-external-facts external_fact")) do
     assert_equal("", stdout.chomp, "Expected external fact to be disabled, but it resolved as #{stdout.chomp}")
   end
 
   step "--external-dir option should allow external facts to be resolved from a specific directory"
-  on(agent, "facter --external-dir #{custom_external_dir} external_fact") do
+  on(agent, facter("--external-dir #{custom_external_dir} external_fact")) do
     assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -8,7 +8,7 @@ test_name "--help command-line option prints usage information to stdout"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve usage info from stdout using --help option"
-  on(agent, "facter --help") do
+  on(agent, facter('--help')) do
     assert_match(/facter \[options\] \[query\] \[query\] \[...\]/, stdout, "Expected stdout to contain usage information")
   end
 end

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -23,7 +23,7 @@ agents.each do |agent|
   custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
-  custom_fact = "#{custom_dir}/custom_fact.rb"
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
   on(agent, "mkdir -p '#{custom_dir}'")
   create_remote_file(agent, custom_fact, content)
   on(agent, "chmod +x #{custom_fact}")

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -33,7 +33,7 @@ agents.each do |agent|
   end
 
   step "Agent #{agent}: retrieve output using the --json option"
-  on(agent, "FACTERLIB=#{custom_dir} facter structured_fact --json") do
+  on(agent, facter("--custom-dir #{custom_dir} --json structured_fact")) do
     begin
       expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3"}})
       assert_equal(expected, stdout.chomp, "JSON output does not match expected output")

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -7,7 +7,7 @@ test_name "--log-level command-line option can be used to specify logging level"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option"
-  on(agent, "facter --log-level debug") do
+  on(agent, facter('--log-level debug')) do
     assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
   end
 end

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -22,7 +22,7 @@ agents.each do |agent|
 
   step "Agent #{agent}: create custom fact directory and executable custom fact"
   on(agent, "mkdir -p '#{custom_dir}'")
-  custom_fact = "#{custom_dir}/custom_fact.rb"
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
   create_remote_file(agent, custom_fact, content)
   on(agent, "chmod +x #{custom_fact}")
 

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -32,7 +32,7 @@ agents.each do |agent|
 
   step "--trace option should provide a backtrace for a custom fact with errors"
   begin
-    on(agent, "FACTERLIB=#{custom_dir} facter --trace custom_fact")
+      on(agent, facter("--custom-dir #{custom_dir} --trace custom_fact"))
   rescue Exception => e
     assert_match(/backtrace:\s+#{custom_fact}/, e.message, "Expected a backtrace for erroneous custom fact")
   end

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -7,7 +7,7 @@ test_name "--verbose command-line option prints verbose information to stderr"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve verbose info from stderr using --verbose option"
-  on(agent, "facter --verbose") do
+  on(agent, facter('--verbose')) do
     assert_match(/INFO  puppetlabs.facter - executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
   end
 end

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -7,7 +7,7 @@ test_name "--version command-line option returns the version string"
 
 agents.each do |agent|
   step "Agent #{agent}: retrieve version info using the --version option"
-  on(agent, "facter --version") do
+  on(agent, facter('--version')) do
     assert_match(/\d+\.\d+\.\d+/, stdout, "Output #{stdout} is not a recognized version string")
   end
 end

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -32,7 +32,7 @@ agents.each do |agent|
   end
 
   step "Agent #{agent}: retrieve output using the --yaml option"
-  on(agent, "FACTERLIB=#{custom_dir} facter structured_fact --yaml") do
+  on(agent, facter("--custom-dir #{custom_dir} --yaml structured_fact")) do
     begin
       expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}.to_yaml.gsub("---\n", '')
       assert_equal(expected, stdout, "YAML output does not match expected output")

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -22,7 +22,7 @@ agents.each do |agent|
   custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
 
   step "Agent #{agent}: create a structured custom fact"
-  custom_fact = "#{custom_dir}/custom_fact.rb"
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
   on(agent, "mkdir -p '#{custom_dir}'")
   create_remote_file(agent, custom_fact, content)
   on(agent, "chmod +x #{custom_fact}")

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -305,6 +305,16 @@ ec2_userdata:
     caveats: |
         All platforms: `libfacter` must be built with `libcurl` support.
 
+env_windows_installdir:
+    type: string
+    description: Return the path of the directory in which Puppet was installed.
+    resolution: |
+      Windows: This fact is specific to the Windows MSI generated environment, and is
+        set using the `environment.bat` script that configures the runtime environment
+        for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
+    caveats: |
+      This fact is specific to Windows, and will not resolve on any other platform.
+
 facterversion:
     type: string
     description: Return the version of facter.

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -395,6 +395,7 @@ protected:
 
 void add_all_facts(collection& facts)
 {
+    facts.add("env_windows_installdir", make_value<string_value>("C:\\Program Files\\Some\\Path"));
     facts.add("facterversion", make_value<string_value>("version"));
     facts.add(make_shared<disk_resolver>());
     facts.add(make_shared<dmi_resolver>());


### PR DESCRIPTION
The Puppet 4 AIO pathing changes exposed a lack of tests
around the default external facts (facts.d) directory. This commit
adds an acceptance test to ensure that external facts placed into
the default facts.d directory are found and resolved by Facter.