### PR TITLE
(FACT-1164) Fix acceptance test

### DIFF
--- a/acceptance/tests/ticket_1164_win32ole_custom_fact.rb
+++ b/acceptance/tests/ticket_1164_win32ole_custom_fact.rb
@@ -8,7 +8,7 @@ Facter.add('custom_fact') do
   setcode do
     require 'win32ole'
     locator = WIN32OLE.new('WbemScripting.SWbemLocator')
-    locator.ConnectServer('', "root/CIMV2", '', '', nil, nil, nil, nil)
+    locator.ConnectServer('', "root/CIMV2", '', '', nil, nil, nil, nil).to_s
   end
 end
 EOM


### PR DESCRIPTION
The custom fact in the acceptance test for FACT-1164 returns an object
that doesn't automatically convert to a string. Explicitly return a
string representation in the custom fact.