### PR TITLE
(FACT-982) Don't use conflicting options in no-ruby acceptance test

### DIFF
--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -34,7 +34,7 @@ agents.each do |agent|
   custom_fact = File.join(custom_dir, 'custom_fact.rb')
   create_remote_file(agent, custom_fact, content)
 
-  on(agent, facter("--no-ruby --custom-dir #{custom_dir} custom_fact")) do
+  on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do
     assert_equal("", stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{stdout.chomp}")
   end
 end


### PR DESCRIPTION
This commit removes the use of the --custom-dir option in conjunction
with the --no-ruby option, which are, in fact, conflicting! Instead,
we use FACTERLIB to specifiy the custom fact directory.