### PR TITLE
(FACT-976) Report correct OS for Cisco NXOS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -184,6 +184,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
         "src/facts/linux/memory_resolver.cc"
         "src/facts/linux/networking_resolver.cc"
         "src/facts/linux/operating_system_resolver.cc"
+        "src/facts/linux/os_linux.cc"
         "src/facts/linux/uptime_resolver.cc"
         "src/facts/linux/collection.cc"
         "src/facts/linux/processor_resolver.cc"

--- a/lib/inc/internal/facts/glib/load_average_resolver.hpp
+++ b/lib/inc/internal/facts/glib/load_average_resolver.hpp
@@ -16,6 +16,7 @@ namespace facter { namespace facts { namespace glib {
      protected:
         /**
          * Gets the load averages (for 1, 5 and 15 minutes period).
+         * @return The load averages.
          */
         virtual boost::optional<std::tuple<double, double, double>> get_load_averages() override;
     };

--- a/lib/inc/internal/facts/linux/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/linux/operating_system_resolver.hpp
@@ -30,16 +30,7 @@ namespace facter { namespace facts { namespace linux {
         virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const override;
 
      private:
-        static std::string get_name(std::string const& distro_id);
-        static std::string get_release(std::string const& name, std::string const& distro_release);
-        static std::string check_os_release_linux();
-        static std::string check_debian_linux(std::string const& distro_id);
-        static std::string check_oracle_linux();
-        static std::string check_redhat_linux();
-        static std::string check_suse_linux();
-        static std::string check_other_linux();
         static selinux_data collect_selinux_data();
-        static std::string get_selinux_mountpoint();
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/linux/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/linux/operating_system_resolver.hpp
@@ -21,14 +21,6 @@ namespace facter { namespace facts { namespace linux {
          */
         virtual data collect_data(collection& facts) override;
 
-        /**
-         * Parses the major and minor OS release versions.
-         * @param name The name of the OS.
-         * @param release The release to parse.
-         * @return Returns a tuple of major and minor release versions.
-         */
-        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const override;
-
      private:
         static selinux_data collect_selinux_data();
     };

--- a/lib/inc/internal/facts/linux/os_cisco.hpp
+++ b/lib/inc/internal/facts/linux/os_cisco.hpp
@@ -52,6 +52,18 @@ namespace facter { namespace facts { namespace linux {
             auto val = _release_info.find("VERSION");
             return (val != _release_info.end()) ? val->second : std::string();
         }
+
+        /**
+         * Parses the release version string to return the major version.
+         * @param name Unused.
+         * @param release Unused.
+         * @return Returns a tuple of the major version and an empty string.
+         */
+        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const override
+        {
+            auto pos = release.find('(');
+            return std::make_tuple(release.substr(0, pos), std::string());
+        }
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/linux/os_cisco.hpp
+++ b/lib/inc/internal/facts/linux/os_cisco.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * Declares the Cisco Linux operating system query helper.
+ */
+#pragma once
+
+#include <internal/facts/linux/os_linux.hpp>
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for determining the name/family/release of Cisco operating systems.
+     */
+    struct os_cisco : os_linux
+    {
+        /**
+         * Constructs the os_cisco and reads a release file to gather relevant details.
+         * @param file The release file to read for OS data.
+         */
+        os_cisco(std::string const& file) : os_linux({"ID", "ID_LIKE", "VERSION"}, file) {}
+
+        /**
+         * Finds ID from the release file contents and returns it as the name.
+         * @param distro_id Unused.
+         * @return Returns the release name.
+         */
+        virtual std::string get_name(std::string const& distro_id) const override
+        {
+            auto val = _release_info.find("ID");
+            return (val != _release_info.end()) ? val->second : std::string();
+        }
+
+        /**
+         * Finds ID_LIKE from the release file contents and returns it as the family.
+         * @param name Unused.
+         * @return Returns the release family.
+         */
+        virtual std::string get_family(std::string const& name) const override
+        {
+            auto val = _release_info.find("ID_LIKE");
+            return (val != _release_info.end()) ? val->second : std::string();
+        }
+
+        /**
+         * Finds VERSION from the release file contents and returns it as the release.
+         * @param name Unused.
+         * @param distro_release Unused.
+         * @return Returns the release version.
+         */
+        virtual std::string get_release(std::string const& name, std::string const& distro_release) const override
+        {
+            auto val = _release_info.find("VERSION");
+            return (val != _release_info.end()) ? val->second : std::string();
+        }
+    };
+
+}}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/linux/os_coreos.hpp
+++ b/lib/inc/internal/facts/linux/os_coreos.hpp
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Declares the CoreOS Linux operating system query helper.
+ */
+#pragma once
+
+#include <internal/facts/linux/os_linux.hpp>
+#include <facter/facts/os.hpp>
+#include <facter/facts/os_family.hpp>
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for determining the name/family/release of CoreOS operating systems.
+     */
+    struct os_coreos : os_linux
+    {
+        /**
+         * Constructs the os_cumulus and reads /etc/os-release to gather relevant details.
+         */
+        os_coreos() : os_linux({"VERSION_ID"}) {}
+
+        /**
+         * Returns the release name.
+         * @param distro_id Unused.
+         * @return Returns "CoreOS".
+         */
+        virtual std::string get_name(std::string const& distro_id) const override
+        {
+            return os::coreos;
+        }
+
+        /**
+         * Returns the release family.
+         * @param name Unused.
+         * @return Returns "CoreOS".
+         */
+        virtual std::string get_family(std::string const& name) const override
+        {
+            return os_family::coreos;
+        }
+
+        /**
+         * Finds VERSION_ID from the release file contents and returns it as the release.
+         * @param name Unused.
+         * @param distro_release Unused.
+         * @return Returns the release version.
+         */
+        virtual std::string get_release(std::string const& name, std::string const& distro_release) const override
+        {
+            auto val = _release_info.find("VERSION_ID");
+            return (val != _release_info.end()) ? val->second : std::string();
+        }
+    };
+
+}}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/linux/os_cumulus.hpp
+++ b/lib/inc/internal/facts/linux/os_cumulus.hpp
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Declares the Cumulus Linux operating system query helper.
+ */
+#pragma once
+
+#include <internal/facts/linux/os_linux.hpp>
+#include <facter/facts/os.hpp>
+#include <facter/facts/os_family.hpp>
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for determining the name/family/release of Cumulus operating systems.
+     */
+    struct os_cumulus : os_linux
+    {
+        /**
+         * Constructs the os_cumulus and reads /etc/os-release to gather relevant details.
+         */
+        os_cumulus() : os_linux({"VERSION_ID"}) {}
+
+        /**
+         * Returns the release name.
+         * @param distro_id Unused.
+         * @return Returns "CumulusLinux".
+         */
+        virtual std::string get_name(std::string const& distro_id) const override
+        {
+            return os::cumulus;
+        }
+
+        /**
+         * Returns the release family.
+         * @param name Unused.
+         * @return Returns "Debian".
+         */
+        virtual std::string get_family(std::string const& name) const override
+        {
+            return os_family::debian;
+        }
+
+        /**
+         * Finds VERSION_ID from the release file contents and returns it as the release.
+         * @param name Unused.
+         * @param distro_release Unused.
+         * @return Returns the release version.
+         */
+        virtual std::string get_release(std::string const& name, std::string const& distro_release) const override
+        {
+            auto val = _release_info.find("VERSION_ID");
+            return (val != _release_info.end()) ? val->second : std::string();
+        }
+    };
+
+}}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/linux/os_linux.hpp
+++ b/lib/inc/internal/facts/linux/os_linux.hpp
@@ -7,6 +7,8 @@
 #include <internal/facts/linux/release_file.hpp>
 #include <set>
 #include <map>
+#include <tuple>
+#include <string>
 
 namespace facter { namespace facts { namespace linux {
 
@@ -43,6 +45,14 @@ namespace facter { namespace facts { namespace linux {
          * @return Returns the release version.
          */
         virtual std::string get_release(std::string const& name, std::string const& distro_release) const;
+
+        /**
+         * Parses the release version string to return the major version.
+         * @param name The release name determined using get_name.
+         * @param release The release version determined using get_release.
+         * @return Returns a tuple of the major and minor versions.
+         */
+        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const;
 
         /**
          * Parses a file containing key-value pairs separated by an equal (=) sign, one pair per line.

--- a/lib/inc/internal/facts/linux/os_linux.hpp
+++ b/lib/inc/internal/facts/linux/os_linux.hpp
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * Declares the generic Linux operating system query helper.
+ */
+#pragma once
+
+#include <internal/facts/linux/release_file.hpp>
+#include <set>
+#include <map>
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for determining the name/family/release of common operating systems.
+     */
+    struct os_linux
+    {
+        /**
+         * Constructs the os_linux.
+         * @param items Items to read from the release file; used by inheriting classes.
+         * @param file The release file to read for OS data; used by inheriting classes.
+         */
+        os_linux(std::set<std::string> items = {}, std::string file = release_file::os);
+
+        /**
+         * Returns the name of the operating system.
+         * @param distro_id The distro ID; can be queried as the "Distributor ID" given by lsb_release.
+         * @return Returns the release name.
+         */
+        virtual std::string get_name(std::string const& distro_id) const;
+
+        /**
+         * Returns the family of the operating system.
+         * @param name The release name determined using get_name.
+         * @return Returns the release family.
+         */
+        virtual std::string get_family(std::string const& name) const;
+
+        /**
+         * Returns the release of the operating system.
+         * @param name The release name determined using get_name.
+         * @param distro_release The distro release; can be queried as the "Release" given by lsb_release.
+         * @return Returns the release version.
+         */
+        virtual std::string get_release(std::string const& name, std::string const& distro_release) const;
+
+        /**
+         * Parses a file containing key-value pairs separated by an equal (=) sign, one pair per line.
+         * @param file The file to parse.
+         * @param items The keys to save from the file. Only keys given in this parameter will be returned.
+         * @return The key-value pairs identified in the items argument and found in the file.
+         */
+        static std::map<std::string, std::string> key_value_file(std::string file, std::set<std::string> const& items);
+
+     protected:
+        /**
+         * A map of key-value pairs read from the release file.
+         */
+        std::map<std::string, std::string> _release_info;
+    };
+
+}}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -142,9 +142,14 @@ namespace facter { namespace facts { namespace resolvers {
         struct data
         {
             /**
-             * Stores the OS name (e.g. Archlinux).
+             * Stores the OS name (e.g. CentOS).
              */
             std::string name;
+
+            /**
+             * Stores the OS family name (e.g. Debian).
+             */
+            std::string family;
 
             /**
              * Stores the OS release.
@@ -201,14 +206,6 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns a tuple of major and minor release versions.
          */
         virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const;
-
-        /**
-         * Determines the OS family given an OS name.
-         * @param facts The fact collection that is resolving facts.
-         * @param name The name of the OS.
-         * @return Returns the OS family or empty string if there is no family.
-         */
-        virtual std::string determine_os_family(collection& facts, std::string const& name) const;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -25,6 +25,14 @@ namespace facter { namespace facts { namespace resolvers {
          */
         virtual void resolve(collection& facts) override;
 
+        /**
+         * Parses the major and minor OS release versions for Linux distros.
+         * @param name The name of the OS.
+         * @param release The release to parse.
+         * @return Returns a tuple of major and minor release versions.
+         */
+        static std::tuple<std::string, std::string> parse_distro(std::string const& name, std::string const& release);
+
      protected:
         /**
          * Represents information about an operating system distribution.
@@ -157,6 +165,16 @@ namespace facter { namespace facts { namespace resolvers {
             std::string release;
 
             /**
+             * Stores the OS major release.
+             */
+            std::string major;
+
+            /**
+             * Stores the OS minor release.
+             */
+            std::string minor;
+
+            /**
              * Stores the processor hardware model.
              */
             std::string hardware;
@@ -198,14 +216,6 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns the resolver data.
          */
         virtual data collect_data(collection& facts);
-
-        /**
-         * Parses the major and minor OS release versions.
-         * @param name The name of the OS.
-         * @param release The release to parse.
-         * @return Returns a tuple of major and minor release versions.
-         */
-        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/solaris/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/operating_system_resolver.hpp
@@ -20,14 +20,6 @@ namespace facter { namespace facts { namespace solaris {
          * @return Returns the resolver data.
          */
         virtual data collect_data(collection& facts) override;
-
-        /**
-         * Parses the major and minor OS release versions.
-         * @param name The name of the OS.
-         * @param release The release to parse.
-         * @return Returns a tuple of major and minor release versions.
-         */
-        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const override;
     };
 
 }}}  // namespace facter::facts::solaris

--- a/lib/inc/internal/facts/windows/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/windows/operating_system_resolver.hpp
@@ -29,14 +29,6 @@ namespace facter { namespace facts { namespace windows {
          */
         virtual data collect_data(collection& facts) override;
 
-        /**
-         * Returns the major release version on Windows; it has no consistent minor release naming scheme.
-         * @param name The name of the OS.
-         * @param release The release to parse.
-         * @return Returns a tuple of major and minor release versions.
-         */
-        virtual std::tuple<std::string, std::string> parse_release(std::string const& name, std::string const& release) const;
-
      private:
         std::shared_ptr<util::windows::wmi> _wmi;
     };

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -1,5 +1,8 @@
 #include <internal/facts/linux/operating_system_resolver.hpp>
 #include <internal/facts/linux/release_file.hpp>
+#include <internal/facts/linux/os_linux.hpp>
+#include <internal/facts/linux/os_cumulus.hpp>
+#include <internal/facts/linux/os_coreos.hpp>
 #include <internal/util/regex.hpp>
 #include <facter/facts/os.hpp>
 #include <facter/facts/scalar_value.hpp>
@@ -12,369 +15,38 @@
 #include <map>
 #include <vector>
 #include <tuple>
+#include <memory>
 
 using namespace std;
 using namespace facter::util;
 using namespace facter::execution;
 using namespace boost::filesystem;
-namespace bs = boost::system;
 
 namespace facter { namespace facts { namespace linux {
 
-    operating_system_resolver::data operating_system_resolver::collect_data(collection& facts)
+    static unique_ptr<os_linux> get_os()
     {
-        // Default to the base implementation
-        data result = posix::operating_system_resolver::collect_data(facts);
+        auto release_info = os_linux::key_value_file(release_file::os, {"NAME"});
+        auto const& name = release_info["NAME"];
+        if (name == "Cumulus Linux") {
+            return unique_ptr<os_linux>(new os_cumulus());
+        } else if (name == "CoreOS") {
+            return unique_ptr<os_linux>(new os_coreos());
+        }
+        return unique_ptr<os_linux>(new os_linux());
+    }
 
-        // Populate distro info
-        execution::each_line("lsb_release", {"-a"}, [&](string& line) {
-            string* variable = nullptr;
-            size_t offset = 0;
-            if (boost::starts_with(line, "LSB Version:")) {
-                variable = &result.specification_version;
-                offset = 12;
-            } else if (boost::starts_with(line, "Distributor ID:")) {
-                variable = &result.distro.id;
-                offset = 15;
-            } else if (boost::starts_with(line, "Description:")) {
-                variable = &result.distro.description;
-                offset = 12;
-            } else if (boost::starts_with(line, "Codename:")) {
-                variable = &result.distro.codename;
-                offset = 9;
-            } else if (boost::starts_with(line, "Release:")) {
-                variable = &result.distro.release;
-                offset = 8;
+    static string get_selinux_mountpoint()
+    {
+        static boost::regex regexp("\\S+ (\\S+) selinuxfs");
+        string mountpoint;
+        file::each_line("/proc/self/mounts", [&](string& line) {
+            if (re_search(line, regexp, &mountpoint)) {
+                return false;
             }
-            if (!variable) {
-                return true;
-            }
-            *variable = line.substr(offset);
-            boost::trim(*variable);
             return true;
         });
-
-        auto name = get_name(result.distro.id);
-        if (!name.empty()) {
-            result.name = move(name);
-        }
-
-        auto release = get_release(result.name, result.distro.release);
-        if (!release.empty()) {
-            result.release = move(release);
-        }
-
-        // Convert the architecture value depending on distro
-        // For certain distros, use "amd64" for "x86_64"
-        // For certain distros, use "x86" for "i386"
-        if (result.architecture == "x86_64" && (
-             result.name == os::debian ||
-             result.name == os::gentoo ||
-             result.name == os::kfreebsd ||
-             result.name == os::ubuntu)) {
-            result.architecture = "amd64";
-        } else if (re_search(result.architecture, boost::regex("i[3456]86|pentium"))) {
-            // For 32-bit, use "x86" for Gentoo and "i386" for everyone else
-            if (result.name == os::gentoo) {
-                result.architecture = "x86";
-            } else {
-                result.architecture = "i386";
-            }
-        }
-
-        result.selinux = collect_selinux_data();
-
-        return result;
-    }
-
-    string operating_system_resolver::get_name(string const& distro_id)
-    {
-        // Start by checking for Cumulus Linux or CoreOS
-        string value = check_os_release_linux();
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for Debian next
-        value = check_debian_linux(distro_id);
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for Oracle Enterprise Linux next
-        value = check_oracle_linux();
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for RedHat next
-        value = check_redhat_linux();
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for SuSE next
-        value = check_suse_linux();
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for some other Linux last
-        return check_other_linux();
-    }
-
-    string operating_system_resolver::get_release(string const& name, string const& distro_release)
-    {
-        // Map of release files that contain a "release X.X.X" on the first line
-        static map<string, string> const release_files = {
-                { string(os::centos),                   string(release_file::redhat) },
-                { string(os::redhat),                   string(release_file::redhat) },
-                { string(os::scientific),               string(release_file::redhat) },
-                { string(os::scientific_cern),          string(release_file::redhat) },
-                { string(os::ascendos),                 string(release_file::redhat) },
-                { string(os::cloud_linux),              string(release_file::redhat) },
-                { string(os::psbm),                     string(release_file::redhat) },
-                { string(os::xen_server),               string(release_file::redhat) },
-                { string(os::fedora),                   string(release_file::fedora) },
-                { string(os::meego),                    string(release_file::meego) },
-                { string(os::oracle_linux),             string(release_file::oracle_linux) },
-                { string(os::oracle_enterprise_linux),  string(release_file::oracle_enterprise_linux) },
-                { string(os::oracle_vm_linux),          string(release_file::oracle_vm_linux) },
-                { string(os::arista_eos),               string(release_file::arista_eos) },
-        };
-
-        string value;
-        auto it = release_files.find(name);
-        if (it != release_files.end()) {
-            string contents;
-            if (file::each_line(it->second, [&](string& line) {
-                // We only need the first line
-                contents = move(line);
-                return false;
-            })) {
-                if (boost::ends_with(contents, "(Rawhide)")) {
-                    value = "Rawhide";
-                } else {
-                    re_search(contents, boost::regex("release (\\d[\\d.]*)"), &value);
-                }
-            }
-        }
-
-        // Debian uses the entire contents of the release file as the version
-        if (value.empty() && name == os::debian) {
-            value = file::read(release_file::debian);
-            boost::trim_right(value);
-        }
-
-        // Alpine uses the entire contents of the release file as the version
-        if (value.empty() && name == os::alpine) {
-            value = file::read(release_file::alpine);
-            boost::trim_right(value);
-        }
-
-        // Check for SuSE related distros, read the release file
-        if (value.empty() && (
-                name == os::suse ||
-                name == os::suse_enterprise_server ||
-                name == os::suse_enterprise_desktop ||
-                name == os::open_suse)) {
-            string contents = file::read(release_file::suse);
-            string major;
-            string minor;
-            if (re_search(contents, boost::regex("(?m)^VERSION\\s*=\\s*(\\d+)\\.?(\\d+)?"), &major, &minor)) {
-                // Check that we have a minor version; if not, use the patch level
-                if (minor.empty()) {
-                    if (!re_search(contents, boost::regex("(?m)^PATCHLEVEL\\s*=\\s*(\\d+)"), &minor)) {
-                        minor = "0";
-                    }
-                }
-                value = major + "." + minor;
-            } else {
-                value = "unknown";
-            }
-        }
-
-        // Read version files of particular operating systems
-        if (value.empty()) {
-            const char* file = nullptr;
-            boost::regex pattern;
-            if (name == os::ubuntu) {
-                file = release_file::lsb;
-                pattern = "(?m)^DISTRIB_RELEASE=(\\d+\\.\\d+)(?:\\.\\d+)*";
-            } else if (name == os::slackware) {
-                file = release_file::slackware;
-                pattern = "Slackware ([0-9.]+)";
-            } else if (name == os::mageia) {
-                file = release_file::mageia;
-                pattern = "Mageia release ([0-9.]+)";
-            } else if (name == os::cumulus || name == os::coreos) {
-                file = release_file::os;
-                pattern = "(?m)^VERSION_ID\\s*=\\s*(\\d+\\.\\d+\\.\\d+)";
-            } else if (name == os::linux_mint) {
-                file = release_file::linux_mint_info;
-                pattern = "(?m)^RELEASE=(\\d+)";
-            } else if (name == os::openwrt) {
-                file = release_file::openwrt_version;
-                pattern = "(?m)^(\\d+\\.\\d+.*)";
-            } else if (name == os::arista_eos) {
-                file = release_file::arista_eos;
-                pattern = "Arista Networks EOS (\\d+\\.\\d+\\.\\d+[A-M]?)";
-            }
-            if (file) {
-                string contents = file::read(file);
-                re_search(contents, pattern, &value);
-            }
-        }
-
-        // For VMware ESX, execute the vmware tool
-        if (value.empty() && name == os::vmware_esx) {
-            bool success;
-            string output, none;
-            tie(success, output, none) = execute("vmware", { "-v" });
-            if (success) {
-                re_search(output, boost::regex("VMware ESX .*?(\\d.*)"), &value);
-            }
-        }
-
-        // For Amazon, use the distro release
-        if (value.empty() && name == os::amazon) {
-            return distro_release;
-        }
-
-        return value;
-    }
-
-    tuple<string, string> operating_system_resolver::parse_release(string const& name, string const& release) const
-    {
-        if (name != os::ubuntu) {
-            return resolvers::operating_system_resolver::parse_release(name, release);
-        }
-
-        string major, minor;
-        re_search(release, boost::regex("(\\d+\\.\\d*)\\.?(\\d*)"), &major, &minor);
-        return make_tuple(move(major), move(minor));
-    }
-
-    string operating_system_resolver::check_os_release_linux()
-    {
-        // Check for NAME in /etc/os-release
-        bs::error_code ec;
-        if (is_regular_file(release_file::os, ec)) {
-            string contents = file::read(release_file::os);
-            boost::trim(contents);
-
-            string release;
-            if (re_search(contents, boost::regex("(?m)^NAME=[\"']?(.+?)[\"']?$"), &release)) {
-                if (release == "Cumulus Linux") {
-                    return os::cumulus;
-                } else if (release == "CoreOS") {
-                    return os::coreos;
-                }
-            }
-        }
-        return {};
-    }
-
-    string operating_system_resolver::check_debian_linux(string const& distro_id)
-    {
-        // Check for Debian variants
-        bs::error_code ec;
-        if (is_regular_file(release_file::debian, ec)) {
-            if (distro_id == os::ubuntu || distro_id == os::linux_mint) {
-                return distro_id;
-            }
-            return os::debian;
-        }
-        return {};
-    }
-
-    string operating_system_resolver::check_oracle_linux()
-    {
-        bs::error_code ec;
-        if (is_regular_file(release_file::oracle_enterprise_linux, ec)) {
-            if (is_regular_file(release_file::oracle_vm_linux, ec)) {
-                return os::oracle_vm_linux;
-            }
-            return os::oracle_enterprise_linux;
-        }
-        return {};
-    }
-
-    string operating_system_resolver::check_redhat_linux()
-    {
-        bs::error_code ec;
-        if (is_regular_file(release_file::redhat, ec)) {
-            static vector<tuple<boost::regex, string>> const regexs {
-                make_tuple(boost::regex("(?i)centos"),                        string(os::centos)),
-                make_tuple(boost::regex("(?i)scientific linux CERN"),         string(os::scientific_cern)),
-                make_tuple(boost::regex("(?i)scientific linux release"),      string(os::scientific)),
-                make_tuple(boost::regex("(?im)^cloudlinux"),                  string(os::cloud_linux)),
-                make_tuple(boost::regex("(?i)Ascendos"),                      string(os::ascendos)),
-                make_tuple(boost::regex("(?im)^XenServer"),                   string(os::xen_server)),
-                make_tuple(boost::regex("XCP"),                               string(os::zen_cloud_platform)),
-                make_tuple(boost::regex("(?im)^Parallels Server Bare Metal"), string(os::psbm)),
-                make_tuple(boost::regex("(?m)^Fedora release"),               string(os::fedora)),
-            };
-
-            string contents = file::read(release_file::redhat);
-            boost::trim(contents);
-            for (auto const& regex : regexs) {
-                if (re_search(contents, get<0>(regex))) {
-                    return get<1>(regex);
-                }
-            }
-            return os::redhat;
-        }
-        return {};
-    }
-
-    string operating_system_resolver::check_suse_linux()
-    {
-        bs::error_code ec;
-        if (is_regular_file(release_file::suse, ec)) {
-            static vector<tuple<boost::regex, string>> const regexs {
-                make_tuple(boost::regex("(?im)^SUSE LINUX Enterprise Server"),  string(os::suse_enterprise_server)),
-                make_tuple(boost::regex("(?im)^SUSE LINUX Enterprise Desktop"), string(os::suse_enterprise_desktop)),
-                make_tuple(boost::regex("(?im)^openSUSE"),                      string(os::open_suse)),
-            };
-
-            string contents = file::read(release_file::suse);
-            boost::trim(contents);
-            for (auto const& regex : regexs) {
-                if (re_search(contents, get<0>(regex))) {
-                    return get<1>(regex);
-                }
-            }
-            return os::suse;
-        }
-        return {};
-    }
-
-    string operating_system_resolver::check_other_linux()
-    {
-        static vector<tuple<string, string>> const files {
-            make_tuple(string(release_file::openwrt),        string(os::openwrt)),
-            make_tuple(string(release_file::gentoo),         string(os::gentoo)),
-            make_tuple(string(release_file::mandriva),       string(os::mandriva)),
-            make_tuple(string(release_file::mandrake),       string(os::mandrake)),
-            make_tuple(string(release_file::meego),          string(os::meego)),
-            make_tuple(string(release_file::archlinux),      string(os::archlinux)),
-            make_tuple(string(release_file::oracle_linux),   string(os::oracle_linux)),
-            make_tuple(string(release_file::vmware_esx),     string(os::vmware_esx)),
-            make_tuple(string(release_file::slackware),      string(os::slackware)),
-            make_tuple(string(release_file::alpine),         string(os::alpine)),
-            make_tuple(string(release_file::mageia),         string(os::mageia)),
-            make_tuple(string(release_file::amazon),         string(os::amazon)),
-            make_tuple(string(release_file::arista_eos),     string(os::arista_eos)),
-        };
-
-        for (auto const& file : files) {
-            bs::error_code ec;
-            if (is_regular_file(get<0>(file), ec)) {
-                return get<1>(file);
-            }
-        }
-        return {};
+        return mountpoint;
     }
 
     operating_system_resolver::selinux_data operating_system_resolver::collect_selinux_data()
@@ -417,17 +89,87 @@ namespace facter { namespace facts { namespace linux {
         return result;
     }
 
-    string operating_system_resolver::get_selinux_mountpoint()
+    operating_system_resolver::data operating_system_resolver::collect_data(collection& facts)
     {
-        static boost::regex regexp("\\S+ (\\S+) selinuxfs");
-        string mountpoint;
-        file::each_line("/proc/self/mounts", [&](string& line) {
-            if (re_search(line, regexp, &mountpoint)) {
-                return false;
+        // Default to the base implementation
+        data result = posix::operating_system_resolver::collect_data(facts);
+
+        // Populate distro info
+        execution::each_line("lsb_release", {"-a"}, [&](string& line) {
+            string* variable = nullptr;
+            size_t offset = 0;
+            if (boost::starts_with(line, "LSB Version:")) {
+                variable = &result.specification_version;
+                offset = 12;
+            } else if (boost::starts_with(line, "Distributor ID:")) {
+                variable = &result.distro.id;
+                offset = 15;
+            } else if (boost::starts_with(line, "Description:")) {
+                variable = &result.distro.description;
+                offset = 12;
+            } else if (boost::starts_with(line, "Codename:")) {
+                variable = &result.distro.codename;
+                offset = 9;
+            } else if (boost::starts_with(line, "Release:")) {
+                variable = &result.distro.release;
+                offset = 8;
             }
+            if (!variable) {
+                return true;
+            }
+            *variable = line.substr(offset);
+            boost::trim(*variable);
             return true;
         });
-        return mountpoint;
+
+        auto implementation = get_os();
+        auto name = implementation->get_name(result.distro.id);
+        if (!name.empty()) {
+            result.name = move(name);
+        }
+
+        auto family = implementation->get_family(result.name);
+        if (!family.empty()) {
+            result.family = move(family);
+        }
+
+        auto release = implementation->get_release(result.name, result.distro.release);
+        if (!release.empty()) {
+            result.release = move(release);
+        }
+
+        // Convert the architecture value depending on distro
+        // For certain distros, use "amd64" for "x86_64"
+        // For certain distros, use "x86" for "i386"
+        if (result.architecture == "x86_64" && (
+             result.name == os::debian ||
+             result.name == os::gentoo ||
+             result.name == os::kfreebsd ||
+             result.name == os::ubuntu)) {
+            result.architecture = "amd64";
+        } else if (re_search(result.architecture, boost::regex("i[3456]86|pentium"))) {
+            // For 32-bit, use "x86" for Gentoo and "i386" for everyone else
+            if (result.name == os::gentoo) {
+                result.architecture = "x86";
+            } else {
+                result.architecture = "i386";
+            }
+        }
+
+        result.selinux = collect_selinux_data();
+
+        return result;
+    }
+
+    tuple<string, string> operating_system_resolver::parse_release(string const& name, string const& release) const
+    {
+        if (name != os::ubuntu) {
+            return resolvers::operating_system_resolver::parse_release(name, release);
+        }
+
+        string major, minor;
+        re_search(release, boost::regex("(\\d+\\.\\d*)\\.?(\\d*)"), &major, &minor);
+        return make_tuple(move(major), move(minor));
     }
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -143,6 +143,7 @@ namespace facter { namespace facts { namespace linux {
         auto release = implementation->get_release(result.name, result.distro.release);
         if (!release.empty()) {
             result.release = move(release);
+            tie(result.major, result.minor) = implementation->parse_release(result.name, result.release);
         }
 
         // Convert the architecture value depending on distro
@@ -166,17 +167,6 @@ namespace facter { namespace facts { namespace linux {
         result.selinux = collect_selinux_data();
 
         return result;
-    }
-
-    tuple<string, string> operating_system_resolver::parse_release(string const& name, string const& release) const
-    {
-        if (name != os::ubuntu) {
-            return resolvers::operating_system_resolver::parse_release(name, release);
-        }
-
-        string major, minor;
-        re_search(release, boost::regex("(\\d+\\.\\d*)\\.?(\\d*)"), &major, &minor);
-        return make_tuple(move(major), move(minor));
     }
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -1,0 +1,328 @@
+#include <internal/facts/linux/os_linux.hpp>
+#include <internal/util/regex.hpp>
+#include <facter/execution/execution.hpp>
+#include <facter/facts/os.hpp>
+#include <facter/facts/os_family.hpp>
+#include <facter/util/file.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <vector>
+
+using namespace std;
+using namespace facter::util;
+using namespace facter::execution;
+using namespace boost::filesystem;
+namespace bs = boost::system;
+
+namespace facter { namespace facts { namespace linux {
+
+    // Return contents of the os-release file
+    // http://www.freedesktop.org/software/systemd/man/os-release.html
+    map<string, string> os_linux::key_value_file(string file, set<string> const& items)
+    {
+        map<string, string> values;
+        bs::error_code ec;
+        if (!items.empty() && is_regular_file(file, ec)) {
+            string key, value;
+            file::each_line(file, [&](string& line) {
+                if (re_search(line, boost::regex("(?m)^(\\w+)=[\"']?(.+?)[\"']?$"), &key, &value)) {
+                    if (items.count(key)) {
+                        values.insert(make_pair(key, value));
+                    }
+                }
+                return items.size() != values.size();
+            });
+        }
+        return values;
+    }
+
+    os_linux::os_linux(std::set<std::string> items, std::string file) :
+            _release_info(key_value_file(file, items)) {}
+
+    static string check_debian_linux(string const& distro_id)
+    {
+        // Check for Debian variants
+        bs::error_code ec;
+        if (is_regular_file(release_file::debian, ec)) {
+            if (distro_id == os::ubuntu || distro_id == os::linux_mint) {
+                return distro_id;
+            }
+            return os::debian;
+        }
+        return {};
+    }
+
+    static string check_oracle_linux()
+    {
+        bs::error_code ec;
+        if (is_regular_file(release_file::oracle_enterprise_linux, ec)) {
+            if (is_regular_file(release_file::oracle_vm_linux, ec)) {
+                return os::oracle_vm_linux;
+            }
+            return os::oracle_enterprise_linux;
+        }
+        return {};
+    }
+
+    static string check_redhat_linux()
+    {
+        bs::error_code ec;
+        if (is_regular_file(release_file::redhat, ec)) {
+            static vector<tuple<boost::regex, string>> const regexs {
+                make_tuple(boost::regex("(?i)centos"),                        string(os::centos)),
+                make_tuple(boost::regex("(?i)scientific linux CERN"),         string(os::scientific_cern)),
+                make_tuple(boost::regex("(?i)scientific linux release"),      string(os::scientific)),
+                make_tuple(boost::regex("(?im)^cloudlinux"),                  string(os::cloud_linux)),
+                make_tuple(boost::regex("(?i)Ascendos"),                      string(os::ascendos)),
+                make_tuple(boost::regex("(?im)^XenServer"),                   string(os::xen_server)),
+                make_tuple(boost::regex("XCP"),                               string(os::zen_cloud_platform)),
+                make_tuple(boost::regex("(?im)^Parallels Server Bare Metal"), string(os::psbm)),
+                make_tuple(boost::regex("(?m)^Fedora release"),               string(os::fedora)),
+            };
+
+            string contents = file::read(release_file::redhat);
+            boost::trim(contents);
+            for (auto const& regex : regexs) {
+                if (re_search(contents, get<0>(regex))) {
+                    return get<1>(regex);
+                }
+            }
+            return os::redhat;
+        }
+        return {};
+    }
+
+    static string check_suse_linux()
+    {
+        bs::error_code ec;
+        if (is_regular_file(release_file::suse, ec)) {
+            static vector<tuple<boost::regex, string>> const regexs {
+                make_tuple(boost::regex("(?im)^SUSE LINUX Enterprise Server"),  string(os::suse_enterprise_server)),
+                make_tuple(boost::regex("(?im)^SUSE LINUX Enterprise Desktop"), string(os::suse_enterprise_desktop)),
+                make_tuple(boost::regex("(?im)^openSUSE"),                      string(os::open_suse)),
+            };
+
+            string contents = file::read(release_file::suse);
+            boost::trim(contents);
+            for (auto const& regex : regexs) {
+                if (re_search(contents, get<0>(regex))) {
+                    return get<1>(regex);
+                }
+            }
+            return os::suse;
+        }
+        return {};
+    }
+
+    static string check_other_linux()
+    {
+        static vector<tuple<string, string>> const files {
+            make_tuple(string(release_file::openwrt),        string(os::openwrt)),
+            make_tuple(string(release_file::gentoo),         string(os::gentoo)),
+            make_tuple(string(release_file::mandriva),       string(os::mandriva)),
+            make_tuple(string(release_file::mandrake),       string(os::mandrake)),
+            make_tuple(string(release_file::meego),          string(os::meego)),
+            make_tuple(string(release_file::archlinux),      string(os::archlinux)),
+            make_tuple(string(release_file::oracle_linux),   string(os::oracle_linux)),
+            make_tuple(string(release_file::vmware_esx),     string(os::vmware_esx)),
+            make_tuple(string(release_file::slackware),      string(os::slackware)),
+            make_tuple(string(release_file::alpine),         string(os::alpine)),
+            make_tuple(string(release_file::mageia),         string(os::mageia)),
+            make_tuple(string(release_file::amazon),         string(os::amazon)),
+            make_tuple(string(release_file::arista_eos),     string(os::arista_eos)),
+        };
+
+        for (auto const& file : files) {
+            bs::error_code ec;
+            if (is_regular_file(get<0>(file), ec)) {
+                return get<1>(file);
+            }
+        }
+        return {};
+    }
+
+    string os_linux::get_name(string const& distro_id) const
+    {
+        // Check for Debian next
+        auto value = check_debian_linux(distro_id);
+        if (!value.empty()) {
+            return value;
+        }
+
+        // Check for Oracle Enterprise Linux next
+        value = check_oracle_linux();
+        if (!value.empty()) {
+            return value;
+        }
+
+        // Check for RedHat next
+        value = check_redhat_linux();
+        if (!value.empty()) {
+            return value;
+        }
+
+        // Check for SuSE next
+        value = check_suse_linux();
+        if (!value.empty()) {
+            return value;
+        }
+
+        // Check for some other Linux last
+        return check_other_linux();
+    }
+
+    string os_linux::get_family(string const& name) const
+    {
+        static map<string, string> const systems = {
+            { string(os::redhat),                   string(os_family::redhat) },
+            { string(os::fedora),                   string(os_family::redhat) },
+            { string(os::centos),                   string(os_family::redhat) },
+            { string(os::scientific),               string(os_family::redhat) },
+            { string(os::scientific_cern),          string(os_family::redhat) },
+            { string(os::ascendos),                 string(os_family::redhat) },
+            { string(os::cloud_linux),              string(os_family::redhat) },
+            { string(os::psbm),                     string(os_family::redhat) },
+            { string(os::oracle_linux),             string(os_family::redhat) },
+            { string(os::oracle_vm_linux),          string(os_family::redhat) },
+            { string(os::oracle_enterprise_linux),  string(os_family::redhat) },
+            { string(os::amazon),                   string(os_family::redhat) },
+            { string(os::xen_server),               string(os_family::redhat) },
+            { string(os::linux_mint),               string(os_family::debian) },
+            { string(os::ubuntu),                   string(os_family::debian) },
+            { string(os::debian),                   string(os_family::debian) },
+            { string(os::suse_enterprise_server),   string(os_family::suse) },
+            { string(os::suse_enterprise_desktop),  string(os_family::suse) },
+            { string(os::open_suse),                string(os_family::suse) },
+            { string(os::suse),                     string(os_family::suse) },
+            { string(os::gentoo),                   string(os_family::gentoo) },
+            { string(os::archlinux),                string(os_family::archlinux) },
+            { string(os::mandrake),                 string(os_family::mandrake) },
+            { string(os::mandriva),                 string(os_family::mandrake) },
+            { string(os::mageia),                   string(os_family::mandrake) },
+        };
+        auto const& it = systems.find(name);
+        if (it != systems.end()) {
+            return it->second;
+        }
+        return {};
+    }
+
+    string os_linux::get_release(string const& name, string const& distro_release) const
+    {
+        // Map of release files that contain a "release X.X.X" on the first line
+        static map<string, string> const release_files = {
+                { string(os::centos),                   string(release_file::redhat) },
+                { string(os::redhat),                   string(release_file::redhat) },
+                { string(os::scientific),               string(release_file::redhat) },
+                { string(os::scientific_cern),          string(release_file::redhat) },
+                { string(os::ascendos),                 string(release_file::redhat) },
+                { string(os::cloud_linux),              string(release_file::redhat) },
+                { string(os::psbm),                     string(release_file::redhat) },
+                { string(os::xen_server),               string(release_file::redhat) },
+                { string(os::fedora),                   string(release_file::fedora) },
+                { string(os::meego),                    string(release_file::meego) },
+                { string(os::oracle_linux),             string(release_file::oracle_linux) },
+                { string(os::oracle_enterprise_linux),  string(release_file::oracle_enterprise_linux) },
+                { string(os::oracle_vm_linux),          string(release_file::oracle_vm_linux) },
+                { string(os::arista_eos),               string(release_file::arista_eos) },
+        };
+
+        string value;
+        auto it = release_files.find(name);
+        if (it != release_files.end()) {
+            string contents;
+            if (file::each_line(it->second, [&](string& line) {
+                // We only need the first line
+                contents = move(line);
+                return false;
+            })) {
+                if (boost::ends_with(contents, "(Rawhide)")) {
+                    value = "Rawhide";
+                } else {
+                    re_search(contents, boost::regex("release (\\d[\\d.]*)"), &value);
+                }
+            }
+        }
+
+        // Debian uses the entire contents of the release file as the version
+        if (value.empty() && name == os::debian) {
+            value = file::read(release_file::debian);
+            boost::trim_right(value);
+        }
+
+        // Alpine uses the entire contents of the release file as the version
+        if (value.empty() && name == os::alpine) {
+            value = file::read(release_file::alpine);
+            boost::trim_right(value);
+        }
+
+        // Check for SuSE related distros, read the release file
+        if (value.empty() && (
+                name == os::suse ||
+                name == os::suse_enterprise_server ||
+                name == os::suse_enterprise_desktop ||
+                name == os::open_suse)) {
+            string contents = file::read(release_file::suse);
+            string major;
+            string minor;
+            if (re_search(contents, boost::regex("(?m)^VERSION\\s*=\\s*(\\d+)\\.?(\\d+)?"), &major, &minor)) {
+                // Check that we have a minor version; if not, use the patch level
+                if (minor.empty()) {
+                    if (!re_search(contents, boost::regex("(?m)^PATCHLEVEL\\s*=\\s*(\\d+)"), &minor)) {
+                        minor = "0";
+                    }
+                }
+                value = major + "." + minor;
+            } else {
+                value = "unknown";
+            }
+        }
+
+        // Read version files of particular operating systems
+        if (value.empty()) {
+            const char* file = nullptr;
+            boost::regex pattern;
+            if (name == os::ubuntu) {
+                file = release_file::lsb;
+                pattern = "(?m)^DISTRIB_RELEASE=(\\d+\\.\\d+)(?:\\.\\d+)*";
+            } else if (name == os::slackware) {
+                file = release_file::slackware;
+                pattern = "Slackware ([0-9.]+)";
+            } else if (name == os::mageia) {
+                file = release_file::mageia;
+                pattern = "Mageia release ([0-9.]+)";
+            } else if (name == os::linux_mint) {
+                file = release_file::linux_mint_info;
+                pattern = "(?m)^RELEASE=(\\d+)";
+            } else if (name == os::openwrt) {
+                file = release_file::openwrt_version;
+                pattern = "(?m)^(\\d+\\.\\d+.*)";
+            } else if (name == os::arista_eos) {
+                file = release_file::arista_eos;
+                pattern = "Arista Networks EOS (\\d+\\.\\d+\\.\\d+[A-M]?)";
+            }
+            if (file) {
+                string contents = file::read(file);
+                re_search(contents, pattern, &value);
+            }
+        }
+
+        // For VMware ESX, execute the vmware tool
+        if (value.empty() && name == os::vmware_esx) {
+            bool success;
+            string output, none;
+            tie(success, output, none) = execute("vmware", { "-v" });
+            if (success) {
+                re_search(output, boost::regex("VMware ESX .*?(\\d.*)"), &value);
+            }
+        }
+
+        // For Amazon, use the distro release
+        if (value.empty() && name == os::amazon) {
+            return distro_release;
+        }
+
+        return value;
+    }
+
+}}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -1,4 +1,5 @@
 #include <internal/facts/linux/os_linux.hpp>
+#include <internal/facts/resolvers/operating_system_resolver.hpp>
 #include <internal/util/regex.hpp>
 #include <facter/execution/execution.hpp>
 #include <facter/facts/os.hpp>
@@ -323,6 +324,11 @@ namespace facter { namespace facts { namespace linux {
         }
 
         return value;
+    }
+
+    tuple<string, string> os_linux::parse_release(string const& name, string const& release) const
+    {
+        return facter::facts::resolvers::operating_system_resolver::parse_distro(name, release);
     }
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -1,6 +1,4 @@
 #include <internal/facts/resolvers/operating_system_resolver.hpp>
-#include <facter/facts/os.hpp>
-#include <facter/facts/os_family.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include <facter/facts/collection.hpp>
@@ -49,10 +47,9 @@ namespace facter { namespace facts { namespace resolvers {
         auto data = collect_data(facts);
 
         auto os = make_value<map_value>();
-        auto family = determine_os_family(facts, data.name);
-        if (!family.empty()) {
-            facts.add(fact::os_family, make_value<string_value>(family, true));
-            os->add("family", make_value<string_value>(move(family)));
+        if (!data.family.empty()) {
+            facts.add(fact::os_family, make_value<string_value>(data.family, true));
+            os->add("family", make_value<string_value>(move(data.family)));
         }
 
         if (!data.release.empty()) {
@@ -229,6 +226,7 @@ namespace facter { namespace facts { namespace resolvers {
         auto kernel = facts.get<string_value>(fact::kernel);
         if (kernel) {
             result.name = kernel->value();
+            result.family = kernel->value();
         }
 
         auto release = facts.get<string_value>(fact::kernel_release);
@@ -247,59 +245,6 @@ namespace facter { namespace facts { namespace resolvers {
             return make_tuple(release.substr(0, pos), release.substr(pos + 1, second - (pos + 1)));
         }
         return make_tuple(release, string());
-    }
-
-    string operating_system_resolver::determine_os_family(collection& facts, string const& name) const
-    {
-        if (!name.empty()) {
-            static map<string, string> const systems = {
-                { string(os::coreos),                   string(os_family::coreos) },
-                { string(os::redhat),                   string(os_family::redhat) },
-                { string(os::fedora),                   string(os_family::redhat) },
-                { string(os::centos),                   string(os_family::redhat) },
-                { string(os::scientific),               string(os_family::redhat) },
-                { string(os::scientific_cern),          string(os_family::redhat) },
-                { string(os::ascendos),                 string(os_family::redhat) },
-                { string(os::cloud_linux),              string(os_family::redhat) },
-                { string(os::psbm),                     string(os_family::redhat) },
-                { string(os::oracle_linux),             string(os_family::redhat) },
-                { string(os::oracle_vm_linux),          string(os_family::redhat) },
-                { string(os::oracle_enterprise_linux),  string(os_family::redhat) },
-                { string(os::amazon),                   string(os_family::redhat) },
-                { string(os::xen_server),               string(os_family::redhat) },
-                { string(os::linux_mint),               string(os_family::debian) },
-                { string(os::ubuntu),                   string(os_family::debian) },
-                { string(os::debian),                   string(os_family::debian) },
-                { string(os::cumulus),                  string(os_family::debian) },
-                { string(os::suse_enterprise_server),   string(os_family::suse) },
-                { string(os::suse_enterprise_desktop),  string(os_family::suse) },
-                { string(os::open_suse),                string(os_family::suse) },
-                { string(os::suse),                     string(os_family::suse) },
-                { string(os::sunos),                    string(os_family::solaris) },
-                { string(os::solaris),                  string(os_family::solaris) },
-                { string(os::nexenta),                  string(os_family::solaris) },
-                { string(os::omni),                     string(os_family::solaris) },
-                { string(os::open_indiana),             string(os_family::solaris) },
-                { string(os::smart),                    string(os_family::solaris) },
-                { string(os::gentoo),                   string(os_family::gentoo) },
-                { string(os::archlinux),                string(os_family::archlinux) },
-                { string(os::mandrake),                 string(os_family::mandrake) },
-                { string(os::mandriva),                 string(os_family::mandrake) },
-                { string(os::mageia),                   string(os_family::mandrake) },
-                { string(os::windows),                  string(os_family::windows) },
-            };
-            auto const& it = systems.find(name);
-            if (it != systems.end()) {
-                return it->second;
-            }
-        }
-
-        // Default to the same value as the kernel
-        auto kernel = facts.get<string_value>(fact::kernel);
-        if (!kernel) {
-            return {};
-        }
-        return  kernel->value();
     }
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/solaris/operating_system_resolver.cc
+++ b/lib/src/facts/solaris/operating_system_resolver.cc
@@ -56,28 +56,26 @@ namespace facter { namespace facts { namespace solaris {
         static boost::regex regexp_s11("Solaris (\\d+)[.](\\d+)");
         static boost::regex regexp_s11b("Solaris (\\d+) ");
         file::each_line("/etc/release", [&](string& line) {
-            string major;
-            string minor;
+            string major, minor;
             if (re_search(line, regexp_s10, &major, &minor)) {
                 result.release = major + "_u" + minor;
+                result.major = move(major);
+                result.minor = move(minor);
                 return false;
             } else if (re_search(line, regexp_s11, &major, &minor)) {
                 result.release = major + "." + minor;
+                result.major = move(major);
+                result.minor = move(minor);
                 return false;
             } else if (re_search(line, regexp_s11b, &major)) {
                 result.release = major + ".0";
+                result.major = move(major);
+                result.minor = "0";
                 return false;
             }
             return true;
         });
         return result;
-    }
-
-    tuple<string, string> operating_system_resolver::parse_release(string const& name, string const& release) const
-    {
-        string major, minor;
-        re_search(release, boost::regex("^(\\d+)(?:_u|\\.)(\\d+)"), &major, &minor);
-        return make_tuple(major, minor);
     }
 
 }}}  // namespace facter::facts::solaris

--- a/lib/src/facts/solaris/operating_system_resolver.cc
+++ b/lib/src/facts/solaris/operating_system_resolver.cc
@@ -1,6 +1,7 @@
 #include <internal/facts/solaris/operating_system_resolver.hpp>
 #include <internal/util/regex.hpp>
 #include <facter/facts/os.hpp>
+#include <facter/facts/os_family.hpp>
 #include <facter/util/file.hpp>
 
 using namespace std;
@@ -8,12 +9,36 @@ using namespace facter::util;
 
 namespace facter { namespace facts { namespace solaris {
 
+    static string get_family(string const& name)
+    {
+        if (!name.empty()) {
+            static map<string, string> const systems = {
+                { string(os::sunos),                    string(os_family::solaris) },
+                { string(os::solaris),                  string(os_family::solaris) },
+                { string(os::nexenta),                  string(os_family::solaris) },
+                { string(os::omni),                     string(os_family::solaris) },
+                { string(os::open_indiana),             string(os_family::solaris) },
+                { string(os::smart),                    string(os_family::solaris) },
+            };
+            auto const& it = systems.find(name);
+            if (it != systems.end()) {
+                return it->second;
+            }
+        }
+        return {};
+    }
+
     operating_system_resolver::data operating_system_resolver::collect_data(collection& facts)
     {
         // Default to the base implementation
         auto result = posix::operating_system_resolver::collect_data(facts);
         if (result.name == os::sunos) {
             result.name = os::solaris;
+        }
+
+        auto family = get_family(result.name);
+        if (!family.empty()) {
+            result.family = move(family);
         }
 
         /*

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -117,13 +117,9 @@ namespace facter { namespace facts { namespace windows {
                 result.release = (wmi::get(vals, wmi::othertypedescription) == "R2") ? "2003 R2" : "2003";
             }
         }
+        result.major = result.release;
 
         return result;
-    }
-
-    tuple<string, string> operating_system_resolver::parse_release(string const& name, string const& release) const
-    {
-        return make_tuple(release, string());
     }
 
 }}}  // namespace facter::facts::windows

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -4,6 +4,7 @@
 #include <internal/util/windows/wmi.hpp>
 #include <internal/util/windows/windows.hpp>
 #include <facter/facts/collection.hpp>
+#include <facter/facts/os_family.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <intrin.h>
 #include <winnt.h>
@@ -81,6 +82,7 @@ namespace facter { namespace facts { namespace windows {
         // Default to the base implementation
         data result = resolvers::operating_system_resolver::collect_data(facts);
 
+        result.family = os_family::windows;
         result.hardware = get_hardware();
         result.architecture = get_architecture(result.hardware);
         result.win.system32 = get_system32();

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -25,6 +25,7 @@ struct test_os_resolver : operating_system_resolver
     {
         data result;
         result.name = "Archlinux";
+        result.family = "Archlinux";
         result.release = "1.2.3";
         result.specification_version = "1.4";
         result.distro.id = "Arch";

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -27,6 +27,8 @@ struct test_os_resolver : operating_system_resolver
         result.name = "Archlinux";
         result.family = "Archlinux";
         result.release = "1.2.3";
+        result.major = "1";
+        result.minor = "2";
         result.specification_version = "1.4";
         result.distro.id = "Arch";
         result.distro.release = "1.2.3";
@@ -46,11 +48,6 @@ struct test_os_resolver : operating_system_resolver
         result.selinux.config_policy = "config policy";
         result.selinux.policy_version = "policy version";
         return result;
-    }
-
-    virtual tuple<string, string> parse_release(string const& name, string const& release) const override
-    {
-        return make_tuple("1.2", "3");
     }
 };
 
@@ -92,10 +89,10 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(release->value() == "1.2.3");
             auto major = release_attribute->get<string_value>("major");
             REQUIRE(major);
-            REQUIRE(major->value() == "1.2");
+            REQUIRE(major->value() == "1");
             auto minor = release_attribute->get<string_value>("minor");
             REQUIRE(minor);
-            REQUIRE(minor->value() == "3");
+            REQUIRE(minor->value() == "2");
             auto family = os->get<string_value>("family");
             REQUIRE(family);
             REQUIRE(family->value() == "Archlinux");
@@ -116,10 +113,10 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(release->value() == "1.2.3");
             major = release_attribute->get<string_value>("major");
             REQUIRE(major);
-            REQUIRE(major->value() == "1.2");
+            REQUIRE(major->value() == "1");
             minor = release_attribute->get<string_value>("minor");
             REQUIRE(minor);
-            REQUIRE(minor->value() == "3");
+            REQUIRE(minor->value() == "2");
             auto macosx = os->get<map_value>("macosx");
             REQUIRE(macosx);
             REQUIRE(macosx->size() == 3);
@@ -184,7 +181,7 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(release->value() == "1.2.3");
             auto major = facts.get<string_value>(fact::operating_system_major_release);
             REQUIRE(major);
-            REQUIRE(major->value() == "1.2");
+            REQUIRE(major->value() == "1");
             auto family = facts.get<string_value>(fact::os_family);
             REQUIRE(family);
             REQUIRE(family->value() == "Archlinux");
@@ -202,10 +199,10 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(release->value() == "1.2.3");
             major = facts.get<string_value>(fact::lsb_dist_major_release);
             REQUIRE(major);
-            REQUIRE(major->value() == "1.2");
+            REQUIRE(major->value() == "1");
             auto minor = facts.get<string_value>(fact::lsb_dist_minor_release);
             REQUIRE(minor);
-            REQUIRE(minor->value() == "3");
+            REQUIRE(minor->value() == "2");
             auto lsbrelease = facts.get<string_value>(fact::lsb_release);
             REQUIRE(lsbrelease);
             REQUIRE(lsbrelease->value() == "1.4");

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -198,6 +198,7 @@ struct operating_system_resolver : resolvers::operating_system_resolver
     {
         data result;
         result.name = "name";
+        result.family = "family";
         result.release = "1.2.3";
         result.specification_version = "1.4";
         result.distro.id = "id";

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -200,6 +200,8 @@ struct operating_system_resolver : resolvers::operating_system_resolver
         result.name = "name";
         result.family = "family";
         result.release = "1.2.3";
+        result.major = "1.2";
+        result.minor = "3";
         result.specification_version = "1.4";
         result.distro.id = "id";
         result.distro.release = "1.2.3";
@@ -219,11 +221,6 @@ struct operating_system_resolver : resolvers::operating_system_resolver
         result.selinux.config_policy = "config policy";
         result.selinux.policy_version = "policy version";
         return result;
-    }
-
-    virtual tuple<string, string> parse_release(string const& name, string const& release) const override
-    {
-        return make_tuple("1.2", "3");
     }
 };
 


### PR DESCRIPTION
Native facter port of https://github.com/puppetlabs/facter/pull/949.

Major design decisions:
* I steered away from was extending `resolvers::operating_system_resolver` for specific distros, as I didn't want to move deciding which to instantiate to where `operating_system_resolver` is created.
* I decided not to make the implementation object (`os_linux` and children) a member of `linux::operating_system_resolver` because I didn't see any major benefit for keeping the overloaded `parse_release` and `determine_os_family` methods. That functionality was easily pulled into `collect_data` to be handled earlier.
* The distro release parsing in `resolvers::operating_system_resolver` should likely be moved into the Linux implementation, similar to the move for os release. I haven't done so because it's not needed for this work.