### PR TITLE
(FACT-1055) Fix search_external, add_external_facts

### DIFF
--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -212,6 +212,9 @@ namespace facter { namespace facts {
          */
         void resolve_facts();
 
+     protected:
+        virtual std::vector<std::string> get_external_fact_directories() const;
+
      private:
         LIBFACTER_NO_EXPORT void resolve_fact(std::string const& name);
         LIBFACTER_NO_EXPORT value const* get_value(std::string const& name);
@@ -221,10 +224,10 @@ namespace facter { namespace facts {
         LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries);
         LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries);
         LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
+        LIBFACTER_NO_EXPORT bool add_external_facts_dir(std::vector<std::unique_ptr<external::resolver>> const& resolvers, std::string const& directory, bool warn);
 
         // Platform specific members
         LIBFACTER_NO_EXPORT void add_platform_facts();
-        LIBFACTER_NO_EXPORT std::vector<std::string> get_external_fact_directories();
         LIBFACTER_NO_EXPORT std::vector<std::unique_ptr<external::resolver>> get_external_resolvers();
 
         std::map<std::string, std::unique_ptr<value>> _facts;

--- a/lib/src/facts/posix/collection.cc
+++ b/lib/src/facts/posix/collection.cc
@@ -16,16 +16,19 @@ using namespace facter::facts::external;
 
 namespace facter { namespace facts {
 
-    vector<string> collection::get_external_fact_directories()
+    vector<string> collection::get_external_fact_directories() const
     {
         vector<string> directories;
         if (getuid()) {
             string home;
             if (environment::get("HOME", home)) {
                 directories.emplace_back(home + "/.puppetlabs/opt/facter/facts.d");
+                directories.emplace_back(home + "/.facter/facts.d");
             }
         } else {
             directories.emplace_back("/opt/puppetlabs/facter/facts.d");
+            directories.emplace_back("/etc/facter/facts.d");
+            directories.emplace_back("/etc/puppetlabs/facter/facts.d");
         }
         return directories;
     }

--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -31,7 +31,7 @@ using namespace boost::filesystem;
 
 namespace facter { namespace facts {
 
-    vector<string> collection::get_external_fact_directories()
+    vector<string> collection::get_external_fact_directories() const
     {
         if (user::is_admin()) {
             // Get the common data path
@@ -45,8 +45,9 @@ namespace facter { namespace facts {
         } else {
             auto home = user::home_dir();
             if (!home.empty()) {
-                path p = path(home) / ".puppetlabs" / "opt" / "facter" / "facts.d";
-                return {p.string()};
+                path p1 = path(home) / ".puppetlabs" / "opt" / "facter" / "facts.d";
+                path p2 = path(home) / ".facter" / "facts.d";
+                return {p1.string(), p2.string()};
             }
 
             LOG_DEBUG("HOME environment variable not set, external facts unavailable");

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "util/scoped_env.cc"
     "util/string.cc"
     "fixtures.cc"
+    "collection_fixture.cc"
 )
 
 # Set compiler-specific flags

--- a/lib/tests/collection_fixture.cc
+++ b/lib/tests/collection_fixture.cc
@@ -1,0 +1,12 @@
+#include "collection_fixture.hpp"
+
+namespace facter { namespace testing {
+
+    using namespace std;
+
+    vector<string> collection_fixture::get_external_fact_directories() const
+    {
+        return {};
+    }
+
+}}  // namespace facter::testing

--- a/lib/tests/collection_fixture.hpp
+++ b/lib/tests/collection_fixture.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <facter/facts/collection.hpp>
+#include <vector>
+#include <string>
+
+namespace facter { namespace testing {
+
+    class collection_fixture : public facter::facts::collection
+    {
+     protected:
+        virtual std::vector<std::string> get_external_fact_directories() const override;
+    };
+
+}}  // namespace facter::testing

--- a/lib/tests/facts/external/json_resolver.cc
+++ b/lib/tests/facts/external/json_resolver.cc
@@ -9,9 +9,10 @@
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::external;
+using namespace facter::testing;
 
 SCENARIO("resolving external JSON facts") {
-    collection facts;
+    collection_fixture facts;
     json_resolver resolver;
 
     GIVEN("a non-JSON file extension") {

--- a/lib/tests/facts/external/posix/execution_resolver.cc
+++ b/lib/tests/facts/external/posix/execution_resolver.cc
@@ -15,7 +15,7 @@ using namespace facter::logging;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts") {
-    collection facts;
+    collection_fixture facts;
     execution_resolver resolver;
 
     GIVEN("a non-executable file") {

--- a/lib/tests/facts/external/text_resolver.cc
+++ b/lib/tests/facts/external/text_resolver.cc
@@ -7,9 +7,10 @@
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::external;
+using namespace facter::testing;
 
 SCENARIO("resolving external text facts") {
-    collection facts;
+    collection_fixture facts;
     text_resolver resolver;
 
     GIVEN("a non-text file extension") {

--- a/lib/tests/facts/external/windows/execution_resolver.cc
+++ b/lib/tests/facts/external/windows/execution_resolver.cc
@@ -15,7 +15,7 @@ using namespace facter::logging;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts") {
-    collection facts;
+    collection_fixture facts;
     execution_resolver resolver;
 
     GIVEN("a non-executable file") {

--- a/lib/tests/facts/external/windows/powershell_resolver.cc
+++ b/lib/tests/facts/external/windows/powershell_resolver.cc
@@ -15,7 +15,7 @@ using namespace facter::testing;
 using namespace facter::facts::external;
 
 SCENARIO("resolving external powershell facts") {
-    collection facts;
+    collection_fixture facts;
     powershell_resolver resolver;
 
     GIVEN("a non-powershell file") {

--- a/lib/tests/facts/external/yaml_resolver.cc
+++ b/lib/tests/facts/external/yaml_resolver.cc
@@ -9,9 +9,10 @@
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::external;
+using namespace facter::testing;
 
 SCENARIO("resolving external YAML facts") {
-    collection facts;
+    collection_fixture facts;
     yaml_resolver resolver;
 
     GIVEN("a non-YAML file extension") {

--- a/lib/tests/facts/posix/collection.cc
+++ b/lib/tests/facts/posix/collection.cc
@@ -12,7 +12,7 @@ using namespace facter::facts;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts into a collection") {
-    collection facts;
+    collection_fixture facts;
     REQUIRE(facts.size() == 0u);
     GIVEN("an absolute path") {
         facts.add_external_facts({

--- a/lib/tests/facts/resolvers/augeas_resolver.cc
+++ b/lib/tests/facts/resolvers/augeas_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_augeas_resolver : augeas_resolver
 {
@@ -28,7 +30,7 @@ struct fixed_augeas_resolver : augeas_resolver
 };
 
 SCENARIO("using the augeas resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("no version is returned") {
         facts.add(make_shared<empty_augeas_resolver>());
         THEN("the fact is not present") {

--- a/lib/tests/facts/resolvers/disk_resolver.cc
+++ b/lib/tests/facts/resolvers/disk_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct test_disk_resolver : disk_resolver
 {
@@ -35,7 +37,7 @@ struct test_disk_resolver : disk_resolver
 };
 
 SCENARIO("using the disk resolver") {
-    collection facts;
+    collection_fixture facts;
     auto resolver = make_shared<test_disk_resolver>();
     facts.add(resolver);
     GIVEN("no disks present") {

--- a/lib/tests/facts/resolvers/dmi_resolver.cc
+++ b/lib/tests/facts/resolvers/dmi_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_dmi_resolver : dmi_resolver
 {
@@ -42,7 +44,7 @@ struct test_dmi_resolver : dmi_resolver
 };
 
 SCENARIO("using the DMI resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_dmi_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/filesystem_resolver.cc
+++ b/lib/tests/facts/resolvers/filesystem_resolver.cc
@@ -5,10 +5,12 @@
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include <facter/facts/array_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct test_filesystem_resolver : filesystem_resolver
 {
@@ -59,7 +61,7 @@ struct test_filesystem_resolver : filesystem_resolver
 };
 
 SCENARIO("using the file system resolver") {
-    collection facts;
+    collection_fixture facts;
     auto resolver = make_shared<test_filesystem_resolver>();
     facts.add(resolver);
 

--- a/lib/tests/facts/resolvers/identity_resolver.cc
+++ b/lib/tests/facts/resolvers/identity_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_identity_resolver : identity_resolver
 {
@@ -33,7 +35,7 @@ struct test_identity_resolver : identity_resolver
 };
 
 SCENARIO("using the identity resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_identity_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/kernel_resolver.cc
+++ b/lib/tests/facts/resolvers/kernel_resolver.cc
@@ -3,10 +3,12 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_kernel_resolver : kernel_resolver
 {
@@ -31,7 +33,7 @@ struct test_kernel_resolver : kernel_resolver
 };
 
 SCENARIO("using the kernel resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_kernel_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/memory_resolver.cc
+++ b/lib/tests/facts/resolvers/memory_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_memory_resolver : memory_resolver
 {
@@ -34,7 +36,7 @@ struct test_memory_resolver : memory_resolver
 };
 
 SCENARIO("using the memory resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_memory_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/networking_resolver.cc
+++ b/lib/tests/facts/resolvers/networking_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_networking_resolver : networking_resolver
 {
@@ -91,7 +93,7 @@ struct test_interface_resolver : networking_resolver
 };
 
 SCENARIO("using the networking resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_networking_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_os_resolver : operating_system_resolver
 {
@@ -52,7 +54,7 @@ struct test_os_resolver : operating_system_resolver
 };
 
 SCENARIO("using the operating system resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_os_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/processor_resolver.cc
+++ b/lib/tests/facts/resolvers/processor_resolver.cc
@@ -5,10 +5,12 @@
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include <facter/facts/array_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_processor_resolver : processor_resolver
 {
@@ -40,7 +42,7 @@ struct test_processor_resolver : processor_resolver
 };
 
 SCENARIO("using the processor resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_processor_resolver>());
         THEN("only the processor counts are present and are zero") {

--- a/lib/tests/facts/resolvers/ruby_resolver.cc
+++ b/lib/tests/facts/resolvers/ruby_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_ruby_resolver : ruby_resolver
 {
@@ -32,7 +34,7 @@ struct test_ruby_resolver : ruby_resolver
 };
 
 SCENARIO("using the ruby resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_ruby_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/ssh_resolver.cc
+++ b/lib/tests/facts/resolvers/ssh_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_ssh_resolver : ssh_resolver
 {
@@ -41,7 +43,7 @@ struct test_ssh_resolver : ssh_resolver
 };
 
 SCENARIO("using the ssh resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_ssh_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/system_profiler_resolver.cc
+++ b/lib/tests/facts/resolvers/system_profiler_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_system_profiler_resolver : system_profiler_resolver
 {
@@ -50,7 +52,7 @@ struct test_system_profiler_resolver : system_profiler_resolver
 };
 
 SCENARIO("using the system profiler resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_system_profiler_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/timezone_resolver.cc
+++ b/lib/tests/facts/resolvers/timezone_resolver.cc
@@ -3,10 +3,12 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_timezone_resolver : timezone_resolver
 {
@@ -27,7 +29,7 @@ struct test_timezone_resolver : timezone_resolver
 };
 
 SCENARIO("using the timezone resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_timezone_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/uptime_resolver.cc
+++ b/lib/tests/facts/resolvers/uptime_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct test_less_than_day_resolver : uptime_resolver
 {
@@ -40,7 +42,7 @@ struct test_more_than_day_resolver : uptime_resolver
 };
 
 SCENARIO("using the uptime resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("the uptime is less than one day") {
         facts.add(make_shared<test_less_than_day_resolver>());
         THEN("a structured fact with 'hours' uptime is added") {

--- a/lib/tests/facts/resolvers/virtualization_resolver.cc
+++ b/lib/tests/facts/resolvers/virtualization_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/vm.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_virtualization_resolver : virtualization_resolver
 {
@@ -51,7 +53,7 @@ struct known_hypervisor_resolver : virtualization_resolver
 };
 
 SCENARIO("using the virtualization resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("no hypervisor is returned") {
         facts.add(make_shared<empty_virtualization_resolver>());
         THEN("the system is reported as physical") {

--- a/lib/tests/facts/resolvers/zfs_resolver.cc
+++ b/lib/tests/facts/resolvers/zfs_resolver.cc
@@ -3,10 +3,12 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_zfs_resolver : zfs_resolver
 {
@@ -41,7 +43,7 @@ struct test_zfs_resolver : zfs_resolver
 };
 
 SCENARIO("using the ZFS resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_zfs_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/resolvers/zone_resolver.cc
+++ b/lib/tests/facts/resolvers/zone_resolver.cc
@@ -4,10 +4,12 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_zone_resolver : zone_resolver
 {
@@ -41,7 +43,7 @@ struct test_zone_resolver : zone_resolver
 };
 
 SCENARIO("using the Solaris zone resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_zone_resolver>());
         THEN("only the zone count should be added") {

--- a/lib/tests/facts/resolvers/zpool_resolver.cc
+++ b/lib/tests/facts/resolvers/zpool_resolver.cc
@@ -3,10 +3,12 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include "../../collection_fixture.hpp"
 
 using namespace std;
 using namespace facter::facts;
 using namespace facter::facts::resolvers;
+using namespace facter::testing;
 
 struct empty_zpool_resolver : zpool_resolver
 {
@@ -41,7 +43,7 @@ struct test_zpool_resolver : zpool_resolver
 };
 
 SCENARIO("using the zpool resolver") {
-    collection facts;
+    collection_fixture facts;
     WHEN("data is not present") {
         facts.add(make_shared<empty_zpool_resolver>());
         THEN("facts should not be added") {

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -38,6 +38,7 @@
 using namespace std;
 using namespace facter::facts;
 using namespace facter::util;
+using namespace facter::testing;
 
 // For every base resolver, implement a resolver that outputs the minimum values to pass schema validation
 // We don't care about the actual data in the facts, only that it conforms to the schema
@@ -638,7 +639,7 @@ SCENARIO("validating schema") {
     boost::nowide::ifstream stream(LIBFACTER_TESTS_DIRECTORY "/../schema/facter.yaml");
 
     YAML::Node schema = YAML::Load(stream);
-    collection facts;
+    collection_fixture facts;
 
     WHEN("validating the schema itself") {
         THEN("all attributes must be valid") {

--- a/lib/tests/facts/windows/collection.cc
+++ b/lib/tests/facts/windows/collection.cc
@@ -12,7 +12,7 @@ using namespace facter::facts;
 using namespace facter::testing;
 
 SCENARIO("resolving external executable facts into a collection") {
-    collection facts;
+    collection_fixture facts;
     REQUIRE(facts.size() == 0u);
     GIVEN("an absolute path") {
         facts.add_external_facts({

--- a/lib/tests/fixtures.hpp.in
+++ b/lib/tests/fixtures.hpp.in
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <functional>
+#include "collection_fixture.hpp"
 
 #define JAVA_EXECUTABLE "@Java_JAVA_EXECUTABLE@"
 #define BINARY_DIRECTORY "@CMAKE_BINARY_DIR@"

--- a/lib/tests/java/facter.cc
+++ b/lib/tests/java/facter.cc
@@ -10,9 +10,10 @@ using namespace facter::facts;
 using namespace facter::execution;
 using namespace facter::util;
 using namespace boost::filesystem;
+using namespace facter::testing;
 
 SCENARIO("using libfacter from Java") {
-    collection facts;
+    collection_fixture facts;
     facts.add_default_facts(true);
 
     path jar_path = path(BINARY_DIRECTORY) / "lib" / "facter.jar";

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -50,7 +50,7 @@ string ruby_value_to_string(value const* value)
 }
 
 SCENARIO("custom facts written in Ruby") {
-    collection facts;
+    collection_fixture facts;
     REQUIRE(facts.size() == 0u);
 
     // Setup ruby


### PR DESCRIPTION
Without this change, add_external_facts overrides Facter's default
external fact paths. As a result, the Ruby API method search_external
also overrides the defaults. This is an unintended breaking change
relative to Facter 2. Legacy external fact paths were also removed
without proper warning.

Restore search_external's behavior to match Facter 2.