### PR TITLE
(maint) Use cmake 3.2.2 for Boost 1.57 support

### DIFF
--- a/contrib/facter.ps1
+++ b/contrib/facter.ps1
@@ -74,7 +74,7 @@ if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
     iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 }
 Install-Choco 7zip.commandline 9.20.0.20150210
-Install-Choco cmake 3.1.0
+Install-Choco cmake 3.2.2
 Install-Choco git.install 1.9.5.20150320
 
 # For MinGW, we expect specific project defaults


### PR DESCRIPTION
A prior commit updated Boost to 1.57 and cmake to 3.1.0. On Windows
cmake 3.1.0 isn't recent enough to find Boost 1.57, so update to a newer
version that supports it.