### PR TITLE
(FACT-1046) Use augparse instead of augtool for augeas fact

### DIFF
--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -35,18 +35,18 @@ augeas:
     type: map
     description: Return information about augeas.
     resolution: |
-        All platforms: query augtool for augeas metadata.
+        All platforms: query augparse for augeas metadata.
     elements:
         version:
             type: string
-            description: The version of augtool.
+            description: The version of augparse.
 
 augeasversion:
     type: string
     hidden: true
     description: Return the version of augeas.
     resolution: |
-        All platforms: query augtool for the augeas version.
+        All platforms: query augparse for the augeas version.
 
 blockdevices:
     type: string

--- a/lib/src/facts/resolvers/augeas_resolver.cc
+++ b/lib/src/facts/resolvers/augeas_resolver.cc
@@ -25,22 +25,22 @@ namespace facter { namespace facts { namespace resolvers {
 
     string augeas_resolver::get_version()
     {
-        string augtool = [] {
+        string augparse = [] {
 #ifdef FACTER_PATH
-            string fixed = which("augtool", {FACTER_PATH});
+            string fixed = which("augparse", {FACTER_PATH});
             if (fixed.empty()) {
-                LOG_WARNING("augtool not found at configured location %1%, using PATH instead", FACTER_PATH);
+                LOG_WARNING("augparse not found at configured location %1%, using PATH instead", FACTER_PATH);
             } else {
                 return fixed;
             }
 #endif
-            return string("augtool");
+            return string("augparse");
         }();
 
         string value;
-        boost::regex regexp("^augtool (\\d+\\.\\d+\\.\\d+)");
+        boost::regex regexp("^augparse (\\d+\\.\\d+\\.\\d+)");
         // Version info goes on stderr.
-        each_line(augtool, {"--version"}, nullptr, [&](string& line) {
+        each_line(augparse, {"--version"}, nullptr, [&](string& line) {
             if (re_search(line, regexp, &value)) {
                 return false;
             }


### PR DESCRIPTION
Some packaging may not include `augtool` but will include
`augparse`. The two are interchangable in terms of grabbing
the version, so this commit replaces calls to `augtool`
with `augparse` for wider platform compatibility.