### PR TITLE
(FACT-1018) Use Ruby from CMake for tests

### DIFF
--- a/lib/tests/fixtures/ruby/execute_timeout.rb
+++ b/lib/tests/fixtures/ruby/execute_timeout.rb
@@ -1,1 +1,1 @@
-Facter::Core::Execution.execute("ruby -e 'sleep 15'", :timeout => 1)
+Facter::Core::Execution.execute("#{RbConfig.ruby} -e 'sleep 15'", :timeout => 1)


### PR DESCRIPTION
Prior to this commit, tests would fail if cmake was invoked with Ruby
on the PATH, but `make test` wasn't.

Fix by finding the binary related to the Ruby environment custom facts
execute.