### PR TITLE
(maint) Update LIBFACTER_PLATFORM_LIBRARIES for SunOS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -176,6 +176,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         kstat
         socket
         nsl
+        rt
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_PLATFORM_SOURCES


### PR DESCRIPTION
nanosleep, sched_yield and clock_gettime are required for building
libfacter_test. These libraries live in librt on solaris, so this commit
adds rt to the LIBFACTER_PLATFORM_LIBRARIES for SunOS.