### PR TITLE
(FACT-1134) Fix Facter operatingsystem resolution

### DIFF
--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -118,19 +118,19 @@ namespace facter { namespace facts { namespace linux {
     static string check_other_linux()
     {
         static vector<tuple<string, string>> const files {
-            make_tuple(string(release_file::openwrt),        string(os::openwrt)),
+            make_tuple(string(release_file::arista_eos),     string(os::arista_eos)),
             make_tuple(string(release_file::gentoo),         string(os::gentoo)),
+            make_tuple(string(release_file::mageia),         string(os::mageia)),
             make_tuple(string(release_file::mandriva),       string(os::mandriva)),
             make_tuple(string(release_file::mandrake),       string(os::mandrake)),
             make_tuple(string(release_file::meego),          string(os::meego)),
             make_tuple(string(release_file::archlinux),      string(os::archlinux)),
             make_tuple(string(release_file::oracle_linux),   string(os::oracle_linux)),
+            make_tuple(string(release_file::openwrt),        string(os::openwrt)),
+            make_tuple(string(release_file::alpine),         string(os::alpine)),
             make_tuple(string(release_file::vmware_esx),     string(os::vmware_esx)),
             make_tuple(string(release_file::slackware),      string(os::slackware)),
-            make_tuple(string(release_file::alpine),         string(os::alpine)),
-            make_tuple(string(release_file::mageia),         string(os::mageia)),
             make_tuple(string(release_file::amazon),         string(os::amazon)),
-            make_tuple(string(release_file::arista_eos),     string(os::arista_eos)),
         };
 
         for (auto const& file : files) {
@@ -144,8 +144,15 @@ namespace facter { namespace facts { namespace linux {
 
     string os_linux::get_name(string const& distro_id) const
     {
-        // Check for Debian next
+        // Check for Debian first; this happens after AristaEOS in Facter 2.x
+        // but that platform is not a Debian so shouldn't matter.
         auto value = check_debian_linux(distro_id);
+        if (!value.empty()) {
+            return value;
+        }
+
+        // Check for specialized distributions next
+        value = check_other_linux();
         if (!value.empty()) {
             return value;
         }
@@ -163,13 +170,7 @@ namespace facter { namespace facts { namespace linux {
         }
 
         // Check for SuSE next
-        value = check_suse_linux();
-        if (!value.empty()) {
-            return value;
-        }
-
-        // Check for some other Linux last
-        return check_other_linux();
+        return check_suse_linux();
     }
 
     string os_linux::get_family(string const& name) const


### PR DESCRIPTION
Facter 3's operatingsystem fact resolution rearranged the order release
files were searched for so that some RedHat distributions would resolve
to RedHat instead of more specific names, for example OracleLinux.

Restore original ordering with respect to searching specific
distributions before RedHat and SUSE.