### PR TITLE
(FACT-1075) Add flag to display legacy facts

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -119,6 +119,7 @@ int main(int argc, char **argv)
             ("external-dir", po::value<vector<string>>(&external_directories), "A directory to use for external facts.")
             ("help", "Print this help message.")
             ("json,j", "Output in JSON format.")
+            ("show-legacy", "Show legacy facts when querying all facts.")
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), "Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.")
             ("no-color", "Disables color output.")
             ("no-custom-facts", "Disables custom facts.")
@@ -252,7 +253,9 @@ int main(int argc, char **argv)
         } else if (vm.count("yaml")) {
             fmt = format::yaml;
         }
-        facts.write(boost::nowide::cout, fmt, queries);
+
+        bool show_legacy = vm.count("show-legacy");
+        facts.write(boost::nowide::cout, fmt, queries, show_legacy);
         boost::nowide::cout << endl;
     } catch (exception& ex) {
         log(level::fatal, "unhandled exception: %1%", ex.what());

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -203,9 +203,10 @@ namespace facter { namespace facts {
          * @param stream The stream to write the facts to.
          * @param fmt The output format to use.
          * @param queries The set of queries to filter the output to. If empty, all facts will be output.
+         * @param show_legacy Show legacy facts when querying all facts.
          * @return Returns the stream being written to.
          */
-        std::ostream& write(std::ostream& stream, format fmt = format::hash, std::set<std::string> const& queries = std::set<std::string>());
+        std::ostream& write(std::ostream& stream, format fmt = format::hash, std::set<std::string> const& queries = std::set<std::string>(), bool show_legacy = false);
 
         /**
          * Resolves all facts in the collection.
@@ -220,9 +221,9 @@ namespace facter { namespace facts {
         LIBFACTER_NO_EXPORT value const* get_value(std::string const& name);
         LIBFACTER_NO_EXPORT value const* query_value(std::string const& query);
         LIBFACTER_NO_EXPORT value const* lookup(value const* value, std::string const& name);
-        LIBFACTER_NO_EXPORT void write_hash(std::ostream& stream, std::set<std::string> const& queries);
-        LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries);
-        LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries);
+        LIBFACTER_NO_EXPORT void write_hash(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
+        LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
+        LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
         LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
         LIBFACTER_NO_EXPORT bool add_external_facts_dir(std::vector<std::unique_ptr<external::resolver>> const& resolvers, std::string const& directory, bool warn);
 

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -262,7 +262,7 @@ namespace facter { namespace facts {
         });
     }
 
-    ostream& collection::write(ostream& stream, format fmt, set<string> const& queries)
+    ostream& collection::write(ostream& stream, format fmt, set<string> const& queries, bool show_legacy)
     {
         if (queries.empty()) {
             // Resolve all facts
@@ -270,11 +270,11 @@ namespace facter { namespace facts {
         }
 
         if (fmt == format::hash) {
-            write_hash(stream, queries);
+            write_hash(stream, queries, show_legacy);
         } else if (fmt == format::json) {
-            write_json(stream, queries);
+            write_json(stream, queries, show_legacy);
         } else if (fmt == format::yaml) {
-            write_yaml(stream, queries);
+            write_yaml(stream, queries, show_legacy);
         }
         return stream;
     }
@@ -402,7 +402,7 @@ namespace facter { namespace facts {
         return nullptr;
     }
 
-    void collection::write_hash(ostream& stream, set<string> const& queries)
+    void collection::write_hash(ostream& stream, set<string> const& queries, bool show_legacy)
     {
         // If there's only one query, print the result without the name
         if (queries.size() == 1u) {
@@ -416,7 +416,7 @@ namespace facter { namespace facts {
         bool first = true;
         auto writer = ([&](string const& key, value const* val) {
             // Ignore facts with hidden values
-            if (queries.empty() && val && val->hidden()) {
+            if (!show_legacy && queries.empty() && val && val->hidden()) {
                 return;
             }
             if (first) {
@@ -463,14 +463,14 @@ namespace facter { namespace facts {
          ostream& _stream;
     };
 
-    void collection::write_json(ostream& stream, set<string> const& queries)
+    void collection::write_json(ostream& stream, set<string> const& queries, bool show_legacy)
     {
         Document document;
         document.SetObject();
 
         auto builder = ([&](string const& key, value const* val) {
             // Ignore facts with hidden values
-            if (queries.empty() && val && val->hidden()) {
+            if (!show_legacy && queries.empty() && val && val->hidden()) {
                 return;
             }
             rapidjson::Value value;
@@ -498,14 +498,14 @@ namespace facter { namespace facts {
         document.Accept(writer);
     }
 
-    void collection::write_yaml(ostream& stream, set<string> const& queries)
+    void collection::write_yaml(ostream& stream, set<string> const& queries, bool show_legacy)
     {
         Emitter emitter(stream);
         emitter << BeginMap;
 
         auto writer = ([&](string const& key, value const* val) {
             // Ignore facts with hidden values
-            if (queries.empty() && val && val->hidden()) {
+            if (!show_legacy && queries.empty() && val && val->hidden()) {
                 return;
             }
             emitter << Key;

--- a/man/man8/facter.8
+++ b/man/man8/facter.8
@@ -35,6 +35,7 @@ If no queries are given, then all facts will be returned\.
       \fB\-\-external-dir\fR arg           A directory to use for external facts\.
       \fB\-\-help\fR                       Print help and usage information\.
 \fB\-j, [ \-\-json ]\fR                     Output facts in JSON format\.
+      \fB\-\-show-legacy\fR                Show legacy facts when querying all facts\.
 \fB\-l, [ \-\-log-level ]\fR arg (=warn)    Set logging level\.
                                    Supported levels are: none, trace, debug,
                                    info, warn, error, and fatal\.


### PR DESCRIPTION
Facter 3 moved to only showing structured facts, hiding most flat fact
names used by Facter 2 in the default command-line output. This is
difficult for tools parsing the command-line output, particularly when
using json or yaml output.

Add a flag to enable displaying all legacy facts as part of command-line
output querying all facts.