### PR TITLE
(MAINT) Cache output of df/mount and speed up resolution about 15-times

### DIFF
--- a/lib/facter/partitions.rb
+++ b/lib/facter/partitions.rb
@@ -36,4 +36,7 @@ Facter.add(:partitions) do
     end
     partitions
   end
+  on_flush do
+    Facter::Util::Partitions.flush! if Facter::Util::Partitions.flushable?
+  end
 end

--- a/lib/facter/util/partitions.rb
+++ b/lib/facter/util/partitions.rb
@@ -44,4 +44,16 @@ module Facter::Util::Partitions
   def self.available?
     !self.list.empty?
   end
+
+  def self.flushable?
+    implementation.flushable?
+  end
+
+  def self.flushed?
+    implementation.flushed?
+  end
+
+  def self.flush!
+    implementation.flush!
+  end
 end

--- a/lib/facter/util/partitions/linux.rb
+++ b/lib/facter/util/partitions/linux.rb
@@ -22,6 +22,10 @@ module Facter::Util::Partitions
       end
     end
 
+    def self.flushable?
+      false
+    end
+
     def self.uuid(partition)
       uuid = nil
       if File.exist?(DEVDISK_BY_UUID_DIRECTORY)

--- a/lib/facter/util/partitions/openbsd.rb
+++ b/lib/facter/util/partitions/openbsd.rb
@@ -1,7 +1,24 @@
 module Facter::Util::Partitions
   module OpenBSD
+    @df_output = nil
+    @mount_output = nil
+
     def self.list
-      Facter::Core::Execution.exec('df').scan(/\/dev\/(\S+)/).flatten
+      @df_output ||= run_df
+      @df_output.scan(/\/dev\/(\S+)/).flatten
+    end
+
+    def self.flushable?
+      true
+    end
+
+    def self.flush!
+      @df_output = nil
+      @mount_output = nil
+    end
+
+    def self.flushed?
+      !@df_output
     end
 
     # On OpenBSD partitions don't have a UUID; disks have DUID but that's not
@@ -22,19 +39,29 @@ module Facter::Util::Partitions
     def self.filesystem(partition)
       scan_mount(/\/dev\/#{partition}\son\s\S+\stype\s(\S+)/)
     end
-   
+
     # On OpenBSD there are no labels for partitions
     def self.label(partition)
       nil
     end
 
     private
+    def self.run_mount
+      Facter::Core::Execution.exec('mount')
+    end
+
+    def self.run_df
+      Facter::Core::Execution.exec('df -k')
+    end
+
     def self.scan_mount(scan_regex)
-      Facter::Core::Execution.exec('mount').scan(scan_regex).flatten.first
+      @mount_output ||= run_mount
+      @mount_output.scan(scan_regex).flatten.first
     end
 
     def self.scan_df(scan_regex)
-      Facter::Core::Execution.exec('df -k').scan(scan_regex).flatten.first
+      @df_output ||= run_df
+      @df_output.scan(scan_regex).flatten.first
     end
   end
 end


### PR DESCRIPTION
Are PRs for the ruby facter still accepted? If so, here's one that reduces the resolution time of the `partitions` facter dramatically. On my i5 it goes down from 96ms to about 6ms. There's no need to run `mount` or `df` 3 times per partition if we can just cache the full output up front.