### PR TITLE
(FACT-975) Add ppc64le to processors discovery

### DIFF
--- a/lib/facter/util/processor.rb
+++ b/lib/facter/util/processor.rb
@@ -232,7 +232,7 @@ module Processor
           end
         end
 
-      when "ppc64"
+      when "ppc64", "ppc64le"
         File.readlines(cpuinfo).each do |l|
           if l =~ /processor\s+:\s+(\d+)/
             processor_num = $1.to_i

--- a/spec/fixtures/cpuinfo/ppc64le
+++ b/spec/fixtures/cpuinfo/ppc64le
@@ -1,0 +1,15 @@
+processor       : 0
+cpu             : POWER8E (raw), altivec supported
+clock           : 3690.000000MHz
+revision        : 2.1 (pvr 004b 0201)
+
+processor       : 1
+cpu             : POWER8E (raw), altivec supported
+clock           : 3690.000000MHz
+revision        : 2.1 (pvr 004b 0201)
+
+timebase        : 512000000
+platform        : PowerNV
+model           : 8247-22L
+machine         : PowerNV 8247-22L
+firmware        : OPAL v3

--- a/spec/unit/processors/os_spec.rb
+++ b/spec/unit/processors/os_spec.rb
@@ -40,6 +40,13 @@ describe Facter::Processors::Linux do
         expect(count).to eq 2
       end
 
+      it "should be 2 in ppc64le fixture on Linux" do
+        Facter.fact(:architecture).stubs(:value).returns("ppc64le")
+        File.expects(:readlines).with("/proc/cpuinfo").returns(cpuinfo_fixture_readlines("ppc64le"))
+        count = subject.get_processor_count
+        expect(count).to eq 2
+      end
+
       it "should be 2 in panda-armel fixture on Linux" do
         Facter.fact(:architecture).stubs(:value).returns("arm")
         File.expects(:readlines).with("/proc/cpuinfo").returns(cpuinfo_fixture_readlines("panda-armel"))


### PR DESCRIPTION
Adding ppc64le architecture for processors discovery.
It's exactly as ppc64 behaviour.