### PR TITLE
(FACT-704) Fix docker detection for systemd slices

### DIFF
--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -162,7 +162,7 @@ module Facter::Util::Virtual
     path = Pathname.new('/proc/1/cgroup')
     return false unless path.readable?
     begin
-      in_lxc = path.readlines.any? {|l| l.split(":")[2].to_s.start_with? '/lxc/' }
+      in_lxc = path.readlines.any? {|l| l.split(":")[2].to_s.include? '/lxc' }
     rescue Errno::EPERM => exc
       # If we get "operation not permitted" here, it probably means we are
       # running OpenVZ. We are not running LXC anyway, so...
@@ -179,7 +179,7 @@ module Facter::Util::Virtual
     path = Pathname.new('/proc/1/cgroup')
     return false unless path.readable?
     begin
-      in_docker = path.readlines.any? {|l| l.split(":")[2].to_s.start_with? '/docker/' }
+      in_docker = path.readlines.any? {|l| l.split(":")[2].to_s.include? '/docker' }
     rescue Errno::EPERM => exc
       # This can fail under OpenVZ, just like in .lxc?
       return false

--- a/spec/fixtures/virtual/proc_1_cgroup/in_a_docker_container_with_systemd_slices
+++ b/spec/fixtures/virtual/proc_1_cgroup/in_a_docker_container_with_systemd_slices
@@ -1,0 +1,10 @@
+10:hugetlb:/
+9:perf_event:/
+8:blkio:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+7:net_cls:/
+6:freezer:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+5:devices:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+4:memory:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+3:cpuacct,cpu:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+2:cpuset:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope
+1:name=systemd:/system.slice/docker-8255e18aa44c5809a33db5f324a4b34e3a73b246394e4070cff752cd84d79a6d.scope

--- a/spec/unit/util/virtual_spec.rb
+++ b/spec/unit/util/virtual_spec.rb
@@ -368,6 +368,17 @@ describe Facter::Util::Virtual do
       end
     end
 
+    context '/proc/1/cgroup has at least one hierarchy with docker underneath a systemd slice parent' do
+      before :each do
+        fakepath = Pathname.new(File.join(fixture_path, 'in_a_docker_container_with_systemd_slices'))
+        Pathname.stubs(:new).with('/proc/1/cgroup').returns(fakepath)
+      end
+
+      it 'is true' do
+        subject.should be_true
+      end
+    end
+
     context '/proc/1/cgroup has no hierarchies rooted in /docker/' do
       before :each do
         fakepath = Pathname.new(File.join(fixture_path, 'not_in_a_container'))


### PR DESCRIPTION
Just ran into this whilst trying to run puppet inside a docker container on top of CentOS 7 and noticed that the `virtual` fact was mis-detecting the underlying VMware VM rather than the docker container.

I've changed the logic to match `/docker` somewhere in the string rather than `/docker/` at the beginning of the string.

I've added a sample `/proc/1/cgroup` fixture and updated the tests.