### PR TITLE
(maint) remove master from PE platform configs

### DIFF
--- a/acceptance/config/nodes/centos-4-i386.yaml
+++ b/acceptance/config/nodes/centos-4-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/centos-4-x86_64.yaml
+++ b/acceptance/config/nodes/centos-4-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/centos-7-x86_64.yaml
+++ b/acceptance/config/nodes/centos-7-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/oracle-5-i386.yaml
+++ b/acceptance/config/nodes/oracle-5-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/oracle-5-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-5-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/oracle-6-i386.yaml
+++ b/acceptance/config/nodes/oracle-6-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/oracle-6-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-6-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/oracle-7-x86_64.yaml
+++ b/acceptance/config/nodes/oracle-7-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/osx-1010-x86_64.yaml
+++ b/acceptance/config/nodes/osx-1010-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/osx-109-x86_64.yaml
+++ b/acceptance/config/nodes/osx-109-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/redhat-4-i386.yaml
+++ b/acceptance/config/nodes/redhat-4-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/redhat-4-x86_64.yaml
+++ b/acceptance/config/nodes/redhat-4-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/scientific-5-i386.yaml
+++ b/acceptance/config/nodes/scientific-5-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/scientific-5-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-5-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/scientific-6-i386.yaml
+++ b/acceptance/config/nodes/scientific-6-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/scientific-6-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-6-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/scientific-7-x86_64.yaml
+++ b/acceptance/config/nodes/scientific-7-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/sles-10-i386.yaml
+++ b/acceptance/config/nodes/sles-10-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/sles-10-x86_64.yaml
+++ b/acceptance/config/nodes/sles-10-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/sles-11-i386.yaml
+++ b/acceptance/config/nodes/sles-11-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/sles-11-x86_64.yaml
+++ b/acceptance/config/nodes/sles-11-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/sles-12-x86_64.yaml
+++ b/acceptance/config/nodes/sles-12-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1004-i386.yaml
+++ b/acceptance/config/nodes/ubuntu-1004-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1004-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1004-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1504-i386.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-i386.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent

--- a/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1504-x86_64.yaml
@@ -1,11 +1,5 @@
 ---
 HOSTS:
-  master:
-    roles:
-    - master
-    platform: el-7-x86_64
-    hypervisor: vcloud
-    template: redhat-7-x86_64
   agent:
     roles:
     - agent


### PR DESCRIPTION
New platform configs were accidentally merged with master/agent configs.
Facter doesn't test master, it only requires an agent, so remove the
extra nodes.