### PR TITLE
(maint) Only install msi and dmg once

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.16"
+gem "beaker", "~> 2.19"
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -161,29 +161,12 @@ module Puppet
                     :puppet_agent_sha => ENV['SHA'],
                     :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
                 }
+                # this installs puppet-agent on windows (msi) and osx (dmg)
                 install_puppet_agent_dev_repo_on(agent, opts)
             else
                 fail_test("No repository installation step for #{platform} yet...")
             end
         end
-      end
-
-      def install_puppet_from_msi( host, opts )
-        if not link_exists?(opts[:url])
-          raise "Puppet does not exist at #{opts[:url]}!"
-        end
-
-        # `start /w` blocks until installation is complete, but needs to be wrapped in `cmd.exe /c`
-        on host, "cmd.exe /c start /w msiexec /qn /i #{opts[:url]} /L*V C:\\\\Windows\\\\Temp\\\\Puppet-Install.log"
-
-        # make sure the background service isn't running while the test executes
-        on host, "net stop puppet"
-
-        # make sure install is sane, beaker has already added puppet and ruby
-        # to PATH in ~/.ssh/environment
-        on host, puppet('--version')
-        ruby = Puppet::Acceptance::CommandUtils.ruby_command(host)
-        on host, "#{ruby} --version"
       end
     end
   end


### PR DESCRIPTION
Prior to Beaker 2.19, facter's acceptance tests installed puppet-agent
twice on Windows and OSX. On Windows, the first install did nothing, and
only when we installed the second time did it work:

    $ cmd.exe /c start /w C:/PROGRA~3/puppet-agent-x86.msi
    ...
    $ cmd.exe /c start /w msiexec /qn /i \
      http://builds.puppetlabs.lan/puppet-agent/be1f554d82b2f6a8ee335e97d102e62209155266/artifacts/windows/puppet-agent-x86.msi \
      /L*V C:\\Windows\\Temp\\Puppet-Install.log

On OSX, it installed successfully the first time and did an upgrade the
second time:

    $ installer -pkg /Volumes/puppet-agent-1.2.1.119.gbe1f554*/puppet-agent-1.2.1.119.gbe1f554*.pkg -target /
    installer: Package name is puppet-agent
    installer: Installing at base path /
    installer: The install was successful.
    ...
    $ installer -pkg /Volumes/puppet-agent-1.2.1.119.gbe1f554*/puppet-agent-1.2.1.119.gbe1f554*.pkg -target /
    installer: Package name is puppet-agent
    installer: Upgrading at base path /
    installer: The upgrade was successful.

It turns out that Beaker's `install_puppet_agent_dev_repo_on` method
installs puppet-agent on platforms that don't have a package manager, as
opposed to doing a no-op.

Beaker 2.19.0 was modified to install the MSI as a manual service by
default, and the `install_puppet_agent_dev_repo_on` method was modified
to correctly install the MSI. When the `010_Install` step installed the
MSI the second time, it preserved the service state, and tried to stop
the service, but failed because the service was already stopped.

This commit bumps our Beaker dependency to 2.19.0, which correctly
installs the puppet-agent MSI and DMG. It eliminates the second install
on Windows and OSX. It also moves the logic for verifying the puppet and
ruby versions so it is executed on all hosts, not just windows.