### PR TITLE
(FACT-1078) Fix FQDN resolution where canonical name is node name.

### DIFF
--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -79,8 +79,8 @@ namespace facter { namespace facts { namespace posix {
             scoped_addrinfo info(result.hostname);
             if (info.result() != 0 && info.result() != EAI_NONAME) {
                 LOG_ERROR("getaddrinfo failed: %1% (%2%): hostname may not be externally resolvable.", gai_strerror(info.result()), info.result());
-            } else if (!info || info.result() == EAI_NONAME) {
-                LOG_INFO("hostname \"%1%\" could not be resolved: hostname may not be externally resolvable.", result.hostname);
+            } else if (!info || info.result() == EAI_NONAME || result.hostname == static_cast<addrinfo*>(info)->ai_canonname) {
+                LOG_DEBUG("hostname \"%1%\" could not be resolved: hostname may not be externally resolvable.", result.hostname);
             } else {
                 result.fqdn = static_cast<addrinfo*>(info)->ai_canonname;
             }


### PR DESCRIPTION
From getaddrinfo's man page:

> if the canonical name is not available, then ai_canonname shall refer
> to the nodename argument or a string with the same contents.

This means that FQDN may resolve back to only the hostname when this
happens.  This fix treats a canonical name that matches the hostname to
be the same as if the hostname did not resolve, resulting in an empty
FQDN.  This causes the base resolver to fallback to using "hostname +
domain" as the FQDN.