### PR TITLE
(FACT-965) Ensure fact resolution occurs under JNI lock for JRuby.

### DIFF
--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -9,7 +9,7 @@ module Facter
 
     # Pass value call through to JNI interface
     def self.value(name)
-      com.puppetlabs.Facter.lookup(name)
+      Java::ComPuppetlabs::Facter.lookup(name)
     end
 
     def self.search(*paths)
@@ -17,7 +17,7 @@ module Facter
     end
 
     def self.version
-      com.puppetlabs.Facter.lookup("facterversion")
+      Java::ComPuppetlabs::Facter.lookup("facterversion")
     end
 
     def self.add(*params)

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -158,6 +158,20 @@ namespace facter { namespace facts {
         }
 
         /**
+        * Gets a fact value by name without resolving the fact.
+        * @tparam T The expected type of the value.
+        * @param name The name of the fact to get the value of.
+        * @return Returns a pointer to the fact value or nullptr if the fact is not resolved or the value is not the expected type.
+        */
+        template <typename T = value>
+        T const* get_resolved(std::string const& name) const
+        {
+            // Lookup the fact without resolving
+            auto it = _facts.find(name);
+            return dynamic_cast<T const*>(it == _facts.end() ? nullptr : it->second.get());
+        }
+
+        /**
          * Gets a fact value by name
          * @param name The name of the fact to get the value of.
          * @return Returns a pointer to the fact value or nullptr if the fact is not in the fact collection.
@@ -193,8 +207,12 @@ namespace facter { namespace facts {
          */
         std::ostream& write(std::ostream& stream, format fmt = format::hash, std::set<std::string> const& queries = std::set<std::string>());
 
+        /**
+         * Resolves all facts in the collection.
+         */
+        void resolve_facts();
+
      private:
-        LIBFACTER_NO_EXPORT void resolve_facts();
         LIBFACTER_NO_EXPORT void resolve_fact(std::string const& name);
         LIBFACTER_NO_EXPORT value const* get_value(std::string const& name);
         LIBFACTER_NO_EXPORT value const* query_value(std::string const& query);


### PR DESCRIPTION
Currently, fact resolution occurs upon the first call to
`com.puppetlabs.Facter.lookup`. Because native libraries are shared between
Java threads and fact collections are not thread-safe, this is inherently unsafe.

This moves the resolution of the facts into loading of the library,
which is protected by a JVM mutex.  Puppet Server will now load the facter
JNI shim class at startup, causing all fact resolution to occur only
once at startup.  Because the JNI shim only supports reading a fact's
value, subsequent calls to `com.puppetlabs.Facter.lookup` do not need to
be protected as the collection is considered to be immutable after
loading of the native library.