### PR TITLE
(FACT-1164) Uninitialize Ruby before dll unload

### DIFF
--- a/acceptance/tests/ticket_1164_win32ole_custom_fact.rb
+++ b/acceptance/tests/ticket_1164_win32ole_custom_fact.rb
@@ -1,0 +1,27 @@
+test_name "Custom facts should not hang Facter when using win32ole"
+
+confine :to, :platform => /windows/
+require 'timeout'
+
+content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    require 'win32ole'
+    locator = WIN32OLE.new('WbemScripting.SWbemLocator')
+    locator.ConnectServer('', "root/CIMV2", '', '', nil, nil, nil, nil)
+  end
+end
+EOM
+
+agents.each do |agent|
+  custom_dir = agent.tmpdir('arbitrary_dir')
+  custom_fact = File.join(custom_dir, 'custom_fact.rb')
+  create_remote_file(agent, custom_fact, content)
+
+  # Test is assumed to have hung if it takes longer than 5 seconds.
+  Timeout::timeout(5) do
+    on agent, facter('--custom-dir', custom_dir, 'custom_fact') do
+      assert_equal(/#<WIN32OLE:0x\d+>/, stdout.chomp, 'Custom fact output does not match expected output')
+    end
+  end
+end

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -2,6 +2,7 @@
 #include <facter/logging/logging.hpp>
 #include <facter/facts/collection.hpp>
 #include <facter/ruby/ruby.hpp>
+#include <facter/util/scope_exit.hpp>
 #include <boost/algorithm/string.hpp>
 // Note the caveats in nowide::cout/cerr; they're not synchronized with stdio.
 // Thus they can't be relied on to flush before program exit.
@@ -215,6 +216,11 @@ int main(int argc, char **argv)
 
         // Initialize Ruby in main
         bool ruby = (vm.count("no-ruby") == 0) && facter::ruby::initialize(vm.count("trace") == 1);
+        facter::util::scope_exit ruby_cleanup{[ruby]() {
+            if (ruby) {
+                facter::ruby::uninitialize();
+            }
+        }};
 
         // Build a set of queries from the command line
         set<string> queries;

--- a/lib/inc/facter/ruby/ruby.hpp
+++ b/lib/inc/facter/ruby/ruby.hpp
@@ -40,4 +40,12 @@ namespace facter { namespace ruby {
      */
     LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, std::vector<std::string> const& paths = {});
 
+    /**
+     * Uninitialize Ruby integration in Facter.
+     * This is unneeded if libfacter was loaded from Ruby. If libfacter instead loads Ruby's dynamic library
+     * you should call uninitialize before exiting to avoid dynamic library unload ordering issues with
+     * destructors and atexit handlers.
+     */
+    LIBFACTER_EXPORT void uninitialize();
+
 }}  // namespace facter::ruby

--- a/lib/inc/internal/ruby/api.hpp
+++ b/lib/inc/internal/ruby/api.hpp
@@ -109,6 +109,13 @@ namespace facter {  namespace ruby {
         bool initialized() const;
 
         /**
+         * Called to uninitialize the API.
+         * Called during destruction, but can also be called earlier to cleanup Ruby, avoiding potential
+         * ordering conflicts between unloading the libfacter DLL and libruby DLL.
+         */
+        void uninitialize();
+
+        /**
          * Gets whether or not exception stack traces are included when formatting exception messages.
          * @return Returns true if stack traces will be included in exception messages or false if they will not be.
          */

--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -46,4 +46,12 @@ namespace facter { namespace ruby {
     {
          load_custom_facts(facts, false, paths);
     }
+
+    void uninitialize()
+    {
+        api* ruby = api::instance();
+        if (ruby) {
+            ruby->uninitialize();
+        }
+    }
 }}  // namespace facter::ruby


### PR DESCRIPTION
When unloading libruby.dll on Windows loaded by libfacter.dll, OLE server
disconnects seem to hang. This appears to be due to some ordering issue in
how libruby.dll and libfacter.dll are unloaded.

Add a function to explicitly uninitialize Ruby from Facter that is used by
facter.exe to ensure Ruby shutdown occurs before atexit handlers trigger.