### PR TITLE
(maint) Restore setting CMAKE_INSTALL_RPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ endif()
 include(FeatureSummary)
 feature_summary(WHAT ALL)
 
+# Set RPATH if not installing to a system library directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" INSTALL_IS_SYSTEM_DIR)
+if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
 # Pull in common cflags setting from leatherman
 include(cflags)
 set(FACTER_CXX_FLAGS "${LEATHERMAN_CXX_FLAGS}")


### PR DESCRIPTION
CMP0042 means CMAKE_MACOSX_RPATH no longer needs to be set, but we still
need to set the CMAKE_INSTALL_RPATH based on the install prefix if not
going to a system library. Removing it causes Facter to fail to find
libfacter when running from the puppet-agent install location, so
restore setting CMAKE_INSTALL_RPATH.