### PR TITLE
(FACT-1147) Fix networking resolver to ignore all IPv4 loopback addrs.

### DIFF
--- a/lib/src/facts/resolvers/networking_resolver.cc
+++ b/lib/src/facts/resolvers/networking_resolver.cc
@@ -165,7 +165,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
         // Excluding localhost and 169.254.x.x in Windows - this is the DHCP APIPA, meaning that if the node cannot
         // get an ip address from the dhcp server, it auto-assigns a private ip address
-        return addr.empty() || addr == "127.0.0.1" || boost::starts_with(addr, "169.254.");
+        return addr.empty() ||  boost::starts_with(addr, "127.") || boost::starts_with(addr, "169.254.");
     }
 
     bool networking_resolver::ignored_ipv6_address(string const& addr)

--- a/lib/tests/facts/resolvers/networking_resolver.cc
+++ b/lib/tests/facts/resolvers/networking_resolver.cc
@@ -384,6 +384,9 @@ SCENARIO("ignored IPv4 addresses") {
     char const* ignored_addresses[] = {
             "",
             "127.0.0.1",
+            "127.0.0.2",
+            "127.1.0.0",
+            "127.0.1.0",
             "169.254.7.14",
             "169.254.0.0",
             "169.254.255.255"
@@ -400,7 +403,8 @@ SCENARIO("ignored IPv4 addresses") {
             "1.1.1.1",
             "10.0.18.142",
             "192.168.0.1",
-            "255.255.255.255"
+            "255.255.255.255",
+            "128.0.0.1",
     };
     for (auto s : accepted_addresses) {
         CAPTURE(s);


### PR DESCRIPTION
Fixing the networking resolver to ignore all IPv4 loopback addresses
(127.0.0.0/8) instead of just 127.0.0.1.

Without this, multiple IPv4 loopbacks assigned to an interface result in
respecting latter ones if 127.0.0.1 comes first.  Instead, all should be
ignored and it should then consider the first to be primary.