### PR TITLE
(maint) Fix windows build following stable merge.

### DIFF
--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -20,6 +20,7 @@
 
 using namespace std;
 using namespace facter::util;
+using namespace facter::util::windows;
 using namespace boost::algorithm;
 using namespace leatherman::windows;
 


### PR DESCRIPTION
Despite not showing any conflicts, the merge of the Windows networking
resolver removed a required using statement.  This commit adds it back.