### PR TITLE
(maint) Remove debian stable

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -5,7 +5,7 @@ deb_build_mirrors:
   - deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main
 default_cow: 'base-wheezy-i386.cow'
 # Which debian distributions to build for. Noarch packages only need one arch of each cow.
-cows: 'base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-stable-amd64.cow base-stable-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
+cows: 'base-precise-amd64.cow base-precise-i386.cow base-squeeze-amd64.cow base-squeeze-i386.cow base-trusty-amd64.cow base-trusty-i386.cow base-wheezy-amd64.cow base-wheezy-i386.cow'
 # The pbuilder configuration file to use
 pbuild_conf: '/etc/pbuilderrc'
 # Who is packaging. Turns up in various packaging artifacts


### PR DESCRIPTION
Debian 8 jessie was released April 25th, 2015 and became "stable". As
part of this, system ruby was bumped to 2.1, and RbConfig['libdir'] no
longer points at the library location, which prevents native facter from
resolving ruby facts in a non-AIO configuration.

We will officially be adding jessie support to AIO at a later date, and
that change will be done in the AIO pipeline.