### PR TITLE
(FACT-982) Add --no-ruby command-line option

### DIFF
--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -1,0 +1,40 @@
+test_name "--no-ruby commandline option"
+
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+#
+# These tests are intended to ensure that the --no-ruby command-line option
+# works properly. The first ensures that the built in Ruby fact does not resolve
+# when using the --no-ruby fact, and also checks that the 'No Ruby' warning does
+# not appear in stderr. The second test ensures that custom facts are not resolved
+# when the --no-ruby option is present.
+#
+
+content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+agents.each do |agent|
+  step "--no-ruby option should disable Ruby and facts requiring ruby from being loaded"
+  on(agent, facter("--no-ruby ruby")) do
+    assert_equal("", stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{stdout.chomp}")
+    assert_equal("", stderr.chomp, "Expected no warnings about Ruby on stderr, but got output: #{stderr.chomp}")
+  end
+
+  step "--no-ruby option should disable custom facts"
+  custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+  step "Agent #{agent}: create custom fact directory and custom fact"
+  on(agent, "mkdir -p '#{custom_dir}'")
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
+  create_remote_file(agent, custom_fact, content)
+
+  on(agent, facter("--no-ruby --custom-dir #{custom_dir} custom_fact")) do
+    assert_equal("", stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{stdout.chomp}")
+  end
+end

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -83,8 +83,9 @@ namespace facter { namespace facts {
 
         /**
          * Adds the default facts to the collection.
+         * @param include_ruby_facts Whether or not to include facts which require Ruby in the collection.
          */
-        void add_default_facts();
+        void add_default_facts(bool include_ruby_facts);
 
         /**
          * Adds a resolver to the fact collection.
@@ -201,7 +202,7 @@ namespace facter { namespace facts {
         LIBFACTER_NO_EXPORT void write_hash(std::ostream& stream, std::set<std::string> const& queries);
         LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries);
         LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries);
-        LIBFACTER_NO_EXPORT void add_common_facts();
+        LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
 
         // Platform specific members
         LIBFACTER_NO_EXPORT void add_platform_facts();

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -55,9 +55,9 @@ namespace facter { namespace facts {
         return *this;
     }
 
-    void collection::add_default_facts()
+    void collection::add_default_facts(bool include_ruby_facts)
     {
-        add_common_facts();
+        add_common_facts(include_ruby_facts);
         add_platform_facts();
     }
 
@@ -529,10 +529,13 @@ namespace facter { namespace facts {
         emitter << EndMap;
     }
 
-    void collection::add_common_facts()
+    void collection::add_common_facts(bool include_ruby_facts)
     {
         add("facterversion", make_value<string_value>(LIBFACTER_VERSION));
-        add(make_shared<resolvers::ruby_resolver>());
+
+        if (include_ruby_facts) {
+            add(make_shared<resolvers::ruby_resolver>());
+        }
         add(make_shared<resolvers::path_resolver>());
         add(make_shared<resolvers::ec2_resolver>());
         add(make_shared<resolvers::gce_resolver>());

--- a/lib/src/java/facter.cc
+++ b/lib/src/java/facter.cc
@@ -126,7 +126,9 @@ extern "C" {
         set_level(level::warning);
 
         facts_collection.reset(new collection());
-        facts_collection->add_default_facts();
+
+        bool include_ruby_facts = true;
+        facts_collection->add_default_facts(include_ruby_facts);
         facts_collection->add_external_facts();
         return JNI_VERSION_1_6;
     }

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -129,7 +129,7 @@ namespace facter { namespace ruby {
     {
         dynamic_library library = find_library();
         if (!library.loaded()) {
-            LOG_WARNING("could not locate a ruby library: custom facts will not be resolved.");
+            LOG_WARNING("could not locate a ruby library: facts requiring Ruby will not be resolved.");
             return nullptr;
         } else if (library.first_load()) {
             LOG_INFO("ruby loaded from \"%1%\".", library.name());

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -317,7 +317,8 @@ namespace facter { namespace ruby {
     collection& module::facts()
     {
         if (_collection.empty()) {
-            _collection.add_default_facts();
+            bool include_ruby_facts = true;
+            _collection.add_default_facts(include_ruby_facts);
             _collection.add_external_facts(_external_search_paths);
 
             auto const& ruby = *api::instance();

--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -59,7 +59,7 @@ SCENARIO("using the fact collection") {
     REQUIRE(facts.empty());
 
     GIVEN("default facts") {
-        facts.add_default_facts();
+        facts.add_default_facts(true);
         THEN("facts should resolve") {
             REQUIRE(facts.size() > 0);
             REQUIRE_FALSE(facts.empty());
@@ -323,7 +323,7 @@ SCENARIO("using the fact collection") {
         }
     }
     GIVEN("a fact from an environment with the same name as a built-in fact") {
-        facts.add_default_facts();
+        facts.add_default_facts(true);
         auto var = temp_variable("FACTER_KERNEL", "overridden");
         bool added = false;
         facts.add_environment_facts([&](string const& name) {

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -660,7 +660,7 @@ SCENARIO("validating schema") {
             REQUIRE(found.size() == schema.size());
         }
         THEN("the current platform's facts must conform to the schema") {
-            facts.add_default_facts();
+            facts.add_default_facts(true);
 
             set<string> found;
 

--- a/lib/tests/java/facter.cc
+++ b/lib/tests/java/facter.cc
@@ -13,7 +13,7 @@ using namespace boost::filesystem;
 
 SCENARIO("using libfacter from Java") {
     collection facts;
-    facts.add_default_facts();
+    facts.add_default_facts(true);
 
     path jar_path = path(BINARY_DIRECTORY) / "lib" / "facter.jar";
 

--- a/man/man8/facter.8
+++ b/man/man8/facter.8
@@ -41,6 +41,7 @@ If no queries are given, then all facts will be returned\.
       \fB\-\-no-color\fR                   Disables color output\.
       \fB\-\-no-custom-fact\fR             Disables custom facts\.
       \fB\-\-no-external-facts\fR          Disables external facts\.
+      \fB\-\-no-ruby\fR                    Disables loading Ruby, facts requiring Ruby, and custom facts\.
       \fB\-\-trace\fR                      Enables backtraces for custom facts\.
       \fB\-\-verbose\fR                    Enables verbose (info) output\.
 \fB\-v, [ \-\-version ]\fR                  Print the version and exit\.


### PR DESCRIPTION
This commit adds a new command-line option: --no-ruby. This
option disables Ruby from being loaded, and thus disables
the Ruby loading warning when no Ruby is present. In addition,
this option disables custom facts and built-in facts which
require Ruby.