### PR TITLE
(maint) Cherry-pick AIO Windows support to master

### DIFF
--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -1,0 +1,19 @@
+module Puppet
+  module Acceptance
+    module CommandUtils
+      def ruby_command(host)
+        "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+      end
+      module_function :ruby_command
+
+      def gem_command(host)
+        if host['platform'] =~ /windows/
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+        else
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+        end
+      end
+      module_function :gem_command
+    end
+  end
+end

--- a/acceptance/lib/puppet/acceptance/common_utils.rb
+++ b/acceptance/lib/puppet/acceptance/common_utils.rb
@@ -5,15 +5,6 @@ module Puppet
         "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
       end
       module_function :ruby_command
-
-      def gem_command(host)
-        if host['platform'] =~ /windows/
-          "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
-        else
-          "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
-        end
-      end
-      module_function :gem_command
     end
   end
 end

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -159,25 +159,6 @@ module Puppet
         end
       end
 
-      # Configures gem sources on hosts to use a mirror, if specified
-      # This is a duplicate of the Gemfile logic.
-      def configure_gem_mirror(hosts)
-        hosts = [hosts] unless hosts.kind_of?(Array)
-        gem_source = ENV['GEM_SOURCE'] || 'https://rubygems.org'
-
-        hosts.each do |host|
-          case host['platform']
-          when /windows/
-            gem = 'cmd /c gem'
-          else
-            gem = 'gem'
-          end
-
-          on host, "#{gem} source --clear-all"
-          on host, "#{gem} source --add #{gem_source}"
-        end
-      end
-
       def install_puppet_from_msi( host, opts )
         if not link_exists?(opts[:url])
           raise "Puppet does not exist at #{opts[:url]}!"

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -31,3 +31,13 @@ PACKAGES = {
 }
 
 install_packages_on(hosts, PACKAGES)
+
+agents.each do |agent|
+  if agent['platform'] =~ /windows/
+    arch = agent[:ruby_arch] || 'x86'
+    base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
+    filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
+
+    install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  end
+end

--- a/acceptance/tests/operatingsystem_detection_after_clear_on_ubuntu.rb
+++ b/acceptance/tests/operatingsystem_detection_after_clear_on_ubuntu.rb
@@ -14,5 +14,5 @@ agents.each do |agent|
 
   create_remote_file(agent, script_name, script_contents)
 
-  on(agent, "#{agent['privatebindir']}/ruby #{script_name}")
+  on(agent, "#{Puppet::Acceptance::CommandUtils.ruby_command(agent)} #{script_name}")
 end


### PR DESCRIPTION
A prior merge from stable to master lost changes to acceptance setup required for AIO on Windows. Cherry-pick Kylo's change to master, and remove some of the unused cruft.