### PR TITLE
(FACT-704) Fix docker detection for systemd slices

### DIFF
--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -78,11 +78,11 @@ namespace facter { namespace facts { namespace linux {
             if (parts.size() < 3) {
                 return true;
             }
-            if (boost::starts_with(parts[2], boost::as_literal("/docker/"))) {
+            if (boost::contains(parts[2], boost::as_literal("/docker"))) {
                 value = vm::docker;
                 return false;
             }
-            if (boost::starts_with(parts[2], boost::as_literal("/lxc/"))) {
+            if (boost::contains(parts[2], boost::as_literal("/lxc"))) {
                 value = vm::lxc;
                 return false;
             }


### PR DESCRIPTION
Similar to #974 this adds the same fix to cfacter. I'm not at all familiar with C++ or Boost so I've just compile tested the change but looking at the Boost API docs it should be the right "algorithm". I couldn't also see any obvious test fixtures I could update akin to the original Ruby-based facter.