### PR TITLE
Merge stable up to master

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -266,6 +266,9 @@ int main(int argc, char **argv)
         bool show_legacy = vm.count("show-legacy");
         facts.write(boost::nowide::cout, fmt, queries, show_legacy);
         boost::nowide::cout << endl;
+    } catch (locale_error const& e) {
+        boost::nowide::cerr << "failed to initialize logging system due to a locale error: " << e.what() << "\n" << endl;
+        return 2;  // special error code to indicate we failed harder than normal
     } catch (exception& ex) {
         log(level::fatal, "unhandled exception: %1%", ex.what());
     }

--- a/lib/inc/facter/logging/logging.hpp
+++ b/lib/inc/facter/logging/logging.hpp
@@ -4,6 +4,7 @@
 */
 #pragma once
 
+#include <stdexcept>
 #include <ostream>
 #include <string>
 #include <boost/format.hpp>
@@ -163,5 +164,10 @@ namespace facter { namespace logging {
      * @param lvl The logging level to colorize for. Defaults to none, which resets colorization.
      */
     LIBFACTER_EXPORT void colorize(std::ostream &os, level lvl = level::none);
+
+    class locale_error : public std::runtime_error {
+    public:
+         explicit locale_error(const std::string& msg) : std::runtime_error(msg) {}
+    };
 
 }}  // namespace facter::logging

--- a/lib/inc/facter/logging/logging.hpp
+++ b/lib/inc/facter/logging/logging.hpp
@@ -165,8 +165,15 @@ namespace facter { namespace logging {
      */
     LIBFACTER_EXPORT void colorize(std::ostream &os, level lvl = level::none);
 
+    /**
+     * Exception to indicate that locale setup was not possible.
+     */
     class locale_error : public std::runtime_error {
     public:
+         /**
+          * Constructs a locale_error exception.
+          * @param msg The exception message.
+          */
          explicit locale_error(const std::string& msg) : std::runtime_error(msg) {}
     };
 

--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -1,13 +1,40 @@
 #include <facter/logging/logging.hpp>
+#include <leatherman/util/environment.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <leatherman/locale/locale.hpp>
 #include <boost/filesystem.hpp>
 
 using namespace std;
+using namespace leatherman::util;
 namespace lm = leatherman::logging;
 
-namespace facter { namespace logging {
+static void setup_logging_internal(ostream& os)
+{
+    // Initialize boost filesystem's locale to a UTF-8 default.
+    // Logging gets setup the same way via the default 2nd argument.
+#if !defined(__sun) || !defined(__GNUC__)
+    // Locale support in GCC on Solaris is busted, so skip it.
+    boost::filesystem::path::imbue(leatherman::locale::get_locale());
+#endif
+    lm::setup_logging(os);
+}
 
+static const char* lc_vars[] = {
+    "LC_CTYPE",
+    "LC_NUMERIC",
+    "LC_TIME",
+    "LC_COLLATE",
+    "LC_MONETARY",
+    "LC_MESSAGES",
+    "LC_PAPER",
+    "LC_ADDRESS",
+    "LC_TELEPHONE",
+    "LC_MEASUREMENT",
+    "LC_IDENTIFICATION",
+    "LC_ALL"
+};
+
+namespace facter { namespace logging {
     istream& operator>>(istream& in, level& lvl)
     {
         lm::log_level lm_level;
@@ -24,13 +51,27 @@ namespace facter { namespace logging {
 
     void setup_logging(ostream& os)
     {
-        // Initialize boost filesystem's locale to a UTF-8 default.
-        // Logging gets setup the same way via the default 2nd argument.
-#if !defined(__sun) || !defined(__GNUC__)
-        // Locale support in GCC on Solaris is busted, so skip it.
-        boost::filesystem::path::imbue(leatherman::locale::get_locale());
-#endif
-        lm::setup_logging(os);
+        try {
+            setup_logging_internal(os);
+        } catch (exception const&) {
+            for (auto var : lc_vars) {
+                environment::clear(var);
+            }
+            environment::set("LANG", "C");
+            try {
+                setup_logging_internal(os);
+            } catch (exception const& e) {
+                // If we fail again even with a clean environment, we
+                // need to signal to our consumer that things went
+                // sideways.
+                //
+                // Since logging is busted, we raise an exception that
+                // signals to the consumer that a special action must
+                // be taken to alert the user.
+                throw locale_error(e.what());
+            }
+            log(level::warning, "locale environment variables were bad; continuing with LANG=C");
+        }
     }
 
     void set_level(level lvl)


### PR DESCRIPTION
Stable and Master both contained separate changes to error handling in
the ruby module. This attempts to merge those two different error
paths.

This also includes a submodule bump for leatherman, since some of the
stable changes were on components that are part of leatherman in
master.