### PR TITLE
(FACT-965) Implement initial support for JRuby.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ compile_commands.json
 /lib/inc/facter/export.h
 /lib/inc/facter/version.h
 /lib/tests/fixtures.hpp
+/lib/src/java/com_puppetlabs_Facter.h
 /debug*/
 /release*/
 /.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,24 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND NOT WITHOUT_CURL)
     set_package_properties(CURL PROPERTIES TYPE OPTIONAL PURPOSE "Enables facts that require HTTP.")
 endif()
 
+if (NOT WITHOUT_JRUBY AND NOT WIN32)
+    find_package(JNI)
+    set_package_properties(JNI PROPERTIES DESCRIPTION "Java Native Interface (JNI) is a programming framework that enables Java code running in a Java Virtual Machine (JVM) to call and be called by native applications.")
+    set_package_properties(JNI PROPERTIES TYPE OPTIONAL PURPOSE "Enables JRuby support in Facter.")
+
+    if (JNI_FOUND)
+        find_package(Java)
+        set_package_properties(Java PROPERTIES DESCRIPTION "Java compiler for JNI.")
+        set_package_properties(Java PROPERTIES TYPE OPTIONAL PURPOSE "Enables JRuby support in Facter.")
+
+        if (Java_JAVAC_EXECUTABLE)
+            set(JRUBY_SUPPORT TRUE)
+            set(CMAKE_JAVA_COMPILE_FLAGS -source 1.6 -target 1.6)
+            add_definitions(-DUSE_JRUBY_SUPPORT)
+        endif()
+    endif()
+endif()
+
 # Display a summary of the features
 include(FeatureSummary)
 feature_summary(WHAT ALL)
@@ -93,7 +111,9 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 if (WIN32)
     # On Windows, DLL paths aren't hardcoded in the executable. We place all the executables and libraries
     # in the same directory to avoid having to setup the DLL search path in the dev environment.
-    set(LIBRARY_OUTPUT_PATH    ${PROJECT_BINARY_DIR}/bin)
+    set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
+else()
+    set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 endif()
 
 add_definitions(${LEATHERMAN_DEFINITIONS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -228,6 +228,28 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPSAPI_VERSION=1")
 endif()
 
+if (WIN32)
+    set(LIBFACTER_INSTALL_DESTINATION bin)
+else()
+    # TODO: lib64 for certain operating systems?
+    set(LIBFACTER_INSTALL_DESTINATION lib)
+endif()
+
+if (JRUBY_SUPPORT)
+    include_directories(${JNI_INCLUDE_DIRS})
+    set(LIBFACTER_COMMON_SOURCES ${LIBFACTER_COMMON_SOURCES} src/java/facter.cc)
+
+    configure_file(
+        Facter.java.in
+        "${CMAKE_BINARY_DIR}/lib/com/puppetlabs/Facter.java"
+    )
+
+    include(UseJava)
+    add_jar(facter-jruby "${CMAKE_BINARY_DIR}/lib/com/puppetlabs/Facter.java" OUTPUT_NAME facter OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib" ENTRY_POINT com/puppetlabs/Facter)
+
+    add_custom_command(TARGET facter-jruby POST_BUILD COMMAND javah ARGS -d "${CMAKE_CURRENT_LIST_DIR}/src/java" com.puppetlabs.Facter WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+endif()
+
 # Set include directories
 include_directories(
     inc
@@ -274,13 +296,6 @@ elseif (WIN32)
     add_definitions("-Dlibfacter_EXPORTS")
 endif()
 
-if (WIN32)
-    set(LIBFACTER_INSTALL_DESTINATION bin)
-else()
-    # TODO: lib64 for certain operating systems?
-    set(LIBFACTER_INSTALL_DESTINATION lib)
-endif()
-
 install(TARGETS libfacter DESTINATION ${LIBFACTER_INSTALL_DESTINATION})
 install(DIRECTORY inc/facter DESTINATION include)
 
@@ -304,6 +319,15 @@ if (RUBY_FOUND)
     string(STRIP ${RUBY_VENDORDIR_OUT} RUBY_VENDORDIR)
     message(STATUS "\"make install\" will install facter.rb to ${RUBY_VENDORDIR}")
     install(FILES ${CMAKE_BINARY_DIR}/lib/facter.rb DESTINATION ${RUBY_VENDORDIR})
+
+    if (JRUBY_SUPPORT)
+        message(STATUS "\"make install\" will install facter.jar to ${RUBY_VENDORDIR} to support JRuby")
+        install(FILES ${CMAKE_BINARY_DIR}/lib/facter.jar DESTINATION ${RUBY_VENDORDIR})
+    endif()
+endif()
+
+if (JRUBY_SUPPORT)
+    add_dependencies(libfacter facter-jruby)
 endif()
 
 cotire(libfacter)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -270,9 +270,9 @@ link_directories(
 
 # Add the library target without a prefix (name already has the 'lib') and use '.so' for all platforms (Ruby extension file extension)
 add_library(libfactersrc OBJECT ${LIBFACTER_COMMON_SOURCES} ${LIBFACTER_STANDARD_SOURCES} ${LIBFACTER_PLATFORM_SOURCES})
-set_target_properties(libfactersrc PROPERTIES POSITION_INDEPENDENT_CODE true)
+set_target_properties(libfactersrc PROPERTIES POSITION_INDEPENDENT_CODE true COTIRE_ENABLE_PRECOMPILED_HEADER ${PRECOMPILED_HEADERS} COTIRE_ADD_UNITY_BUILD FALSE)
 add_library(libfacter SHARED $<TARGET_OBJECTS:libfactersrc>)
-set_target_properties(libfacter PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a" VERSION "${LIBFACTER_VERSION_MAJOR}.${LIBFACTER_VERSION_MINOR}.${LIBFACTER_VERSION_PATCH}" COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY" COTIRE_ENABLE_PRECOMPILED_HEADER ${PRECOMPILED_HEADERS})
+set_target_properties(libfacter PROPERTIES PREFIX "" SUFFIX ".so" IMPORT_PREFIX "" IMPORT_SUFFIX ".so.a" VERSION "${LIBFACTER_VERSION_MAJOR}.${LIBFACTER_VERSION_MINOR}.${LIBFACTER_VERSION_PATCH}" COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY")
 
 # Link in additional libraries
 target_link_libraries(libfacter PRIVATE
@@ -330,6 +330,6 @@ if (JRUBY_SUPPORT)
     add_dependencies(libfacter facter-jruby)
 endif()
 
-cotire(libfacter)
+cotire(libfactersrc)
 
 add_subdirectory(tests)

--- a/lib/Facter.java.in
+++ b/lib/Facter.java.in
@@ -9,7 +9,7 @@ import java.util.TreeSet;
 public class Facter {
     static {
         // Look for libfacter in the same place as facter.rb does
-        String facterDir = System.getenv("FACTER_DIR");
+        String facterDir = System.getenv("FACTERDIR");
         if (facterDir == null) {
             facterDir = "${CMAKE_INSTALL_PREFIX}/${LIBFACTER_INSTALL_DESTINATION}";
         }

--- a/lib/Facter.java.in
+++ b/lib/Facter.java.in
@@ -1,0 +1,110 @@
+package com.puppetlabs;
+
+import java.util.HashMap;
+import java.util.TreeSet;
+
+/**
+ * The Java shim for libfacter.
+ */
+public class Facter {
+    static {
+        // Look for libfacter in the same place as facter.rb does
+        String facterDir = System.getenv("FACTER_DIR");
+        if (facterDir == null) {
+            facterDir = "${CMAKE_INSTALL_PREFIX}/${LIBFACTER_INSTALL_DESTINATION}";
+        }
+
+        // Load the library
+        System.load(facterDir.replaceAll("/$", "") + "/libfacter.so");
+    }
+
+    /**
+     * Lookup a fact value by name.
+     * @param name The fact name.
+     * @return Returns the fact's value or null if not found.
+     */
+    public static native Object lookup(String name);
+
+    /**
+     * Entry point for testing.
+     * Expects one argument which is the fact to lookup.
+     * @param args The program arguments.
+     */
+    public static void main(String[] args) {
+        if (args.length != 1) {
+            System.out.println("usage: Facter <fact>");
+            return;
+        }
+        print(lookup(args[0]), 1);
+        System.out.println();
+    }
+
+    private static void indent(int level) {
+        if (level < 1) {
+            return;
+        }
+        for (int i = 0; i < (level * 2); ++i) {
+            System.out.print(" ");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void print(Object value, int level) {
+        if (value == null) {
+            return;
+        }
+
+        // Check for arrays
+        if (value instanceof Object[]) {
+            Object[] array = (Object[])value;
+            System.out.print("[\n");
+            boolean first = true;
+            for (Object element : array) {
+                if (first) {
+                    first = false;
+                } else {
+                    System.out.print(",\n");
+                }
+                indent(level);
+                print(element, 0);
+            }
+            System.out.print("\n");
+            indent(level - 1);
+            System.out.print("]");
+            return;
+        }
+
+        // Check for maps
+        if (value instanceof HashMap) {
+            HashMap map = (HashMap)value;
+            System.out.print("{\n");
+
+            // Print out the keys in lexicographical order (like a std::map)
+            TreeSet<String> keys = new TreeSet<String>(map.keySet());
+            boolean first = true;
+            for (String key : keys) {
+                if (first) {
+                    first = false;
+                } else {
+                    System.out.print(",\n");
+                }
+                indent(level);
+                System.out.format("%s => ", key);
+                print(map.get(key), level + 1);
+            }
+            System.out.print("\n");
+            indent(level - 1);
+            System.out.print("}");
+            return;
+        }
+
+        // Check for strings (print with quotes)
+        if (value instanceof String) {
+            System.out.format("\"%s\"", value);
+            return;
+        }
+
+        // Output the value
+        System.out.print(value);
+    }
+}

--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -27,7 +27,7 @@ module Facter
   else
     # Simply require libfacter.so; this will define all of the Facter API
     begin
-      require "#{ENV['FACTER_DIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
+      require "#{ENV['FACTERDIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
     rescue LoadError
       raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
     end

--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -1,8 +1,35 @@
 module Facter
-  # Initialize native facter.
-  begin
-    require "#{ENV['FACTER_DIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
-  rescue LoadError
-    raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
+  if RUBY_PLATFORM == "java"
+    # For JRuby, require 'facter.jar'
+    begin
+      require 'facter.jar'
+    rescue LoadError
+      raise LoadError.new('libfacter was not built with JRuby support.')
+    end
+
+    # Pass value call through to JNI interface
+    def self.value(name)
+      com.puppetlabs.Facter.lookup(name)
+    end
+
+    def self.search(*paths)
+      # No-op; we don't support custom facts under JRuby
+    end
+
+    def self.version
+      com.puppetlabs.Facter.lookup("facterversion")
+    end
+
+    def self.add(*params)
+      raise 'adding facts under JRuby is not implemented.'
+    end
+
+  else
+    # Simply require libfacter.so; this will define all of the Facter API
+    begin
+      require "#{ENV['FACTER_DIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
+    rescue LoadError
+      raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
+    end
   end
 end

--- a/lib/src/java/facter.cc
+++ b/lib/src/java/facter.cc
@@ -1,0 +1,175 @@
+#include "com_puppetlabs_Facter.h"
+#include <facter/facts/collection.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/array_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include <facter/logging/logging.hpp>
+#include <facter/export.h>
+#include <boost/nowide/iostream.hpp>
+#include <string>
+#include <memory>
+
+using namespace std;
+using namespace facter::facts;
+using namespace facter::logging;
+
+static jclass object_class, long_class, double_class, boolean_class, hash_class;
+static jmethodID long_constructor, double_constructor, boolean_constructor, hash_constructor, hash_put;
+static std::unique_ptr<collection> facts_collection;
+
+static string to_string(JNIEnv* env, jstring str)
+{
+    if (!str) {
+        return {};
+    }
+
+    auto ptr = env->GetStringUTFChars(str, nullptr);
+    if (!ptr) {
+        return {};
+    }
+
+    auto size = env->GetStringUTFLength(str);
+    string result(ptr, size);
+
+    env->ReleaseStringUTFChars(str, ptr);
+    return result;
+}
+
+static jclass find_class(JNIEnv* env, char const* name)
+{
+    // Find the class and return a global reference
+    auto klass = env->FindClass(name);
+    if (!klass) {
+        return nullptr;
+    }
+    return static_cast<jclass>(env->NewGlobalRef(klass));
+}
+
+static jobject to_object(JNIEnv* env, value const* val)
+{
+    if (!val) {
+        return nullptr;
+    }
+    if (auto ptr = dynamic_cast<string_value const*>(val)) {
+        return env->NewStringUTF(ptr->value().c_str());
+    }
+    if (auto ptr = dynamic_cast<integer_value const*>(val)) {
+        return env->NewObject(long_class, long_constructor, static_cast<jlong>(ptr->value()));
+    }
+    if (auto ptr = dynamic_cast<boolean_value const*>(val)) {
+        return env->NewObject(boolean_class, boolean_constructor, static_cast<jboolean>(ptr->value()));
+    }
+    if (auto ptr = dynamic_cast<double_value const*>(val)) {
+        return env->NewObject(double_class, double_constructor, static_cast<jdouble>(ptr->value()));
+    }
+    if (auto ptr = dynamic_cast<array_value const*>(val)) {
+        auto array = env->NewObjectArray(ptr->size(), object_class, nullptr);
+
+        // Recurse on each element of the array
+        jsize index = 0;
+        ptr->each([&](value const* element) {
+            env->SetObjectArrayElement(array, index++, to_object(env, element));
+            return true;
+        });
+        return array;
+    }
+    if (auto ptr = dynamic_cast<map_value const*>(val)) {
+        auto hashmap = env->NewObject(hash_class, hash_constructor, static_cast<jint>(ptr->size()));
+
+        // Recurse on each element in the map
+        ptr->each([&](string const& name, value const* element) {
+            env->CallObjectMethod(hashmap, hash_put, env->NewStringUTF(name.c_str()), to_object(env, element));
+            return true;
+        });
+        return hashmap;
+    }
+    return nullptr;
+}
+
+extern "C" {
+    LIBFACTER_EXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved)
+    {
+        JNIEnv* env;
+        if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+            return JNI_ERR;
+        }
+        // For the classes, we need global refs
+        object_class = find_class(env, "java/lang/Object");
+        if (!object_class) {
+            return JNI_ERR;
+        }
+        long_class = find_class(env, "java/lang/Long");
+        if (!long_class) {
+            return JNI_ERR;
+        }
+        double_class = find_class(env, "java/lang/Double");
+        if (!double_class) {
+            return JNI_ERR;
+        }
+        boolean_class = find_class(env, "java/lang/Boolean");
+        if (!boolean_class) {
+            return JNI_ERR;
+        }
+        hash_class = find_class(env, "java/util/HashMap");
+        if (!hash_class) {
+            return JNI_ERR;
+        }
+
+        // For the method ids, we can keep these cached as is
+        long_constructor = env->GetMethodID(long_class, "<init>", "(J)V");
+        double_constructor = env->GetMethodID(double_class, "<init>", "(D)V");
+        boolean_constructor = env->GetMethodID(boolean_class, "<init>", "(Z)V");;
+        hash_constructor = env->GetMethodID(hash_class, "<init>", "(I)V");
+        hash_put = env->GetMethodID(hash_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+        setup_logging(boost::nowide::cerr);
+        set_level(level::warning);
+
+        facts_collection.reset(new collection());
+        facts_collection->add_default_facts();
+        facts_collection->add_external_facts();
+        return JNI_VERSION_1_6;
+    }
+
+    LIBFACTER_EXPORT void JNI_OnUnload(JavaVM* vm, void* reserved)
+    {
+        // Delete the fact collection
+        facts_collection.reset();
+
+        JNIEnv* env;
+        if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
+            return;
+        }
+        // Free all of the global references above
+        if (object_class) {
+            env->DeleteGlobalRef(object_class);
+            object_class = nullptr;
+        }
+        if (long_class) {
+            env->DeleteGlobalRef(long_class);
+            long_class = nullptr;
+        }
+        if (double_class) {
+            env->DeleteGlobalRef(double_class);
+            double_class = nullptr;
+        }
+        if (boolean_class) {
+            env->DeleteGlobalRef(boolean_class);
+            boolean_class = nullptr;
+        }
+        if (hash_class) {
+            env->DeleteGlobalRef(hash_class);
+            hash_class = nullptr;
+        }
+    }
+
+    LIBFACTER_EXPORT jobject JNICALL Java_com_puppetlabs_Facter_lookup(JNIEnv* env, jclass klass, jstring name)
+    {
+        // Ensure initialized
+        if (!facts_collection) {
+            return nullptr;
+        }
+
+        return to_object(env, (*facts_collection)[to_string(env, name)]);
+    }
+}  // extern "C"

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -97,6 +97,11 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     )
 endif()
 
+if (JRUBY_SUPPORT)
+    include_directories(${JNI_INCLUDE_DIRS})
+    set(LIBFACTER_TESTS_COMMON_SOURCES ${LIBFACTER_TESTS_COMMON_SOURCES} java/facter.cc)
+endif()
+
 include_directories(
     ../inc
     ${Boost_INCLUDE_DIRS}

--- a/lib/tests/fixtures.hpp.in
+++ b/lib/tests/fixtures.hpp.in
@@ -3,6 +3,9 @@
 #include <string>
 #include <functional>
 
+#define JAVA_EXECUTABLE "@Java_JAVA_EXECUTABLE@"
+#define BINARY_DIRECTORY "@CMAKE_BINARY_DIR@"
+#define LIBFACTER_OUTPUT_DIRECTORY "@LIBRARY_OUTPUT_PATH@"
 #define LIBFACTER_TESTS_DIRECTORY "@CMAKE_CURRENT_LIST_DIR@"
 
 namespace facter { namespace testing {

--- a/lib/tests/java/facter.cc
+++ b/lib/tests/java/facter.cc
@@ -36,7 +36,7 @@ SCENARIO("using libfacter from Java") {
                     "os"
                 },
                 {
-                    { "FACTER_DIR", LIBFACTER_OUTPUT_DIRECTORY },
+                    { "FACTERDIR", LIBFACTER_OUTPUT_DIRECTORY },
                     { "PATH", string(LIBFACTER_OUTPUT_DIRECTORY) + environment::get_path_separator() + system_path }
                 },
                 0,

--- a/lib/tests/java/facter.cc
+++ b/lib/tests/java/facter.cc
@@ -1,0 +1,69 @@
+#include <catch.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/execution/execution.hpp>
+#include <facter/util/environment.hpp>
+#include <boost/filesystem.hpp>
+#include "../fixtures.hpp"
+
+using namespace std;
+using namespace facter::facts;
+using namespace facter::execution;
+using namespace facter::util;
+using namespace boost::filesystem;
+
+SCENARIO("using libfacter from Java") {
+    collection facts;
+    facts.add_default_facts();
+
+    path jar_path = path(BINARY_DIRECTORY) / "lib" / "facter.jar";
+
+    string system_path;
+    environment::get("PATH", system_path);
+
+    CAPTURE(JAVA_EXECUTABLE);
+    CAPTURE(LIBFACTER_OUTPUT_DIRECTORY);
+    CAPTURE(jar_path);
+
+    GIVEN("the os fact") {
+        try {
+            bool success;
+            string output, error;
+            tie(success, output, error) = execute(
+                JAVA_EXECUTABLE,
+                {
+                    "-jar",
+                    jar_path.string(),
+                    "os"
+                },
+                {
+                    { "FACTER_DIR", LIBFACTER_OUTPUT_DIRECTORY },
+                    { "PATH", string(LIBFACTER_OUTPUT_DIRECTORY) + environment::get_path_separator() + system_path }
+                },
+                0,
+                {
+                    execution_options::trim_output,
+                    execution_options::merge_environment,
+                    execution_options::throw_on_failure
+                });
+            THEN("the value should match") {
+                REQUIRE(success);
+                REQUIRE(error.empty());
+                ostringstream ss;
+                auto value = facts["os"];
+                REQUIRE(value);
+                value->write(ss);
+                REQUIRE(output == ss.str());
+            }
+        } catch (child_exit_exception const& ex) {
+            CAPTURE(ex.output());
+            CAPTURE(ex.error());
+            CAPTURE(ex.status_code());
+            FAIL("exception from child process.");
+        } catch (child_signal_exception const& ex) {
+            CAPTURE(ex.output());
+            CAPTURE(ex.error());
+            CAPTURE(ex.signal());
+            FAIL("signal from child process.");
+        }
+    }
+}


### PR DESCRIPTION
This enables `require 'facter'` to work under JRuby.

Currently the only functionality supported is `Facter#value`, which will
return a Java object representing the fact's value.

Custom facts are not implemented.

Basically this is the bare minimum to get puppetserver working with
Facter 3.