### PR TITLE
(FACT-1016) Prevent unbounded growth of fact resolutions.

### DIFF
--- a/lib/src/ruby/fact.cc
+++ b/lib/src/ruby/fact.cc
@@ -14,6 +14,9 @@ using namespace facter::util;
 
 namespace facter { namespace ruby {
 
+    // The maximum number of resolutions allowed for a fact
+    static const size_t MAXIMUM_RESOLUTIONS = 100;
+
     fact::fact() :
         _resolved(false),
         _resolving(false)
@@ -225,6 +228,10 @@ namespace facter { namespace ruby {
         // Find or create the resolution
         VALUE resolution_self = find_resolution(name);
         if (ruby.is_nil(resolution_self)) {
+            if (_resolutions.size() == MAXIMUM_RESOLUTIONS) {
+                ruby.rb_raise(*ruby.rb_eRuntimeError, "fact \"%s\" already has the maximum number of resolutions allowed (%d).", ruby.rb_string_value_ptr(&_name), MAXIMUM_RESOLUTIONS);
+            }
+
             if (aggregate) {
                 _resolutions.push_back(aggregate_resolution::create());
             } else {

--- a/lib/tests/fixtures/ruby/100_resolutions.rb
+++ b/lib/tests/fixtures/ruby/100_resolutions.rb
@@ -1,0 +1,7 @@
+(1..100).each do
+    Facter.add(:foo) do
+        setcode do
+            'bar'
+        end
+    end
+end

--- a/lib/tests/fixtures/ruby/101_resolutions.rb
+++ b/lib/tests/fixtures/ruby/101_resolutions.rb
@@ -1,0 +1,7 @@
+(0..100).each do
+    Facter.add(:foo) do
+        setcode do
+            'bar'
+        end
+    end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -592,4 +592,19 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
         }
     }
+    GIVEN("a fact that has 100 resolutions") {
+        REQUIRE(load_custom_fact("100_resolutions.rb", facts));
+        THEN("the fact evaluates") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+        }
+    }
+    GIVEN("a fact that has 101 resolutions") {
+        log_capture capture(level::error);
+        REQUIRE_FALSE(load_custom_fact("101_resolutions.rb", facts));
+        THEN("an error is logged") {
+            auto output = capture.result();
+            CAPTURE(output);
+            REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - .* fact \"foo\" already has the maximum number of resolutions allowed \\(100\\)")));
+        }
+    }
 }


### PR DESCRIPTION
A bug in Puppet exposed an unbounded memory growth if the same custom
fact file is repeatedly loaded.  The reason is that every execution
results in a new resolution being added to the fact.  While this itself
is desired behavior, we should limit the number of resolutions to some
arbitrary size so that memory doesn't grow unbounded.