### PR TITLE
(FACT-1082) Fix loading custom fact with win32ole

### DIFF
--- a/lib/src/util/windows/wmi.cc
+++ b/lib/src/util/windows/wmi.cc
@@ -32,7 +32,7 @@ namespace facter { namespace util { namespace windows {
     wmi::wmi()
     {
         LOG_DEBUG("initializing WMI");
-        auto hres = CoInitializeEx(0, COINIT_MULTITHREADED);
+        auto hres = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
         if (FAILED(hres)) {
             if (hres == RPC_E_CHANGED_MODE) {
                 LOG_DEBUG("using prior COM concurrency model");

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -53,7 +53,16 @@ set(CMAKE_CXX_FLAGS ${FACTER_CXX_FLAGS})
 
 # Add the ruby tests if there's a ruby installed
 if (RUBY_FOUND)
-    set(LIBFACTER_TESTS_COMMON_SOURCES ${LIBFACTER_TESTS_COMMON_SOURCES} "ruby/ruby.cc")
+    set(LIBFACTER_TESTS_COMMON_SOURCES
+        ${LIBFACTER_TESTS_COMMON_SOURCES}
+        "ruby/ruby.cc"
+        "ruby/ruby_helper.cc")
+
+    if (WIN32)
+        set(LIBFACTER_TESTS_COMMON_SOURCES
+            ${LIBFACTER_TESTS_COMMON_SOURCES}
+            "ruby/windows/ruby.cc")
+    endif()
 endif()
 
 # Set the POSIX sources if on a POSIX platform

--- a/lib/tests/fixtures/ruby/windows/ole.rb
+++ b/lib/tests/fixtures/ruby/windows/ole.rb
@@ -1,0 +1,7 @@
+Facter.add(:foo) do
+  setcode do
+    require 'win32ole'
+    context = WIN32OLE.new('WbemScripting.SWbemNamedValueSet')
+    'bar' unless context.nil?
+  end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -1,14 +1,12 @@
 #include <catch.hpp>
 #include <facter/version.h>
-#include <facter/facts/collection.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <internal/ruby/api.hpp>
-#include <internal/ruby/module.hpp>
 #include <internal/ruby/ruby_value.hpp>
 #include <internal/util/regex.hpp>
 #include <internal/util/scoped_env.hpp>
-#include <leatherman/logging/logging.hpp>
-#include "../fixtures.hpp"
+#include "./ruby_helper.hpp"
+#include "../collection_fixture.hpp"
 #include "../log_capture.hpp"
 
 using namespace std;
@@ -17,37 +15,6 @@ using namespace facter::ruby;
 using namespace facter::util;
 using namespace facter::logging;
 using namespace facter::testing;
-
-bool load_custom_fact(string const& filename, collection& facts)
-{
-    auto ruby = api::instance();
-
-    module mod(facts);
-
-    string file = LIBFACTER_TESTS_DIRECTORY "/fixtures/ruby/" + filename;
-    VALUE result = ruby->rescue([&]() {
-        // Do not construct C++ objects in a rescue callback
-        // C++ stack unwinding will not take place if a Ruby exception is thrown!
-        ruby->rb_load(ruby->utf8_value(file), 0);
-        return ruby->true_value();
-    }, [&](VALUE ex) {
-        LOG_ERROR("error while resolving custom facts in %1%: %2%", file, ruby->exception_to_string(ex));
-        return ruby->false_value();
-    });
-
-    mod.resolve_facts();
-
-    return ruby->is_true(result);
-}
-
-string ruby_value_to_string(value const* value)
-{
-    ostringstream ss;
-    if (value) {
-        value->write(ss);
-    }
-    return ss.str();
-}
 
 SCENARIO("custom facts written in Ruby") {
     collection_fixture facts;

--- a/lib/tests/ruby/ruby_helper.cc
+++ b/lib/tests/ruby/ruby_helper.cc
@@ -1,0 +1,40 @@
+#include "ruby_helper.hpp"
+#include <leatherman/logging/logging.hpp>
+#include <internal/ruby/api.hpp>
+#include <internal/ruby/module.hpp>
+#include "../fixtures.hpp"
+
+using namespace std;
+using namespace facter::ruby;
+using namespace facter::facts;
+
+bool load_custom_fact(string const& filename, collection& facts)
+{
+    auto ruby = api::instance();
+
+    module mod(facts);
+
+    string file = LIBFACTER_TESTS_DIRECTORY "/fixtures/ruby/" + filename;
+    VALUE result = ruby->rescue([&]() {
+        // Do not construct C++ objects in a rescue callback
+        // C++ stack unwinding will not take place if a Ruby exception is thrown!
+        ruby->rb_load(ruby->utf8_value(file), 0);
+        return ruby->true_value();
+    }, [&](VALUE ex) {
+        LOG_ERROR("error while resolving custom facts in %1%: %2%", file, ruby->exception_to_string(ex));
+        return ruby->false_value();
+    });
+
+    mod.resolve_facts();
+
+    return ruby->is_true(result);
+}
+
+string ruby_value_to_string(value const* value)
+{
+    ostringstream ss;
+    if (value) {
+        value->write(ss);
+    }
+    return ss.str();
+}

--- a/lib/tests/ruby/ruby_helper.hpp
+++ b/lib/tests/ruby/ruby_helper.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <facter/facts/collection.hpp>
+#include <facter/facts/value.hpp>
+#include <string>
+
+bool load_custom_fact(std::string const& filename, facter::facts::collection& facts);
+
+std::string ruby_value_to_string(facter::facts::value const* value);

--- a/lib/tests/ruby/windows/ruby.cc
+++ b/lib/tests/ruby/windows/ruby.cc
@@ -1,0 +1,27 @@
+#include <catch.hpp>
+#include <internal/ruby/api.hpp>
+#include <internal/ruby/ruby_value.hpp>
+#include "../ruby_helper.hpp"
+#include "../../collection_fixture.hpp"
+
+using namespace std;
+using namespace facter::testing;
+using namespace facter::ruby;
+
+SCENARIO("Windows custom facts written in Ruby") {
+    collection_fixture facts;
+    REQUIRE(facts.size() == 0u);
+
+    // Setup ruby
+    auto ruby = api::instance();
+    REQUIRE(ruby);
+    REQUIRE(ruby->initialized());
+    ruby->include_stack_trace(true);
+
+    GIVEN("a fact that loads win32ole") {
+        REQUIRE(load_custom_fact("windows/ole.rb", facts));
+        THEN("the value should be in the collection") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
+        }
+    }
+}


### PR DESCRIPTION
Loading a custom fact on the command-line that uses win32ole results in an
error, because Ruby's win32ole library initializes COM with
single-threaded and Facter previously initialized it with multi-threaded.

Change Facter to initialize COM single-threaded, and add tests verifying
custom facts can use win32ole successfully.