### PR TITLE
(maint) Ignore acceptance libs in Coveralls

### DIFF
--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -58,7 +58,7 @@ function travis_make()
         fi
 
         if [ $1 == "debug" ]; then
-            coveralls --gcov-options '\-lp' -r .. >/dev/null
+            coveralls --gcov-options '\-lp' -r .. --exclude ../acceptance >/dev/null
         fi
 
         # Install into the system for the spec tests 


### PR DESCRIPTION
Code coverage with Coveralls includes the libraries used by acceptance
tests, which we expect will not be exercised. Exclude them from the
coverage reports so we don't have a misleading representation of code we
care about.