### PR TITLE
(FACT-1044) Add Linux-specific kernel resolver

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -7,10 +7,23 @@ test_name "Facts should resolve as expected in Debian 6 and 7"
 # Facts tested: os, processors, networking, identity, kernel
 #
 
-confine :to, :platform => /debian-squeeze|debian-wheezy/
+confine :to, :platform => /debian-squeeze|debian-wheezy|debian-jessie/
 
 agents.each do |agent|
-  os_version = agent['platform'] =~ /squeeze/ ? '6' : '7'
+  if agent['platform'] =~ /squeeze/
+    codename   = 'squeeze'
+    os_version = '6'
+    os_kernel = '2.6'
+  elsif agent['platform'] =~ /wheezy/
+    codename   = 'wheezy'
+    os_version = '7'
+    os_kernel = '3.2'
+  elsif agent['platform'] =~ /jessie/
+    codename   = 'jessie'
+    os_version = '8'
+    os_kernel = '3.16'
+  end
+
   if agent['platform'] =~ /x86_64/
     os_arch     = 'amd64'
     os_hardware = 'x86_64'
@@ -22,7 +35,7 @@ agents.each do |agent|
   step "Ensure the OS fact resolves as expected"
   expected_os = {
                   'os.architecture'         => os_arch,
-                  'os.distro.codename'      => os_version == '6' ? 'squeeze' : 'wheezy',
+                  'os.distro.codename'      => codename,
                   'os.distro.description'   => /Debian GNU\/Linux #{os_version}\.\d/,
                   'os.distro.id'            => 'Debian',
                   'os.distro.release.full'  => /#{os_version}\.\d/,
@@ -83,13 +96,11 @@ agents.each do |agent|
   end
 
   step "Ensure the kernel fact resolves as expected"
-  kernel_version = os_version == '7' ? '3.2' : '2.6'
-
   expected_kernel = {
                       'kernel'           => 'Linux',
-                      'kernelrelease'    => kernel_version,
-                      'kernelversion'    => kernel_version,
-                      'kernelmajversion' => kernel_version
+                      'kernelrelease'    => os_kernel,
+                      'kernelversion'    => os_kernel,
+                      'kernelmajversion' => os_kernel
                     }
 
   expected_kernel.each do |fact, value|

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -7,7 +7,7 @@ test_name "Facts should resolve as expected in Ubuntu 12.04, 14.04, and 14.10"
 # Facts tested: os, processors, networking, identity, kernel
 #
 
-confine :to, :platform => /ubuntu-precise|ubuntu-trusty|ubuntu-utopic/
+confine :to, :platform => /ubuntu-precise|ubuntu-trusty|ubuntu-utopic|ubuntu-vivid/
 
 agents.each do |agent|
   if agent['platform'] =~ /ubuntu-precise/
@@ -18,10 +18,14 @@ agents.each do |agent|
     os_name    = 'trusty'
     os_version = '14.04'
     os_kernel  = '3.13'
-  else
+  elsif agent['platform'] =~ /ubuntu-utopic/
     os_name    = 'utopic'
     os_version = '14.10'
     os_kernel  = '3.16'
+  elsif agent['platform'] =~ /ubuntu-vivid/
+    os_name    = 'vivid'
+    os_version = '15.04'
+    os_kernel  = '3.19'
   end
 
   if agent['platform'] =~ /x86_64/

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -182,6 +182,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
         "src/facts/linux/disk_resolver.cc"
         "src/facts/linux/dmi_resolver.cc"
         "src/facts/linux/filesystem_resolver.cc"
+        "src/facts/linux/kernel_resolver.cc"
         "src/facts/linux/memory_resolver.cc"
         "src/facts/linux/networking_resolver.cc"
         "src/facts/linux/operating_system_resolver.cc"

--- a/lib/inc/internal/facts/linux/kernel_resolver.hpp
+++ b/lib/inc/internal/facts/linux/kernel_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the Linux kernel fact resolver.
+ */
+#pragma once
+
+#include "../posix/kernel_resolver.hpp"
+
+namespace facter { namespace facts { namespace linux {
+
+    /**
+     * Responsible for resolving kernel facts.
+     */
+    struct kernel_resolver : posix::kernel_resolver
+    {
+     protected:
+        /**
+         * Parses the major and minor kernel versions.
+         * @param version The version to parse.
+         * @return Returns a tuple of major and minor versions.
+         */
+        std::tuple<std::string, std::string> parse_version(std::string const& version) const override;
+    };
+
+}}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/collection.cc
+++ b/lib/src/facts/linux/collection.cc
@@ -1,5 +1,5 @@
 #include <facter/facts/collection.hpp>
-#include <internal/facts/posix/kernel_resolver.hpp>
+#include <internal/facts/linux/kernel_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/linux/operating_system_resolver.hpp>
 #include <internal/facts/linux/networking_resolver.hpp>
@@ -21,7 +21,7 @@ namespace facter { namespace facts {
 
     void collection::add_platform_facts()
     {
-        add(make_shared<posix::kernel_resolver>());
+        add(make_shared<linux::kernel_resolver>());
         add(make_shared<linux::operating_system_resolver>());
         add(make_shared<linux::networking_resolver>());
         add(make_shared<linux::disk_resolver>());

--- a/lib/src/facts/linux/kernel_resolver.cc
+++ b/lib/src/facts/linux/kernel_resolver.cc
@@ -1,0 +1,20 @@
+#include <internal/facts/linux/kernel_resolver.hpp>
+#include <internal/util/regex.hpp>
+#include <boost/regex.hpp>
+#include <tuple>
+
+using namespace std;
+using namespace facter::util;
+
+namespace facter { namespace facts { namespace linux {
+
+    tuple<string, string> kernel_resolver::parse_version(string const& version) const
+    {
+        string major, minor;
+        if (re_search(version, boost::regex("(\\d+\\.\\d+)(.*)"), &major, &minor)) {
+            return make_tuple(major, minor);
+        }
+        return make_tuple(move(version), string());
+    }
+
+}}}  // namespace facter::facts::resolvers


### PR DESCRIPTION
This commit adds a new Linux-specific kernel resolver, which
is needed to handle the slightly changed `uname` output
of Debian 8.

Also added are updates to the Debian and Ubuntu fact-based
acceptance tests for Debian 8 and Ubuntu 15.04.