### PR TITLE
(FACT-1158) Fix expanding commands with spaces in the path.

### DIFF
--- a/lib/inc/facter/execution/execution.hpp
+++ b/lib/inc/facter/execution/execution.hpp
@@ -51,6 +51,10 @@ namespace facter { namespace execution {
          */
         redirect_stderr_to_null = (1 << 6),
         /**
+         * Preserve (do not quote) arguments.
+         */
+        preserve_arguments = (1 << 7),
+        /**
          * A combination of all throw options.
          */
         throw_on_failure = throw_on_nonzero_exit | throw_on_signal,

--- a/lib/src/execution/windows/execution.cc
+++ b/lib/src/execution/windows/execution.cc
@@ -156,7 +156,7 @@ namespace facter { namespace execution {
     }
 
     // Source: http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
-    static string ArgvToCommandLine(vector<string> const& arguments)
+    static string ArgvToCommandLine(vector<string> const& arguments, bool preserve = false)
     {
         // Unless we're told otherwise, don't quote unless we actually need to do so - hopefully avoid problems if
         // programs won't parse quotes properly.
@@ -164,7 +164,7 @@ namespace facter { namespace execution {
         for (auto const& arg : arguments) {
             if (arg.empty()) {
                 continue;
-            } else if (arg.find_first_of(" \t\n\v\"") == arg.npos) {
+            } else if (preserve || arg.find_first_of(" \t\n\v\"") == arg.npos) {
                 commandline += arg;
             } else {
                 commandline += '"';
@@ -470,7 +470,7 @@ namespace facter { namespace execution {
 
         // Execute the command with arguments. Prefix arguments with the executable, or quoted arguments won't work.
         auto commandLine = arguments ?
-            boost::nowide::widen(ArgvToCommandLine({ executable }) + " " + ArgvToCommandLine(*arguments)) : L"";
+            boost::nowide::widen(ArgvToCommandLine({ executable }) + " " + ArgvToCommandLine(*arguments, options[execution_options::preserve_arguments])) : L"";
 
         STARTUPINFO startupInfo = {};
         startupInfo.cb = sizeof(startupInfo);

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -754,7 +754,19 @@ namespace facter { namespace ruby {
             try {
                 bool success = false;
                 string output, none;
-                tie(success, output, none) = execution::execute(execution::command_shell, {execution::command_args, expanded}, timeout);
+                tie(success, output, none) = execution::execute(
+                    execution::command_shell,
+                    {
+                        execution::command_args,
+                        expanded
+                    },
+                    timeout,
+                    {
+                        execution_options::trim_output,
+                        execution_options::merge_environment,
+                        execution_options::redirect_stderr_to_null,
+                        execution_options::preserve_arguments
+                    });
                 return ruby.utf8_value(output);
             } catch (timeout_exception const& ex) {
                 // Always raise for timeouts

--- a/lib/tests/fixtures/execution/with space/command_with_space.bat
+++ b/lib/tests/fixtures/execution/with space/command_with_space.bat
@@ -1,0 +1,2 @@
+@echo off
+echo %1

--- a/lib/tests/fixtures/ruby/command_with_space.rb
+++ b/lib/tests/fixtures/ruby/command_with_space.rb
@@ -1,0 +1,5 @@
+Facter.add('foo') do
+  setcode do
+    Facter::Util::Resolution.exec('command_with_space.bat bar')
+  end
+end


### PR DESCRIPTION
On Windows, expanding commands like "git" which are on the path under the
program files directory that contains a space, resulted in the command not
being properly quoted.  The result was a failure to execute the command
because the command shell was not properly given a quoted path.

Two fixes are needed: execution::expand_command should properly quote the
expanded command if it contains a space and Windows execution should
respect an option to "preserve" the arguments as given because the Ruby
execution functions pass the command lines themselves (user's
responsibility to quote arguments).