### PR TITLE
(FACT-1021) Allow custom facts to `require 'facter'`.

### DIFF
--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -213,6 +213,14 @@ namespace facter { namespace ruby {
         fact::define();
         simple_resolution::define();
         aggregate_resolution::define();
+
+        // Custom facts may `require 'facter'`
+        // To allow those custom facts to still function, add facter.rb to loaded features using the first directory in the load path
+        // Note: use forward slashes in the path even on Windows because that's what Ruby expects in $LOADED_FEATURES
+        volatile VALUE first = ruby.rb_ary_entry(ruby.rb_gv_get("$LOAD_PATH"), 0);
+        if (!ruby.is_nil(first)) {
+            ruby.rb_ary_push(ruby.rb_gv_get("$LOADED_FEATURES"), ruby.utf8_value(ruby.to_string(first) + "/facter.rb"));
+        }
     }
 
     module::~module()

--- a/lib/tests/fixtures/ruby/facter.rb
+++ b/lib/tests/fixtures/ruby/facter.rb
@@ -1,0 +1,7 @@
+require 'facter'
+
+Facter.add(:foo) do
+  setcode do
+    'bar'
+  end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -586,4 +586,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "{\n  foo => \"bar\"\n}");
         }
     }
+    GIVEN("a fact that requires facter") {
+        REQUIRE(load_custom_fact("facter.rb", facts));
+        THEN("the require succeeds") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+        }
+    }
 }


### PR DESCRIPTION
Some existing custom facts will `require 'facter'` even though it is
unnecessary.  A previous code cleanup removed some code that allowed
this to work when custom facts are evaluated from command line facter
(note: it still worked in Puppet because puppet requires facter).

This commit puts the previous workaround back so that custom facts that
`require 'facter'` can still work from the command line.