### PR TITLE
(maint) Use correct minitest assertion in acceptance tests.

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -85,7 +85,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -75,7 +75,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -66,7 +66,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -72,7 +72,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -74,7 +74,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -90,7 +90,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -63,7 +63,7 @@ agents.each do |agent|
 
   step "Ensure a primary networking interface was determined."
   primary_interface = fact_on(agent, 'networking.primary')
-  assert_not_equal("", primary_interface)
+  refute_empty(primary_interface)
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {


### PR DESCRIPTION
`assert_not_equal` doesn't exist in minitest.  Instead, the correct
`refute_empty` should be used to check if the values are non-empty.

[skip ci]