### PR TITLE
(FACT-965) Java unit test should not fail with stderr output.

### DIFF
--- a/lib/tests/java/facter.cc
+++ b/lib/tests/java/facter.cc
@@ -45,9 +45,10 @@ SCENARIO("using libfacter from Java") {
                     execution_options::merge_environment,
                     execution_options::throw_on_failure
                 });
+            CAPTURE(output);
+            CAPTURE(error);
             THEN("the value should match") {
                 REQUIRE(success);
-                REQUIRE(error.empty());
                 ostringstream ss;
                 auto value = facts["os"];
                 REQUIRE(value);


### PR DESCRIPTION
The test should capture the stdout and stderr from the java invocation
and only fail if either the stdout output is not the expected format or
java returns a non-zero exit code.  Output on stderr should not cause
the test to fail.