### PR TITLE
(FACT-1125) Include facter bin in PATH on windows

### DIFF
--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -27,6 +27,13 @@ module Facter
   else
     # Simply require libfacter.so; this will define all of the Facter API
     begin
+      # This is a cmake pre-processor check.  On *nix it will end up '' == '1'
+      # On windows, where we want the changes it will be '1' == '1'
+      if '${WIN32}' == '1'
+        facter_root = File.expand_path("#{File.dirname(__FILE__)}/..")
+        ENV['PATH'] = "#{File.join(facter_root, 'bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+        ENV['FACTERDIR'] ||= facter_root
+      end
       require "#{ENV['FACTERDIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
     rescue LoadError
       raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')


### PR DESCRIPTION
Facter was not loading on Windows because the path to the libfacter.so
is not present and Facter could not load itself.  This was affecting MCO
on windows in particular when trying to run the puppet agent plugin
which requires Puppet, which requires Facter.  The work around here is
to prepend the windows PATH environment variable with the directory
libfacter.so is located in.  We're looking it up relative to the
facter.rb file being executed, and the expectation is that the directory
structure on Windows should remain stable.