### PR TITLE
(maint) Remove lucid from build targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -5,7 +5,7 @@ deb_build_mirrors:
   - deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main
 default_cow: 'base-wheezy-i386.cow'
 # Which debian distributions to build for. Noarch packages only need one arch of each cow.
-cows: 'base-lucid-amd64.cow base-lucid-i386.cow base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-stable-amd64.cow base-stable-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
+cows: 'base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-stable-amd64.cow base-stable-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
 # The pbuilder configuration file to use
 pbuild_conf: '/etc/pbuilderrc'
 # Who is packaging. Turns up in various packaging artifacts


### PR DESCRIPTION
Ubuntu 10.04 (Lucid Lynx) goes EoL 2015-04-30, and as such, we no longer
want to be building packages for this platform.

https://lists.ubuntu.com/archives/ubuntu-announce/2015-March/000193.html