### PR TITLE
(FACT-892) Change "POSIX" load average resolver to "glib".

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -96,7 +96,6 @@ if (UNIX)
         "src/facts/posix/collection.cc"
         "src/facts/posix/identity_resolver.cc"
         "src/facts/posix/kernel_resolver.cc"
-        "src/facts/posix/load_average_resolver.cc"
         "src/facts/posix/networking_resolver.cc"
         "src/facts/posix/operatingsystem_resolver.cc"
         "src/facts/posix/processor_resolver.cc"
@@ -139,6 +138,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
         "src/facts/bsd/filesystem_resolver.cc"
         "src/facts/bsd/networking_resolver.cc"
         "src/facts/bsd/uptime_resolver.cc"
+        "src/facts/glib/load_average_resolver.cc"
         "src/facts/osx/dmi_resolver.cc"
         "src/facts/osx/networking_resolver.cc"
         "src/facts/osx/collection.cc"
@@ -151,8 +151,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
     set(LIBFACTER_PLATFORM_SOURCES
-        "src/util/solaris/k_stat.cc"
-        "src/util/solaris/scoped_kstat.cc"
+        "src/facts/glib/load_average_resolver.cc"
         "src/facts/solaris/collection.cc"
         "src/facts/solaris/disk_resolver.cc"
         "src/facts/solaris/uptime_resolver.cc"
@@ -167,6 +166,8 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         "src/facts/solaris/zfs_resolver.cc"
         "src/facts/solaris/zone_resolver.cc"
         "src/facts/solaris/zpool_resolver.cc"
+        "src/util/solaris/k_stat.cc"
+        "src/util/solaris/scoped_kstat.cc"
     )
     set(LIBFACTER_PLATFORM_LIBRARIES
         kstat
@@ -176,6 +177,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_PLATFORM_SOURCES
         "src/facts/bsd/networking_resolver.cc"
+        "src/facts/glib/load_average_resolver.cc"
         "src/facts/linux/disk_resolver.cc"
         "src/facts/linux/dmi_resolver.cc"
         "src/facts/linux/filesystem_resolver.cc"
@@ -195,6 +197,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
     set(LIBFACTER_PLATFORM_SOURCES
         "src/facts/bsd/collection.cc"
+        "src/facts/glib/load_average_resolver.cc"
         "src/facts/bsd/filesystem_resolver.cc"
         "src/facts/bsd/networking_resolver.cc"
         "src/facts/bsd/uptime_resolver.cc"

--- a/lib/inc/internal/facts/glib/load_average_resolver.hpp
+++ b/lib/inc/internal/facts/glib/load_average_resolver.hpp
@@ -1,12 +1,12 @@
 /**
  * @file
- * Declares the posix load average fact resolver.
+ * Declares the glib load average fact resolver.
  */
 #pragma once
 
 #include "../resolvers/load_average_resolver.hpp"
 
-namespace facter { namespace facts { namespace posix {
+namespace facter { namespace facts { namespace glib {
 
     /**
      * Responsible for resolving the load average facts.
@@ -17,7 +17,7 @@ namespace facter { namespace facts { namespace posix {
         /**
          * Gets the load averages (for 1, 5 and 15 minutes period).
          */
-        virtual boost::optional<std::tuple<double, double, double> > get_load_averages() override;
+        virtual boost::optional<std::tuple<double, double, double>> get_load_averages() override;
     };
 
-}}}  // namespace facter::facts::posix
+}}}  // namespace facter::facts::glib

--- a/lib/src/facts/bsd/collection.cc
+++ b/lib/src/facts/bsd/collection.cc
@@ -6,6 +6,7 @@
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
 
 using namespace std;
 
@@ -20,6 +21,7 @@ namespace facter { namespace facts {
         add(make_shared<posix::ssh_resolver>());
         add(make_shared<posix::identity_resolver>());
         add(make_shared<posix::timezone_resolver>());
+        add(make_shared<glib::load_average_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/glib/load_average_resolver.cc
+++ b/lib/src/facts/glib/load_average_resolver.cc
@@ -1,8 +1,6 @@
-#include <internal/facts/posix/load_average_resolver.hpp>
-#include <stdlib.h>
-#include <array>
-#include <boost/optional.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <cstdlib>
 
 #ifdef __sun
 #include <sys/loadavg.h>
@@ -10,7 +8,7 @@
 
 using namespace std;
 
-namespace facter { namespace facts { namespace posix {
+namespace facter { namespace facts { namespace glib {
 
     boost::optional<tuple<double, double, double> > load_average_resolver::get_load_averages()
     {
@@ -21,4 +19,4 @@ namespace facter { namespace facts { namespace posix {
         }
         return make_tuple(averages[0], averages[1], averages[2]);
     }
-}}}  // namespace facter::facts::posix
+}}}  // namespace facter::facts::glib

--- a/lib/src/facts/linux/collection.cc
+++ b/lib/src/facts/linux/collection.cc
@@ -12,7 +12,7 @@
 #include <internal/facts/posix/timezone_resolver.hpp>
 #include <internal/facts/linux/filesystem_resolver.hpp>
 #include <internal/facts/linux/memory_resolver.hpp>
-#include <internal/facts/posix/load_average_resolver.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
 
 
 using namespace std;
@@ -34,7 +34,7 @@ namespace facter { namespace facts {
         add(make_shared<posix::timezone_resolver>());
         add(make_shared<linux::filesystem_resolver>());
         add(make_shared<linux::memory_resolver>());
-        add(make_shared<posix::load_average_resolver>());
+        add(make_shared<glib::load_average_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/osx/collection.cc
+++ b/lib/src/facts/osx/collection.cc
@@ -12,6 +12,7 @@
 #include <internal/facts/posix/timezone_resolver.hpp>
 #include <internal/facts/bsd/filesystem_resolver.hpp>
 #include <internal/facts/osx/memory_resolver.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
 
 using namespace std;
 
@@ -32,6 +33,7 @@ namespace facter { namespace facts {
         add(make_shared<posix::timezone_resolver>());
         add(make_shared<bsd::filesystem_resolver>());
         add(make_shared<osx::memory_resolver>());
+        add(make_shared<glib::load_average_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/solaris/collection.cc
+++ b/lib/src/facts/solaris/collection.cc
@@ -15,6 +15,7 @@
 #include <internal/facts/solaris/zpool_resolver.hpp>
 #include <internal/facts/solaris/zfs_resolver.hpp>
 #include <internal/facts/solaris/zone_resolver.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
 
 using namespace std;
 
@@ -35,6 +36,7 @@ namespace facter { namespace facts {
         add(make_shared<solaris::disk_resolver>());
         add(make_shared<solaris::virtualization_resolver>());
         add(make_shared<solaris::memory_resolver>());
+        add(make_shared<glib::load_average_resolver>());
 
         // solaris specific
         add(make_shared<solaris::zpool_resolver>());


### PR DESCRIPTION
The base load average resolver implementation is currently building as
part of the POSIX resolvers, but it calls getloadavg, which is not a
POSIX function.  It is actually a glib function.

This breaks the build on systems where "getloadavg" isn't part of the
standard library implementation, such as AIX.

This moves the resolver into a "glib" namespace and adds the resolver to
instances where a conforming glib is present (OSX, BSD, Linux, and
Solaris).