### PR TITLE
(maint) Fix mis-spelled 'Retrieve'

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -5,7 +5,7 @@ module Facter
       # Determine paths for testing custom and external facts.
       # Paths vary by platform.
 
-      # Retreive the path of a non-standard directory for custom or external facts.
+      # Retrieve the path of a non-standard directory for custom or external facts.
       #
       def get_user_fact_dir(platform, version)
         if platform =~ /windows/
@@ -19,7 +19,7 @@ module Facter
         end
       end
 
-      # Retreive the path of the standard facts.d directory.
+      # Retrieve the path of the standard facts.d directory.
       #
       def get_factsd_dir(platform, version)
         if platform =~ /windows/
@@ -33,7 +33,7 @@ module Facter
         end
       end
 
-      # Retreive the extension to use for an external fact script.
+      # Retrieve the extension to use for an external fact script.
       # Windows uses '.bat' and everything else uses '.sh'
       def get_external_fact_script_extension(platform)
         if platform =~ /windows/


### PR DESCRIPTION
Correct the misspelling of the word, retrieve. Because you never know when the NSA might audit our spelling.