### PR TITLE
(maint) Beaker methods don't raise remote exceptions

### DIFF
--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -31,9 +31,6 @@ agents.each do |agent|
   end
 
   step "--trace option should provide a backtrace for a custom fact with errors"
-  begin
-      on(agent, facter("--custom-dir #{custom_dir} --trace custom_fact"))
-  rescue Exception => e
-    assert_match(/backtrace:\s+#{custom_fact}/, e.message, "Expected a backtrace for erroneous custom fact")
-  end
+  on(agent, facter("--custom-dir '#{custom_dir}' --trace custom_fact"), :acceptable_exit_codes => [1])
+  assert_match(/backtrace:\s+#{custom_fact}/, stderr, "Expected a backtrace for erroneous custom fact")
 end


### PR DESCRIPTION
Previously, we weren't quoting the `custom_dir` argument, which
misbehaved on 2003 during acceptance:

    cmd.exe /c facter --custom-dir C:/Documents and Settings/All
    Users/Application Data/PuppetLabs/facter/custom --trace custom_fact
    Data/PuppetLabs/facter/custom =>
    Settings/All =>
    ...

Also beaker doesn't raise exception for non-zero exit codes, so the
expectation was never verified (on all platforms).

This commit quotes `custom_dir`, expects an exit code of 1, and verifies
the backtrace is written to stderr.