### PR TITLE
(FACT-1137) Use dmidecode if Linux kernel does not support DMI.

### DIFF
--- a/lib/inc/internal/facts/linux/dmi_resolver.hpp
+++ b/lib/inc/internal/facts/linux/dmi_resolver.hpp
@@ -22,7 +22,15 @@ namespace facter { namespace facts { namespace linux {
          */
         virtual data collect_data(collection& facts) override;
 
-     private:
+        /**
+         * Parses the output of dmidecode.
+         * @param result The resulting data.
+         * @param line The line to parse.
+         * @param dmi_type The current DMI header type.
+         */
+        static void parse_dmidecode_output(data& result, std::string& line, int& dmi_type);
+
+    private:
         std::string read(std::string const& path);
     };
 

--- a/lib/src/facts/linux/dmi_resolver.cc
+++ b/lib/src/facts/linux/dmi_resolver.cc
@@ -1,5 +1,7 @@
 #include <internal/facts/linux/dmi_resolver.hpp>
+#include <internal/util/regex.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <facter/execution/execution.hpp>
 #include <facter/util/file.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
@@ -14,20 +16,153 @@ namespace facter { namespace facts { namespace linux {
     dmi_resolver::data dmi_resolver::collect_data(collection& facts)
     {
         data result;
-        result.bios_vendor          = read("/sys/class/dmi/id/bios_vendor");
-        result.bios_version         = read("/sys/class/dmi/id/bios_version");
-        result.bios_release_date    = read("/sys/class/dmi/id/bios_date");
-        result.board_asset_tag      = read("/sys/class/dmi/id/board_asset_tag");
-        result.board_manufacturer   = read("/sys/class/dmi/id/board_vendor");
-        result.board_product_name   = read("/sys/class/dmi/id/board_name");
-        result.board_serial_number  = read("/sys/class/dmi/id/board_serial");
-        result.chassis_asset_tag    = read("/sys/class/dmi/id/chassis_asset_tag");
-        result.manufacturer         = read("/sys/class/dmi/id/sys_vendor");
-        result.product_name         = read("/sys/class/dmi/id/product_name");
-        result.serial_number        = read("/sys/class/dmi/id/product_serial");
-        result.uuid                 = read("/sys/class/dmi/id/product_uuid");
-        result.chassis_type         = to_chassis_description(read("/sys/class/dmi/id/chassis_type"));
+
+        // Check that /sys/class/dmi exists (requires kernel 2.6.23+)
+        bs::error_code ec;
+        if (exists("/sys/class/dmi/", ec)) {
+            result.bios_vendor          = read("/sys/class/dmi/id/bios_vendor");
+            result.bios_version         = read("/sys/class/dmi/id/bios_version");
+            result.bios_release_date    = read("/sys/class/dmi/id/bios_date");
+            result.board_asset_tag      = read("/sys/class/dmi/id/board_asset_tag");
+            result.board_manufacturer   = read("/sys/class/dmi/id/board_vendor");
+            result.board_product_name   = read("/sys/class/dmi/id/board_name");
+            result.board_serial_number  = read("/sys/class/dmi/id/board_serial");
+            result.chassis_asset_tag    = read("/sys/class/dmi/id/chassis_asset_tag");
+            result.manufacturer         = read("/sys/class/dmi/id/sys_vendor");
+            result.product_name         = read("/sys/class/dmi/id/product_name");
+            result.serial_number        = read("/sys/class/dmi/id/product_serial");
+            result.uuid                 = read("/sys/class/dmi/id/product_uuid");
+            result.chassis_type         = to_chassis_description(read("/sys/class/dmi/id/chassis_type"));
+        } else {
+            LOG_DEBUG("/sys/class/dmi cannot be accessed: using dmidecode to query DMI information.");
+
+            int dmi_type = -1;
+            execution::each_line("dmidecode", [&](string& line) {
+                parse_dmidecode_output(result, line, dmi_type);
+                return true;
+            });
+        }
         return result;
+    }
+
+    void dmi_resolver::parse_dmidecode_output(data& result, string& line, int& dmi_type)
+    {
+        static const boost::regex dmi_section_pattern("^Handle 0x.{4}, DMI type (\\d{1,3})");
+
+        // Stores the relevant sections; this is in order based on DMI type ID
+        // Ensure there's a trailing semicolon on each entry and keep in sync with the switch statement below
+        static const vector<vector<string>> sections = {
+            {   // BIOS (0)
+                "vendor:",
+                "version:",
+                "release date:",
+            },
+            {   // System (1)
+                "manufacturer:",
+                "product:",
+                "product name:",
+                "serial number:",
+                "uuid:",
+            },
+            {   // Base Board (2)
+                "manufacturer:",
+                "product:",
+                "product name:",
+                "serial number:",
+                "asset tag:",
+            },
+            {   // Chassis (3)
+                "type:",
+                "chassis type:",
+                "asset tag:",
+            }
+        };
+
+        // Check for a section header
+        if (re_search(line, dmi_section_pattern, &dmi_type)) {
+            return;
+        }
+
+        // Check that we're in a relevant section
+        if (dmi_type < 0 || static_cast<size_t>(dmi_type) >= sections.size()) {
+            return;
+        }
+
+        // Trim leading whitespace
+        boost::trim_left(line);
+
+        // Find a matching header
+        auto const& headers = sections[dmi_type];
+        auto it = find_if(headers.begin(), headers.end(), [&](string const& header) {
+            return boost::istarts_with(line, header);
+        });
+        if (it == headers.end()) {
+            return;
+        }
+
+        // Get the value and trim it
+        string value = line.substr(it->size());
+        boost::trim(value);
+
+        // Calculate the index into the header vector
+        size_t index = it - headers.begin();
+
+        // Assign to the appropriate member
+        string* member = nullptr;
+        switch (dmi_type) {
+            case 0: {  // BIOS information
+                if (index == 0) {
+                    member = &result.bios_vendor;
+                } else if (index == 1) {
+                    member = &result.bios_version;
+                }  else if (index == 2) {
+                    member = &result.bios_release_date;
+                }
+                break;
+            }
+
+            case 1: {  // System information
+                if (index == 0) {
+                    member = &result.manufacturer;
+                } else if (index == 1 || index == 2) {
+                    member = &result.product_name;
+                } else if (index == 3) {
+                    member = &result.serial_number;
+                } else if (index == 4) {
+                    member = &result.uuid;
+                }
+                break;
+            }
+
+            case 2: {  // Base board information
+                if (index == 0) {
+                    member = &result.board_manufacturer;
+                } else if (index == 1 || index == 2) {
+                    member = &result.board_product_name;
+                } else if (index == 3) {
+                    member = &result.board_serial_number;
+                } else if (index == 4) {
+                    member = &result.board_asset_tag;
+                }
+                break;
+            }
+
+            case 3: {  // Chassis information
+                if (index == 0 || index == 1) {
+                    member = &result.chassis_type;
+                } else if (index == 2) {
+                    member = &result.chassis_asset_tag;
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        if (member) {
+            *member = std::move(value);
+        }
     }
 
     string dmi_resolver::read(std::string const& path)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -105,6 +105,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_TESTS_PLATFORM_SOURCES
+        "facts/linux/dmi_resolver.cc"
         "util/bsd/scoped_ifaddrs.cc"
     )
 endif()

--- a/lib/tests/facts/linux/dmi_resolver.cc
+++ b/lib/tests/facts/linux/dmi_resolver.cc
@@ -1,0 +1,116 @@
+#include <catch.hpp>
+#include <facter/util/string.hpp>
+#include <internal/facts/linux/dmi_resolver.hpp>
+#include "../../fixtures.hpp"
+
+using namespace std;
+using namespace facter::util;
+using namespace facter::testing;
+
+struct dmi_output : facter::facts::linux::dmi_resolver
+{
+    explicit dmi_output(string const& output)
+    {
+        data result;
+        int dmi_type = -1;
+
+        each_line(output, [&](string& line) {
+            parse_dmidecode_output(result, line, dmi_type);
+            return true;
+        });
+
+        bios_vendor = std::move(result.bios_vendor);
+        bios_version = std::move(result.bios_version);
+        bios_release_date = std::move(result.bios_release_date);
+        board_asset_tag = std::move(result.board_asset_tag);
+        board_manufacturer = std::move(result.board_manufacturer);
+        board_product_name = std::move(result.board_product_name);
+        board_serial_number = std::move(result.board_serial_number);
+        chassis_asset_tag = std::move(result.chassis_asset_tag);
+        manufacturer = std::move(result.manufacturer);
+        product_name = std::move(result.product_name);
+        serial_number = std::move(result.serial_number);
+        uuid = std::move(result.uuid);
+        chassis_type = std::move(result.chassis_type);
+    }
+
+    string bios_vendor;
+    string bios_version;
+    string bios_release_date;
+    string board_asset_tag;
+    string board_manufacturer;
+    string board_product_name;
+    string board_serial_number;
+    string chassis_asset_tag;
+    string manufacturer;
+    string product_name;
+    string serial_number;
+    string uuid;
+    string chassis_type;
+};
+
+SCENARIO("parsing empty dmidecode output") {
+    string contents;
+    REQUIRE(load_fixture("facts/linux/dmidecode/none.txt", contents));
+    dmi_output output(contents);
+
+    THEN("all fields should be empty") {
+        REQUIRE(output.bios_vendor.empty());
+        REQUIRE(output.bios_version.empty());
+        REQUIRE(output.bios_release_date.empty());
+        REQUIRE(output.board_asset_tag.empty());
+        REQUIRE(output.board_manufacturer.empty());
+        REQUIRE(output.board_product_name.empty());
+        REQUIRE(output.board_serial_number.empty());
+        REQUIRE(output.chassis_asset_tag.empty());
+        REQUIRE(output.manufacturer.empty());
+        REQUIRE(output.serial_number.empty());
+        REQUIRE(output.product_name.empty());
+        REQUIRE(output.uuid.empty());
+        REQUIRE(output.chassis_type.empty());
+    }
+}
+
+SCENARIO("parsing full dmidecode output") {
+    string contents;
+    REQUIRE(load_fixture("facts/linux/dmidecode/full.txt", contents));
+    dmi_output output(contents);
+
+    THEN("all fields should be populated") {
+        REQUIRE(output.bios_vendor == "innotek GmbH");
+        REQUIRE(output.bios_version == "VirtualBox");
+        REQUIRE(output.bios_release_date == "12/01/2006");
+        REQUIRE(output.board_asset_tag == "Not Specified");
+        REQUIRE(output.board_manufacturer == "Oracle Corporation");
+        REQUIRE(output.board_product_name == "VirtualBox");
+        REQUIRE(output.board_serial_number == "0");
+        REQUIRE(output.chassis_asset_tag == "Not Specified");
+        REQUIRE(output.manufacturer == "innotek GmbH");
+        REQUIRE(output.serial_number == "0");
+        REQUIRE(output.product_name == "VirtualBox");
+        REQUIRE(output.uuid == "735AE71B-8655-4AE2-9CA9-172C1BBEDAB5");
+        REQUIRE(output.chassis_type == "Other");
+    }
+}
+
+SCENARIO("parsing full dmidecode output in an alternative format") {
+    string contents;
+    REQUIRE(load_fixture("facts/linux/dmidecode/full_alternative.txt", contents));
+    dmi_output output(contents);
+
+    THEN("all fields should be populated") {
+        REQUIRE(output.bios_vendor == "innotek GmbH");
+        REQUIRE(output.bios_version == "VirtualBox");
+        REQUIRE(output.bios_release_date == "12/01/2006");
+        REQUIRE(output.board_asset_tag == "Not Specified");
+        REQUIRE(output.board_manufacturer == "Oracle Corporation");
+        REQUIRE(output.board_product_name == "VirtualBox");
+        REQUIRE(output.board_serial_number == "0");
+        REQUIRE(output.chassis_asset_tag == "Not Specified");
+        REQUIRE(output.manufacturer == "innotek GmbH");
+        REQUIRE(output.serial_number == "0");
+        REQUIRE(output.product_name == "VirtualBox");
+        REQUIRE(output.uuid == "735AE71B-8655-4AE2-9CA9-172C1BBEDAB5");
+        REQUIRE(output.chassis_type == "Other");
+    }
+}

--- a/lib/tests/fixtures/facts/linux/dmidecode/full.txt
+++ b/lib/tests/fixtures/facts/linux/dmidecode/full.txt
@@ -1,0 +1,83 @@
+# dmidecode 2.12
+SMBIOS 2.5 present.
+10 structures occupying 450 bytes.
+Table at 0x000E1000.
+
+Handle 0x0000, DMI type 0, 20 bytes
+BIOS Information
+        Vendor: innotek GmbH
+        Version: VirtualBox
+        Release Date: 12/01/2006
+        Address: 0xE0000
+        Runtime Size: 128 kB
+        ROM Size: 128 kB
+        Characteristics:
+                ISA is supported
+                PCI is supported
+                Boot from CD is supported
+                Selectable boot is supported
+                8042 keyboard services are supported (int 9h)
+                CGA/mono video services are supported (int 10h)
+                ACPI is supported
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+        Manufacturer: innotek GmbH
+        Product Name: VirtualBox
+        Version: 1.2
+        Serial Number: 0
+        UUID: 735AE71B-8655-4AE2-9CA9-172C1BBEDAB5
+        Wake-up Type: Power Switch
+        SKU Number: Not Specified
+        Family: Virtual Machine
+
+Handle 0x0008, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Oracle Corporation
+        Product Name: VirtualBox
+        Version: 1.2
+        Serial Number: 0
+        Asset Tag: Not Specified
+        Features:
+                Board is a hosting board
+        Location In Chassis: Not Specified
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 13 bytes
+Chassis Information
+        Manufacturer: Oracle Corporation
+        Type: Other
+        Lock: Not Present
+        Version: Not Specified
+        Serial Number: Not Specified
+        Asset Tag: Not Specified
+        Boot-up State: Safe
+        Asset Tag: Not Specified
+        Boot-up State: Safe
+        Power Supply State: Safe
+        Thermal State: Safe
+        Security Status: None
+
+Handle 0x0007, DMI type 126, 42 bytes
+Inactive
+
+Handle 0x0005, DMI type 126, 15 bytes
+Inactive
+
+Handle 0x0006, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x0002, DMI type 11, 7 bytes
+OEM Strings
+        String 1: vboxVer_4.3.30
+        String 2: vboxRev_101610
+
+Handle 0x0008, DMI type 128, 8 bytes
+OEM-specific Type
+        Header and Data:
+                80 08 08 00 CA 1D 23 00
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table

--- a/lib/tests/fixtures/facts/linux/dmidecode/full_alternative.txt
+++ b/lib/tests/fixtures/facts/linux/dmidecode/full_alternative.txt
@@ -1,0 +1,83 @@
+# dmidecode 2.12
+SMBIOS 2.5 present.
+10 structures occupying 450 bytes.
+Table at 0x000E1000.
+
+Handle 0x0000, DMI type 0, 20 bytes
+BIOS Information
+        Vendor: innotek GmbH
+        Version: VirtualBox
+        Release Date: 12/01/2006
+        Address: 0xE0000
+        Runtime Size: 128 kB
+        ROM Size: 128 kB
+        Characteristics:
+                ISA is supported
+                PCI is supported
+                Boot from CD is supported
+                Selectable boot is supported
+                8042 keyboard services are supported (int 9h)
+                CGA/mono video services are supported (int 10h)
+                ACPI is supported
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+        Manufacturer: innotek GmbH
+        Product: VirtualBox
+        Version: 1.2
+        Serial Number: 0
+        UUID: 735AE71B-8655-4AE2-9CA9-172C1BBEDAB5
+        Wake-up Type: Power Switch
+        SKU Number: Not Specified
+        Family: Virtual Machine
+
+Handle 0x0008, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Oracle Corporation
+        Product: VirtualBox
+        Version: 1.2
+        Serial Number: 0
+        Asset Tag: Not Specified
+        Features:
+                Board is a hosting board
+        Location In Chassis: Not Specified
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+Handle 0x0003, DMI type 3, 13 bytes
+Chassis Information
+        Manufacturer: Oracle Corporation
+        Chassis Type: Other
+        Lock: Not Present
+        Version: Not Specified
+        Serial Number: Not Specified
+        Asset Tag: Not Specified
+        Boot-up State: Safe
+        Asset Tag: Not Specified
+        Boot-up State: Safe
+        Power Supply State: Safe
+        Thermal State: Safe
+        Security Status: None
+
+Handle 0x0007, DMI type 126, 42 bytes
+Inactive
+
+Handle 0x0005, DMI type 126, 15 bytes
+Inactive
+
+Handle 0x0006, DMI type 126, 28 bytes
+Inactive
+
+Handle 0x0002, DMI type 11, 7 bytes
+OEM Strings
+        String 1: vboxVer_4.3.30
+        String 2: vboxRev_101610
+
+Handle 0x0008, DMI type 128, 8 bytes
+OEM-specific Type
+        Header and Data:
+                80 08 08 00 CA 1D 23 00
+
+Handle 0xFEFF, DMI type 127, 4 bytes
+End Of Table

--- a/lib/tests/fixtures/facts/linux/dmidecode/none.txt
+++ b/lib/tests/fixtures/facts/linux/dmidecode/none.txt
@@ -1,0 +1,2 @@
+# dmidecode 2.12
+# No SMBIOS nor DMI entry point found, sorry.


### PR DESCRIPTION
Linux kernels older than 2.6.23 do not support exposing DMI information
via sysfs.  To support those kernels, we should fallback to parsing the
output of the dmidecode utility (when root).