### PR TITLE
(FACT-1123) Test facter with invalid locale

### DIFF
--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -1,0 +1,11 @@
+test_name 'ticket 1123  facter should not crash with invalid locale setting'
+confine :except, :platform => 'windows'
+agents.each do |host|
+  step 'set an invalid value for locale and run facter'
+  result = on host, 'LANG=ABCD facter facterversion'
+  fail_test 'facter did not warn about the locale' unless
+    result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
+  fail_test 'facter did not continue running' unless
+    result.stdout =~ /^\d+\.\d+\.\d+$/
+end
+


### PR DESCRIPTION
This commit adds an acceptance test to make sure facter is not crashing
when locale is set to an invalid value.

[skip ci]