### PR TITLE
(FACT-1114) updated :peaio build location

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -77,11 +77,6 @@ def beaker_test(mode = :packages, options = {})
     final_options[:install] << "#{build_giturl('facter')}##{sha}"
   end
 
-  if mode == :peaio
-    final_options[:puppet_agent_sha] = sha
-    final_options[:puppet_agent_version] = sha
-  end
-
   options_file = 'merged_options.rb'
   File.open(options_file, 'w') do |merged|
     merged.puts <<-EOS

--- a/acceptance/setup/peaio/pre-suite/010_Install.rb
+++ b/acceptance/setup/peaio/pre-suite/010_Install.rb
@@ -6,9 +6,9 @@ hosts.each do |host|
     host['type'] = 'aio'
 end
 
-install_puppet_agent_pe_promoted_repo_on(hosts, { :puppet_agent_version => options[:puppet_agent_version],
-                                                  :puppet_agent_sha => options[:puppet_agent_sha],
-                                                  :pe_ver => options[:pe_ver],
-                                                  :puppet_collection => options[:puppet_collection] })
+install_puppet_agent_dev_repo_on(hosts, { :puppet_agent_version => options[:puppet_agent_version],
+                                          :puppet_agent_sha => options[:puppet_agent_sha],
+                                          :pe_ver => options[:pe_ver],
+                                          :puppet_collection => options[:puppet_collection] })
 
 configure_pe_defaults_on(hosts)


### PR DESCRIPTION
before, :peaio was set to build from the pe_promoted repo.
this was a misunderstanding of the context of the pipeline
that this task is used in. this commit fixes that so that
it gets puppet-agent from the builds server.

[skip ci]