### PR TITLE
(FACT-1132) dmi resolver for OpenBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -192,6 +192,16 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/bsd/uptime_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
     )
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
+    set(LIBFACTER_PLATFORM_SOURCES
+        "src/facts/openbsd/collection.cc"
+        "src/facts/glib/load_average_resolver.cc"
+        "src/facts/bsd/filesystem_resolver.cc"
+        "src/facts/bsd/uptime_resolver.cc"
+        "src/facts/openbsd/dmi_resolver.cc"
+        "src/facts/openbsd/networking_resolver.cc"
+        "src/util/bsd/scoped_ifaddrs.cc"
+    )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(LIBFACTER_PLATFORM_SOURCES
         "src/facts/windows/dmi_resolver.cc"

--- a/lib/inc/internal/facts/openbsd/dmi_resolver.hpp
+++ b/lib/inc/internal/facts/openbsd/dmi_resolver.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * Declares the OpenBSD Desktop Management Interface (DMI) fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/dmi_resolver.hpp"
+
+namespace facter { namespace facts { namespace openbsd {
+
+    /**
+     * Responsible for resolving DMI facts.
+     */
+    struct dmi_resolver : resolvers::dmi_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+
+     private:
+        std::string sysctl_lookup(int mib);
+    };
+
+}}}  // namespace facter::facts::openbsd

--- a/lib/src/facts/openbsd/collection.cc
+++ b/lib/src/facts/openbsd/collection.cc
@@ -1,13 +1,14 @@
 #include <facter/facts/collection.hpp>
-#include <internal/facts/posix/kernel_resolver.hpp>
-#include <internal/facts/resolvers/operating_system_resolver.hpp>
-#include <internal/facts/bsd/uptime_resolver.hpp>
-#include <internal/facts/openbsd/networking_resolver.hpp>
 #include <internal/facts/bsd/filesystem_resolver.hpp>
-#include <internal/facts/posix/ssh_resolver.hpp>
-#include <internal/facts/posix/identity_resolver.hpp>
-#include <internal/facts/posix/timezone_resolver.hpp>
+#include <internal/facts/bsd/uptime_resolver.hpp>
 #include <internal/facts/glib/load_average_resolver.hpp>
+#include <internal/facts/openbsd/dmi_resolver.hpp>
+#include <internal/facts/openbsd/networking_resolver.hpp>
+#include <internal/facts/posix/identity_resolver.hpp>
+#include <internal/facts/posix/kernel_resolver.hpp>
+#include <internal/facts/posix/ssh_resolver.hpp>
+#include <internal/facts/posix/timezone_resolver.hpp>
+#include <internal/facts/resolvers/operating_system_resolver.hpp>
 
 using namespace std;
 
@@ -24,6 +25,7 @@ namespace facter { namespace facts {
         add(make_shared<posix::timezone_resolver>());
         add(make_shared<glib::load_average_resolver>());
         add(make_shared<openbsd::networking_resolver>());
+        add(make_shared<openbsd::dmi_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/openbsd/dmi_resolver.cc
+++ b/lib/src/facts/openbsd/dmi_resolver.cc
@@ -1,0 +1,40 @@
+#include <internal/facts/openbsd/dmi_resolver.hpp>
+#include <leatherman/logging/logging.hpp>
+
+#include <sys/sysctl.h>
+
+using namespace std;
+
+namespace facter { namespace facts { namespace openbsd {
+
+    dmi_resolver::data dmi_resolver::collect_data(collection& facts)
+    {
+        data result;
+        result.bios_vendor = sysctl_lookup(HW_VENDOR);
+        result.uuid = sysctl_lookup(HW_UUID);
+        result.serial_number = sysctl_lookup(HW_SERIALNO);
+        result.product_name = sysctl_lookup(HW_PRODUCT);
+        result.bios_version = sysctl_lookup(HW_VERSION);
+
+        return result;
+    }
+
+    string dmi_resolver::sysctl_lookup(int mib_2)
+    {
+        int mib[2];
+        size_t len;
+        char value[BUFSIZ];
+
+        mib[0] = CTL_HW;
+        mib[1] = mib_2;
+        len = sizeof(value) - 1;
+
+        if (sysctl(mib, 2, &value, &len, nullptr, 0) == -1) {
+            LOG_DEBUG("sysctl_lookup failed: %1% (%2%).", strerror(errno), errno);
+            return "";
+        }
+
+        return value;
+    }
+
+} } }  // namespace facter::facts::openbsd


### PR DESCRIPTION
Ok, while the issues are being ironed out in the networking resolver, let's add the dmi resolver which also adds the infrastructure to actually build OpenBSD facts.