### PR TITLE
(FACT-1147, FACT-1150) Fix network interfaces with multiple addresses.

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -83,6 +83,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -73,6 +73,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -64,6 +64,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -70,6 +70,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -72,6 +72,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -88,6 +88,23 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
+                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'   => '0',

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -61,6 +61,20 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  assert_not_equal("", primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.user'   => /.*\\cyg_server/,

--- a/lib/inc/internal/facts/bsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/bsd/networking_resolver.hpp
@@ -52,8 +52,7 @@ namespace facter { namespace facts { namespace bsd {
         virtual std::string find_dhcp_server(std::string const& interface) const;
 
      private:
-        void populate_address(interface& iface, ifaddrs const* addr) const;
-        void populate_network(interface& iface, ifaddrs const* addr) const;
+        void populate_binding(interface& iface, ifaddrs const* addr) const;
         void populate_mtu(interface& iface, ifaddrs const* addr) const;
     };
 

--- a/lib/inc/internal/facts/solaris/networking_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/networking_resolver.hpp
@@ -38,9 +38,8 @@ namespace facter { namespace facts { namespace solaris {
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
 
      private:
-        void populate_address(interface& iface, lifreq const* addr) const;
+        void populate_binding(interface& iface, lifreq const* addr) const;
         void populate_macaddress(interface& iface, lifreq const* addr) const;
-        void populate_network(interface& iface, lifreq const* addr) const;
         void populate_mtu(interface& iface, lifreq const* addr) const;
         std::string find_dhcp_server(std::string const& interface) const;
         std::string get_primary_interface() const;

--- a/lib/inc/internal/facts/windows/networking_resolver.hpp
+++ b/lib/inc/internal/facts/windows/networking_resolver.hpp
@@ -39,21 +39,6 @@ namespace facter { namespace facts { namespace windows {
         virtual data collect_data(collection& facts) override;
 
         /**
-         * Returns whether the address is an ignored IPv4 address.
-         * Ignored addresses are local or auto-assigned private IP.
-         * @param addr The string representation of an IPv4 address.
-         * @return Returns true if an ignored IPv4 address.
-         */
-        static bool ignored_ipv4_address(std::string const& addr);
-
-        /**
-         * Returns whether the address is an ignored IPv6 address. Ignored addresses are local or link-local.
-         * @param addr The string representation of an IPv6 address.
-         * @return Returns true if an ignored IPv6 address.
-         */
-        static bool ignored_ipv6_address(std::string const& addr);
-
-        /**
          * Creates an IPv4 sockaddr_in of the mask. If masklen is too large, returns a full mask.
          * Windows only allows contiguous subnet masks, representing them by their length.
          * @param masklen Length of the contiguous mask.

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -939,6 +939,12 @@ networking:
                     type: map
                     description: Represents a network interface.
                     elements:
+                        bindings:
+                            type: array
+                            description: The array of IPv4 address bindings for the interface.
+                        bindings6:
+                            type: array
+                            description: The array of IPv6 address bindings for the interface.
                         dhcp:
                             type: ip
                             description: The DHCP server for the network interface.
@@ -990,6 +996,9 @@ networking:
         network6:
             type: ip6
             description: The IPv6 network of the default network interface.
+        primary:
+            type: string
+            description: The name of the primary interface.
 
 operatingsystem:
     type: string
@@ -1721,20 +1730,20 @@ xen:
     resolution: |
         POSIX platforms: use `/usr/lib/xen-common/bin/xen-toolstack` to locate xen admin commands if available, otherwise fallback to `/usr/sbin/xl` or `/usr/sbin/xm`. Use the found command to execute the `list` query.
     caveats: |
-        POSIX platforms: confined to Xen privileged virtual machines
+        POSIX platforms: confined to Xen privileged virtual machines.
     elements:
         domains:
             type: array
-            description: list of strings identifying active Xen domains
+            description: list of strings identifying active Xen domains.
 
 xendomains:
     type: string
     hidden: true
-    description: Return a list of comma-separated active Xen domain names
+    description: Return a list of comma-separated active Xen domain names.
     resolution: |
-        POSIX platforms: see the `xen` structured fact
+        POSIX platforms: see the `xen` structured fact.
     caveats: |
-        POSIX platforms: confined to Xen privileged virtual machines
+        POSIX platforms: confined to Xen privileged virtual machines.
 
 zfs_featurenumbers:
     type: string

--- a/lib/src/facts/bsd/networking_resolver.cc
+++ b/lib/src/facts/bsd/networking_resolver.cc
@@ -62,7 +62,8 @@ namespace facter { namespace facts { namespace bsd {
                     }
 
                     string ip = address_to_string(addr->ifa_addr, addr->ifa_netmask);
-                    if (!boost::starts_with(ip, "127.") && ip != "::1" && !boost::starts_with(ip, "fe80")) {
+                    if ((addr->ifa_addr->sa_family == AF_INET && !ignored_ipv4_address(ip)) ||
+                        (addr->ifa_addr->sa_family == AF_INET6 && !ignored_ipv6_address(ip))) {
                         data.primary_interface = name;
                         break;
                     }
@@ -74,8 +75,7 @@ namespace facter { namespace facts { namespace bsd {
 
             // Walk the addresses of this interface and populate the data
             for (; it != interface_map.end() && it->first == name; ++it) {
-                populate_address(iface, it->second);
-                populate_network(iface, it->second);
+                populate_binding(iface, it->second);
                 populate_mtu(iface, it->second);
             }
 
@@ -92,48 +92,33 @@ namespace facter { namespace facts { namespace bsd {
         return data;
     }
 
-    void networking_resolver::populate_address(interface& iface, ifaddrs const* addr) const
+    void networking_resolver::populate_binding(interface& iface, ifaddrs const* addr) const
     {
-        string* address = nullptr;
+        // If the address is a link address, populate the MAC
+        if (is_link_address(addr->ifa_addr)) {
+            iface.macaddress = address_to_string(addr->ifa_addr);
+            return;
+        }
+
+        // Populate the correct bindings list
+        vector<binding>* bindings = nullptr;
         if (addr->ifa_addr->sa_family == AF_INET) {
-            address = &iface.address.v4;
+            bindings = &iface.ipv4_bindings;
         } else if (addr->ifa_addr->sa_family == AF_INET6) {
-            address = &iface.address.v6;
-        } else if (is_link_address(addr->ifa_addr)) {
-            address = &iface.macaddress;
+            bindings = &iface.ipv6_bindings;
         }
 
-        if (!address) {
-            // Unsupported address
+        if (!bindings) {
             return;
         }
 
-        *address = address_to_string(addr->ifa_addr);
-    }
-
-    void networking_resolver::populate_network(interface& iface, ifaddrs const* addr) const
-    {
-        // Limit these facts to IPv4 and IPv6 with a netmask address
-        if ((addr->ifa_addr->sa_family != AF_INET &&
-             addr->ifa_addr->sa_family != AF_INET6) || !addr->ifa_netmask) {
-            return;
+        binding b;
+        b.address = address_to_string(addr->ifa_addr);
+        if (addr->ifa_netmask) {
+            b.netmask = address_to_string(addr->ifa_netmask);
+            b.network = address_to_string(addr->ifa_addr, addr->ifa_netmask);
         }
-
-        if (addr->ifa_addr->sa_family == AF_INET) {
-            // Check to see if the data already exists; interfaces can have multiple addresses of the same type
-            if (!iface.netmask.v4.empty()) {
-                return;
-            }
-            iface.netmask.v4 = address_to_string(addr->ifa_netmask);
-            iface.network.v4 = address_to_string(addr->ifa_addr, addr->ifa_netmask);
-        } else {
-            // Check to see if the data already exists; interfaces can have multiple addresses of the same type
-            if (!iface.netmask.v6.empty()) {
-                return;
-            }
-            iface.netmask.v6 = address_to_string(addr->ifa_netmask);
-            iface.network.v6 = address_to_string(addr->ifa_addr, addr->ifa_netmask);
-        }
+        bindings->emplace_back(std::move(b));
     }
 
     void networking_resolver::populate_mtu(interface& iface, ifaddrs const* addr) const

--- a/lib/src/facts/resolvers/networking_resolver.cc
+++ b/lib/src/facts/resolvers/networking_resolver.cc
@@ -2,8 +2,10 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/collection.hpp>
 #include <facter/facts/map_value.hpp>
+#include <facter/facts/array_value.hpp>
 #include <facter/facts/scalar_value.hpp>
 #include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
 #include <sstream>
 
 using namespace std;
@@ -52,73 +54,21 @@ namespace facter { namespace facts { namespace resolvers {
 
         auto networking = make_value<map_value>();
 
-        if (!data.hostname.empty()) {
-            facts.add(fact::hostname, make_value<string_value>(data.hostname, true));
-            networking->add("hostname", make_value<string_value>(move(data.hostname)));
-        }
-        if (!data.domain.empty()) {
-            facts.add(fact::domain, make_value<string_value>(data.domain, true));
-            networking->add("domain", make_value<string_value>(move(data.domain)));
-        }
-        if (!data.fqdn.empty()) {
-            facts.add(fact::fqdn, make_value<string_value>(data.fqdn, true));
-            networking->add("fqdn", make_value<string_value>(move(data.fqdn)));
-        }
-
+        // Add the interface data
         ostringstream interface_names;
         auto dhcp_servers = make_value<map_value>(true);
         auto interfaces = make_value<map_value>();
         for (auto& interface : data.interfaces) {
             bool primary = interface.name == data.primary_interface;
             auto value = make_value<map_value>();
-            if (!interface.address.v4.empty()) {
-                facts.add(string(fact::ipaddress) + "_" + interface.name, make_value<string_value>(interface.address.v4, true));
-                if (primary) {
-                    facts.add(fact::ipaddress, make_value<string_value>(interface.address.v4, true));
-                    networking->add("ip", make_value<string_value>(interface.address.v4));
-                }
-                value->add("ip", make_value<string_value>(move(interface.address.v4)));
-            }
-            if (!interface.address.v6.empty()) {
-                facts.add(string(fact::ipaddress6) + "_" + interface.name, make_value<string_value>(interface.address.v6, true));
-                if (primary) {
-                    facts.add(fact::ipaddress6, make_value<string_value>(interface.address.v6, true));
-                    networking->add("ip6", make_value<string_value>(interface.address.v6));
-                }
-                value->add("ip6", make_value<string_value>(move(interface.address.v6)));
-            }
-            if (!interface.netmask.v4.empty()) {
-                facts.add(string(fact::netmask) + "_" + interface.name, make_value<string_value>(interface.netmask.v4, true));
-                if (primary) {
-                    facts.add(fact::netmask, make_value<string_value>(interface.netmask.v4, true));
-                    networking->add("netmask", make_value<string_value>(interface.netmask.v4));
-                }
-                value->add("netmask", make_value<string_value>(move(interface.netmask.v4)));
-            }
-            if (!interface.netmask.v6.empty()) {
-                facts.add(string(fact::netmask6) + "_" + interface.name, make_value<string_value>(interface.netmask.v6, true));
-                if (primary) {
-                    facts.add(fact::netmask6, make_value<string_value>(interface.netmask.v6, true));
-                    networking->add("netmask6", make_value<string_value>(interface.netmask.v6));
-                }
-                value->add("netmask6", make_value<string_value>(move(interface.netmask.v6)));
-            }
-            if (!interface.network.v4.empty()) {
-                facts.add(string(fact::network) + "_" + interface.name, make_value<string_value>(interface.network.v4, true));
-                if (primary) {
-                    facts.add(fact::network, make_value<string_value>(interface.network.v4, true));
-                    networking->add("network", make_value<string_value>(interface.network.v4));
-                }
-                value->add("network", make_value<string_value>(move(interface.network.v4)));
-            }
-            if (!interface.network.v6.empty()) {
-                facts.add(string(fact::network6) + "_" + interface.name, make_value<string_value>(interface.network.v6, true));
-                if (primary) {
-                    facts.add(fact::network6, make_value<string_value>(interface.network.v6, true));
-                    networking->add("network6", make_value<string_value>(interface.network.v6));
-                }
-                value->add("network6", make_value<string_value>(move(interface.network.v6)));
-            }
+
+            // Add the ipv4 bindings
+            add_bindings(interface, primary, true, facts, *networking, *value);
+
+            // Add the ipv6 bindings
+            add_bindings(interface, primary, false, facts, *networking, *value);
+
+            // Add the MAC address
             if (!interface.macaddress.empty()) {
                 facts.add(string(fact::macaddress) + "_" + interface.name, make_value<string_value>(interface.macaddress, true));
                 if (primary) {
@@ -127,6 +77,7 @@ namespace facter { namespace facts { namespace resolvers {
                 }
                 value->add("mac", make_value<string_value>(move(interface.macaddress)));
             }
+            // Add the DHCP server
             if (!interface.dhcp_server.empty()) {
                 if (primary) {
                     dhcp_servers->add("system", make_value<string_value>(interface.dhcp_server));
@@ -135,6 +86,7 @@ namespace facter { namespace facts { namespace resolvers {
                 dhcp_servers->add(string(interface.name), make_value<string_value>(interface.dhcp_server));
                 value->add("dhcp", make_value<string_value>(move(interface.dhcp_server)));
             }
+            // Add the interface MTU
             if (interface.mtu) {
                 facts.add(string(fact::mtu) + "_" + interface.name, make_value<integer_value>(*interface.mtu, true));
                 if (primary) {
@@ -150,6 +102,23 @@ namespace facter { namespace facts { namespace resolvers {
             interface_names << interface.name;
 
             interfaces->add(move(interface.name), move(value));
+        }
+
+        // Add top-level network data
+        if (!data.hostname.empty()) {
+            facts.add(fact::hostname, make_value<string_value>(data.hostname, true));
+            networking->add("hostname", make_value<string_value>(move(data.hostname)));
+        }
+        if (!data.domain.empty()) {
+            facts.add(fact::domain, make_value<string_value>(data.domain, true));
+            networking->add("domain", make_value<string_value>(move(data.domain)));
+        }
+        if (!data.fqdn.empty()) {
+            facts.add(fact::fqdn, make_value<string_value>(data.fqdn, true));
+            networking->add("fqdn", make_value<string_value>(move(data.fqdn)));
+        }
+        if (!data.primary_interface.empty()) {
+            networking->add("primary", make_value<string_value>(move(data.primary_interface)));
         }
 
         if (interface_names.tellp() != 0) {
@@ -190,6 +159,91 @@ namespace facter { namespace facts { namespace resolvers {
                 static_cast<int>(bytes[0]) % static_cast<int>(bytes[1]) %
                 static_cast<int>(bytes[2]) % static_cast<int>(bytes[3]) %
                 static_cast<int>(bytes[4]) % static_cast<int>(bytes[5])).str();
+    }
+
+    bool networking_resolver::ignored_ipv4_address(string const& addr)
+    {
+        // Excluding localhost and 169.254.x.x in Windows - this is the DHCP APIPA, meaning that if the node cannot
+        // get an ip address from the dhcp server, it auto-assigns a private ip address
+        return addr.empty() || addr == "127.0.0.1" || boost::starts_with(addr, "169.254.");
+    }
+
+    bool networking_resolver::ignored_ipv6_address(string const& addr)
+    {
+        return addr.empty() || addr == "::1" || boost::starts_with(addr, "fe80");
+    }
+
+    networking_resolver::binding const* networking_resolver::find_default_binding(vector<binding> const& bindings, function<bool(string const&)> const& ignored)
+    {
+        for (auto& binding : bindings) {
+            if (!ignored(binding.address)) {
+                return &binding;
+            }
+        }
+        return bindings.empty() ? nullptr : &bindings.front();
+    }
+
+    void networking_resolver::add_bindings(interface& iface, bool primary, bool ipv4, collection& facts, map_value& networking, map_value& iface_value)
+    {
+        auto ip_fact = ipv4 ? fact::ipaddress : fact::ipaddress6;
+        auto ip_name = ipv4 ? "ip" : "ip6";
+        auto netmask_fact = ipv4 ? fact::netmask : fact::netmask6;
+        auto netmask_name = ipv4 ? "netmask" : "netmask6";
+        auto network_fact = ipv4 ? fact::network : fact::network6;
+        auto network_name = ipv4 ? "network" : "network6";
+        auto& bindings = ipv4 ? iface.ipv4_bindings : iface.ipv6_bindings;
+        auto bindings_name = ipv4 ? "bindings" : "bindings6";
+        auto ignored = ipv4 ? &ignored_ipv4_address : &ignored_ipv6_address;
+
+        // Add the default binding to the collection and interface
+        auto binding = find_default_binding(bindings, ignored);
+        if (binding) {
+            if (!binding->address.empty()) {
+                facts.add(string(ip_fact) + "_" + iface.name, make_value<string_value>(binding->address, true));
+                if (primary) {
+                    facts.add(ip_fact, make_value<string_value>(binding->address, true));
+                    networking.add(ip_name, make_value<string_value>(binding->address));
+                }
+                iface_value.add(ip_name, make_value<string_value>(binding->address));
+            }
+            if (!binding->netmask.empty()) {
+                facts.add(string(netmask_fact) + "_" + iface.name, make_value<string_value>(binding->netmask, true));
+                if (primary) {
+                    facts.add(netmask_fact, make_value<string_value>(binding->netmask, true));
+                    networking.add(netmask_name, make_value<string_value>(binding->netmask));
+                }
+                iface_value.add(netmask_name, make_value<string_value>(binding->netmask));
+            }
+            if (!binding->network.empty()) {
+                facts.add(string(network_fact) + "_" + iface.name, make_value<string_value>(binding->network, true));
+                if (primary) {
+                    facts.add(network_fact, make_value<string_value>(binding->network, true));
+                    networking.add(network_name, make_value<string_value>(binding->network));
+                }
+                iface_value.add(network_name, make_value<string_value>(binding->network));
+            }
+        }
+
+        // Set the bindings in the interface
+        if (!bindings.empty()) {
+            auto bindings_value = make_value<array_value>();
+            for (auto& binding : bindings) {
+                auto binding_value = make_value<map_value>();
+                if (!binding.address.empty()) {
+                    binding_value->add("address", make_value<string_value>(move(binding.address)));
+                }
+                if (!binding.netmask.empty()) {
+                    binding_value->add("netmask", make_value<string_value>(move(binding.netmask)));
+                }
+                if (!binding.network.empty()) {
+                    binding_value->add("network", make_value<string_value>(move(binding.network)));
+                }
+                if (!binding_value->empty()) {
+                    bindings_value->add(move(binding_value));
+                }
+            }
+            iface_value.add(bindings_name, move(bindings_value));
+        }
     }
 
 }}}  // namespace facter::facts::posix

--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -64,8 +64,7 @@ namespace facter { namespace facts { namespace solaris {
 
             // Walk the addresses for this interface
             do {
-                populate_address(iface, it->second);
-                populate_network(iface, it->second);
+                populate_binding(iface, it->second);
                 ++it;
             } while (it != interface_map.end() && it->first == name);
 
@@ -77,21 +76,39 @@ namespace facter { namespace facts { namespace solaris {
         return data;
     }
 
-    void networking_resolver::populate_address(interface& iface, lifreq const* addr) const
+    void networking_resolver::populate_binding(interface& iface, lifreq const* addr) const
     {
-        string* address = nullptr;
+        // Populate the correct bindings list
+        vector<binding>* bindings = nullptr;
         if (addr->lifr_addr.ss_family == AF_INET) {
-            address = &iface.address.v4;
-        } else if (addr->lifr_addr.ss_family == AF_INET6) {
-            address = &iface.address.v6;
+            bindings = &iface.ipv4_bindings;
+        } else if (addr->lifr_addr.ss_family == AF_INET) {
+            bindings = &iface.ipv6_bindings;
         }
 
-        if (!address) {
-            // Unsupported address
+        if (!bindings) {
             return;
         }
 
-        *address = address_to_string(reinterpret_cast<sockaddr const*>(&addr->lifr_addr));
+        // Create a binding
+        binding b;
+        b.address = address_to_string(reinterpret_cast<sockaddr const*>(&addr->lifr_addr));
+
+        // Get the netmask
+        scoped_descriptor ctl(socket(addr->lifr_addr.ss_family, SOCK_DGRAM, 0));
+        if (static_cast<int>(ctl) == -1) {
+            LOG_DEBUG("socket failed: %1% (%2%): netmask and network for interface %3% are unavailable.", strerror(errno), errno, addr->lifr_name);
+        } else {
+            lifreq netmask_addr = *addr;
+            if (ioctl(ctl, SIOCGLIFNETMASK, &netmask_addr) == -1) {
+                LOG_DEBUG("ioctl with SIOCGLIFNETMASK failed: %1% (%2%): netmask and network for interface %3% are unavailable.", strerror(errno), errno, addr->lifr_name);
+            } else {
+                b.netmask = address_to_string(reinterpret_cast<sockaddr const*>(&netmask_addr.lifr_addr));
+                b.network = address_to_string(reinterpret_cast<sockaddr const*>(&addr->lifr_addr), reinterpret_cast<sockaddr const*>(&netmask_addr.lifr_addr));
+            }
+        }
+
+        bindings->emplace_back(std::move(b));
     }
 
     void networking_resolver::populate_macaddress(interface& iface, lifreq const* addr) const
@@ -111,32 +128,6 @@ namespace facter { namespace facts { namespace solaris {
         }
 
         iface.macaddress = macaddress_to_string(reinterpret_cast<uint8_t const*>(arp.arp_ha.sa_data));
-    }
-
-    void networking_resolver::populate_network(interface& iface, lifreq const* addr) const
-    {
-        scoped_descriptor ctl(socket(addr->lifr_addr.ss_family, SOCK_DGRAM, 0));
-        if (static_cast<int>(ctl) == -1) {
-            LOG_DEBUG("socket failed: %1% (%2%): netmask and network for interface %3% are unavailable.", strerror(errno), errno, addr->lifr_name);
-            return;
-        }
-
-        lifreq netmask_addr = *addr;
-        if (ioctl(ctl, SIOCGLIFNETMASK, &netmask_addr) == -1) {
-            LOG_DEBUG("ioctl with SIOCGLIFNETMASK failed: %1% (%2%): netmask and network for interface %3% are unavailable.", strerror(errno), errno, addr->lifr_name);
-            return;
-        }
-
-        string netmask = address_to_string(reinterpret_cast<sockaddr const*>(&netmask_addr.lifr_addr));
-        string network = address_to_string(reinterpret_cast<sockaddr const*>(&addr->lifr_addr), reinterpret_cast<sockaddr const*>(&netmask_addr.lifr_addr));
-
-        if (addr->lifr_addr.ss_family == AF_INET) {
-            iface.netmask.v4 = move(netmask);
-            iface.network.v4 = move(network);
-        } else if (addr->lifr_addr.ss_family == AF_INET6) {
-            iface.netmask.v6 = move(netmask);
-            iface.network.v6 = move(network);
-        }
     }
 
     void networking_resolver::populate_mtu(interface& iface, lifreq const* addr) const

--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -4,7 +4,6 @@
 #include <internal/util/windows/wsa.hpp>
 #include <internal/util/windows/windows.hpp>
 #include <leatherman/logging/logging.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/range/combine.hpp>
 #include <boost/nowide/convert.hpp>
 #include <iomanip>
@@ -21,7 +20,6 @@
 using namespace std;
 using namespace facter::util;
 using namespace facter::util::windows;
-using namespace boost::algorithm;
 
 namespace facter { namespace facts { namespace windows {
 
@@ -53,18 +51,6 @@ namespace facter { namespace facts { namespace windows {
 
         buffer.resize(size);
         return boost::nowide::narrow(buffer);
-    }
-
-    bool networking_resolver::ignored_ipv4_address(string const& addr)
-    {
-        // Excluding localhost and 169.254.x.x in Windows - this is the DHCP APIPA, meaning that if the node cannot
-        // get an ip address from the dhcp server, it auto-assigns a private ip address
-        return addr.empty() || addr == "127.0.0.1" || boost::starts_with(addr, "169.254.");
-    }
-
-    bool networking_resolver::ignored_ipv6_address(string const& addr)
-    {
-        return addr.empty() || addr == "::1" || boost::starts_with(addr, "fe80");
     }
 
     sockaddr_in networking_resolver::create_ipv4_mask(uint8_t masklen)
@@ -249,58 +235,61 @@ namespace facter { namespace facts { namespace windows {
                 }
 #endif
 
-                if (it->Address.lpSockaddr->sa_family == AF_INET) {
-                    net_interface.address.v4 = move(addr);
+                if (it->Address.lpSockaddr->sa_family == AF_INET || it->Address.lpSockaddr->sa_family == AF_INET6) {
+                    bool ipv6 = it->Address.lpSockaddr->sa_family == AF_INET6;
+
+                    binding b;
+                    b.address = addr;
 
                     if (adapterInfoMasks.empty()) {
                         // Need to do lookup based on the structure length.
                         auto adapterAddr = reinterpret_cast<IP_ADAPTER_UNICAST_ADDRESS_LH&>(*it);
-                        auto mask = create_ipv4_mask(adapterAddr.OnLinkPrefixLength);
-                        net_interface.netmask.v4 = winsock.address_to_string(mask);
-
-                        auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
-                        net_interface.network.v4 = winsock.address_to_string(masked);
+                        if (ipv6) {
+                            auto mask = create_ipv6_mask(adapterAddr.OnLinkPrefixLength);
+                            auto masked = mask_ipv6_address(it->Address.lpSockaddr, mask);
+                            b.netmask = winsock.address_to_string(mask);
+                            b.network = winsock.address_to_string(masked);
+                        } else {
+                            auto mask = create_ipv4_mask(adapterAddr.OnLinkPrefixLength);
+                            auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
+                            b.netmask = winsock.address_to_string(mask);
+                            b.network = winsock.address_to_string(masked);
+                        }
                     } else {
 #ifdef WIN_SERVER_2003_SUPPORT
-                        auto ip_mask = adapterInfoMasks.find(net_interface.address.v4);
-                        if (ip_mask != adapterInfoMasks.end()) {
-                            net_interface.netmask.v4 = ip_mask->second.first;
-
-                            auto mask = winsock.string_to_address<sockaddr_in, AF_INET>(ip_mask->second.first);
-                            auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
-                            net_interface.network.v4 = winsock.address_to_string(masked);
+                        if (ipv6) {
+                            LOG_DEBUG("netmask for %1% (IPv6) is not supported on this platform", b.address);
                         } else {
-                            LOG_DEBUG("could not find netmask for %1%", net_interface.address.v4);
+                            auto ip_mask = adapterInfoMasks.find(b.address);
+                            if (ip_mask != adapterInfoMasks.end()) {
+                                b.netmask = ip_mask->second.first;
+
+                                auto mask = winsock.string_to_address<sockaddr_in, AF_INET>(b.netmask);
+                                auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);
+                                b.network = winsock.address_to_string(masked);
+                            } else {
+                                LOG_DEBUG("could not find netmask for %1%", b.address);
+                            }
                         }
 #endif
                     }
-                } else if (it->Address.lpSockaddr->sa_family == AF_INET6) {
-                    net_interface.address.v6 = move(addr);
 
-                    // Get mask if on a system later than Windows Server 2003. On 2003, we can't retrieve IPv6 masks.
-                    if (adapterInfoMasks.empty()) {
-                        auto adapterAddr = reinterpret_cast<IP_ADAPTER_UNICAST_ADDRESS_LH&>(*it);
-                        auto mask = create_ipv6_mask(adapterAddr.OnLinkPrefixLength);
-                        net_interface.netmask.v6 = winsock.address_to_string(mask);
-
-                        auto masked = mask_ipv6_address(it->Address.lpSockaddr, mask);
-                        net_interface.network.v6 = winsock.address_to_string(masked);
+                    if (ipv6) {
+                        net_interface.ipv6_bindings.emplace_back(std::move(b));
                     } else {
-#ifdef WIN_SERVER_2003_SUPPORT
-                        LOG_DEBUG("netmask for %1% (IPv6) is not supported on this platform", net_interface.address.v6);
-#endif
+                        net_interface.ipv4_bindings.emplace_back(std::move(b));
+                    }
+
+                    // http://support.microsoft.com/kb/894564 talks about how binding order is determined.
+                    // GetAdaptersAddresses returns adapters in binding order. This way, the domain and primary_interface match.
+                    // The old facter behavior didn't make a lot of sense (it would pick the last in binding order, not 1st).
+                    // Only accept this as a primary interface if it has a non-link-local address.
+                    if (result.primary_interface.empty() && (
+                        (it->Address.lpSockaddr->sa_family == AF_INET && !ignored_ipv4_address(addr)) ||
+                        (it->Address.lpSockaddr->sa_family == AF_INET6 && !ignored_ipv6_address(addr)))) {
+                        result.primary_interface = net_interface.name;
                     }
                 }
-            }
-
-            // http://support.microsoft.com/kb/894564 talks about how binding order is determined.
-            // GetAdaptersAddresses returns adapters in binding order. This way, the domain and primary_interface match.
-            // The old facter behavior didn't make a lot of sense (it would pick the last in binding order, not 1st).
-            // Only accept this as a primary interface if it has a non-link-local address.
-            if (result.primary_interface.empty() &&
-                (!ignored_ipv4_address(net_interface.address.v4) ||
-                 !ignored_ipv6_address(net_interface.address.v6))) {
-                result.primary_interface = net_interface.name;
             }
 
             stringstream macaddr;

--- a/lib/tests/facts/resolvers/networking_resolver.cc
+++ b/lib/tests/facts/resolvers/networking_resolver.cc
@@ -3,6 +3,7 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include <facter/facts/array_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include "../../collection_fixture.hpp"
 
@@ -75,19 +76,18 @@ struct test_interface_resolver : networking_resolver
             string num = to_string(i);
 
             interface iface;
-            iface.name = "iface" + num;
-            iface.dhcp_server = "dhcp" + num;
-            iface.address.v4 = "ip" + num;
-            iface.address.v6 = "ip6" + num;
-            iface.netmask.v4 = "netmask" + num;
-            iface.netmask.v6 = "netmask6" + num;
-            iface.network.v4 = "network" + num;
-            iface.network.v6 = "network6" + num;
-            iface.macaddress = "macaddress" + num;
+            iface.name = "iface_" + num;
+            iface.dhcp_server = "dhcp_" + num;
+            for (int binding_index = 0; binding_index < 2; ++binding_index) {
+                string binding_num = to_string(binding_index);
+                iface.ipv4_bindings.emplace_back(binding { "ip_" + num + "_" + binding_num, "netmask_" + num + "_" + binding_num, "network_" + num + "_" + binding_num });
+                iface.ipv6_bindings.emplace_back(binding { "ip6_" + num + "_" + binding_num, "netmask6_" + num + "_" + binding_num, "network6_" + num + "_" + binding_num });
+            }
+            iface.macaddress = "macaddress_" + num;
             iface.mtu = i;
             result.interfaces.emplace_back(move(iface));
         }
-        result.primary_interface = "iface2";
+        result.primary_interface = "iface_2";
         return result;
     }
 };
@@ -209,99 +209,102 @@ SCENARIO("using the networking resolver") {
             REQUIRE(dhcp_servers->size() == 6u);
             for (unsigned int i = 0; i < 5; ++i) {
                 string num = to_string(i);
-                auto server = dhcp_servers->get<string_value>("iface" + num);
+                auto server = dhcp_servers->get<string_value>("iface_" + num);
                 REQUIRE(server);
-                REQUIRE(server->value() == "dhcp" + num);
+                REQUIRE(server->value() == "dhcp_" + num);
             }
             auto dhcp = dhcp_servers->get<string_value>("system");
             REQUIRE(dhcp);
-            REQUIRE(dhcp->value() == "dhcp2");
+            REQUIRE(dhcp->value() == "dhcp_2");
         }
         THEN("the interface names fact is present") {
             auto interfaces_list = facts.get<string_value>(fact::interfaces);
             REQUIRE(interfaces_list);
-            REQUIRE(interfaces_list->value() == "iface0,iface1,iface2,iface3,iface4");
+            REQUIRE(interfaces_list->value() == "iface_0,iface_1,iface_2,iface_3,iface_4");
         }
         THEN("the interface flat facts are present") {
             for (unsigned int i = 0; i < 5; ++i) {
                 string num = to_string(i);
-                auto ip = facts.get<string_value>(fact::ipaddress + string("_iface") + num);
+                auto ip = facts.get<string_value>(fact::ipaddress + string("_iface_") + num);
                 REQUIRE(ip);
-                REQUIRE(ip->value() == "ip" + num);
-                auto ip6 = facts.get<string_value>(fact::ipaddress6 + string("_iface") + num);
+                REQUIRE(ip->value() == "ip_" + num + "_0");
+                auto ip6 = facts.get<string_value>(fact::ipaddress6 + string("_iface_") + num);
                 REQUIRE(ip6);
-                REQUIRE(ip6->value() == "ip6" + num);
-                auto macaddress = facts.get<string_value>(fact::macaddress + string("_iface") + num);
+                REQUIRE(ip6->value() == "ip6_" + num + "_0");
+                auto macaddress = facts.get<string_value>(fact::macaddress + string("_iface_") + num);
                 REQUIRE(macaddress);
-                REQUIRE(macaddress->value() == "macaddress" + num);
-                auto mtu = facts.get<integer_value>(fact::mtu + string("_iface") + num);
+                REQUIRE(macaddress->value() == "macaddress_" + num);
+                auto mtu = facts.get<integer_value>(fact::mtu + string("_iface_") + num);
                 REQUIRE(mtu);
                 REQUIRE(mtu->value() == i);
-                auto netmask = facts.get<string_value>(fact::netmask + string("_iface") + num);
+                auto netmask = facts.get<string_value>(fact::netmask + string("_iface_") + num);
                 REQUIRE(netmask);
-                REQUIRE(netmask->value() == "netmask" + num);
-                auto netmask6 = facts.get<string_value>(fact::netmask6 + string("_iface") + num);
+                REQUIRE(netmask->value() == "netmask_" + num + "_0");
+                auto netmask6 = facts.get<string_value>(fact::netmask6 + string("_iface_") + num);
                 REQUIRE(netmask6);
-                REQUIRE(netmask6->value() == "netmask6" + num);
-                auto network = facts.get<string_value>(fact::network + string("_iface") + num);
+                REQUIRE(netmask6->value() == "netmask6_" + num + "_0");
+                auto network = facts.get<string_value>(fact::network + string("_iface_") + num);
                 REQUIRE(network);
-                REQUIRE(network->value() == "network" + num);
-                auto network6 = facts.get<string_value>(fact::network6 + string("_iface") + num);
+                REQUIRE(network->value() == "network_" + num + "_0");
+                auto network6 = facts.get<string_value>(fact::network6 + string("_iface_") + num);
                 REQUIRE(network6);
-                REQUIRE(network6->value() == "network6" + num);
+                REQUIRE(network6->value() == "network6_" + num + "_0");
             }
         }
         THEN("the system fact facts are present") {
             auto ip = facts.get<string_value>(fact::ipaddress);
             REQUIRE(ip);
-            REQUIRE(ip->value() == "ip2");
+            REQUIRE(ip->value() == "ip_2_0");
             auto ip6 = facts.get<string_value>(fact::ipaddress6);
             REQUIRE(ip6);
-            REQUIRE(ip6->value() == "ip62");
+            REQUIRE(ip6->value() == "ip6_2_0");
             auto macaddress = facts.get<string_value>(fact::macaddress);
             REQUIRE(macaddress);
-            REQUIRE(macaddress->value() == "macaddress2");
+            REQUIRE(macaddress->value() == "macaddress_2");
             auto netmask = facts.get<string_value>(fact::netmask);
             REQUIRE(netmask);
-            REQUIRE(netmask->value() == "netmask2");
+            REQUIRE(netmask->value() == "netmask_2_0");
             auto netmask6 = facts.get<string_value>(fact::netmask6);
             REQUIRE(netmask6);
-            REQUIRE(netmask6->value() == "netmask62");
+            REQUIRE(netmask6->value() == "netmask6_2_0");
             auto network = facts.get<string_value>(fact::network);
             REQUIRE(network);
-            REQUIRE(network->value() == "network2");
+            REQUIRE(network->value() == "network_2_0");
             auto network6 = facts.get<string_value>(fact::network6);
             REQUIRE(network6);
-            REQUIRE(network6->value() == "network62");
+            REQUIRE(network6->value() == "network6_2_0");
         }
         THEN("the networking structured fact is present") {
             auto networking = facts.get<map_value>(fact::networking);
             REQUIRE(networking);
-            REQUIRE(networking->size() == 10u);
+            REQUIRE(networking->size() == 11u);
+            auto primary = networking->get<string_value>("primary");
+            REQUIRE(primary);
+            REQUIRE(primary->value() == "iface_2");
             auto dhcp = networking->get<string_value>("dhcp");
             REQUIRE(dhcp);
-            REQUIRE(dhcp->value() == "dhcp2");
+            REQUIRE(dhcp->value() == "dhcp_2");
             auto ip = networking->get<string_value>("ip");
             REQUIRE(ip);
-            REQUIRE(ip->value() == "ip2");
+            REQUIRE(ip->value() == "ip_2_0");
             auto ip6 = networking->get<string_value>("ip6");
             REQUIRE(ip6);
-            REQUIRE(ip6->value() == "ip62");
+            REQUIRE(ip6->value() == "ip6_2_0");
             auto macaddress = networking->get<string_value>("mac");
             REQUIRE(macaddress);
-            REQUIRE(macaddress->value() == "macaddress2");
+            REQUIRE(macaddress->value() == "macaddress_2");
             auto netmask = networking->get<string_value>("netmask");
             REQUIRE(netmask);
-            REQUIRE(netmask->value() == "netmask2");
+            REQUIRE(netmask->value() == "netmask_2_0");
             auto netmask6 = networking->get<string_value>("netmask6");
             REQUIRE(netmask6);
-            REQUIRE(netmask6->value() == "netmask62");
+            REQUIRE(netmask6->value() == "netmask6_2_0");
             auto network = networking->get<string_value>("network");
             REQUIRE(network);
-            REQUIRE(network->value() == "network2");
+            REQUIRE(network->value() == "network_2_0");
             auto network6 = networking->get<string_value>("network6");
             REQUIRE(network6);
-            REQUIRE(network6->value() == "network62");
+            REQUIRE(network6->value() == "network6_2_0");
             auto mtu = networking->get<integer_value>("mtu");
             REQUIRE(mtu);
             REQUIRE(mtu->value() == 2);
@@ -309,36 +312,123 @@ SCENARIO("using the networking resolver") {
             REQUIRE(interfaces);
             for (unsigned int i = 0; i < 5; ++i) {
                 string num = to_string(i);
-                auto interface = interfaces->get<map_value>("iface" + num);
+                auto interface = interfaces->get<map_value>("iface_" + num);
                 REQUIRE(interface);
                 dhcp = interface->get<string_value>("dhcp");
                 REQUIRE(dhcp);
-                REQUIRE(dhcp->value() == "dhcp" + num);
+                REQUIRE(dhcp->value() == "dhcp_" + num);
                 ip = interface->get<string_value>("ip");
                 REQUIRE(ip);
-                REQUIRE(ip->value() == "ip" + num);
+                REQUIRE(ip->value() == "ip_" + num + "_0");
                 ip6 = interface->get<string_value>("ip6");
                 REQUIRE(ip6);
-                REQUIRE(ip6->value() == "ip6" + num);
+                REQUIRE(ip6->value() == "ip6_" + num + "_0");
                 macaddress = interface->get<string_value>("mac");
                 REQUIRE(macaddress);
-                REQUIRE(macaddress->value() == "macaddress" + num);
+                REQUIRE(macaddress->value() == "macaddress_" + num);
                 netmask = interface->get<string_value>("netmask");
                 REQUIRE(netmask);
-                REQUIRE(netmask->value() == "netmask" + num);
+                REQUIRE(netmask->value() == "netmask_" + num + "_0");
                 netmask6 = interface->get<string_value>("netmask6");
                 REQUIRE(netmask6);
-                REQUIRE(netmask6->value() == "netmask6" + num);
+                REQUIRE(netmask6->value() == "netmask6_" + num + "_0");
                 network = interface->get<string_value>("network");
                 REQUIRE(network);
-                REQUIRE(network->value() == "network" + num);
+                REQUIRE(network->value() == "network_" + num + "_0");
                 network6 = interface->get<string_value>("network6");
                 REQUIRE(network6);
-                REQUIRE(network6->value() == "network6" + num);
+                REQUIRE(network6->value() == "network6_" + num + "_0");
                 mtu = interface->get<integer_value>("mtu");
                 REQUIRE(mtu);
                 REQUIRE(mtu->value() == i);
+                auto bindings = interface->get<array_value>("bindings");
+                REQUIRE(bindings);
+                REQUIRE(bindings->size() == 2);
+                for (size_t binding_index = 0; binding_index < bindings->size(); ++binding_index) {
+                    auto interface_num = to_string(binding_index);
+                    auto binding = bindings->get<map_value>(binding_index);
+                    REQUIRE(binding);
+                    auto address = binding->get<string_value>("address");
+                    REQUIRE(address);
+                    REQUIRE(address->value() == "ip_" + num + "_" + interface_num);
+                    auto netmask = binding->get<string_value>("netmask");
+                    REQUIRE(netmask);
+                    REQUIRE(netmask->value() == "netmask_" + num + "_" + interface_num);
+                    auto network = binding->get<string_value>("network");
+                    REQUIRE(network);
+                    REQUIRE(network->value() == "network_" + num + "_" + interface_num);
+                }
+                bindings = interface->get<array_value>("bindings6");
+                REQUIRE(bindings);
+                REQUIRE(bindings->size() == 2);
+                for (size_t binding_index = 0; binding_index < bindings->size(); ++binding_index) {
+                    auto interface_num = to_string(binding_index);
+                    auto binding = bindings->get<map_value>(binding_index);
+                    REQUIRE(binding);
+                    auto address = binding->get<string_value>("address");
+                    REQUIRE(address);
+                    REQUIRE(address->value() == "ip6_" + num + "_" + interface_num);
+                    auto netmask = binding->get<string_value>("netmask");
+                    REQUIRE(netmask);
+                    REQUIRE(netmask->value() == "netmask6_" + num + "_" + interface_num);
+                    auto network = binding->get<string_value>("network");
+                    REQUIRE(network);
+                    REQUIRE(network->value() == "network6_" + num + "_" + interface_num);
+                }
             }
         }
+    }
+}
+
+SCENARIO("ignored IPv4 addresses") {
+    char const* ignored_addresses[] = {
+            "",
+            "127.0.0.1",
+            "169.254.7.14",
+            "169.254.0.0",
+            "169.254.255.255"
+    };
+    for (auto s : ignored_addresses) {
+        CAPTURE(s);
+        REQUIRE(networking_resolver::ignored_ipv4_address(s));
+    }
+    char const* accepted_addresses[] = {
+            "169.253.0.0",
+            "169.255.0.0",
+            "100.100.100.100",
+            "0.0.0.0",
+            "1.1.1.1",
+            "10.0.18.142",
+            "192.168.0.1",
+            "255.255.255.255"
+    };
+    for (auto s : accepted_addresses) {
+        CAPTURE(s);
+        REQUIRE_FALSE(networking_resolver::ignored_ipv4_address(s));
+    }
+}
+
+
+SCENARIO("ignore IPv6 adddresses") {
+    char const* ignored_addresses[] = {
+            "",
+            "::1",
+            "fe80::9c84:7ca1:794b:12ed",
+            "fe80::75f2:2f55:823b:a513%10"
+    };
+    for (auto s : ignored_addresses) {
+        CAPTURE(s);
+        REQUIRE(networking_resolver::ignored_ipv6_address(s));
+    }
+    char const* accepted_addresses[] = {
+            "::fe80:75f2:2f55:823b:a513",
+            "fe7f::75f2:2f55:823b:a513%10",
+            "::2",
+            "::fe01",
+            "::fe80"
+    };
+    for (auto s : accepted_addresses) {
+        CAPTURE(s);
+        REQUIRE_FALSE(networking_resolver::ignored_ipv6_address(s));
     }
 }

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -192,12 +192,10 @@ struct networking_resolver : resolvers::networking_resolver
         interface iface;
         iface.name = "interface1";
         iface.dhcp_server = "192.168.1.1";
-        iface.address.v4 = "127.0.0.1";
-        iface.address.v6 = "fe80::1";
-        iface.netmask.v4 = "255.0.0.0";
-        iface.netmask.v6 = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
-        iface.network.v4 = "127.0.0.0";
-        iface.network.v6 = "::1";
+        iface.ipv4_bindings.emplace_back(binding { "127.0.0.1", "255.0.0.0", "127.0.0.0"});
+        iface.ipv4_bindings.emplace_back(binding { "123.123.123.123", "255.255.255.0", "123.123.123.0"});
+        iface.ipv6_bindings.emplace_back(binding { "fe80::1", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "::1"});
+        iface.ipv6_bindings.emplace_back(binding { "fe80::2", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", "::2"});
         iface.macaddress = "00:00:00:00:00:00";
         iface.mtu = 12345;
         result.interfaces.emplace_back(move(iface));

--- a/lib/tests/facts/windows/networking_resolver.cc
+++ b/lib/tests/facts/windows/networking_resolver.cc
@@ -11,8 +11,6 @@ using namespace std;
 struct networking_utilities : facter::facts::windows::networking_resolver
 {
  public:
-    using networking_resolver::ignored_ipv4_address;
-    using networking_resolver::ignored_ipv6_address;
     using networking_resolver::create_ipv4_mask;
     using networking_resolver::create_ipv6_mask;
     using networking_resolver::mask_ipv4_address;
@@ -47,32 +45,6 @@ std::string networking_utilities::address_to_string<sockaddr_in6>(sockaddr_in6 c
 {
     auto masked = mask_ipv6_address(reinterpret_cast<sockaddr const*>(addr), *mask);
     return address_to_string(masked);
-}
-
-// IPv4 Tests
-SCENARIO("ignore IPv4 addresses") {
-    char const* ignored_addresses[] = {
-        "127.0.0.1",
-        "169.254.7.14",
-        "169.254.0.0",
-        "169.254.255.255"
-    };
-    for (auto s : ignored_addresses) {
-        REQUIRE(networking_utilities::ignored_ipv4_address(s));
-    }
-    char const* accepted_addresses[] = {
-        "169.253.0.0",
-        "169.255.0.0",
-        "100.100.100.100",
-        "0.0.0.0",
-        "1.1.1.1",
-        "10.0.18.142",
-        "192.168.0.1",
-        "255.255.255.255"
-    };
-    for (auto s : accepted_addresses) {
-        REQUIRE_FALSE(networking_utilities::ignored_ipv4_address(s));
-    }
 }
 
 static constexpr sockaddr_in make_sockaddr_in(u_char a, u_char b, u_char c, u_char d)
@@ -156,28 +128,6 @@ SCENARIO("IPv4 address with mask to string") {
     REQUIRE("200.0.154.12" == util.address_to_string(&outer, &max));
     REQUIRE("200.0.128.0" == util.address_to_string(&outer, &zoro));
     REQUIRE("128.0.0.0" == util.address_to_string(&outer, &v));
-}
-
-SCENARIO("ignore IPv6 adddresses") {
-    networking_utilities util;
-    char const* ignored_addresses[] = {
-        "::1",
-        "fe80::9c84:7ca1:794b:12ed",
-        "fe80::75f2:2f55:823b:a513%10"
-    };
-    for (auto s : ignored_addresses) {
-        REQUIRE(networking_utilities::ignored_ipv6_address(s));
-    }
-    char const* accepted_addresses[] = {
-        "::fe80:75f2:2f55:823b:a513",
-        "fe7f::75f2:2f55:823b:a513%10",
-        "::2",
-        "::fe01",
-        "::fe80"
-    };
-    for (auto s : accepted_addresses) {
-        REQUIRE_FALSE(networking_utilities::ignored_ipv6_address(s));
-    }
 }
 
 static sockaddr_in6 make_sockaddr_in6(array<u_char, 16> x)


### PR DESCRIPTION
Network interfaces with multiple assigned addresses were not being
handled properly.  Facter was considering the last address enumerated to
be the address of the interface.  This may not be correct as the order
may have a non-link-local address first and a link-local address later.
This would result in facter favoring the link-local address which is not
desired (FACT-1150).

Additionally, if the interface had only link-local addresses, the last
address was being selected rather than the first (FACT-1147).

The fix is for the resolvers to return an array of bound addresses for
each network interface. The base resolver now selects what it considers
to be the address of the interface by finding the first address that is
not link-local. If all addresses are link-local, then the first bound
address is used.

Additionally, if network interfaces have more than one bound address,
a new `bindings` (or `bindings6` for IPv6) element will appear on the
interface containing an array of structures containing the address,
network, and netmask for each binding.  This will allow users to see all
addresses on the interface.

This fix also includes returning a "primary" element in the "networking"
fact which is set to the name of the primary interface.  Users can use
this to quickly determine the interface that facter considers to be the
interface used for the top-level networking facts.