### PR TITLE
(maint) Fix tests on Windows Server 2003

### DIFF
--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -36,7 +36,7 @@ agents.each do |agent|
   step "Agent #{agent}: create an executable external fact in default facts.d"
   ext_fact = File.join(factsd, "external_fact#{ext}")
   create_remote_file(agent, ext_fact, content)
-  on(agent, "chmod +x #{ext_fact}")
+  on(agent, "chmod +x '#{ext_fact}'")
 
   teardown do
     on(agent, "rm -f '#{ext_fact}'")

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -27,7 +27,7 @@ agents.each do |agent|
   on(agent, "mkdir -p '#{custom_dir}'")
   custom_fact = File.join(custom_dir, 'custom_fact.rb')
   create_remote_file(agent, custom_fact, content)
-  on(agent, "chmod +x #{custom_fact}")
+  on(agent, "chmod +x '#{custom_fact}'")
 
   teardown do
     on(agent, "rm -f '#{custom_fact}'")
@@ -39,7 +39,7 @@ agents.each do |agent|
   end
 
   step "--custom-dir option should allow custom facts to be resolved from a specific directory"
-  on(agent, facter("--custom-dir #{custom_dir} custom_fact")) do
+  on(agent, facter("--custom-dir '#{custom_dir}' custom_fact")) do
     assert_equal("testvalue", stdout.chomp, "Custom fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -42,10 +42,10 @@ agents.each do |agent|
   ext_fact_custom_dir = File.join(custom_external_dir, "external_fact#{ext}")
   create_remote_file(agent, ext_fact_factsd, content)
   create_remote_file(agent, ext_fact_custom_dir, content)
-  on(agent, "chmod +x #{ext_fact_factsd} #{ext_fact_custom_dir}")
+  on(agent, "chmod +x '#{ext_fact_factsd}' '#{ext_fact_custom_dir}'")
 
   teardown do
-    on(agent, "rm -f '#{ext_fact_factsd} #{ext_fact_custom_dir}'")
+    on(agent, "rm -f '#{ext_fact_factsd}' '#{ext_fact_custom_dir}'")
   end
 
   step "--no-external-facts option should disable external facts"
@@ -54,7 +54,7 @@ agents.each do |agent|
   end
 
   step "--external-dir option should allow external facts to be resolved from a specific directory"
-  on(agent, facter("--external-dir #{custom_external_dir} external_fact")) do
+  on(agent, facter("--external-dir '#{custom_external_dir}' external_fact")) do
     assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
   end
 end

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -26,14 +26,14 @@ agents.each do |agent|
   custom_fact = File.join(custom_dir, 'custom_fact.rb')
   on(agent, "mkdir -p '#{custom_dir}'")
   create_remote_file(agent, custom_fact, content)
-  on(agent, "chmod +x #{custom_fact}")
+  on(agent, "chmod +x '#{custom_fact}'")
 
   teardown do
     on(agent, "rm -f '#{custom_fact}'")
   end
 
   step "Agent #{agent}: retrieve output using the --json option"
-  on(agent, facter("--custom-dir #{custom_dir} --json structured_fact")) do
+  on(agent, facter("--custom-dir '#{custom_dir}' --json structured_fact")) do
     begin
       expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3"}})
       assert_equal(expected, stdout.chomp, "JSON output does not match expected output")

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -24,7 +24,7 @@ agents.each do |agent|
   on(agent, "mkdir -p '#{custom_dir}'")
   custom_fact = File.join(custom_dir, 'custom_fact.rb')
   create_remote_file(agent, custom_fact, content)
-  on(agent, "chmod +x #{custom_fact}")
+  on(agent, "chmod +x '#{custom_fact}'")
 
   teardown do
     on(agent, "rm -f '#{custom_fact}'")

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -25,14 +25,14 @@ agents.each do |agent|
   custom_fact = File.join(custom_dir, 'custom_fact.rb')
   on(agent, "mkdir -p '#{custom_dir}'")
   create_remote_file(agent, custom_fact, content)
-  on(agent, "chmod +x #{custom_fact}")
+  on(agent, "chmod +x '#{custom_fact}'")
 
   teardown do
     on(agent, "rm -f '#{custom_fact}'")
   end
 
   step "Agent #{agent}: retrieve output using the --yaml option"
-  on(agent, facter("--custom-dir #{custom_dir} --yaml structured_fact")) do
+  on(agent, facter("--custom-dir '#{custom_dir}' --yaml structured_fact")) do
     begin
       expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}.to_yaml.gsub("---\n", '')
       assert_equal(expected, stdout, "YAML output does not match expected output")


### PR DESCRIPTION
Windows Server 2003 still used the 'Documents and Settings' directory as
part of the user's home directory. These acceptance tests weren't
written to take spaces into account. Update them to correctly quote
paths.