### PR TITLE
(FACT-1042) Allow time for EC2 to respond

### DIFF
--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -24,6 +24,11 @@ using namespace rapidjson;
 
 namespace facter { namespace facts { namespace resolvers {
 
+#ifdef USE_CURL
+    static const unsigned int GCE_CONNECTION_TIMEOUT = 1000;
+    static const unsigned int GCE_SESSION_TIMEOUT = 5000;
+#endif
+
     // Helper event handler for parsing JSON data
     struct gce_event_handler
     {
@@ -219,7 +224,8 @@ namespace facter { namespace facts { namespace resolvers {
         try
         {
             request req("http://metadata/computeMetadata/v1beta1/?recursive=true&alt=json");
-            req.timeout(1000);
+            req.connection_timeout(GCE_CONNECTION_TIMEOUT);
+            req.timeout(GCE_SESSION_TIMEOUT);
 
             client cli;
             auto response = cli.get(req);


### PR DESCRIPTION
Without this change, EC2 will not always respond to the metadata request
before the http session times out. Extend the session timeout to 5
seconds, and add a connection timeout of 200 ms to ensure Facter doesn't
spend too long waiting on the http request if not in EC2. Update the
error and add more detailed trace info in case EC2 is very slow to
respond.

Also extend the GCE session timeout to 5 seconds, and set a connection
timeout of 1 second to avoid long waits if GCE is unavailable.