### PR TITLE
WIP (FACT-1164) Uninitialize Ruby before dll unload

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -264,6 +264,10 @@ int main(int argc, char **argv)
         bool show_legacy = vm.count("show-legacy");
         facts.write(boost::nowide::cout, fmt, queries, show_legacy);
         boost::nowide::cout << endl;
+
+        if (ruby) {
+            facter::ruby::uninitialize();
+        }
     } catch (locale_error const& e) {
         boost::nowide::cerr << "failed to initialize logging system due to a locale error: " << e.what() << "\n" << endl;
         return 2;  // special error code to indicate we failed harder than normal

--- a/lib/inc/facter/ruby/ruby.hpp
+++ b/lib/inc/facter/ruby/ruby.hpp
@@ -40,4 +40,12 @@ namespace facter { namespace ruby {
      */
     LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, std::vector<std::string> const& paths = {});
 
+    /**
+     * Uninitialize Ruby integration in Facter.
+     * This is unneeded if libfacter was loaded from Ruby. If libfacter instead loads Ruby's dynamic library
+     * you should call uninitialize before exiting to avoid dynamic library unload ordering issues with
+     * destructors and atexit handlers.
+     */
+    LIBFACTER_EXPORT void uninitialize();
+
 }}  // namespace facter::ruby

--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -109,6 +109,13 @@ namespace facter {  namespace ruby {
         bool initialized() const;
 
         /**
+         * Called to uninitialize the API.
+         * Called during destruction, but can also be called earlier to cleanup Ruby, avoiding potential
+         * ordering conflicts between unloading the libfacter DLL and libruby DLL.
+         */
+        void uninitialize();
+
+        /**
          * Gets whether or not exception stack traces are included when formatting exception messages.
          * @return Returns true if stack traces will be included in exception messages or false if they will not be.
          */

--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -46,4 +46,12 @@ namespace facter { namespace ruby {
     {
          load_custom_facts(facts, false, paths);
     }
+
+    void uninitialize()
+    {
+        api* ruby = api::instance();
+        if (ruby) {
+            ruby->uninitialize();
+        }
+    }
 }}  // namespace facter::ruby


### PR DESCRIPTION
When unloading libruby.dll on Windows loaded by libfacter.dll, OLE server
disconnects seem to hang. This appears to be due to some ordering issue in
how libruby.dll and libfacter.dll are unloaded.

Add a function to explicitly uninitialize Ruby from Facter that is used by
facter.exe to ensure Ruby shutdown occurs before atexit handlers trigger.