### PR TITLE
(FACT-963) Remove pre-suite env setup for AIO

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,7 +1,6 @@
 {
   :type => 'aio',
   :pre_suite => [
-    'setup/common/00_EnvSetup.rb',
     'setup/aio/pre-suite/010_Install.rb',
   ],
 }


### PR DESCRIPTION
The acceptance tests attempt to install the JSON gem everywhere for all
types of installations. AIO tests do not require them, and the other
testing types are no longer supported (by virtue of them simply not
working and we haven't figured out what to do with them).

Specifically testing is blocked for AIO on Debian 8 because it does not
contain the same libjson-gem that the tests try to install. Remove the
entire environment setup pre-suite step, as with AIO there's no need to
install git, ruby, or any gems.