### PR TITLE
WIP (FACT-1090) Query Ruby `$LOAD_PATH` when used

### DIFF
--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -387,7 +387,7 @@ namespace facter {  namespace ruby {
          * Gets the load path being used by Ruby.
          * @return Returns the load path being used by Ruby.
          */
-        std::vector<std::string> get_load_path() const;
+        VALUE get_load_path() const;
 
         /**
          * Converts a Ruby value into a C++ string.

--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -10,6 +10,12 @@
 #include <set>
 #include <string>
 
+namespace boost { namespace filesystem {
+
+    class path;
+
+}}  // namespace boost::filesystem
+
 namespace facter { namespace facts {
 
     struct collection;
@@ -130,6 +136,7 @@ namespace facter { namespace ruby {
         void load_file(std::string const& path);
         VALUE create_fact(VALUE name);
         static VALUE level_to_symbol(leatherman::logging::log_level level);
+        static void each_facter_path(std::function<bool(boost::filesystem::path&)> callback);
 
         facter::facts::collection& _collection;
         std::map<std::string, VALUE> _facts;

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -206,21 +206,9 @@ namespace facter { namespace ruby {
         _include_stack_trace = value;
     }
 
-    vector<string> api::get_load_path() const
+    VALUE api::get_load_path() const
     {
-        vector<string> directories;
-
-        array_for_each(rb_gv_get("$LOAD_PATH"), [&](VALUE value) {
-            string path = to_string(value);
-            // Ignore "." as a load path (present in 1.8.7)
-            if (path == ".") {
-                return false;
-            }
-            directories.emplace_back(move(path));
-            return true;
-        });
-
-        return directories;
+        return rb_gv_get("$LOAD_PATH");
     }
 
     string api::to_string(VALUE v) const

--- a/lib/tests/fixtures/ruby/lib/facter/named_fact.rb
+++ b/lib/tests/fixtures/ruby/lib/facter/named_fact.rb
@@ -1,0 +1,5 @@
+Facter.add(:named_fact) do
+  setcode do
+    'foo'
+  end
+end

--- a/lib/tests/fixtures/ruby/lib/facter/other_fact.rb
+++ b/lib/tests/fixtures/ruby/lib/facter/other_fact.rb
@@ -1,0 +1,5 @@
+Facter.add(:unnamed_fact) do
+  setcode do
+    'baz'
+  end
+end

--- a/lib/tests/fixtures/ruby/load_path.rb
+++ b/lib/tests/fixtures/ruby/load_path.rb
@@ -1,0 +1,15 @@
+libdir = File.join(File.expand_path(File.dirname(__FILE__)), 'lib')
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+Facter.add(:named) do
+  setcode do
+    Facter.value('named_fact')
+  end
+end
+
+Facter.add(:unnamed) do
+  setcode do
+    Facter.value('unnamed_fact')
+  end
+end
+

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -580,4 +580,11 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("third")) == "\"pass\"");
         }
     }
+    GIVEN("a fact that modifies $LOAD_PATH") {
+        REQUIRE(load_custom_fact("load_path.rb", facts));
+        THEN("should resolve facts on that $LOAD_PATH") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("named")) == "\"foo\"");
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("unnamed")) == "\"baz\"");
+        }
+    }
 }


### PR DESCRIPTION
Facter 3.0 included a regression where running Facter in some Puppet
commands would not include the correct Ruby `$LOAD_PATH`, resulting in
missing facts. This happens because Facter caches the `$LOAD_PATH` when
initialized, and only resets it when `Facter.reset` is called.

Fix the regression by updating Facter to query `$LOAD_PATH` when facts
are loaded instead of caching on initialization.