### PR TITLE
(FACT-958) Add tests for platform dependent facts

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -1,0 +1,98 @@
+test_name "Facts should resolve as expected in Debian 6 and 7"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in Debian 6 and 7.
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /debian-squeeze|debian-wheezy/
+
+agents.each do |agent|
+  os_version = agent['platform'] =~ /squeeze/ ? '6' : '7'
+  if agent['platform'] =~ /x86_64/
+    os_arch     = 'amd64'
+    os_hardware = 'x86_64'
+  else
+    os_arch     = 'i386'
+    os_hardware = 'i686'
+  end
+
+  step "Ensure the OS fact resolves as expected"
+  expected_os = {
+                  'os.architecture'         => os_arch,
+                  'os.distro.codename'      => os_version == '6' ? 'squeeze' : 'wheezy',
+                  'os.distro.description'   => /Debian GNU\/Linux #{os_version}\.\d/,
+                  'os.distro.id'            => 'Debian',
+                  'os.distro.release.full'  => /#{os_version}\.\d/,
+                  'os.distro.release.major' => os_version,
+                  'os.distro.release.minor' => /\d/,
+                  'os.family'               => 'Debian',
+                  'os.hardware'             => os_hardware,
+                  'os.name'                 => 'Debian',
+                  'os.release.full'         => /#{os_version}\.\d/,
+                  'os.release.major'        => os_version,
+                  'os.release.minor'        => /\d/,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => /unknown|#{os_hardware}/,
+                          'processors.models'        => /"Intel\(R\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip6"      => /[a-z0-9]+:+/,
+                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.gid'   => '0',
+                        'identity.group' => 'root',
+                        'identity.uid'   => '0',
+                        'identity.user'  => 'root'
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_equal(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  kernel_version = os_version == '7' ? '3.2' : '2.6'
+
+  expected_kernel = {
+                      'kernel'           => 'Linux',
+                      'kernelrelease'    => kernel_version,
+                      'kernelversion'    => kernel_version,
+                      'kernelmajversion' => kernel_version
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -1,0 +1,105 @@
+test_name "Facts should resolve as expected in EL 5, 6 and 7"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in EL 5, 6 and 7.
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /el-5|el-6|el-7|centos-5|centos-6|centos-7/
+
+agents.each do |agent|
+  if agent['platform'] =~ /el-5|centos-5/
+    os_version = '5'
+  elsif agent['platform'] =~ /el-6|centos-6/
+    os_version = '6'
+  else
+    os_version = '7'
+  end
+
+  if agent['platform'] =~ /x86_64/
+    os_arch     = 'x86_64'
+    os_hardware = 'x86_64'
+  else
+    os_arch     = 'i386'
+    os_hardware = 'i686'
+  end
+
+  step "Ensure the OS fact resolves as expected"
+
+  expected_os = {
+                  'os.architecture'         => os_arch,
+                  'os.family'               => 'RedHat',
+                  'os.hardware'             => os_hardware,
+                  'os.name'                 => /(RedHat|CentOS)/,
+                  'os.release.full'         => /#{os_version}\.\d(\.\d)?/,
+                  'os.release.major'        => os_version,
+                  'os.release.minor'        => /\d/,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => os_hardware,
+                          'processors.models'        => /"Intel\(R\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip6"      => /[a-z0-9]+:+/,
+                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.gid'   => '0',
+                        'identity.group' => 'root',
+                        'identity.uid'   => '0',
+                        'identity.user'  => 'root'
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_equal(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  if os_version == '5' || os_version == '6'
+    kernel_version = '2.6'
+  else
+    kernel_version = '3.1'
+  end
+
+  expected_kernel = {
+                      'kernel'           => 'Linux',
+                      'kernelrelease'    => kernel_version,
+                      'kernelversion'    => kernel_version,
+                      'kernelmajversion' => kernel_version
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -1,0 +1,92 @@
+test_name "Facts should resolve as expected in Fedora 20 and 21"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in Fedora 20 and 21.
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /fedora-20|fedora-21/
+
+agents.each do |agent|
+  os_version = agent['platform'] =~ /fedora-20/ ? '20' : '21'
+
+  if agent['platform'] =~ /x86_64/
+    os_arch     = 'x86_64'
+    os_hardware = 'x86_64'
+  else
+    os_arch     = 'i386'
+    os_hardware = 'i686'
+  end
+
+  step "Ensure the OS fact resolves as expected"
+  expected_os = {
+                  'os.architecture'         => os_arch,
+                  'os.family'               => 'RedHat',
+                  'os.hardware'             => os_hardware,
+                  'os.name'                 => /Fedora/,
+                  'os.release.full'         => os_version,
+                  'os.release.major'        => os_version,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => os_hardware,
+                          'processors.models'        => /"Intel\(R\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip6"      => /[a-z0-9]+:+/,
+                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.gid'   => '0',
+                        'identity.group' => 'root',
+                        'identity.uid'   => '0',
+                        'identity.user'  => 'root'
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_equal(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  kernel_version = os_version == '21' ? '3.17' : '3.11'
+
+  expected_kernel = {
+                      'kernel'           => 'Linux',
+                      'kernelrelease'    => kernel_version,
+                      'kernelversion'    => kernel_version,
+                      'kernelmajversion' => kernel_version
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -1,0 +1,31 @@
+test_name "The Ruby fact should resolve as expected in AIO"
+
+#
+# This test is intended to ensure that the the ruby fact resolves
+# as expected in AIO across supported platforms.
+#
+
+skip_test "Ruby fact test is confined to AIO" if @options[:type] != 'aio'
+
+step "Ensure the Ruby fact resolves as expected"
+
+if agent['platform'] =~ /windows/
+  ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
+else
+  if agent['ruby_arch']
+    ruby_platform = agent['ruby_arch'] == 'x64' ? 'x86_64-linux' : /i(4|6)86-linux/
+  else
+    ruby_platform = agent['platform'] =~ /64/ ? 'x86_64-linux' : /i(4|6)86-linux/
+  end
+end
+
+ruby_version = '2.1.6'
+expected_ruby = {
+                  'ruby.platform' => ruby_platform,
+                  'ruby.sitedir'  => /\/site_ruby/,
+                  'ruby.version'  => ruby_version
+                }
+
+expected_ruby.each do |fact, value|
+  assert_match(value, fact_on(agent, fact))
+end

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -1,0 +1,106 @@
+test_name "Facts should resolve as expected in Ubuntu 12.04, 14.04, and 14.10"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in Ubuntu 12.04, 14.04, and 14.10
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /ubuntu-precise|ubuntu-trusty|ubuntu-utopic/
+
+agents.each do |agent|
+  if agent['platform'] =~ /ubuntu-precise/
+    os_name    = 'precise'
+    os_version = '12.04'
+    os_kernel  = '3.2'
+  elsif agent['platform'] =~ /ubuntu-trusty/
+    os_name    = 'trusty'
+    os_version = '14.04'
+    os_kernel  = '3.13'
+  else
+    os_name    = 'utopic'
+    os_version = '14.10'
+    os_kernel  = '3.16'
+  end
+
+  if agent['platform'] =~ /x86_64/
+    os_arch     = 'amd64'
+    os_hardware = 'x86_64'
+  else
+    os_arch     = 'i386'
+    os_hardware = 'i686'
+  end
+
+  step "Ensure the OS fact resolves as expected"
+  expected_os = {
+                  'os.architecture'         => os_arch,
+                  'os.distro.codename'      => os_name,
+                  'os.distro.description'   => /Ubuntu #{os_version}( LTS)?/,
+                  'os.distro.id'            => 'Ubuntu',
+                  'os.distro.release.full'  => os_version,
+                  'os.distro.release.major' => os_version,
+                  'os.family'               => 'Debian',
+                  'os.hardware'             => os_hardware,
+                  'os.name'                 => 'Ubuntu',
+                  'os.release.full'         => os_version,
+                  'os.release.major'        => os_version,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => os_hardware,
+                          'processors.models'        => /"Intel\(R\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip6"      => /[a-z0-9]+:+/,
+                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.gid'   => '0',
+                        'identity.group' => 'root',
+                        'identity.uid'   => '0',
+                        'identity.user'  => 'root'
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_equal(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  expected_kernel = {
+                      'kernel'           => 'Linux',
+                      'kernelrelease'    => os_kernel,
+                      'kernelversion'    => os_kernel,
+                      'kernelmajversion' => os_kernel
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -1,0 +1,92 @@
+test_name "Facts should resolve as expected in Windows 2003R2, 2008R2 and 2012R2"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in Windows 2003R2, 2008R2 and 2012R2.
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /windows-2003r2|windows-2008|windows-2012r2/
+
+agents.each do |agent|
+  step "Ensure the OS fact resolves as expected"
+  if agent['platform'] =~ /2003/
+    os_version  = '2003 R2'
+  elsif agent['platform'] =~ /2008/
+    os_version  = '2008 R2'
+  else
+    os_version  = '2012 R2'
+  end
+
+  expected_os = {
+                  'os.architecture'         => agent['platform'] =~ /64/ ? 'x64' : 'x86',
+                  'os.family'               => 'windows',
+                  'os.hardware'             => agent['platform'] =~ /64/ ? 'x86_64' : 'i686',
+                  'os.name'                 => 'windows',
+                  'os.release.full'         => os_version,
+                  'os.release.major'        => os_version,
+                  'os.windows.system32'     => /C:\\(WINDOWS|Windows)\\(system32|sysnative)/,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => agent['platform'] =~ /64/ ? 'x64' : 'x86',
+                          'processors.models'        => /"Intel\(R\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.user'   => /.*\\cyg_server/,
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  if os_version == '2003 R2'
+    kernel_version = '5.2'
+  elsif os_version == '2008 R2'
+    kernel_version = '6.1'
+  else
+    kernel_version = '6.3'
+  end
+
+  expected_kernel = {
+                      'kernel'           => 'windows',
+                      'kernelrelease'    => kernel_version,
+                      'kernelversion'    => kernel_version,
+                      'kernelmajversion' => kernel_version
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end


### PR DESCRIPTION
This commit adds acceptance tests to verify the resolution of
facts which depend on the platform they are being resolved on.

Facts tested include: os, processors, ruby, networking, identity, kernel