### PR TITLE
(maint) Treat zero processor counts as missing facts

### DIFF
--- a/lib/src/facts/resolvers/processor_resolver.cc
+++ b/lib/src/facts/resolvers/processor_resolver.cc
@@ -37,11 +37,15 @@ namespace facter { namespace facts { namespace resolvers {
             cpus->add("isa", make_value<string_value>(move(data.isa)));
         }
 
-        facts.add(fact::processor_count, make_value<integer_value>(data.logical_count, true));
-        cpus->add("count", make_value<integer_value>(data.logical_count));
+        if (data.logical_count > 0) {
+            facts.add(fact::processor_count, make_value<integer_value>(data.logical_count, true));
+            cpus->add("count", make_value<integer_value>(data.logical_count));
+        }
 
-        facts.add(fact::physical_processor_count, make_value<integer_value>(data.physical_count, true));
-        cpus->add("physicalcount", make_value<integer_value>(data.physical_count));
+        if (data.physical_count > 0) {
+            facts.add(fact::physical_processor_count, make_value<integer_value>(data.physical_count, true));
+            cpus->add("physicalcount", make_value<integer_value>(data.physical_count));
+        }
 
         if (data.speed > 0) {
             cpus->add("speed", make_value<string_value>(frequency(data.speed)));
@@ -58,7 +62,9 @@ namespace facter { namespace facts { namespace resolvers {
             cpus->add("models", move(models));
         }
 
-        facts.add(fact::processors, move(cpus));
+        if (!cpus->empty()) {
+            facts.add(fact::processors, move(cpus));
+        }
     }
 
 }}}  // namespace facter::facts::resolvers


### PR DESCRIPTION
Previously, the processor resolver would faithfully report a value
of 0 for the logical or physical processor counts. However, that is
counterintuitive (since clearly no system ever actually has zero
processors) and is inconsistent with handling of other zero values
both in the processor facts (e.g. a speed of zero is treated as a
missing fact) and with other facts (e.g. zero network interfaces
is treated as a missing fact).

So this simply treats a value of zero for the logical and physical
counts as a missing fact.

This is of real-world interest for platforms, like OpenBSD, which
don't have a way of reporting the physical processor count.