### PR TITLE
(FACT-1152) Fix Linux partitions fact to enumerate devices like 2.x. 

### DIFF
--- a/lib/inc/facter/util/directory.hpp
+++ b/lib/inc/facter/util/directory.hpp
@@ -17,19 +17,19 @@ namespace facter { namespace util {
     {
         /**
          * Enumerates the files that match the given pattern in the given directory.
-         * @param path The directory path to search for the files.
+         * @param directory The directory to search for the files.
          * @param callback The callback to invoke when a matching file is found.
          * @param pattern The pattern to filter the file names by.  If empty, all files are passed.
          */
-        static void each_file(std::string const& path, std::function<bool(std::string const&)> callback, std::string const& pattern = {});
+        static void each_file(std::string const& directory, std::function<bool(std::string const&)> const& callback, std::string const& pattern = {});
 
         /**
          * Enumerates the subdirectories in the given directory.
-         * @param path The directory path to search for the subdirectories.
+         * @param directory The directory to search for the subdirectories.
          * @param callback The callback to invoke when a matching subdirectory is found.
          * @param pattern The pattern to filter the subdirectory names by.  If empty, all subdirectories are passed.
          */
-        static void each_subdirectory(std::string const& path, std::function<bool(std::string const&)> callback, std::string const& pattern = {});
+        static void each_subdirectory(std::string const& directory, std::function<bool(std::string const&)> const& callback, std::string const& pattern = {});
     };
 
 }}  // namespace facter::util

--- a/lib/inc/internal/facts/linux/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/linux/filesystem_resolver.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../resolvers/filesystem_resolver.hpp"
+#include <map>
 
 namespace facter { namespace facts { namespace linux {
 
@@ -25,6 +26,7 @@ namespace facter { namespace facts { namespace linux {
         void collect_mountpoint_data(data& result);
         void collect_filesystem_data(data& result);
         void collect_partition_data(data& result);
+        void populate_partition_attributes(partition& part, std::string const& device_directory, void* cache, std::map<std::string, std::string> const& mountpoints);
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
@@ -126,6 +126,11 @@ namespace facter { namespace facts { namespace resolvers {
              * Stores the partition mountpoint.
              */
             std::string mount;
+
+            /**
+             * Stores the backing file for partitions backed by a file.
+             */
+            std::string backing_file;
         };
 
         /**

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1197,6 +1197,9 @@ partitions:
                 uuid:
                     type: string
                     description: The unique identifier of a partition.
+                backing_file:
+                    type: string
+                    description: The path to the file backing the partition.
 
 path:
     type: string

--- a/lib/src/facts/resolvers/filesystem_resolver.cc
+++ b/lib/src/facts/resolvers/filesystem_resolver.cc
@@ -99,6 +99,9 @@ namespace facter { namespace facts { namespace resolvers {
                 if (!partition.partition_uuid.empty()) {
                     value->add("partuuid", make_value<string_value>(move(partition.partition_uuid)));
                 }
+                if (!partition.backing_file.empty()) {
+                    value->add("backing_file", make_value<string_value>(move(partition.backing_file)));
+                }
                 value->add("size_bytes", make_value<integer_value>(partition.size));
                 value->add("size", make_value<string_value>(si_string(partition.size)));
 

--- a/lib/src/util/directory.cc
+++ b/lib/src/util/directory.cc
@@ -7,9 +7,12 @@ using namespace boost::filesystem;
 
 namespace facter { namespace util {
 
-    void directory::each_file(string const& directory, function<bool(string const&)> callback, string const& pattern)
+    static void each(std::string const& directory, file_type type, std::function<bool(std::string const&)> const& callback, string const& pattern)
     {
-        boost::regex regex(pattern);
+        boost::regex regex;
+        if (!pattern.empty()) {
+            regex = pattern;
+        }
 
         // Attempt to iterate the directory
         boost::system::error_code ec;
@@ -18,14 +21,15 @@ namespace facter { namespace util {
             return;
         }
 
-        // Call the callback for any matching files
+        // Call the callback for any matching entries
         directory_iterator end;
         for (; it != end; ++it) {
-            boost::system::error_code ec;
-            if (!is_regular_file(it->status(ec))) {
+            ec.clear();
+            auto status = it->status(ec);
+            if (ec || (status.type() != type)) {
                 continue;
             }
-            if (re_search(it->path().filename().string(), regex)) {
+            if (regex.empty() || re_search(it->path().filename().string(), regex)) {
                 if (!callback(it->path().string())) {
                     break;
                 }
@@ -33,30 +37,14 @@ namespace facter { namespace util {
         }
     }
 
-    void directory::each_subdirectory(string const& directory, function<bool(string const&)> callback, string const& pattern)
+    void directory::each_file(string const& directory, function<bool(string const&)> const& callback, string const& pattern)
     {
-        boost::regex regex(pattern);
+        each(directory, regular_file, callback, pattern);
+    }
 
-        // Attempt to iterate the directory
-        boost::system::error_code ec;
-        directory_iterator it = directory_iterator(directory, ec);
-        if (ec) {
-            return;
-        }
-
-        // Call the callback for any matching subdirectories
-        directory_iterator end;
-        for (; it != end; ++it) {
-            boost::system::error_code ec;
-            if (!is_directory(it->status(ec))) {
-                continue;
-            }
-            if (re_search(it->path().filename().string(), regex)) {
-                if (!callback(it->path().string())) {
-                    break;
-                }
-            }
-        }
+    void directory::each_subdirectory(string const& directory, function<bool(string const&)> const& callback, string const& pattern)
+    {
+        each(directory, directory_file, callback, pattern);
     }
 
 }}  // namespace facter::util

--- a/lib/tests/facts/resolvers/filesystem_resolver.cc
+++ b/lib/tests/facts/resolvers/filesystem_resolver.cc
@@ -31,7 +31,7 @@ struct test_filesystem_resolver : filesystem_resolver
         filesystems.emplace(move(filesystem));
     }
 
-    void add_partition(string name, string filesystem, uint64_t size, string uuid, string partuuid, string label, string partlabel, string mount)
+    void add_partition(string name, string filesystem, uint64_t size, string uuid, string partuuid, string label, string partlabel, string mount, string backing_file)
     {
         partition p;
         p.name = move(name);
@@ -42,6 +42,7 @@ struct test_filesystem_resolver : filesystem_resolver
         p.label = move(label);
         p.partition_label = move(partlabel);
         p.mount = move(mount);
+        p.backing_file = move(backing_file);
         partitions.emplace_back(move(p));
     }
 
@@ -149,7 +150,7 @@ SCENARIO("using the file system resolver") {
         const unsigned int count = 5;
         for (unsigned int i = 0; i < count; ++i) {
             string num = to_string(i);
-            resolver->add_partition("partition" + num, "filesystem" + num, 12345 + i, "uuid" + num, "partuuid" + num, "label" + num, "partlabel" + num, "mount" + num);
+            resolver->add_partition("partition" + num, "filesystem" + num, 12345 + i, "uuid" + num, "partuuid" + num, "label" + num, "partlabel" + num, "mount" + num, "file" + num);
         }
         THEN("a structured fact is added") {
             REQUIRE(facts.size() == 1u);
@@ -162,7 +163,7 @@ SCENARIO("using the file system resolver") {
 
                 auto partition = partitions->get<map_value>("partition" + num);
                 REQUIRE(partition);
-                REQUIRE(partition->size() == 8u);
+                REQUIRE(partition->size() == 9u);
 
                 auto filesystem = partition->get<string_value>("filesystem");
                 REQUIRE(filesystem);
@@ -195,6 +196,10 @@ SCENARIO("using the file system resolver") {
                 auto size = partition->get<string_value>("size");
                 REQUIRE(size);
                 REQUIRE(size->value() == "12.06 KiB");
+
+                auto file = partition->get<string_value>("backing_file");
+                REQUIRE(file);
+                REQUIRE(file->value() == "file" + num);
             }
         }
     }

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -121,6 +121,7 @@ struct filesystem_resolver : resolvers::filesystem_resolver
         p.label = "label";
         p.partition_label = "partlabel";
         p.mount = "mount";
+        p.backing_file = "/foo/bar";
         result.partitions.emplace_back(move(p));
         return result;
     }


### PR DESCRIPTION
Facter 2.x looked through the /sys/block structure to detect partitions
to populate the fact.  3.x changed this behavior to use libblkid to
enumerate the devices.

Using libblkid to enumerate the devices is problematic as probing
requires root access and if no cache file is present, normal users won't
the partitions populated correctly.

This changes the probing to the 2.x with additional support for
displaying mapped and loop devices.

Now libblkid is only used to query the device attributes, meaning if
libblkid support isn't enabled, the partitions will just show their size
and mount points.

This also fixes the size detection for mapped devices as the opening of
the size file was being done with the mapping name and not the
underlying block device name.  That resulted in some partitions showing
as having 0 bytes.  Now the correct name is used under /sys/block.

This also adds a "backing_file" attribute for partitions that are loop
devices.