### PR TITLE
(WIP)(FACT-984, FACT-983, FACT-1044) Update kernel resolver and acceptance tests for Debian 8 and Ubuntu 15.04

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -7,10 +7,23 @@ test_name "Facts should resolve as expected in Debian 6 and 7"
 # Facts tested: os, processors, networking, identity, kernel
 #
 
-confine :to, :platform => /debian-squeeze|debian-wheezy/
+confine :to, :platform => /debian-squeeze|debian-wheezy|debian-jessie/
 
 agents.each do |agent|
-  os_version = agent['platform'] =~ /squeeze/ ? '6' : '7'
+  if agent['platform'] =~ /squeeze/
+    codename   = 'squeeze'
+    os_version = '6'
+    os_kernel = '2.6'
+  elsif agent['platform'] =~ /wheezy/
+    codename   = 'wheezy'
+    os_version = '7'
+    os_kernel = '3.2'
+  elsif agent['platform'] =~ /jessie/
+    codename   = 'jessie'
+    os_version = '8'
+    os_kernel = '3.16'
+  end
+
   if agent['platform'] =~ /x86_64/
     os_arch     = 'amd64'
     os_hardware = 'x86_64'
@@ -22,7 +35,7 @@ agents.each do |agent|
   step "Ensure the OS fact resolves as expected"
   expected_os = {
                   'os.architecture'         => os_arch,
-                  'os.distro.codename'      => os_version == '6' ? 'squeeze' : 'wheezy',
+                  'os.distro.codename'      => codename,
                   'os.distro.description'   => /Debian GNU\/Linux #{os_version}\.\d/,
                   'os.distro.id'            => 'Debian',
                   'os.distro.release.full'  => /#{os_version}\.\d/,
@@ -83,13 +96,11 @@ agents.each do |agent|
   end
 
   step "Ensure the kernel fact resolves as expected"
-  kernel_version = os_version == '7' ? '3.2' : '2.6'
-
   expected_kernel = {
                       'kernel'           => 'Linux',
-                      'kernelrelease'    => kernel_version,
-                      'kernelversion'    => kernel_version,
-                      'kernelmajversion' => kernel_version
+                      'kernelrelease'    => os_kernel,
+                      'kernelversion'    => os_kernel,
+                      'kernelmajversion' => os_kernel
                     }
 
   expected_kernel.each do |fact, value|

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -7,7 +7,7 @@ test_name "Facts should resolve as expected in Ubuntu 12.04, 14.04, and 14.10"
 # Facts tested: os, processors, networking, identity, kernel
 #
 
-confine :to, :platform => /ubuntu-precise|ubuntu-trusty|ubuntu-utopic/
+confine :to, :platform => /ubuntu-precise|ubuntu-trusty|ubuntu-utopic|ubuntu-vivid/
 
 agents.each do |agent|
   if agent['platform'] =~ /ubuntu-precise/
@@ -18,10 +18,14 @@ agents.each do |agent|
     os_name    = 'trusty'
     os_version = '14.04'
     os_kernel  = '3.13'
-  else
+  elsif agent['platform'] =~ /ubuntu-utopic/
     os_name    = 'utopic'
     os_version = '14.10'
     os_kernel  = '3.16'
+  elsif agent['platform'] =~ /ubuntu-vivid/
+    os_name    = 'vivid'
+    os_version = '15.04'
+    os_kernel  = '3.19'
   end
 
   if agent['platform'] =~ /x86_64/

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -80,6 +80,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/util/scoped_env.cc"
     "src/util/scoped_file.cc"
     "src/util/string.cc"
+    "src/util/version_parsing.cc"
 )
 
 if (CURL_FOUND)
@@ -202,6 +203,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
         "src/facts/linux/collection.cc"
         "src/facts/linux/processor_resolver.cc"
         "src/facts/linux/virtualization_resolver.cc"
+        "src/facts/linux/kernel_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
     )
     set(LIBFACTER_PLATFORM_LIBRARIES

--- a/lib/inc/internal/facts/linux/kernel_resolver.hpp
+++ b/lib/inc/internal/facts/linux/kernel_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the LINUX kernel fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/kernel_resolver.hpp"
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for resolving kernel facts.
+     */
+    struct kernel_resolver : resolvers::kernel_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::posix

--- a/lib/inc/internal/facts/resolvers/kernel_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/kernel_resolver.hpp
@@ -43,9 +43,19 @@ namespace facter { namespace facts { namespace resolvers {
             std::string release;
 
             /**
-             * Stores the version of the kernel.
+             * Stores the major version of the kernel.
              */
-            std::string version;
+            std::string major_version;
+
+            /**
+            * Stores the minor version of the kernel.
+            */
+            std::string minor_version;
+
+            /**
+             * Stores the full version of the kernel.
+             */
+            std::string full_version;
         };
 
         /**
@@ -54,13 +64,6 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns the resolver data.
          */
         virtual data collect_data(collection& facts) = 0;
-
-        /**
-         * Parses the major and minor kernel versions.
-         * @param version The version to parse.
-         * @return Returns a tuple of major and minor versions.
-         */
-        virtual std::tuple<std::string, std::string> parse_version(std::string const& version) const;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/util/version_parsing.hpp
+++ b/lib/inc/internal/util/version_parsing.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * Declares utility functions parsing version strings.
+ */
+#pragma once
+
+#include <string>
+#include <tuple>
+
+namespace facter { namespace util { namespace version_parsing {
+
+    /**
+     * Parses the major and minor kernel versions for all platforms except Linux.
+     * @param version The version to parse.
+     * @return Returns a tuple of major and minor versions.
+     */
+    std::tuple<std::string, std::string> parse_kernel_version(std::string const& version);
+
+    /**
+     * Parses the major and minor kernel versions for Linux platforms
+     * @param version The version to parse.
+     * @return Returns a tuple of major and minor versions.
+     */
+    std::tuple<std::string, std::string> parse_linux_kernel_version(std::string const& version);
+
+}}}  // namespace facter::util::version_parsing

--- a/lib/src/facts/aix/kernel_resolver.cc
+++ b/lib/src/facts/aix/kernel_resolver.cc
@@ -1,5 +1,6 @@
 #include <internal/facts/aix/kernel_resolver.hpp>
 #include <internal/util/regex.hpp>
+#include <internal/util/version_parsing.hpp>
 #include <facter/facts/collection.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <facter/execution/execution.hpp>
@@ -55,8 +56,10 @@ namespace facter { namespace facts { namespace aix   {
         }
 
         result.name = "AIX";
-        result.version = version.substr(0, 2)+"00";
+        result.full_version = version.substr(0, 2)+"00";
         result.release = version.substr(0, 2) + "00" + version.substr(2, 6) + "-" + version.substr(8, 4);
+        tie(result.major_version, result.minor_version) = version_parsing::parse_kernel_version(result.release);
+
         return result;
     }
 

--- a/lib/src/facts/linux/kernel_resolver.cc
+++ b/lib/src/facts/linux/kernel_resolver.cc
@@ -1,4 +1,4 @@
-#include <internal/facts/posix/kernel_resolver.hpp>
+#include <internal/facts/linux/kernel_resolver.hpp>
 #include <internal/util/version_parsing.hpp>
 #include <facter/facts/collection.hpp>
 #include <leatherman/logging/logging.hpp>
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace facter::util;
 
-namespace facter { namespace facts { namespace posix {
+namespace facter { namespace facts { namespace linux {
 
     kernel_resolver::data kernel_resolver::collect_data(collection& facts)
     {
@@ -23,7 +23,7 @@ namespace facter { namespace facts { namespace posix {
         result.full_version = result.release.substr(0, result.release.find('-'));
 
         string major, minor;
-        tie(result.major_version, result.minor_version) = version_parsing::parse_kernel_version(result.release);
+        tie(result.major_version, result.minor_version) = version_parsing::parse_linux_kernel_version(result.release);
 
         return result;
     }

--- a/lib/src/facts/resolvers/kernel_resolver.cc
+++ b/lib/src/facts/resolvers/kernel_resolver.cc
@@ -31,32 +31,15 @@ namespace facter { namespace facts { namespace resolvers {
             facts.add(fact::kernel_release, make_value<string_value>(move(data.release)));
         }
 
-        if (!data.version.empty()) {
-            string major, minor;
-            tie(major, minor) = parse_version(data.version);
-
-            if (!major.empty()) {
-                facts.add(fact::kernel_major_version, make_value<string_value>(move(major)));
-            }
-            if (!minor.empty()) {
-                // TODO: for use in a structured fact; no point adding a new flat fact for it
-            }
-
-            facts.add(fact::kernel_version, make_value<string_value>(move(data.version)));
+        if(!data.full_version.empty()) {
+            facts.add(fact::kernel_version, make_value<string_value>(move(data.full_version)));
         }
-    }
 
-    tuple<string, string> kernel_resolver::parse_version(string const& version) const
-    {
-        auto pos = version.find('.');
-        if (pos != string::npos) {
-            auto second = version.find('.', pos + 1);
-            if (second != string::npos) {
-                pos = second;
-            }
-            return make_tuple(version.substr(0, pos), version.substr(pos + 1));
+        if (!data.major_version.empty()) {
+            facts.add(fact::kernel_major_version, make_value<string_value>(move(data.major_version)));
         }
-        return make_tuple(move(version), string());
+
+        // TODO: place minor_version in a structured fact; no point adding a new flat fact for it
     }
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/solaris/kernel_resolver.cc
+++ b/lib/src/facts/solaris/kernel_resolver.cc
@@ -1,8 +1,10 @@
 #include <internal/facts/solaris/kernel_resolver.hpp>
+#include <internal/util/version_parsing.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <sys/utsname.h>
 
 using namespace std;
+using namespace facter::util;
 
 namespace facter { namespace facts { namespace solaris {
 
@@ -17,7 +19,9 @@ namespace facter { namespace facts { namespace solaris {
 
         result.name = name.sysname;
         result.release = name.release;
-        result.version = name.version;
+        result.full_version = name.version;
+        tie(result.major_version, result.minor_version) = version_parsing::parse_kernel_version(result.release);
+
         return result;
     }
 

--- a/lib/src/facts/windows/kernel_resolver.cc
+++ b/lib/src/facts/windows/kernel_resolver.cc
@@ -1,6 +1,7 @@
 #include <internal/facts/windows/kernel_resolver.hpp>
 #include <internal/util/windows/system_error.hpp>
 #include <internal/util/windows/windows.hpp>
+#include <internal/util/version_parsing.hpp>
 #include <facter/facts/os.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/optional.hpp>
@@ -9,6 +10,7 @@
 #include <boost/nowide/convert.hpp>
 
 using namespace std;
+using namespace facter::util;
 using namespace facter::util::windows;
 
 namespace facter { namespace facts { namespace windows {
@@ -66,7 +68,10 @@ namespace facter { namespace facts { namespace windows {
         auto release = get_release();
         if (release) {
             result.release = move(*release);
-            result.version = result.release;
+            result.full_version = result.release;
+
+            string major, minor;
+            tie(result.major_version, result.minor_version) = version_parsing::parse_kernel_version(result.release);
         } else {
             LOG_DEBUG("failed to retrieve kernel facts: %1%", system_error());
         }

--- a/lib/src/util/version_parsing.cc
+++ b/lib/src/util/version_parsing.cc
@@ -1,0 +1,31 @@
+#include <internal/util/version_parsing.hpp>
+#include <internal/util/regex.hpp>
+#include <boost/regex.hpp>
+
+using namespace std;
+
+namespace facter { namespace util {
+
+    tuple<string, string> version_parsing::parse_kernel_version(string const& version)
+    {
+        auto pos = version.find('.');
+        if (pos != string::npos) {
+            auto second = version.find('.', pos + 1);
+            if (second != string::npos) {
+                pos = second;
+            }
+            return make_tuple(version.substr(0, pos), version.substr(pos + 1));
+        }
+        return make_tuple(move(version), string());
+    }
+
+    tuple<string, string> version_parsing::parse_linux_kernel_version(string const& version)
+    {
+        string major, minor;
+        if (re_search(version, boost::regex("(\\d+\\.\\d+)(.*)"), &major, &minor)) {
+            return make_tuple(major, minor);
+        }
+        return make_tuple(move(version), string());
+    }
+
+}}  // namespace facter::util

--- a/lib/tests/facts/resolvers/kernel_resolver.cc
+++ b/lib/tests/facts/resolvers/kernel_resolver.cc
@@ -25,7 +25,9 @@ struct test_kernel_resolver : kernel_resolver
         data result;
         result.name = "foo";
         result.release = "1.2.3-foo";
-        result.version = "1.2.3";
+        result.full_version = "1.2.3";
+        result.major_version = "1.2";
+        result.minor_version = "3";
         return result;
     }
 };

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -145,7 +145,9 @@ struct kernel_resolver : resolvers::kernel_resolver
         data result;
         result.name = "kernel";
         result.release = "1.2.3-kernel";
-        result.version = "1.2.3";
+        result.full_version = "1.2.3";
+        result.major_version = "1.2";
+        result.minor_version = "3";
         return result;
     }
 };


### PR DESCRIPTION
The first of these commits refactors version parsing in the kernel resolver by creating a new parsing utility function to be used to return major and minor versions via `collect data.` In addition, this commit adds a new Linux kernel resolver which uses a new regex to parse kernel version. This became necessary when `uname` output changed slightly in Debian 8, no longer including the patch level for the kernel.

The other two commits update two fact-based acceptance tests for Debian 8 and Ubuntu 15.04.