### PR TITLE
(maint) Add missing unistd.h include

### DIFF
--- a/lib/src/facts/posix/identity_resolver.cc
+++ b/lib/src/facts/posix/identity_resolver.cc
@@ -1,6 +1,7 @@
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <sys/types.h>
+#include <unistd.h>
 #include <pwd.h>
 #include <grp.h>
 


### PR DESCRIPTION
`unistd.h` is required for `_SC_GETPW_R_SIZE_MAX`, `geteuid()`, `getegid()` as per [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html).