### PR TITLE
(FACT-979) Update Beaker to 2.8

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,14 +1,8 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.2.0"
+gem "beaker", "~> 2.8"
 gem 'rake', "~> 10.1.0"
-
-# json-schema does not support windows, so use the 'ruby' platform to exclude it on windows
-platforms :ruby do
-  # json-schema uses multi_json, but chokes with multi_json 1.7.9, so prefer 1.7.7
-  gem "multi_json", "1.7.7", :require => false
-  gem "json-schema", "2.1.1", :require => false
-end
+gem "multi_json", "~> 1.8"
 
 if File.exists? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)


### PR DESCRIPTION
Facter acceptance in AIO fails at
https://jenkins.puppetlabs.com/view/All%20in%20One%20Agent/view/Master/view/Facter/job/platform_aio-facter_intn-sys_master/1/
because it's using Beaker 2.2. Update to using Beaker 2.8+ to get a
version of Beaker that supports AIO.