### PR TITLE
(maint) Move CURL_STATIC to Leatherman

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,6 @@ endif()
 
 option(YAMLCPP_STATIC "Use yaml-cpp's static libraries" OFF)
 
-option(CURL_STATIC "Use curl's static libraries" OFF)
-
 set(FACTER_PATH "" CACHE PATH "Specify the location to look for specific binaries before trying PATH.")
 if (FACTER_PATH)
     # Specify a preferred location for binary lookup that will be prioritized over PATH.
@@ -62,13 +60,6 @@ if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux") OR WIN32) AND NOT WITHOUT_CURL)
     find_package(CURL)
     if (CURL_FOUND)
         add_definitions(-DUSE_CURL)
-        if (CURL_STATIC)
-            add_definitions(-DCURL_STATICLIB)
-            if (WIN32)
-                # Linking statically on Windows requires some extra libraries.
-                list(APPEND CURL_LIBRARIES wldap32.lib ws2_32.lib)
-            endif()
-        endif()
     endif()
     set_package_properties(CURL PROPERTIES DESCRIPTION "A free and easy-to-use client-side URL transfer library" URL "http://curl.haxx.se/libcurl/")
     set_package_properties(CURL PROPERTIES TYPE OPTIONAL PURPOSE "Enables facts that require HTTP.")


### PR DESCRIPTION
CURL_STATIC option handling was moved to Leatherman to support writing
tests for the libcurl wrapper. Remove it from Facter and update the
Leatherman reference.