### PR TITLE
(FACT-1075) Tests

### DIFF
--- a/acceptance/tests/options/show_legacy.rb
+++ b/acceptance/tests/options/show_legacy.rb
@@ -1,0 +1,13 @@
+test_name "--show-legacy command-line option results in output with legacy (hidden) facts"
+
+agents.each do |agent|
+  step "Agent #{agent}: retrieve legacy output using a hash"
+  on(agent, facter("--show-legacy")) do
+    assert_match(/^rubyversion => [0-9]+\.[0-9]+\.[0-9]+$/, stdout.chomp, 'hash legacy output does not contain legacy fact rubyversion')
+  end
+
+  step "Agent #{agent}: retrieve legacy output using the --json option"
+  on(agent, facter("--show-legacy --json")) do
+    assert_match(/^  "rubyversion": "[0-9]+\.[0-9]+\.[0-9]+",$/, stdout.chomp, 'json legacy output does not contain legacy fact rubyversion')
+  end
+end


### PR DESCRIPTION
### (FACT-1075) Add show-legacy acceptance tests

Adds tests confirming show-legacy outputs all facts identified as hidden in the schema if they have values. Also adds tests that show-legacy with json and hash output print hidden facts.

### (FACT-1075) Add tests for writing legacy facts

No unit tests existed for writing legacy (hidden) facts. Adds tests for writing hidden facts as json, yaml, and a hash.