### PR TITLE
(FACT-765)  Constrain windows `id` gid resolution

### DIFF
--- a/lib/facter/gid.rb
+++ b/lib/facter/gid.rb
@@ -10,7 +10,7 @@
 
 Facter.add(:gid) do
   confine do
-    Facter::Core::Execution.which('id') && Facter.value(:kernel) != "SunOS"
+    Facter::Core::Execution.which('id') && !["SunOS", "windows"].include?(Facter.value(:kernel))
   end
   setcode { Facter::Core::Execution.exec('id -ng') }
 end

--- a/spec/unit/gid_spec.rb
+++ b/spec/unit/gid_spec.rb
@@ -39,4 +39,13 @@ describe "gid fact" do
       Facter.fact(:gid).value.should == nil
     end
   end
+
+  describe "on windows systems" do
+    it "is not supported" do
+      Facter.fact(:kernel).stubs(:value).returns("windows")
+      Facter::Core::Execution.expects(:which).with('id').returns(true)
+
+      Facter.fact(:gid).value.should == nil
+    end
+  end
 end


### PR DESCRIPTION
Windows platforms should not attempt to resolve the gid fact if an "id" executable exists in the path. The gid fact should not return a value on Windows.