### PR TITLE
(FACT-1133) Fix unnecessary object allocation from Facter API.

### DIFF
--- a/lib/src/ruby/fact.cc
+++ b/lib/src/ruby/fact.cc
@@ -107,14 +107,12 @@ namespace facter { namespace ruby {
 
                 // Set the value to what was resolved
                 _value = value;
-                _resolved = true;
                 return 0;
             }, [&](VALUE ex) {
                 LOG_ERROR("error while resolving custom fact \"%1%\": %2%", ruby.rb_string_value_ptr(&_name), ruby.exception_to_string(ex));
 
                 // Failed, so set to nil
                 _value = ruby.nil_value();
-                _resolved = true;
                 return 0;
             });
         }
@@ -123,6 +121,7 @@ namespace facter { namespace ruby {
             facts.add(ruby.to_string(_name), ruby.is_nil(_value) ? nullptr : make_value<ruby::ruby_value>(_value));
         }
 
+        _resolved = true;
         _resolving = false;
         return _value;
     }

--- a/lib/tests/facts/resolvers/virtualization_resolver.cc
+++ b/lib/tests/facts/resolvers/virtualization_resolver.cc
@@ -37,7 +37,7 @@ struct unknown_non_virtual_hypervisor_resolver : virtualization_resolver
         return "foobar";
     }
 
-    virtual bool is_virtual(string const& hypervisor)
+    virtual bool is_virtual(string const& hypervisor) override
     {
         return hypervisor != "foobar";
     }

--- a/lib/tests/facts/resolvers/xen_resolver.cc
+++ b/lib/tests/facts/resolvers/xen_resolver.cc
@@ -16,7 +16,7 @@ using namespace facter::testing;
 struct empty_xen_resolver : xen_resolver
 {
  protected:
-    virtual string xen_command()
+    virtual string xen_command() override
     {
         return "";
     }
@@ -31,7 +31,7 @@ struct empty_xen_resolver : xen_resolver
 struct test_xen_resolver : xen_resolver
 {
  protected:
-    virtual string xen_command()
+    virtual string xen_command() override
     {
         return "";
     }

--- a/lib/tests/facts/resolvers/zfs_resolver.cc
+++ b/lib/tests/facts/resolvers/zfs_resolver.cc
@@ -13,7 +13,7 @@ using namespace facter::testing;
 struct empty_zfs_resolver : zfs_resolver
 {
  protected:
-    virtual string zfs_command()
+    virtual string zfs_command() override
     {
         return "";
     }
@@ -28,7 +28,7 @@ struct empty_zfs_resolver : zfs_resolver
 struct test_zfs_resolver : zfs_resolver
 {
  protected:
-    virtual string zfs_command()
+    virtual string zfs_command() override
     {
         return "";
     }

--- a/lib/tests/facts/resolvers/zpool_resolver.cc
+++ b/lib/tests/facts/resolvers/zpool_resolver.cc
@@ -13,7 +13,7 @@ using namespace facter::testing;
 struct empty_zpool_resolver : zpool_resolver
 {
  protected:
-    virtual string zpool_command()
+    virtual string zpool_command() override
     {
         return "";
     }
@@ -28,7 +28,7 @@ struct empty_zpool_resolver : zpool_resolver
 struct test_zpool_resolver : zpool_resolver
 {
  protected:
-    virtual string zpool_command()
+    virtual string zpool_command() override
     {
         return "";
     }

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -355,7 +355,7 @@ protected:
 struct xen_resolver : resolvers::xen_resolver
 {
 protected:
-    virtual string xen_command()
+    virtual string xen_command() override
     {
         return "";
     }
@@ -371,7 +371,7 @@ protected:
 struct zfs_resolver : resolvers::zfs_resolver
 {
 protected:
-    virtual string zfs_command()
+    virtual string zfs_command() override
     {
         return "";
     }
@@ -408,7 +408,7 @@ protected:
 struct zpool_resolver : resolvers::zpool_resolver
 {
 protected:
-    virtual string zpool_command()
+    virtual string zpool_command() override
     {
         return "";
     }

--- a/lib/tests/fixtures/ruby/single_allocation.rb
+++ b/lib/tests/fixtures/ruby/single_allocation.rb
@@ -1,0 +1,7 @@
+Facter.add(:foo) do
+    setcode do
+        # Ensure that the same object is returned from Facter.value for built-in facts
+        Facter.value(:facterversion) &&
+        Facter.value(:facterversion).object_id == Facter.value(:facterversion).object_id
+    end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -586,4 +586,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(re_search(ruby_value_to_string(facts.get<ruby_value>("foo")), boost::regex("not_a_command")));
         }
     }
+    GIVEN("a built-in fact requested multiple times") {
+        REQUIRE(load_custom_fact("single_allocation.rb", facts));
+        THEN("the value should be properly cached between Facter.value calls") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "true");
+        }
+    }
 }


### PR DESCRIPTION
When resolving a value for a built-in fact, the `_resolved` flag never
gets set, so the cached Ruby object for the built-in fact is thrown
away and a new object is allocated.  This is unnecessary and just
creates garbage.

The fix is to always set the flag to true when we're done resolving the
fact.