### PR TITLE
(FACT-1123) Retry locale setup with LANG=C when we fail

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -264,6 +264,9 @@ int main(int argc, char **argv)
         bool show_legacy = vm.count("show-legacy");
         facts.write(boost::nowide::cout, fmt, queries, show_legacy);
         boost::nowide::cout << endl;
+    } catch (locale_error const& e) {
+        boost::nowide::cerr << "failed to initialize logging system due to a locale error: " << e.what() << "\n" << endl;
+        return 2;  // special error code to indicate we failed harder than normal
     } catch (exception& ex) {
         log(level::fatal, "unhandled exception: %1%", ex.what());
     }

--- a/lib/inc/facter/logging/logging.hpp
+++ b/lib/inc/facter/logging/logging.hpp
@@ -4,6 +4,7 @@
 */
 #pragma once
 
+#include <stdexcept>
 #include <ostream>
 #include <string>
 #include <boost/format.hpp>
@@ -170,5 +171,10 @@ namespace facter { namespace logging {
      * @return Returns the reset code for colorization or an empty string if not supported.
      */
     LIBFACTER_EXPORT std::string const& colorize();
+
+    class locale_error : public std::runtime_error {
+    public:
+         explicit locale_error(const std::string& msg) : std::runtime_error(msg) {}
+    };
 
 }}  // namespace facter::logging

--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -386,6 +386,10 @@ namespace facter {  namespace ruby {
          * See MRI documentation.
          */
         VALUE* const rb_eRuntimeError;
+        /**
+         * See MRI documentation.
+         */
+        VALUE* const rb_eLoadError;
 
         /**
          * Gets the load path being used by Ruby.

--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -58,8 +58,19 @@ namespace facter { namespace logging {
                 environment::clear(var);
             }
             environment::set("LANG", "C");
-            setup_logging_internal(os);
-            log(level::warning, "Locale environment variables were bad; continuing with LANG=C");
+            try {
+                setup_logging_internal(os);
+            } catch (exception const& e) {
+                // If we fail again even with a clean environment, we
+                // need to signal to our consumer that things went
+                // sideways.
+                //
+                // Since logging is busted, we raise an exception that
+                // signals to the consumer that a special action must
+                // be taken to alert the user.
+                throw locale_error(e.what());
+            }
+            log(level::warning, "locale environment variables were bad; continuing with LANG=C");
         }
     }
 

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -92,6 +92,7 @@ namespace facter { namespace ruby {
         LOAD_SYMBOL(rb_eTypeError),
         LOAD_SYMBOL(rb_eStandardError),
         LOAD_SYMBOL(rb_eRuntimeError),
+        LOAD_SYMBOL(rb_eLoadError),
         LOAD_OPTIONAL_SYMBOL(ruby_setup),
         LOAD_SYMBOL(ruby_init),
         LOAD_SYMBOL(ruby_options),

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -108,8 +108,15 @@ extern "C" {
      */
     void LIBFACTER_EXPORT Init_libfacter()
     {
-        facter::logging::setup_logging(boost::nowide::cerr);
-        set_level(log_level::warning);
+        bool logging_init_failed = false;
+        string logging_init_error_msg;
+        try {
+            facter::logging::setup_logging(boost::nowide::cerr);
+            set_level(log_level::warning);
+        } catch(facter::logging::locale_error const& e) {
+            logging_init_failed = true;
+            logging_init_error_msg = e.what();
+        }
 
         // Initialize ruby
         auto ruby = facter::ruby::api::instance();
@@ -118,8 +125,13 @@ extern "C" {
         }
         ruby->initialize();
 
-        // Create the context
-        facter::ruby::require_context::create();
+        // If logging init failed, we'll raise a load error
+        // here. Otherwise we Create the context
+        if (logging_init_failed) {
+            ruby->rb_raise(*ruby->rb_eLoadError, "could not initialize facter due to a locale error: %s", logging_init_error_msg.c_str());
+        } else {
+            facter::ruby::require_context::create();
+        }
     }
 }
 

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -4,6 +4,7 @@
 #include <internal/ruby/confine.hpp>
 #include <internal/ruby/simple_resolution.hpp>
 #include <facter/facts/collection.hpp>
+#include <facter/logging/logging.hpp>
 #include <facter/util/directory.hpp>
 #include <facter/execution/execution.hpp>
 #include <facter/version.h>
@@ -107,7 +108,7 @@ extern "C" {
      */
     void LIBFACTER_EXPORT Init_libfacter()
     {
-        setup_logging(boost::nowide::cerr);
+        facter::logging::setup_logging(boost::nowide::cerr);
         set_level(log_level::warning);
 
         // Initialize ruby


### PR DESCRIPTION
Previously, if we failed to setup a locale (for any reason) we would fail hard. With this PR, we now clear the locale-related environment and try again, printing a warning message to the user.

If this second attempt fails, we'll still fail hard. We have no logging if our locale setup has failed, so there's not a lot we can do.

This also fixes a bug in the ruby module where it was initializing logging incorrectly.