### PR TITLE
(FACT-964) Search archlibdir and sitearchlibdir for libruby

### DIFF
--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -623,7 +623,6 @@ namespace facter {  namespace ruby {
         static std::unique_ptr<api> create();
         static facter::util::dynamic_library find_library();
         static facter::util::dynamic_library find_loaded_library();
-        static std::string libruby_configdir();
         static VALUE callback_thunk(VALUE parameter);
         static VALUE rescue_thunk(VALUE parameter, VALUE exception);
         static VALUE protect_thunk(VALUE parameter);

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -487,7 +487,13 @@ namespace facter { namespace ruby {
 
         bool success;
         string output, none;
-        tie(success, output, none) = execute(ruby, { "-e", "print File.join(RbConfig::CONFIG['"+libruby_configdir()+"'], RbConfig::CONFIG['LIBRUBY_SO'])" });
+
+        tie(success, output, none) = execute(ruby, { "-e", "print(['libdir', 'archlibdir', 'sitearchlibdir', 'bindir'].find do |name|"
+                                                                  "dir = RbConfig::CONFIG[name];"
+                                                                  "next unless dir;"
+                                                                  "file = File.join(dir, RbConfig::CONFIG['LIBRUBY_SO']);"
+                                                                  "break file if File.exist? file;"
+                                                                  "false end)" });
         if (!success) {
             LOG_WARNING("ruby failed to run: %1%", output);
             return library;

--- a/lib/src/ruby/posix/api.cc
+++ b/lib/src/ruby/posix/api.cc
@@ -10,9 +10,4 @@ namespace facter { namespace ruby {
         return dynamic_library::find_by_symbol("ruby_init");
     }
 
-    string api::libruby_configdir()
-    {
-        return "libdir";
-    }
-
 }}  // namespace facter::ruby

--- a/lib/src/ruby/windows/api.cc
+++ b/lib/src/ruby/windows/api.cc
@@ -11,9 +11,4 @@ namespace facter { namespace ruby {
         return dynamic_library::find_by_pattern(libruby_pattern);
     }
 
-    string api::libruby_configdir()
-    {
-        return "bindir";
-    }
-
 }}  // namespace facter::ruby


### PR DESCRIPTION
Prior to this commit, Facter only searched `RbConfig['libdir']`
for libruby. However, the ruby2.1 package places libruby
under `RbConfig['archlibdir']` or `sitearchlibdir` on some platforms.
Thus, Facter wasn't able to find libruby on said systems. This commit
adds `archlibdir` and `sitearchlibdir` to the list of paths to check
for libruby.