### PR TITLE
(FACT-1073) Add major/minor OS release facts for distros that lack them

### DIFF
--- a/lib/inc/internal/util/versions.hpp
+++ b/lib/inc/internal/util/versions.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * Defines helpers for parsing various version strings
+ */
+#pragma once
+
+#include <string>
+#include <tuple>
+
+namespace facter { namespace util { namespace versions {
+    /**
+     * Helper function for parsing X.Y from an arbitrary version
+     * string. If there is a .Z component, it will be ignored.
+     * @param version the version string to parse
+     * @return A tuple of <maj, min>
+     */
+    inline std::tuple<std::string, std::string> major_minor(const std::string& version)
+    {
+         std::string major, minor;
+         auto pos = version.find('.');
+         if (pos != std::string::npos) {
+              auto second = version.find('.', pos+1);
+              decltype(second) end;
+              major = version.substr(0, pos);
+              if (second != std::string::npos) {
+                   end = second - (pos + 1);
+              } else {
+                   end = std::string::npos;
+              }
+              minor = version.substr(pos+1, end);
+         }
+         return std::make_tuple(std::move(major), std::move(minor));
+    }
+}}}  // namespace facter::util::versions

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -1,5 +1,6 @@
 #include <internal/facts/resolvers/operating_system_resolver.hpp>
 #include <internal/util/regex.hpp>
+#include <internal/util/versions.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include <facter/facts/collection.hpp>
@@ -7,6 +8,7 @@
 #include <facter/facts/os.hpp>
 
 using namespace std;
+using namespace facter::util;
 
 namespace facter { namespace facts { namespace resolvers {
 
@@ -56,6 +58,12 @@ namespace facter { namespace facts { namespace resolvers {
 
         if (!data.release.empty()) {
             auto value = make_value<map_value>();
+
+            // When we have no major or minor, do a 'trivial' parse of
+            // the release to try to get SOMETHING out of it.
+            if (data.minor.empty() && data.major.empty()) {
+                 std::tie(data.major, data.minor) = versions::major_minor(data.release);
+            }
 
             if (!data.major.empty()) {
                 facts.add(fact::operating_system_major_release, make_value<string_value>(data.major, true));

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -29,8 +29,6 @@ struct test_os_resolver : operating_system_resolver
         result.name = "Archlinux";
         result.family = "Archlinux";
         result.release = "1.2.3";
-        result.major = "1";
-        result.minor = "2";
         result.specification_version = "1.4";
         result.distro.id = "Arch";
         result.distro.release = "1.2.3";


### PR DESCRIPTION
Previously, if a given OS did not have a proper OS release, we would
use the kernel release. This release would never be split into
major/minor versions.

This now splits that kernel release into major/minor versions, as
Facter 2 did. For platforms that have their own os release
implementation, this will continue to behave as it did before.

Updating the test for this is a simple matter of removing major/minor
from the fixture data so that we can see it has been calculated by the
resolver.