### PR TITLE
(FACT-1115) Fix execution of non-zero command exit treated as failure.

### DIFF
--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -718,26 +718,23 @@ namespace facter { namespace ruby {
     {
         auto const& ruby = *api::instance();
 
-        // Block to ensure that result is destructed before raising.
-        bool found = false;
-        try {
-            auto expanded = execution::expand_command(command);
-            if (!expanded.empty()) {
-                found = true;
+        // Expand the command
+        auto expanded = execution::expand_command(command);
 
-                bool success;
+        if (!expanded.empty()) {
+            try {
+                bool success = false;
                 string output, none;
                 tie(success, output, none) = execution::execute(execution::command_shell, {execution::command_args, expanded}, timeout);
-                if (success) {
-                    return ruby.utf8_value(output);
-                }
+                return ruby.utf8_value(output);
+            } catch (timeout_exception const& ex) {
+                // Always raise for timeouts
+                ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), ex.what());
             }
-        } catch (timeout_exception const& ex) {
-            // Always raise for timeouts
-            ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), ex.what());
         }
+        // Command was not found
         if (raise) {
-            if (!found) {
+            if (expanded.empty()) {
                 ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), "execution of command \"%s\" failed: command not found.", command.c_str());
             }
             ruby.rb_raise(ruby.lookup({ "Facter", "Core", "Execution", "ExecutionFailure"}), "execution of command \"%s\" failed.", command.c_str());

--- a/lib/tests/fixtures/ruby/execution_failure.rb
+++ b/lib/tests/fixtures/ruby/execution_failure.rb
@@ -1,0 +1,5 @@
+Facter.add(:foo) do
+    setcode do
+        Facter::Core::Execution.exec('echo | not_a_command 2>&1')
+    end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -580,4 +580,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("third")) == "\"pass\"");
         }
     }
+    GIVEN("a fact that executes a command that returns non-zero") {
+        REQUIRE(load_custom_fact("execution_failure.rb", facts));
+        THEN("the fact value should be the command's output") {
+            REQUIRE(re_search(ruby_value_to_string(facts.get<ruby_value>("foo")), boost::regex("not_a_command")));
+        }
+    }
 }


### PR DESCRIPTION
Facter 2.x returns output from `Facter::Core::Execution::exec/execute`
even if the command failed (non-zero exit code).  It returned the value
of the `on_fail` option only if the command couldn't be found.

Facter 3 was returning the `on_fail` option if the command returned a
non-zero exit code or couldn't be found.  This commit restores the 2.x
behavior.