### PR TITLE
(FACT-1111) Bring back `facter -p`

### DIFF
--- a/acceptance/tests/runs_puppet_facts.rb
+++ b/acceptance/tests/runs_puppet_facts.rb
@@ -1,0 +1,30 @@
+test_name "facter -p loads facts from puppet"
+
+agents.each do |agent|
+  external_dir = agent.puppet['pluginfactdest']
+  external_file = "#{external_dir}/external.txt"
+  custom_dir = agent.puppet['plugindest']
+  custom_dir += "/facter"
+  custom_file = "#{custom_dir}/custom.rb"
+
+  teardown do
+    on agent, "rm -f #{external_file} #{custom_file}"
+  end
+
+  step "Agent #{agent}: create external fact"
+  agent.mkdir_p(external_dir)
+  create_remote_file(agent, external_file, "external=external")
+
+  step "Agent #{agent}: create custom fact"
+  agent.mkdir_p(custom_dir)
+  create_remote_file(agent, custom_file, "Facter.add(:custom) { setcode { 'custom' } }")
+
+  step "Agent #{agent}: verify facts"
+  on(agent, facter("-p external")) do
+    assert_equal("external", stdout.chomp)
+  end
+
+  on(agent, facter("-p custom")) do
+    assert_equal("custom", stdout.chomp)
+  end
+end

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -125,6 +125,7 @@ int main(int argc, char **argv)
             ("no-custom-facts", "Disables custom facts.")
             ("no-external-facts", "Disables external facts.")
             ("no-ruby", "Disables loading Ruby, facts requiring Ruby, and custom facts.")
+            ("puppet,p", "(Deprecated: use `puppet facts` instead) Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.")
             ("trace", "Enable backtraces for custom facts.")
             ("verbose", "Enable verbose (info) output.")
             ("version,v", "Print the version and exit.")
@@ -173,7 +174,13 @@ int main(int argc, char **argv)
                 throw po::error("debug, verbose, and log-level options conflict: please specify only one.");
             }
             if (vm.count("no-ruby") && vm.count("custom-dir")) {
-              throw po::error("no-ruby and custom-dir options conflict: please specify only one.");
+                throw po::error("no-ruby and custom-dir options conflict: please specify only one.");
+            }
+            if (vm.count("puppet") && vm.count("no-custom-facts")) {
+                throw po::error("puppet and no-custom-facts options conflict: please specify only one.");
+            }
+            if (vm.count("puppet") && vm.count("no-ruby")) {
+                throw po::error("puppet and no-ruby options conflict: please specify only one.");
             }
         }
         catch (exception& ex) {
@@ -243,7 +250,7 @@ int main(int argc, char **argv)
         facts.add_environment_facts();
 
         if (ruby && !vm.count("no-custom-facts")) {
-            facter::ruby::load_custom_facts(facts, custom_directories);
+            facter::ruby::load_custom_facts(facts, vm.count("puppet"), custom_directories);
         }
 
         // Output the facts

--- a/lib/inc/facter/ruby/ruby.hpp
+++ b/lib/inc/facter/ruby/ruby.hpp
@@ -25,6 +25,17 @@ namespace facter { namespace ruby {
      * Important: this function should be called from main().
      * Calling this function from an arbitrary stack depth may result in segfaults during Ruby GC.
      * @param facts The collection to populate with custom facts.
+     * @param initialize_puppet Whether puppet should be loaded to find additional facts.
+     * @param paths The paths to search for custom facts.
+     */
+    LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, bool initialize_puppet, std::vector<std::string> const& paths = {});
+
+    /**
+     * Loads custom facts into the given collection.
+     * Important: this function should be called from main().
+     * Calling this function from an arbitrary stack depth may result in segfaults during Ruby GC.
+     * This is provided for backwards compatibility.
+     * @param facts The collection to populate with custom facts.
      * @param paths The paths to search for custom facts.
      */
     LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, std::vector<std::string> const& paths = {});

--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -171,6 +171,10 @@ namespace facter {  namespace ruby {
         /**
          * See MRI documentation.
          */
+         VALUE (* const rb_eval_string)(char const*);
+        /**
+         * See MRI documentation.
+         */
         VALUE (* const rb_funcall)(VALUE, ID, int, ...);
         /**
          * See MRI documentation.
@@ -573,6 +577,13 @@ namespace facter {  namespace ruby {
          * @return Returns true if === returns true for the first and second values.
          */
         bool case_equals(VALUE first, VALUE second) const;
+
+        /**
+         * Evalutes a string as ruby code.
+         * Any exception raised will be propagated as a C++ runtime_error
+         * @param code the ruby code to execute
+         */
+        void eval(const std::string& code);
 
         /**
          * Gets the underlying native instance from a Ruby data object.

--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -42,6 +42,12 @@ namespace facter { namespace ruby {
         ~module();
 
         /**
+         * Add additional search paths for ruby custom facts
+         * @param paths The search paths for loading custom facts
+         */
+        void search(std::vector<std::string> const& paths);
+
+        /**
          * Loads all custom facts.
          */
         void load_facts();

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -39,6 +39,7 @@ namespace facter { namespace ruby {
         LOAD_SYMBOL(rb_define_singleton_method),
         LOAD_SYMBOL(rb_class_new_instance),
         LOAD_SYMBOL(rb_gv_get),
+        LOAD_SYMBOL(rb_eval_string),
         LOAD_SYMBOL(rb_funcall),
         LOAD_ALIASED_SYMBOL(rb_funcallv, rb_funcall2),
         LOAD_SYMBOL(rb_proc_new),
@@ -445,6 +446,25 @@ namespace facter { namespace ruby {
     bool api::case_equals(VALUE first, VALUE second) const
     {
         return is_true(rb_funcall(first, rb_intern("==="), 1, second));
+    }
+
+    void api::eval(const string& code)
+    {
+        std::string exception;
+
+        rescue(
+            [&]() {
+                rb_eval_string(code.c_str());
+                return nil_value();
+            },
+            [&](VALUE exc) {
+                exception = exception_to_string(exc);
+                return nil_value();
+            });
+
+        if (!exception.empty()) {
+            throw runtime_error(exception);
+        }
     }
 
     dynamic_library api::find_library()

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -243,6 +243,22 @@ namespace facter { namespace ruby {
         ruby->rb_const_remove(*ruby->rb_cObject, ruby->rb_intern("Facter"));
     }
 
+    void module::search(vector<string> const& paths)
+    {
+        for (auto dir : paths) {
+            _additional_search_paths.emplace_back(dir);
+
+            // Get the canonical directory name
+            boost::system::error_code ec;
+            path directory = canonical(_additional_search_paths.back(), ec);
+            if (ec) {
+                continue;
+            }
+
+            _search_paths.push_back(directory.string());
+        }
+    }
+
     void module::load_facts()
     {
         if (_loaded_all) {

--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -1,12 +1,21 @@
 #include <facter/ruby/ruby.hpp>
+#include <facter/logging/logging.hpp>
 #include <internal/ruby/api.hpp>
 #include <internal/ruby/module.hpp>
 
 using namespace std;
 using namespace facter::facts;
 
-namespace facter { namespace ruby {
+static const char load_puppet[] =
+"require 'puppet'\n"
+"Puppet.initialize_settings\n"
+"unless $LOAD_PATH.include?(Puppet[:libdir])\n"
+"    $LOAD_PATH << Puppet[:libdir]\n"
+"end\n"
+"Facter.reset\n"
+"Facter.search_external([Puppet[:pluginfactdest]])";
 
+namespace facter { namespace ruby {
     bool initialize(bool include_stack_trace)
     {
         api* ruby = api::instance();
@@ -18,10 +27,23 @@ namespace facter { namespace ruby {
         return true;
     }
 
-    void load_custom_facts(collection& facts, vector<string> const& paths)
+    void load_custom_facts(collection& facts, bool initialize_puppet, vector<string> const& paths)
     {
-        module mod(facts, paths);
+        api* ruby = api::instance();
+        module mod(facts, {});
+        if (initialize_puppet) {
+            try {
+                ruby->eval(load_puppet);
+            } catch (exception& ex) {
+                log(facter::logging::level::warning, "Could not load puppet; some facts may be unavailable: %1%", ex.what());
+            }
+        }
+        mod.search(paths);
         mod.resolve_facts();
     }
 
+    void load_custom_facts(collection& facts, vector<string> const& paths)
+    {
+         load_custom_facts(facts, false, paths);
+    }
 }}  // namespace facter::ruby


### PR DESCRIPTION
The beast rises from beyond the grave to once again terrorize the
local villagers.

This brings back our circular dependency on Puppet. When the
`--puppet` or `-p` arguments are passed to Facter, it will attempt to
load Puppet's ruby code in order to find additional facts that may
have been pluginsunc to the agent.