### PR TITLE
(FACT-1129) Correctly setup Ruby load path to unbreak loading rbconfig

### DIFF
--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -624,6 +624,7 @@ namespace facter {  namespace ruby {
         void (* const ruby_init)();
         void* (* const ruby_options)(int, char**);
         int (* const ruby_cleanup)(volatile int);
+        void (* const ruby_init_loadpath)();
 
         static std::unique_ptr<api> create();
 

--- a/lib/src/ruby/api.cc
+++ b/lib/src/ruby/api.cc
@@ -96,6 +96,7 @@ namespace facter { namespace ruby {
         LOAD_SYMBOL(ruby_init),
         LOAD_SYMBOL(ruby_options),
         LOAD_SYMBOL(ruby_cleanup),
+        LOAD_SYMBOL(ruby_init_loadpath),
         _library(move(library))
     {
     }
@@ -155,6 +156,8 @@ namespace facter { namespace ruby {
         } else {
             ruby_init();
         }
+
+        ruby_init_loadpath();
 
         LOG_INFO("using ruby version %1% to resolve custom facts.", to_string(rb_const_get(*rb_cObject, rb_intern("RUBY_VERSION"))));
 


### PR DESCRIPTION
This allows the `ruby.sitedir` fact to correctly be resolved on OpenBSD.