### PR TITLE
(FACT-1116) Implement networking facts for OpenBSD

### DIFF
--- a/lib/inc/internal/facts/openbsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/openbsd/networking_resolver.hpp
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Declares the OpenBSD networking fact resolver.
+ */
+#pragma once
+
+#include "../bsd/networking_resolver.hpp"
+#include <map>
+#include <ifaddrs.h>
+
+namespace facter { namespace facts { namespace openbsd {
+
+    /**
+     * Responsible for resolving networking facts.
+     */
+    struct networking_resolver : bsd::networking_resolver
+    {
+     protected:
+        /**
+         * Gets the MTU of the link layer data.
+         * @param interface The name of the link layer interface.
+         * @param data The data pointer from the link layer interface.
+         * @return Returns The MTU of the interface.
+         */
+        virtual boost::optional<uint64_t> get_link_mtu(std::string const& interface, void* data) const override;
+
+        /**
+         * Determines if the given sock address is a link layer address.
+         * @param addr The socket address to check.
+         * @returns Returns true if the socket address is a link layer address or false if it is not.
+         */
+        virtual bool is_link_address(sockaddr const* addr) const override;
+    };
+
+}}}  // namespace facter::facts::openbsd

--- a/lib/src/facts/openbsd/collection.cc
+++ b/lib/src/facts/openbsd/collection.cc
@@ -1,0 +1,29 @@
+#include <facter/facts/collection.hpp>
+#include <internal/facts/posix/kernel_resolver.hpp>
+#include <internal/facts/resolvers/operating_system_resolver.hpp>
+#include <internal/facts/bsd/uptime_resolver.hpp>
+#include <internal/facts/openbsd/networking_resolver.hpp>
+#include <internal/facts/bsd/filesystem_resolver.hpp>
+#include <internal/facts/posix/ssh_resolver.hpp>
+#include <internal/facts/posix/identity_resolver.hpp>
+#include <internal/facts/posix/timezone_resolver.hpp>
+#include <internal/facts/glib/load_average_resolver.hpp>
+
+using namespace std;
+
+namespace facter { namespace facts {
+
+    void collection::add_platform_facts()
+    {
+        add(make_shared<posix::kernel_resolver>());
+        add(make_shared<resolvers::operating_system_resolver>());
+        add(make_shared<bsd::uptime_resolver>());
+        add(make_shared<bsd::filesystem_resolver>());
+        add(make_shared<posix::ssh_resolver>());
+        add(make_shared<posix::identity_resolver>());
+        add(make_shared<posix::timezone_resolver>());
+        add(make_shared<glib::load_average_resolver>());
+        add(make_shared<openbsd::networking_resolver>());
+    }
+
+}}  // namespace facter::facts

--- a/lib/src/facts/openbsd/networking_resolver.cc
+++ b/lib/src/facts/openbsd/networking_resolver.cc
@@ -1,0 +1,43 @@
+#include <internal/facts/openbsd/networking_resolver.hpp>
+#include <internal/util/bsd/scoped_ifaddrs.hpp>
+#include <facter/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <boost/algorithm/string.hpp>
+#include <sys/sockio.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+
+using namespace std;
+using namespace facter::util;
+using namespace facter::util::bsd;
+using namespace facter::execution;
+
+namespace facter { namespace facts { namespace openbsd {
+
+    bool networking_resolver::is_link_address(sockaddr const* addr) const
+    {
+        return addr && addr->sa_family == AF_LINK;
+    }
+
+    boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
+    {
+        ifreq ifr;
+        memset(&ifr, 0, sizeof(ifr));
+        strncpy(ifr.ifr_name, interface.c_str(), sizeof(ifr.ifr_name));
+        int s = socket(AF_INET, SOCK_DGRAM, 0);
+        if (s < 0) {
+            LOG_WARNING("socket failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        if (ioctl(s, SIOCGIFMTU, &ifr) == -1) {
+            LOG_WARNING("ioctl failed: %1% (%2%): interface MTU fact is unavailable for interface %3%.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        return ifr.ifr_mtu;
+    }
+
+}}}  // namespace facter::facts::openbsdbsd


### PR DESCRIPTION
Continuation of #1040 as the first move of OpenBSD bits into a subdir.
When this (along with #1039) has been merged I can submit a PR to actually build this on OpenBSD :)