### PR TITLE
(FACT-1145) Add virtualization resolver for OpenBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -191,6 +191,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
         "src/facts/openbsd/networking_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
         "src/facts/openbsd/memory_resolver.cc"
+        "src/facts/openbsd/virtualization_resolver.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(LIBFACTER_PLATFORM_SOURCES

--- a/lib/inc/internal/facts/openbsd/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/openbsd/virtualization_resolver.hpp
@@ -1,13 +1,12 @@
 /**
  * @file
- * Declares the Linux virtualization fact resolver.
+ * Declares the OpenBSD virtualization fact resolver.
  */
 #pragma once
 
 #include "../resolvers/virtualization_resolver.hpp"
-#include <string>
 
-namespace facter { namespace facts { namespace linux {
+namespace facter { namespace facts { namespace openbsd {
 
     /**
      * Responsible for resolving virtualization facts.
@@ -21,16 +20,6 @@ namespace facter { namespace facts { namespace linux {
          * @return Returns the name of the hypervisor or empty string if no hypervisor.
          */
         virtual std::string get_hypervisor(collection& facts) override;
-
-     private:
-        static std::string get_cgroup_vm();
-        static std::string get_gce_vm(collection& facts);
-        static std::string get_what_vm();
-        static std::string get_vserver_vm();
-        static std::string get_vmware_vm();
-        static std::string get_openvz_vm();
-        static std::string get_xen_vm();
-        static std::string get_lspci_vm();
     };
 
-}}}  // namespace facter::facts::linux
+}}}  // namespace facter::facts::osx

--- a/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
@@ -39,6 +39,14 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns true if the hypervisor is virtual or false if it is physical.
          */
         virtual bool is_virtual(std::string const& hypervisor);
+
+        /**
+         * Gets the product name which is matched against a list of known
+         * hypervisors.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the hypervisor product name if matched.
+         */
+        static std::string get_product_name_vm(collection& facts);
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -235,35 +235,6 @@ namespace facter { namespace facts { namespace linux {
         return {};
     }
 
-    string virtualization_resolver::get_product_name_vm(collection& facts)
-    {
-        static vector<tuple<string, string>> vms = {
-            make_tuple("VMware",            string(vm::vmware)),
-            make_tuple("VirtualBox",        string(vm::virtualbox)),
-            make_tuple("Parallels",         string(vm::parallels)),
-            make_tuple("KVM",               string(vm::kvm)),
-            make_tuple("Virtual Machine",   string(vm::hyperv)),
-            make_tuple("RHEV Hypervisor",   string(vm::redhat_ev)),
-            make_tuple("oVirt Node",        string(vm::ovirt)),
-            make_tuple("HVM domU",          string(vm::xen_hardware)),
-            make_tuple("Bochs",             string(vm::bochs)),
-        };
-
-        auto product_name = facts.get<string_value>(fact::product_name);
-        if (!product_name) {
-            return {};
-        }
-
-        auto const& value = product_name->value();
-
-        for (auto const& vm : vms) {
-            if (value.find(get<0>(vm)) != string::npos) {
-                return get<1>(vm);
-            }
-        }
-        return {};
-    }
-
     string virtualization_resolver::get_lspci_vm()
     {
         static vector<tuple<boost::regex, string>> vms = {

--- a/lib/src/facts/openbsd/collection.cc
+++ b/lib/src/facts/openbsd/collection.cc
@@ -5,6 +5,7 @@
 #include <internal/facts/openbsd/dmi_resolver.hpp>
 #include <internal/facts/openbsd/memory_resolver.hpp>
 #include <internal/facts/openbsd/networking_resolver.hpp>
+#include <internal/facts/openbsd/virtualization_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/posix/kernel_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
@@ -28,6 +29,7 @@ namespace facter { namespace facts {
         add(make_shared<openbsd::networking_resolver>());
         add(make_shared<openbsd::dmi_resolver>());
         add(make_shared<openbsd::memory_resolver>());
+        add(make_shared<openbsd::virtualization_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/openbsd/virtualization_resolver.cc
+++ b/lib/src/facts/openbsd/virtualization_resolver.cc
@@ -1,0 +1,22 @@
+#include <internal/facts/openbsd/virtualization_resolver.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/vm.hpp>
+#include <facter/execution/execution.hpp>
+#include <boost/algorithm/string.hpp>
+
+using namespace std;
+using namespace facter::facts;
+using namespace facter::execution;
+
+namespace facter { namespace facts { namespace openbsd {
+
+    string virtualization_resolver::get_hypervisor(collection& facts)
+    {
+        string value = get_product_name_vm(facts);
+
+        return value;
+    }
+
+} } }  // namespace facter::facts::openbsd

--- a/lib/src/facts/resolvers/virtualization_resolver.cc
+++ b/lib/src/facts/resolvers/virtualization_resolver.cc
@@ -45,4 +45,33 @@ namespace facter { namespace facts { namespace resolvers {
         return hypervisors.count(hypervisor) == 0;
     }
 
+    string virtualization_resolver::get_product_name_vm(collection& facts)
+    {
+        static vector<tuple<string, string>> vms = {
+            make_tuple("VMware",            string(vm::vmware)),
+            make_tuple("VirtualBox",        string(vm::virtualbox)),
+            make_tuple("Parallels",         string(vm::parallels)),
+            make_tuple("KVM",               string(vm::kvm)),
+            make_tuple("Virtual Machine",   string(vm::hyperv)),
+            make_tuple("RHEV Hypervisor",   string(vm::redhat_ev)),
+            make_tuple("oVirt Node",        string(vm::ovirt)),
+            make_tuple("HVM domU",          string(vm::xen_hardware)),
+            make_tuple("Bochs",             string(vm::bochs)),
+        };
+
+        auto product_name = facts.get<string_value>(fact::product_name);
+        if (!product_name) {
+            return {};
+        }
+
+        auto const& value = product_name->value();
+
+        for (auto const& vm : vms) {
+            if (value.find(get<0>(vm)) != string::npos) {
+                return get<1>(vm);
+            }
+        }
+        return {};
+    }
+
 }}}  // namespace facter::facts::resolvers


### PR DESCRIPTION
This is currently implemented only by looking up `fact::product_name`, it could be expanded in the future to use other tools too. Currently only tested on KVM.

Note however that `get_product_name_vm` is a verbatim copy of Linux' resolver. Should it be moved higher up in the hierarchy so it can be shared?