### PR TITLE
(FACT-1116) Unbreak bsd::networking_resolver and implement mtu fact

### DIFF
--- a/lib/inc/internal/facts/bsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/bsd/networking_resolver.hpp
@@ -29,7 +29,21 @@ namespace facter { namespace facts { namespace bsd {
          * @param data The data pointer from the link layer interface.
          * @return Returns The MTU of the interface.
          */
-        virtual boost::optional<uint64_t> get_link_mtu(std::string const& interface, void* data) const = 0;
+        virtual boost::optional<uint64_t> get_link_mtu(std::string const& interface, void* data) const;
+
+        /**
+         * Determines if the given sock address is a link layer address.
+         * @param addr The socket address to check.
+         * @returns Returns true if the socket address is a link layer address or false if it is not.
+         */
+        virtual bool is_link_address(sockaddr const* addr) const override;
+
+        /**
+         * Gets the bytes of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns a pointer to the address bytes or nullptr if not a link address.
+         */
+        virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
 
         /**
          * Gets the primary interface.

--- a/lib/src/facts/bsd/networking_resolver.cc
+++ b/lib/src/facts/bsd/networking_resolver.cc
@@ -5,6 +5,10 @@
 #include <leatherman/file_util/directory.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/algorithm/string.hpp>
+#include <sys/sockio.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_dl.h>
 #include <netinet/in.h>
 
 using namespace std;
@@ -91,6 +95,42 @@ namespace facter { namespace facts { namespace bsd {
             data.interfaces.emplace_back(move(iface));
         }
         return data;
+    }
+
+    bool networking_resolver::is_link_address(sockaddr const* addr) const
+    {
+        return addr && addr->sa_family == AF_LINK;
+    }
+
+    uint8_t const* networking_resolver::get_link_address_bytes(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return nullptr;
+        }
+        sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
+        if (link_addr->sdl_alen != 6) {
+            return nullptr;
+        }
+        return reinterpret_cast<uint8_t const*>(LLADDR(link_addr));
+    }
+
+    boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
+    {
+        ifreq ifr;
+        memset(&ifr, 0, sizeof(ifr));
+        strncpy(ifr.ifr_name, interface.c_str(), sizeof(ifr.ifr_name));
+        int s = socket(AF_INET, SOCK_DGRAM, 0);
+        if (s < 0) {
+            LOG_WARNING("socket failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        if (ioctl(s, SIOCGIFMTU, &ifr) == -1) {
+            LOG_WARNING("ioctl failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        return ifr.ifr_mtu;
     }
 
     void networking_resolver::populate_address(interface& iface, ifaddrs const* addr) const


### PR DESCRIPTION
This unbreaks building the `bsd/networking_resolver.cc` and also implements some missing functionality like the link address and link mtu.
