### PR TITLE
(maint) Restrict IP addresses to hex characters

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -70,13 +70,13 @@ agents.each do |agent|
   expected_networking = {
                           "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip6"      => /[a-z0-9]+:+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.ip6"      => /[a-f0-9]+:+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.netmask6" => /[a-f0-9]+:/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 
   expected_networking.each do |fact, value|

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -60,13 +60,13 @@ agents.each do |agent|
   expected_networking = {
                           "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip6"      => /[a-z0-9]+:+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.ip6"      => /[a-f0-9]+:+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.netmask6" => /[a-f0-9]+:/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 
   expected_networking.each do |fact, value|

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -51,13 +51,13 @@ agents.each do |agent|
   expected_networking = {
                           "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip6"      => /[a-z0-9]+:+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.ip6"      => /[a-f0-9]+:+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.netmask6" => /[a-f0-9]+:/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 
   expected_networking.each do |fact, value|

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -59,13 +59,13 @@ agents.each do |agent|
 
   expected_networking = {
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip6"      => /[a-z0-9]+:+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.ip6"      => /[a-f0-9]+:+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.netmask6" => /[a-f0-9]+:/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 
   expected_networking.each do |fact, value|

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -75,13 +75,13 @@ agents.each do |agent|
   expected_networking = {
                           "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip6"      => /[a-z0-9]+:+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.ip6"      => /[a-f0-9]+:+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-z0-9]+:/,
+                          "networking.netmask6" => /[a-f0-9]+:/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                          "networking.network6" => /([a-z0-9]+)?:([a-z0-9]+)?/
+                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 
   expected_networking.each do |fact, value|

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -51,7 +51,7 @@ agents.each do |agent|
   expected_networking = {
                           "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.mac"      => /[a-z0-9]{2}:/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.network"  => /10\.\d+\.\d+\.\d+/,


### PR DESCRIPTION
Previously validation used a-z, but IP addresses are restricted to hex
characters (i.e. a-f). Restrict validation to those characters.