### PR TITLE
(FACT-1140) Fix decoding DMI data containing non-printable ASCII.

### DIFF
--- a/lib/src/facts/linux/dmi_resolver.cc
+++ b/lib/src/facts/linux/dmi_resolver.cc
@@ -45,6 +45,14 @@ namespace facter { namespace facts { namespace linux {
         }
 
         boost::trim(value);
+
+        // Replace any non-printable ASCII characters with '.'
+        // This mimics the behavior of dmidecode
+        for (auto& c : value) {
+            if (c < 32 || c == 127) {
+                c = '.';
+            }
+        }
         return value;
     }
 


### PR DESCRIPTION
On Linux, we directly read DMI from data that is provided from the kernel.
On some hardware the bytes read are not printable ASCII, resulting in
invalid UTF-8 sequences when interpreted as UTF-8.

The dmidecode utility converts any non-printable character to a '.'
character.  This fix mimics the behavior of dmidecode so that invalid DMI
data is not converted to invalid UTF-8.