### PR TITLE
(FACT-96) Deprecate `facter --puppet`

### DIFF
--- a/lib/facter/application.rb
+++ b/lib/facter/application.rb
@@ -160,7 +160,9 @@ OPTIONS
                 "Enable timing.") { |v| Facter.timing(1) }
         opts.on("-p",
                 "--puppet",
-                "Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.") { |v| load_puppet }
+                "(Deprecated: use `puppet facts` instead) Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.") do |v|
+          load_puppet
+        end
 
         opts.on_tail("-v",
                      "--version",

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -54,6 +54,15 @@ describe Facter::Application do
       end
     end
 
+    ['-h', '--help'].each do |option|
+      it "issues a deprecation message for `--puppet`" do
+        Facter::Application.stubs(:exit).with(0)
+        expect do
+          Facter::Application.parse([option])
+        end.to have_printed('Deprecated: use `puppet facts` instead')
+      end
+    end
+
     it 'mutates argv so that non-option arguments are left' do
       argv = ['-y', '--trace', 'uptime', 'virtual']
       Facter::Application.parse(argv)


### PR DESCRIPTION
The `--puppet` option in facter introduces a cyclic dependency between
the two projects, and adds complexity, as facter needs to know how to
initialize puppet.

This commit causes `facter [-h|--help]` to mention that the `--puppet`
option is deprecated. It does not emit a deprecation warning when
running `facter --puppet` because that command is run often on every
agent. It also adds tests that the warning is printed.

The recommended way to retrieve puppet-specific facts is to run
`puppet facts find`, which includes `puppetversion`, and pluginsync'ed
custom and external facts.