### PR TITLE
(FACT-1083) Replace fork/execv with vfork/execve.

### DIFF
--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -606,12 +606,6 @@ namespace facter {  namespace ruby {
             _data_objects.erase(obj);
         }
 
-        /**
-         * Global flag to disable Ruby VM cleanup.
-         * This should be set to false in any forked child processes.
-         */
-        static bool cleanup;
-
      private:
         explicit api(facter::util::dynamic_library library);
         // Imported Ruby functions that should not be called externally

--- a/lib/src/execution/posix/execution.cc
+++ b/lib/src/execution/posix/execution.cc
@@ -33,6 +33,8 @@ namespace facter { namespace execution {
 
     static uint64_t get_max_descriptor_limit()
     {
+        // WARNING: this function is called under vfork
+        // See comment below in exec_child in case you're not afraid
 #ifdef _SC_OPEN_MAX
         {
             auto open_max = sysconf(_SC_OPEN_MAX);
@@ -176,6 +178,132 @@ namespace facter { namespace execution {
         throw timeout_exception((boost::format("command timed out after %1% seconds.") % timeout).str(), static_cast<size_t>(child));
     }
 
+    static void exec_child(int in, int out, int err, char const* program, char const** argv, char const** envp)
+    {
+        // WARNING: this function is called from a vfork'd child
+        // Do not modify program state from this function; only call setpgid, dup2, close, execve, and _exit
+        // Do not allocate heap memory or throw exceptions
+        // The child is sharing the address space of the parent process, so carelessly modifying this
+        // function may lead to parent state corruption, memory leaks, and/or total protonic reversal
+
+        // Set the process group; this will be used by the parent if we need to kill the process and its children
+        if (setpgid(0, 0) == -1) {
+            char const* message = "failed to setpgid.";
+            if (write(err, message, strlen(message)) == -1) {
+                // Do not care
+            }
+            return;
+        }
+
+        // Redirect stdin
+        if (dup2(in, STDIN_FILENO) == -1) {
+            char const* message = "failed to redirect child stdin.";
+            if (write(err, message, strlen(message)) == -1) {
+                // Do not care
+            }
+            return;
+        }
+
+        // Redirect stdout
+        if (dup2(out, STDOUT_FILENO) == -1) {
+            char const* message = "failed to redirect child stdout.";
+            if (write(err, message, strlen(message)) == -1) {
+                // Do not care
+            }
+            return;
+        }
+
+        // Redirect stderr
+        if (dup2(err, STDERR_FILENO) == -1) {
+            char const* message = "failed to redirect child stderr.";
+            if (write(err, message, strlen(message)) == -1) {
+                // Do not care
+            }
+            return;
+        }
+
+        // Close all open file descriptors above stderr
+        for (decltype(get_max_descriptor_limit()) i = (STDERR_FILENO + 1); i < get_max_descriptor_limit(); ++i) {
+            close(i);
+        }
+
+        // Execute the given program; this should not return if successful
+        execve(program, const_cast<char* const*>(argv), const_cast<char* const*>(envp));
+    }
+
+    // Helper function that turns a vector of strings into a vector of const cstr pointers
+    // This is used to pass arguments and environment to execve
+    static vector<char const*> to_exec_arg(vector<string> const* argument, string const* first = nullptr)
+    {
+        vector<char const*> result;
+        result.reserve((argument ? argument->size() : 0) + (first ? 1 : 0) + 1 /* terminating null */);
+        if (first) {
+            result.push_back(first->c_str());
+        }
+        if (argument) {
+            transform(argument->begin(), argument->end(), back_inserter(result), [](string const& s) { return s.c_str(); });
+        }
+        // Null terminate the list
+        result.push_back(nullptr);
+        return result;
+    }
+
+    // Helper function that creates a vector of environment variables in the format of key=value
+    // Also handles merging of environment and defaulting LC_ALL and LANG to C
+    static vector<string> create_environment(map<string, string> const* environment, bool merge)
+    {
+        vector<string> result;
+
+        // Merge in our current environment, if requested
+        if (merge && environ) {
+            for (auto var = environ; *var; ++var) {
+                // Don't respect LC_ALL or LANG from the parent process
+                if (boost::starts_with(*var, "LC_ALL=") || boost::starts_with(*var, "LANG=")) {
+                    continue;
+                }
+                result.emplace_back(*var);
+            }
+        }
+
+        // Add the given environment
+        if (environment) {
+            for (auto const& kvp : *environment) {
+                result.emplace_back((boost::format("%1%=%2%") % kvp.first % kvp.second).str());
+            }
+        }
+
+        // Set the locale to C unless specified in the given environment
+        if (!environment || environment->count("LC_ALL") == 0) {
+            result.emplace_back("LC_ALL=C");
+        }
+        if (!environment || environment->count("LANG") == 0) {
+            result.emplace_back("LANG=C");
+        }
+        return result;
+    }
+
+    static pid_t create_child(int in, int out, int err, char const* program, char const** argv, char const** envp)
+    {
+        // Fork the child process
+        // Note: this uses vfork, which is inherently unsafe (the parent's address space is shared with the child)
+        pid_t child = vfork();
+        if (child < 0) {
+            throw execution_exception("failed to fork child process.");
+        }
+
+        // If this is the parent process, return
+        if (child != 0) {
+            return child;
+        }
+
+        // Exec the child; this only returns if there was a failure
+        exec_child(in, out, err, program, argv, envp);
+
+        // If we've reached here, we've failed, so exit the child
+        _exit(errno == 0 ? EXIT_FAILURE : errno);
+        return -1;
+    }
+
     tuple<bool, string, string> execute(
         string const& file,
         vector<string> const* arguments,
@@ -210,215 +338,131 @@ namespace facter { namespace execution {
         scoped_descriptor stdout_read(pipes[0]);
         scoped_descriptor stdout_write(pipes[1]);
 
-        // Create optional pipes for stderr redirection (if not redirecting stderr to stdout or null)
+        // Redirect stderr to stdout, null, or to the pipe to read
         scoped_descriptor stderr_read(-1);
         scoped_descriptor stderr_write(-1);
-        if (!options[execution_options::redirect_stderr_to_stdout] && !options[execution_options::redirect_stderr_to_null]) {
+        scoped_descriptor dev_null(-1);
+        int child_stderr = -1;
+        if (options[execution_options::redirect_stderr_to_stdout]) {
+            child_stderr = stdout_write;
+        } else if (options[execution_options::redirect_stderr_to_null]) {
+            dev_null = scoped_descriptor(open("/dev/null", O_RDWR));
+            child_stderr = dev_null;
+        } else {
             if (::pipe(pipes) < 0) {
                 throw execution_exception("failed to allocate pipe for stderr redirection.");
             }
             stderr_read = scoped_descriptor(pipes[0]);
             stderr_write = scoped_descriptor(pipes[1]);
+            child_stderr = stderr_write;
         }
 
-        // Fork the child process
-        pid_t child = fork();
-        if (child < 0) {
-            throw execution_exception("failed to fork child process.");
-        }
+        // Allocate the child process arguments and envp *before* creating the child
+        auto args = to_exec_arg(arguments, &file);
+        auto variables = create_environment(environment, options[execution_options::merge_environment]);
+        auto envp = to_exec_arg(&variables);
 
-        // A non-zero child pid means we're running in the context of the parent process
-        if (child)
-        {
-            // Close the unused descriptors
-            stdin_read.release();
-            stdin_write.release();
-            stdout_write.release();
-            stderr_write.release();
+        // Create the child
+        pid_t child = create_child(stdin_read, stdout_write, child_stderr, executable.c_str(), args.data(), envp.data());
 
-            // Define a reaper that is invoked when we exit this scope
-            // This ensures that the child won't become a zombie if an exception is thrown
-            bool kill_child = true;
-            bool success = false;
-            bool signaled = false;
-            int status = 0;
-            scope_exit reaper([&]() {
-                if (kill_child) {
-                    kill(-child, SIGKILL);
-                }
-                // Wait for the child to exit
-                if (waitpid(child, &status, 0) == -1) {
-                    LOG_DEBUG("waitpid failed: %1% (%2%).", strerror(errno), errno);
-                    return;
-                }
-                if (WIFEXITED(status)) {
-                    status = static_cast<char>(WEXITSTATUS(status));
-                    success = status == 0;
-                    return;
-                }
-                if (WIFSIGNALED(status)) {
-                    signaled = true;
-                    status = static_cast<char>(WTERMSIG(status));
-                    return;
-                }
-            });
+        // Close the unused descriptors
+        stdin_read.release();
+        stdin_write.release();
+        stdout_write.release();
+        stderr_write.release();
 
-            // Set up an interval timer for timeouts
-            // Note: OSX doesn't implement POSIX per-process timers, so we're stuck with the obsolete POSIX timers API
-            scope_exit timer_reset;
-            if (timeout) {
-                struct sigaction sa = {};
-                sa.sa_handler = timer_handler;
-                if (sigaction(SIGALRM, &sa, nullptr) == -1) {
-                    LOG_ERROR("sigaction failed: %1% (%2%).", strerror(errno), errno);
-                    throw execution_exception("failed to setup timer");
-                }
-
-                itimerval timer = {};
-                timer.it_value.tv_sec = static_cast<decltype(timer.it_interval.tv_sec)>(timeout);
-                if (setitimer(ITIMER_REAL, &timer, nullptr) == -1) {
-                    LOG_ERROR("setitimer failed: %1% (%2%).", strerror(errno), errno);
-                    throw execution_exception("failed to setup timer");
-                }
-
-                // Set the resource to disable the timer
-                timer_reset = scope_exit([&]() {
-                    itimerval timer = {};
-                    setitimer(ITIMER_REAL, &timer, nullptr);
-                    command_timedout = false;
-                });
+        // Define a reaper that is invoked when we exit this scope
+        // This ensures that the child won't become a zombie if an exception is thrown
+        bool kill_child = true;
+        bool success = false;
+        bool signaled = false;
+        int status = 0;
+        scope_exit reaper([&]() {
+            if (kill_child) {
+                kill(-child, SIGKILL);
             }
-
-            // This somewhat complicated construct performs the following:
-            // Calls a platform-agnostic implementation of processing stdout/stderr data
-            // The platform agnostic code calls back into the given lambda to do the actual reading
-            // It provides two callbacks of its own to call when there's data available on stdout/stderr
-            // We return from the lambda when all data has been read
-            string output, error;
-            tie(output, error) = process_streams(options[execution_options::trim_output], stdout_callback, stderr_callback, [&](function<bool(string const&)> const& process_stdout, function<bool(string const&)> const& process_stderr) {
-                array<pipe, 2> pipes = { {
-                    pipe("stdout", stdout_read, process_stdout),
-                    pipe("stderr", stderr_read, process_stderr)
-                }};
-                read_from_child(child, pipes, timeout);
-            });
-
-            // Close the read pipes
-            // If the child hasn't sent all the data yet, this may signal SIGPIPE on next write
-            stdout_read.release();
-            stderr_read.release();
-
             // Wait for the child to exit
-            kill_child = false;
-            reaper.invoke();
+            if (waitpid(child, &status, 0) == -1) {
+                LOG_DEBUG("waitpid failed: %1% (%2%).", strerror(errno), errno);
+                return;
+            }
+            if (WIFEXITED(status)) {
+                status = static_cast<char>(WEXITSTATUS(status));
+                success = status == 0;
+                return;
+            }
+            if (WIFSIGNALED(status)) {
+                signaled = true;
+                status = static_cast<char>(WTERMSIG(status));
+                return;
+            }
+        });
 
-            if (signaled) {
-                LOG_DEBUG("process was signaled with signal %1%.", status);
-            } else {
-                LOG_DEBUG("process exited with status code %1%.", status);
+        // Set up an interval timer for timeouts
+        // Note: OSX doesn't implement POSIX per-process timers, so we're stuck with the obsolete POSIX timers API
+        scope_exit timer_reset;
+        if (timeout) {
+            struct sigaction sa = {};
+            sa.sa_handler = timer_handler;
+            if (sigaction(SIGALRM, &sa, nullptr) == -1) {
+                LOG_ERROR("sigaction failed: %1% (%2%).", strerror(errno), errno);
+                throw execution_exception("failed to setup timer");
             }
 
-            // Throw exception if needed
-            if (!success) {
-                if (!signaled && status != 0 && options[execution_options::throw_on_nonzero_exit]) {
-                    throw child_exit_exception("child process returned non-zero exit status.", status, move(output), move(error));
-                }
-                if (signaled && options[execution_options::throw_on_signal]) {
-                    throw child_signal_exception("child process was terminated by signal.", status, move(output), move(error));
-                }
+            itimerval timer = {};
+            timer.it_value.tv_sec = static_cast<decltype(timer.it_interval.tv_sec)>(timeout);
+            if (setitimer(ITIMER_REAL, &timer, nullptr) == -1) {
+                LOG_ERROR("setitimer failed: %1% (%2%).", strerror(errno), errno);
+                throw execution_exception("failed to setup timer");
             }
-            return make_tuple(success, move(output), move(error));
+
+            // Set the resource to disable the timer
+            timer_reset = scope_exit([&]() {
+                itimerval timer = {};
+                setitimer(ITIMER_REAL, &timer, nullptr);
+                command_timedout = false;
+            });
         }
 
-        // Child continues here
-        try
-        {
-            // Disable Ruby cleanup
-            // Ruby doesn't play nice with being forked
-            // The VM records the parent pid, so it doesn't like having ruby_cleanup called from a child process
-            ruby::api::cleanup = false;
+        // This somewhat complicated construct performs the following:
+        // Calls a platform-agnostic implementation of processing stdout/stderr data
+        // The platform agnostic code calls back into the given lambda to do the actual reading
+        // It provides two callbacks of its own to call when there's data available on stdout/stderr
+        // We return from the lambda when all data has been read
+        string output, error;
+        tie(output, error) = process_streams(options[execution_options::trim_output], stdout_callback, stderr_callback, [&](function<bool(string const&)> const& process_stdout, function<bool(string const&)> const& process_stderr) {
+            array<pipe, 2> pipes = { {
+                pipe("stdout", stdout_read, process_stdout),
+                pipe("stderr", stderr_read, process_stderr)
+            }};
+            read_from_child(child, pipes, timeout);
+        });
 
-            // Set the process group; this will be used by the parent if we need to kill the process and its children
-            if (setpgid(0, 0) == -1) {
-                throw execution_exception("failed to set child process group.");
-            }
+        // Close the read pipes
+        // If the child hasn't sent all the data yet, this may signal SIGPIPE on next write
+        stdout_read.release();
+        stderr_read.release();
 
-            if (dup2(stdin_read, STDIN_FILENO) == -1) {
-               throw execution_exception("failed to redirect child stdin.");
-            }
+        // Wait for the child to exit
+        kill_child = false;
+        reaper.invoke();
 
-            if (dup2(stdout_write, STDOUT_FILENO) == -1) {
-               throw execution_exception("failed to redirect child stdout.");
-            }
-
-            // Redirect stderr to stdout, null, or to the pipe to read
-            if (options[execution_options::redirect_stderr_to_stdout]) {
-                if (dup2(stdout_write, STDERR_FILENO) == -1) {
-                    throw execution_exception("failed to redirect child stderr to stdout.");
-                }
-            } else if (options[execution_options::redirect_stderr_to_null]) {
-                scoped_descriptor dev_null(open("/dev/null", O_RDWR));
-                if (dev_null < 0 || dup2(dev_null, STDERR_FILENO) == -1) {
-                    throw execution_exception("failed to redirect child stderr to null.");
-                }
-            } else {
-                if (dup2(stderr_write, STDERR_FILENO) == -1) {
-                    throw execution_exception("failed to redirect child stderr.");
-                }
-            }
-
-            // Close all open file descriptors up to the limit
-            for (decltype(get_max_descriptor_limit()) i = 3; i < get_max_descriptor_limit(); ++i) {
-                close(i);
-            }
-
-            // Build a vector of pointers to the arguments
-            // The first element is the program name
-            // The given program arguments then follow
-            // The last element is a null to terminate the array
-            vector<char const*> args((arguments ? arguments->size() : 0) + 2 /* argv[0] + null */);
-            args[0] = file.c_str();
-            if (arguments) {
-                for (size_t i = 0; i < arguments->size(); ++i) {
-                    args[i + 1] = arguments->at(i).c_str();
-                }
-            }
-
-            // Clear the environment if not merging
-            if (!options[execution_options::merge_environment] && environ) {
-                *environ = nullptr;
-            }
-
-            // Set the locale to C unless specified in the given environment
-            if (!environment || environment->count("LC_ALL") == 0) {
-                environment::set("LC_ALL", "C");
-            }
-            if (!environment || environment->count("LANG") == 0) {
-                environment::set("LANG", "C");
-            }
-            if (environment) {
-                for (auto const& variable : *environment) {
-                    environment::set(variable.first, variable.second);
-                }
-            }
-
-            // Execute the given program and exit in case of failure
-            execv(executable.c_str(), const_cast<char* const*>(args.data()));
-            exit(errno == 0 ? EXIT_FAILURE : errno);
-        }
-        catch (exception& ex)
-        {
-            // Write out any exception message to "stderr" and exit
-            string message = ex.what();
-            message += "\n";
-            int result = write(STDERR_FILENO, message.c_str(), message.size());
-            if (result == -1) {
-                // We don't really care if writing the error message failed
-            }
-            exit(EXIT_FAILURE);
+        if (signaled) {
+            LOG_DEBUG("process was signaled with signal %1%.", status);
+        } else {
+            LOG_DEBUG("process exited with status code %1%.", status);
         }
 
-        // CHILD DOES NOT RETURN
+        // Throw exception if needed
+        if (!success) {
+            if (!signaled && status != 0 && options[execution_options::throw_on_nonzero_exit]) {
+                throw child_exit_exception("child process returned non-zero exit status.", status, move(output), move(error));
+            }
+            if (signaled && options[execution_options::throw_on_signal]) {
+                throw child_signal_exception("child process was terminated by signal.", status, move(output), move(error));
+            }
+        }
+        return make_tuple(success, move(output), move(error));
     }
 
 }}  // namespace facter::executions

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -24,9 +24,6 @@ namespace facter { namespace ruby {
 #define LOAD_ALIASED_SYMBOL(x, y) x(reinterpret_cast<decltype(x)>(library.find_symbol(#x, true, #y)))
 #define LOAD_OPTIONAL_SYMBOL(x) x(reinterpret_cast<decltype(x)>(library.find_symbol(#x)))
 
-    // Default to cleaning up the VM on shutdown
-    bool api::cleanup = true;
-
     set<VALUE> api::_data_objects;
 
     api::api(dynamic_library library) :
@@ -114,7 +111,7 @@ namespace facter { namespace ruby {
                 data->dfree = nullptr;
             }
         }
-        if (_initialized && _library.first_load() && cleanup) {
+        if (_initialized && _library.first_load()) {
             ruby_cleanup(0);
         }
     }


### PR DESCRIPTION
To assist running facter from puppetserver where it is consuming a large
amount of memory in a constrained environment, we should use vfork over
fork so that the parent process' page tables aren't copied into the
child.  This allows facter to spawn additional processes from
puppetserver even when there isn't enough memory to commit to a forked
puppetserver process.

The downside of vfork is that it is a very unsafe system call.  It
creates a child process like fork does, but instead of copying the
parent process' page table, the child process shares the parent process'
address space entirely.  That means that the child can very easily
corrupt the parent.

Therefore, it is with great care that we control exactly what code the
child process runs.  It should not modify any program state, allocate
memory, throw exceptions, or do anything other than duping and closing
file descriptors before calling execve.  Also note that unlike fork,
vfork implementations suspend the parent until the child calls an exec
function or _exit.  This is so that the child can call functions and
append to the current frame's stack space (it must modify the stack
above the current stack pointer, though).

Note: we no longer need the hacky ruby::api::cleanup flag because the
child process now calls _exit when it fails to execve, which prevents
global destructors from running in the child process; therefore
preventing ruby from attempting to shutdown from the child process.