### PR TITLE
(maint) Install dmg on osx

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.8"
+gem "beaker", "~> 2.16"
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -33,11 +33,19 @@ PACKAGES = {
 install_packages_on(hosts, PACKAGES)
 
 agents.each do |agent|
-  if agent['platform'] =~ /windows/
+  case agent['platform']
+  when /windows/
     arch = agent[:ruby_arch] || 'x86'
     base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{ENV['SHA']}/artifacts/windows"
     filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
 
     install_puppet_from_msi(agent, :url => "#{base_url}/#{filename}")
+  when /osx/
+    opts = {
+      :puppet_collection => 'PC1',
+      :puppet_agent_sha => ENV['SHA'],
+      :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
+    }
+    install_puppet_agent_dev_repo_on(agent, opts)
   end
 end

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -9,8 +9,11 @@ skip_test "Ruby fact test is confined to AIO" if @options[:type] != 'aio'
 
 step "Ensure the Ruby fact resolves as expected"
 
-if agent['platform'] =~ /windows/
+case agent['platform']
+when /windows/
   ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
+when /osx/
+  ruby_platform = /x86_64-darwin[\d.]+/
 else
   if agent['ruby_arch']
     ruby_platform = agent['ruby_arch'] == 'x64' ? 'x86_64-linux' : /i(4|6)86-linux/


### PR DESCRIPTION
Install puppet-agent dmg on osx during aio acceptance, which depends on
beaker 2.16 or later.

Updates the expected ruby platform regex to allow for versions of the
form "x86_64-darwin14.0". Note 10.9 and up are only 64-bit, so we can
assume x86_64.