### PR TITLE
(FACT-1084) Catch failures to convert address

### DIFF
--- a/lib/inc/internal/util/windows/wsa.hpp
+++ b/lib/inc/internal/util/windows/wsa.hpp
@@ -53,7 +53,7 @@ namespace facter { namespace util { namespace windows {
          * Throws an exception if passed an IPv6 argument on Windows Server 2003 and IPv6 support isn't installed.
          * See https://social.technet.microsoft.com/Forums/windowsserver/en-US/7166dcbe-d493-4da1-8441-5b5d6aa0d21c/ipv6-and-windows-server-2003
          * @param addr The socket address structure.
-         * @return An IPv4 or IPv6 string.
+         * @return An IPv4 or IPv6 string, or an empty string if addr is uninitialized.
          */
         std::string saddress_to_string(SOCKET_ADDRESS const& addr) const;
 

--- a/lib/src/util/windows/wsa.cc
+++ b/lib/src/util/windows/wsa.cc
@@ -40,8 +40,12 @@ namespace facter { namespace util { namespace windows {
 
     string wsa::saddress_to_string(SOCKET_ADDRESS const& addr) const
     {
-        DWORD size = INET6_ADDRSTRLEN;
-        wchar_t buffer[INET6_ADDRSTRLEN];
+        if (!addr.lpSockaddr) {
+            return {};
+        }
+
+        DWORD size = INET6_ADDRSTRLEN+1;
+        wchar_t buffer[INET6_ADDRSTRLEN+1];
         if (0 != WSAAddressToStringW(addr.lpSockaddr, addr.iSockaddrLength, NULL, buffer, &size)) {
             throw wsa_exception(format_err("address to string translation failed", WSAGetLastError()));
         }


### PR DESCRIPTION
Without this change, Facter calls WSAAddressToStringW with an invalid
SOCKET_ADDRESS and throws an uncaught exception when the call fails. This
leads Facter to exit ungracefully.

Ensure calls to WSAAddressToStringW catch any exceptions thrown as a
result of errors, so we simply fail to resolve the address.

Also extend allowed IP address length on Windows to account for null
terminator, and skip resolving dhcp if not enabled.