### PR TITLE
(FACT-1085) Fix regressions in custom fact command execution from 2.x.

### DIFF
--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -192,7 +192,7 @@ namespace facter { namespace execution {
      * Expands the executable in the command to the full path.
      * @param command The command to expand.
      * @param directories The directories to search.
-     * @return Returns the expanded command if the executable was found or the original command if not.
+     * @return Returns the expanded command if the executable was found or empty if it was not found.
      */
     std::string LIBFACTER_EXPORT expand_command(std::string const& command, std::vector<std::string> const& directories = facter::util::environment::search_paths());
 

--- a/lib/inc/internal/ruby/simple_resolution.hpp
+++ b/lib/inc/internal/ruby/simple_resolution.hpp
@@ -50,7 +50,7 @@ namespace facter { namespace ruby {
 
         VALUE _self;
         VALUE _block;
-        std::string _command;
+        VALUE _command;
     };
 
 }}  // namespace facter::ruby

--- a/lib/src/execution/execution.cc
+++ b/lib/src/execution/execution.cc
@@ -94,7 +94,7 @@ namespace facter { namespace execution {
         boost::trim(result);
 
         if (result.empty()) {
-            return result;
+            return {};
         }
 
         string quote = result[0] == '"' || result[0] == '\'' ? string(1, result[0]) : "";
@@ -122,7 +122,7 @@ namespace facter { namespace execution {
 
         file = which(file, directories);
         if (file.empty()) {
-            return result;
+            return {};
         }
         return quote + file + remainder;
     }

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -78,6 +78,11 @@ namespace facter { namespace execution {
             return is_executable(p, &helper) ? p.string() : string();
         }
 
+        // On Windows, treat 'echo' as a command that can be found
+        if (file == "echo") {
+            return "echo";
+        }
+
         // Otherwise, check for an executable file under the given search paths
         for (auto const& dir : directories) {
             path p = path(dir) / file;

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -722,18 +722,7 @@ namespace facter { namespace ruby {
         try {
             bool success;
             string output, none;
-            tie(success, output, none) = execution::execute(
-                execution::command_shell,
-                {
-                    execution::command_args,
-                    expand_command(command)
-                },
-                timeout,
-                {
-                    execution_options::trim_output,
-                    execution_options::merge_environment,
-                    execution_options::redirect_stderr_to_stdout
-                });
+            tie(success, output, none) = execution::execute(execution::command_shell, { execution::command_args, expand_command(command) }, timeout);
             if (success) {
                 return ruby.utf8_value(output);
             }

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -719,19 +719,28 @@ namespace facter { namespace ruby {
         auto const& ruby = *api::instance();
 
         // Block to ensure that result is destructed before raising.
+        bool found = false;
         try {
-            bool success;
-            string output, none;
-            tie(success, output, none) = execution::execute(execution::command_shell, { execution::command_args, expand_command(command) }, timeout);
-            if (success) {
-                return ruby.utf8_value(output);
+            auto expanded = execution::expand_command(command);
+            if (!expanded.empty()) {
+                found = true;
+
+                bool success;
+                string output, none;
+                tie(success, output, none) = execution::execute(execution::command_shell, {execution::command_args, expanded}, timeout);
+                if (success) {
+                    return ruby.utf8_value(output);
+                }
             }
         } catch (timeout_exception const& ex) {
             // Always raise for timeouts
             ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), ex.what());
         }
         if (raise) {
-            ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), "execution of command \"%s\" failed", command.c_str());
+            if (!found) {
+                ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), "execution of command \"%s\" failed: command not found.", command.c_str());
+            }
+            ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), "execution of command \"%s\" failed.", command.c_str());
         }
         return failure_default;
     }

--- a/lib/src/ruby/simple_resolution.cc
+++ b/lib/src/ruby/simple_resolution.cc
@@ -65,7 +65,7 @@ namespace facter { namespace ruby {
         bool success;
         string output, none;
         tie(success, output, none) = execute(command_shell, { command_args, expand_command(_command) });
-        if (!success) {
+        if (!success || output.empty()) {
             return ruby.nil_value();
         }
         return ruby.utf8_value(output);

--- a/lib/src/ruby/simple_resolution.cc
+++ b/lib/src/ruby/simple_resolution.cc
@@ -64,18 +64,7 @@ namespace facter { namespace ruby {
         // Otherwise, we were given a command so execute it
         bool success;
         string output, none;
-        tie(success, output, none) = execute(
-            command_shell,
-            {
-                command_args,
-                expand_command(_command)
-            },
-            0,
-            {
-                execution_options::trim_output,
-                execution_options::merge_environment,
-                execution_options::redirect_stderr_to_stdout
-            });
+        tie(success, output, none) = execute(command_shell, { command_args, expand_command(_command) });
         if (!success) {
             return ruby.nil_value();
         }

--- a/lib/src/ruby/simple_resolution.cc
+++ b/lib/src/ruby/simple_resolution.cc
@@ -16,6 +16,7 @@ namespace facter { namespace ruby {
         auto const& ruby = *api::instance();
         _self = ruby.nil_value();
         _block = ruby.nil_value();
+        _command = ruby.nil_value();
     }
 
     VALUE simple_resolution::define()
@@ -57,18 +58,16 @@ namespace facter { namespace ruby {
             return ruby.rb_funcall(_block, ruby.rb_intern("call"), 0);
         }
 
-        if (_command.empty()) {
+        if (ruby.is_nil(_command)) {
             return ruby.nil_value();
         }
 
         // Otherwise, we were given a command so execute it
-        bool success;
-        string output, none;
-        tie(success, output, none) = execute(command_shell, { command_args, expand_command(_command) });
-        if (!success || output.empty()) {
+        VALUE result = ruby.rb_funcall(ruby.lookup({ "Facter", "Core", "Execution" }), ruby.rb_intern("exec"), 1, _command);
+        if (ruby.is_nil(result) || ruby.is_true(ruby.rb_funcall(result, ruby.rb_intern("empty?"), 0))) {
             return ruby.nil_value();
         }
-        return ruby.utf8_value(output);
+        return result;
     }
 
     VALUE simple_resolution::alloc(VALUE klass)
@@ -94,8 +93,9 @@ namespace facter { namespace ruby {
         // Call the base first
         instance->resolution::mark();
 
-        // Mark the setcode block
+        // Mark the setcode block and command
         ruby.rb_gc_mark(instance->_block);
+        ruby.rb_gc_mark(instance->_command);
     }
 
     void simple_resolution::free(void* data)
@@ -118,47 +118,24 @@ namespace facter { namespace ruby {
             ruby.rb_raise(*ruby.rb_eArgError, "wrong number of arguments (%d for 1)", argc);
         }
 
-        int tag = 0;
-        {
-            // Declare all C++ objects here
-            string command;
-            volatile VALUE block = ruby.nil_value();
+        auto instance = ruby.to_native<simple_resolution>(self);
 
-            ruby.protect(tag, [&]{
-                // Do not declare any C++ objects inside the protect
-                // Their destructors will not be invoked if there is a Ruby exception
-                if (argc == 0) {
-                    // No arguments, only a block is required
-                    if (!ruby.rb_block_given_p()) {
-                        ruby.rb_raise(*ruby.rb_eArgError, "a block must be provided");
-                    }
-                    block = ruby.rb_block_proc();
-                } else if (argc == 1) {
-                    VALUE arg = argv[0];
-                    if (!ruby.is_string(arg) || ruby.is_true(ruby.rb_funcall(arg, ruby.rb_intern("empty?"), 0))) {
-                        ruby.rb_raise(*ruby.rb_eTypeError, "expected a non-empty String for first argument");
-                    }
-                    if (ruby.rb_block_given_p()) {
-                        ruby.rb_raise(*ruby.rb_eArgError, "a block is unexpected when passing a String");
-                    }
-                    command = ruby.to_string(arg);
-                }
-                return self;
-            });
-
-            if (!tag) {
-                auto instance = ruby.to_native<simple_resolution>(self);
-                if (!ruby.is_nil(block)) {
-                    instance->_block = block;
-                } else {
-                    instance->_command = move(command);
-                }
-                return self;
+        if (argc == 0) {
+            // No arguments, only a block is required
+            if (!ruby.rb_block_given_p()) {
+                ruby.rb_raise(*ruby.rb_eArgError, "a block must be provided");
             }
+            instance->_block = ruby.rb_block_proc();
+        } else if (argc == 1) {
+            VALUE arg = argv[0];
+            if (!ruby.is_string(arg) || ruby.is_true(ruby.rb_funcall(arg, ruby.rb_intern("empty?"), 0))) {
+                ruby.rb_raise(*ruby.rb_eTypeError, "expected a non-empty String for first argument");
+            }
+            if (ruby.rb_block_given_p()) {
+                ruby.rb_raise(*ruby.rb_eArgError, "a block is unexpected when passing a String");
+            }
+            instance->_command = arg;
         }
-
-        // Now that the above block has exited, it's safe to jump to the given tag
-        ruby.rb_jump_tag(tag);
         return self;
     }
 

--- a/lib/tests/execution/posix/execution.cc
+++ b/lib/tests/execution/posix/execution.cc
@@ -100,19 +100,13 @@ SCENARIO("expanding command paths with execution::expand_command") {
         }
     }
     GIVEN("a command not on PATH") {
-        THEN("the command is returned as given") {
-            REQUIRE(
-                expand_command("not_on_the_path") ==
-                "not_on_the_path"
-            );
+        THEN("the returned command is empty") {
+            REQUIRE(expand_command("not_on_the_path") == "");
         }
     }
     GIVEN("a non-executable command on PATH") {
-        THEN("the command is returned as given") {
-            REQUIRE(
-                expand_command("not_executable", { LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution" }) ==
-                "not_executable"
-            );
+        THEN("the returned command is empty") {
+            REQUIRE(expand_command("not_executable", { LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution" }) == "");
         }
     }
 }

--- a/lib/tests/execution/windows/execution.cc
+++ b/lib/tests/execution/windows/execution.cc
@@ -68,13 +68,13 @@ SCENARIO("expanding command paths with execution::expand_command") {
         }
     }
     GIVEN("a command not on PATH") {
-        THEN("the command is returned as given") {
-            REQUIRE(expand_command("not_on_the_path") == "not_on_the_path");
+        THEN("the returned command is empty") {
+            REQUIRE(expand_command("not_on_the_path") == "");
         }
     }
     GIVEN("a non-executable command on PATH") {
-        THEN("the command is returned as given") {
-            REQUIRE(expand_command("not_executable", { LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution" }) == "not_executable");
+        THEN("the returned command is empty") {
+            REQUIRE(expand_command("not_executable", { LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution" }) == "");
         }
     }
 }

--- a/lib/tests/fixtures/ruby/empty_setcode_command.rb
+++ b/lib/tests/fixtures/ruby/empty_setcode_command.rb
@@ -1,0 +1,3 @@
+Facter.add(:foo) do
+    setcode 'echo >&2'
+end

--- a/lib/tests/fixtures/ruby/nonexistent_command.rb
+++ b/lib/tests/fixtures/ruby/nonexistent_command.rb
@@ -1,0 +1,21 @@
+Facter.add(:first) do
+    setcode do
+        next 'fail' unless Facter::Core::Execution.exec("does_not_exist || echo fail").nil?
+        'pass'
+    end
+end
+
+Facter.add(:second) do
+    setcode 'does_not_exist || echo fail'
+end
+
+Facter.add(:third) do
+    setcode do
+        begin
+            Facter::Core::Execution.execute("does_not_exist || echo fail")
+        rescue Facter::Core::Execution::ExecutionFailure
+            next 'pass'
+        end
+        'fail'
+    end
+end

--- a/lib/tests/fixtures/ruby/stderr_output.rb
+++ b/lib/tests/fixtures/ruby/stderr_output.rb
@@ -1,0 +1,9 @@
+Facter.add(:first) do
+    setcode do
+        Facter::Core::Execution.exec("echo foo 1>&2 && echo bar")
+    end
+end
+
+Facter.add(:second) do
+    setcode 'echo foo 1>&2 && echo bar'
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -559,4 +559,11 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "\"bar\"");
         }
     }
+    GIVEN("a fact that runs a command outputting to stderr") {
+        REQUIRE(load_custom_fact("stderr_output.rb", facts));
+        THEN("the values should only contain stdout output") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("first")) == "\"bar\"");
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("second")) == "\"bar\"");
+        }
+    }
 }

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -566,4 +566,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("second")) == "\"bar\"");
         }
     }
+    GIVEN("a fact that runs a setcode command that returns no output") {
+        REQUIRE(load_custom_fact("empty_setcode_command.rb", facts));
+        THEN("the fact should not resolve") {
+            REQUIRE_FALSE(facts["foo"]);
+        }
+    }
 }

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -572,4 +572,12 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE_FALSE(facts["foo"]);
         }
     }
+    GIVEN("a fact that runs executes nonexistent commands") {
+        REQUIRE(load_custom_fact("nonexistent_command.rb", facts));
+        THEN("the fact should not resolve") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("first")) == "\"pass\"");
+            REQUIRE_FALSE(facts["second"]);
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("third")) == "\"pass\"");
+        }
+    }
 }


### PR DESCRIPTION
This fixes a few regressions that were noticed when executing commands between 2.x and 3.x.

* 3.x was incorrectly redirecting stderr to stdout for command execution.
* 3.x was incorrectly returning empty string fact values when setcode with a command returned no output on stderr; it should not resolve the fact instead.
* 3.x was not properly handling non-existent commands such that they should not be executed, instead nil should be returned for `Facter::Core::Execution::exec` and `Facter::Core::Execution::execute` should raise a command not found error by default.