### PR TITLE
(FACT-1144) Add memory resolver for OpenBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -193,6 +193,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
         "src/facts/openbsd/dmi_resolver.cc"
         "src/facts/openbsd/networking_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
+        "src/facts/openbsd/memory_resolver.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(LIBFACTER_PLATFORM_SOURCES

--- a/lib/inc/internal/facts/openbsd/memory_resolver.hpp
+++ b/lib/inc/internal/facts/openbsd/memory_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the OpenBSD memory fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/memory_resolver.hpp"
+
+namespace facter { namespace facts { namespace openbsd {
+
+    /**
+     * Responsible for resolving memory facts.
+     */
+    struct memory_resolver : resolvers::memory_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::osx

--- a/lib/src/facts/openbsd/collection.cc
+++ b/lib/src/facts/openbsd/collection.cc
@@ -3,6 +3,7 @@
 #include <internal/facts/bsd/uptime_resolver.hpp>
 #include <internal/facts/glib/load_average_resolver.hpp>
 #include <internal/facts/openbsd/dmi_resolver.hpp>
+#include <internal/facts/openbsd/memory_resolver.hpp>
 #include <internal/facts/openbsd/networking_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/posix/kernel_resolver.hpp>
@@ -26,6 +27,7 @@ namespace facter { namespace facts {
         add(make_shared<glib::load_average_resolver>());
         add(make_shared<openbsd::networking_resolver>());
         add(make_shared<openbsd::dmi_resolver>());
+        add(make_shared<openbsd::memory_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/openbsd/memory_resolver.cc
+++ b/lib/src/facts/openbsd/memory_resolver.cc
@@ -1,0 +1,43 @@
+#include <internal/facts/openbsd/memory_resolver.hpp>
+#include <facter/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/mount.h>
+#include <sys/sysctl.h>
+#include <sys/swap.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace facter::execution;
+using namespace facter::util;
+
+namespace facter { namespace facts { namespace openbsd {
+
+    memory_resolver::data memory_resolver::collect_data(collection& facts)
+    {
+        data result;
+
+        // Get the system page size
+        int pagesize_mib[] = { CTL_HW, HW_PAGESIZE};
+        int page_size = 0;
+        size_t len = sizeof(page_size);
+        if (sysctl(pagesize_mib, 2, &page_size, &len, nullptr, 0) == -1) {
+            LOG_DEBUG("sysctl failed: %1% (%2%): system page size is unknown.", strerror(errno), errno);
+        } else {
+            int uvmexp_mib[] = { CTL_VM, VM_UVMEXP };
+            struct uvmexp uvmexp;
+            len = sizeof(uvmexp);
+            if (sysctl(uvmexp_mib, 2, &uvmexp, &len, nullptr, 0) == -1) {
+                LOG_DEBUG("sysctl uvmexp failed: %1% (%2%): free memory is not available.", strerror(errno), errno);
+            }
+
+            // Should we account for the buffer cache?
+            result.mem_total = static_cast<u_int64_t>(uvmexp.npages) << uvmexp.pageshift;
+            result.mem_free = static_cast<u_int64_t>(uvmexp.free) << uvmexp.pageshift;
+        }
+
+        return result;
+    }
+
+}}}  // namespace facter::facts::openbsd


### PR DESCRIPTION
Currently without `swap` facts while those are being sorted out.