### PR TITLE
(maint) Fix Windows 2003 acceptance test failure.

### DIFF
--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -67,9 +67,9 @@ agents.each do |agent|
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
+                        "networking.interfaces.\"#{primary_interface}\".bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.\"#{primary_interface}\".bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.\"#{primary_interface}\".bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
                       }
   expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))


### PR DESCRIPTION
On Windows 2003, the interface name contains a space.  To query a value
with an embedded space, quotes are needed in the query.

[skip ci]