### PR TITLE
(maint) Don't attempt to link with libdl on OpenBSD.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -119,7 +119,11 @@ if (UNIX)
         )
     endif()
 
-    set(POSIX_LIBRARIES pthread dl)
+    if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+        set(POSIX_LIBRARIES pthread)
+    else()
+        set(POSIX_LIBRARIES pthread dl)
+    endif()
 endif()
 
 if (WIN32)


### PR DESCRIPTION
This isn't enough yet to get (c)facter working on OpenBSD but it's a start.