### PR TITLE
(FACT-628) Move LDOM virtual implementation to virtual.rb

### DIFF
--- a/lib/facter/ldom.rb
+++ b/lib/facter/ldom.rb
@@ -47,15 +47,5 @@ if Facter.value(:kernel) == 'SunOS' &&
         end
       end
     end
-
-    # When ldom domainrole control = false, the system is a guest, so we mark it
-    # as a virtual system:
-    Facter.add("virtual") do
-      confine :ldom_domainrole_control => 'false'
-      has_weight 10
-      setcode do
-        Facter.value(:ldom_domainrole_impl)
-      end
-    end
   end
 end

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -90,6 +90,17 @@ Facter.add("virtual") do
 end
 
 Facter.add("virtual") do
+  confine :kernel => 'SunOS'
+  confine :hardwareisa => 'sparc'
+  confine :ldom_domainrole_control => 'false'
+  has_weight 20 # Weight this before the default solaris implementation
+  setcode do
+    Facter.value(:ldom_domainrole_impl)
+  end
+end
+
+
+Facter.add("virtual") do
   confine :kernel => 'HP-UX'
   has_weight 10
   setcode do

--- a/spec/unit/ldom_spec.rb
+++ b/spec/unit/ldom_spec.rb
@@ -57,10 +57,6 @@ describe "ldom fact" do
     it "should return correct serial on version 1.0" do
       Facter.fact(:ldom_domainchassis).value.should == "0704RB0280"
     end
-
-    it "should return correct virtual on version 1.0" do
-      Facter.fact(:virtual).value.should == "LDoms"
-    end
   end
 
   describe "when running on non ldom hardware" do

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -31,6 +31,18 @@ describe "Virtual fact" do
     Facter.fact(:virtual).value.should == "zone"
   end
 
+  it "should be LDoms on Solaris when an ldom" do
+    ldom_fixture = File.read(fixtures('ldom', 'ldom_v1'))
+    Facter.fact(:kernel).stubs(:value).returns("SunOS")
+    Facter.fact(:operatingsystem).stubs(:value).returns("Solaris")
+    Facter.fact(:hardwareisa).stubs(:value).returns("sparc")
+    Facter::Core::Execution.stubs(:which).with("virtinfo").returns 'virtinfo'
+    Facter::Core::Execution.stubs(:which).with("vmware").returns nil
+    Facter::Core::Execution.stubs(:exec).with("virtinfo -ap").returns(ldom_fixture)
+    Facter.collection.internal_loader.load(:ldom)
+    Facter.fact(:virtual).value.should == "LDoms"
+  end
+
   it "should be jail on FreeBSD when a jail in kvm" do
     Facter.fact(:kernel).stubs(:value).returns("FreeBSD")
     Facter::Util::Virtual.stubs(:jail?).returns(true)


### PR DESCRIPTION
Previously, the implementation of the `virtual` fact that evaluated
LDOM info was stored in `ldom.rb`. This would cause the value of
`virtual` to be different depending on whether or not ldom.rb was
loaded.

This moves the implementation of the virtual fact to virtual.rb, and
weights it appropriately within the set of implementations there.