### PR TITLE
(FACT-96) Deprecate `facter --puppet`

### DIFF
--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -160,7 +160,10 @@ OPTIONS
                 "Enable timing.") { |v| Facter.timing(1) }
         opts.on("-p",
                 "--puppet",
-                "Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.") { |v| load_puppet }
+                "Deprecated: Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.") do |v|
+          Facter.warnonce("The --puppet option is deprecated; use `puppet facts find` instead.")
+          load_puppet
+        end
 
         opts.on_tail("-v",
                      "--version",

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -49,6 +49,7 @@ describe Facter::Application do
 
     ['-p', '--puppet'].each do |option|
       it "calls load_puppet when given #{option}" do
+        Facter.expects(:warnonce).with("The --puppet option is deprecated; use `puppet facts find` instead.")
         Facter::Application.expects(:load_puppet)
         Facter::Application.parse([option])
       end


### PR DESCRIPTION
The `--puppet` option in facter introduces a cyclic dependency between
the two projects, and adds complexity as facter needs to know how to
initialize puppet.

This commit adds a deprecation warning when executing `facter --puppet`
and in viewing facter help. The alternative is to run `puppet facts find`.
It already handles puppet-specific facts, e.g. puppetversion,
custom facts in `$vardir/lib/facter`, and external facts in
`$vardir/facts.d`.

Note the deprecation warning is not triggered if code loads facter as a
library and calls `load_puppet` directly. Trying to account for that
case seems like more trouble than it's worth.