### PR TITLE
(FACT-1167) Fix Solaris networking resolver not resolving primary interface.

### DIFF
--- a/lib/inc/internal/facts/resolvers/networking_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/networking_resolver.hpp
@@ -149,6 +149,7 @@ namespace facter { namespace facts { namespace resolvers {
      private:
         static binding const* find_default_binding(std::vector<binding> const& bindings, std::function<bool(std::string const&)> const& ignored);
         static void add_bindings(interface& iface, bool primary, bool ipv4, collection& facts, map_value& networking, map_value& iface_value);
+        interface const* find_primary_interface(std::vector<interface> const& interfaces);
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/bsd/networking_resolver.cc
+++ b/lib/src/facts/bsd/networking_resolver.cc
@@ -41,9 +41,6 @@ namespace facter { namespace facts { namespace bsd {
         }
 
         data.primary_interface = get_primary_interface();
-        if (data.primary_interface.empty()) {
-            LOG_DEBUG("no primary interface found: using first interface with an assigned address.");
-        }
 
         // Start by getting the DHCP servers
         auto dhcp_servers = find_dhcp_servers();
@@ -52,24 +49,6 @@ namespace facter { namespace facts { namespace bsd {
         decltype(interface_map.begin()) it = interface_map.begin();
         while (it != interface_map.end()) {
             string const& name = it->first;
-
-            // If we don't have a primary interface yet, walk the addresses
-            // If there's a non-loopback address assigned, treat it as primary
-            if (data.primary_interface.empty()) {
-                for (auto addr_it = it; addr_it != interface_map.end() && addr_it->first == name; ++addr_it) {
-                    ifaddrs const *addr = addr_it->second;
-                    if (addr->ifa_addr->sa_family != AF_INET && addr->ifa_addr->sa_family != AF_INET6) {
-                        continue;
-                    }
-
-                    string ip = address_to_string(addr->ifa_addr, addr->ifa_netmask);
-                    if ((addr->ifa_addr->sa_family == AF_INET && !ignored_ipv4_address(ip)) ||
-                        (addr->ifa_addr->sa_family == AF_INET6 && !ignored_ipv6_address(ip))) {
-                        data.primary_interface = name;
-                        break;
-                    }
-                }
-            }
 
             interface iface;
             iface.name = name;

--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -46,9 +46,6 @@ namespace facter { namespace facts { namespace solaris {
         }
 
         data.primary_interface = get_primary_interface();
-        if (data.primary_interface.empty()) {
-            LOG_DEBUG("no primary interface found.");
-        }
 
         // Walk the interfaces
         decltype(interface_map.begin()) it = interface_map.begin();


### PR DESCRIPTION
The Solaris networking resolver was missing the fallback logic to assign the
primary interface to the first interface that contains a valid address.

This logic existed in the BSD resolver, but it makes more sense to move it into
the base resolver itself so that the fallback logic is shared between all
platforms.