### PR TITLE
(FACT-1010) Fix innacurate uptime on Solaris zones

### DIFF
--- a/lib/inc/internal/facts/bsd/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/bsd/uptime_resolver.hpp
@@ -16,9 +16,10 @@ namespace facter { namespace facts { namespace bsd {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() override;
+        virtual int64_t get_uptime(collection& facts) override;
     };
 
 }}}  // namespace facter::facts::bsd

--- a/lib/inc/internal/facts/linux/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/linux/uptime_resolver.hpp
@@ -16,9 +16,10 @@ namespace facter { namespace facts { namespace linux {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() override;
+        virtual int64_t get_uptime(collection& facts) override;
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/inc/internal/facts/posix/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/posix/uptime_resolver.hpp
@@ -24,9 +24,10 @@ namespace facter { namespace facts { namespace posix {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() override;
+        virtual int64_t get_uptime(collection& facts) override;
     };
 
 }}}  // namespace facter::facts::posix

--- a/lib/inc/internal/facts/resolvers/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/uptime_resolver.hpp
@@ -28,9 +28,10 @@ namespace facter { namespace facts { namespace resolvers {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection. On Solaris we depend on the current zone.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() = 0;
+        virtual int64_t get_uptime(collection& facts) = 0;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/solaris/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/uptime_resolver.hpp
@@ -16,9 +16,10 @@ namespace facter { namespace facts { namespace solaris {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() override;
+        virtual int64_t get_uptime(collection& facts) override;
     };
 
 }}}  // namespace facter::facts::solaris

--- a/lib/inc/internal/facts/windows/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/windows/uptime_resolver.hpp
@@ -25,9 +25,10 @@ namespace facter { namespace facts { namespace windows {
      protected:
         /**
          * Gets the system uptime in seconds.
+         * @param facts The fact collection.
          * @return Returns the system uptime in seconds.
          */
-        virtual int64_t get_uptime() override;
+        virtual int64_t get_uptime(collection& facts) override;
 
      private:
         std::shared_ptr<leatherman::windows::wmi> _wmi;

--- a/lib/src/facts/bsd/uptime_resolver.cc
+++ b/lib/src/facts/bsd/uptime_resolver.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 namespace facter { namespace facts { namespace bsd {
 
-    int64_t uptime_resolver::get_uptime()
+    int64_t uptime_resolver::get_uptime(collection& facts)
     {
         // this approach adapted from: http://stackoverflow.com/a/11676260/1004272
         timeval boottime;
@@ -17,7 +17,7 @@ namespace facter { namespace facts { namespace bsd {
             time_t now = time(NULL);
             return now - bsec;
         }
-        return posix::uptime_resolver::get_uptime();
+        return posix::uptime_resolver::get_uptime(facts);
     }
 
 }}}  // namespace facter::facts::bsd

--- a/lib/src/facts/linux/uptime_resolver.cc
+++ b/lib/src/facts/linux/uptime_resolver.cc
@@ -3,13 +3,13 @@
 
 namespace facter { namespace facts { namespace linux {
 
-    int64_t uptime_resolver::get_uptime()
+    int64_t uptime_resolver::get_uptime(collection& facts)
     {
         struct sysinfo info;
         if (sysinfo(&info) == 0) {
             return info.uptime;
         }
-        return posix::uptime_resolver::get_uptime();
+        return posix::uptime_resolver::get_uptime(facts);
     }
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/posix/uptime_resolver.cc
+++ b/lib/src/facts/posix/uptime_resolver.cc
@@ -41,7 +41,7 @@ namespace facter { namespace facts { namespace posix {
         return -1;
     }
 
-    int64_t uptime_resolver::get_uptime()
+    int64_t uptime_resolver::get_uptime(collection& facts)
     {
         bool success;
         string output, none;

--- a/lib/src/facts/resolvers/uptime_resolver.cc
+++ b/lib/src/facts/resolvers/uptime_resolver.cc
@@ -24,7 +24,7 @@ namespace facter { namespace facts { namespace resolvers {
 
     void uptime_resolver::resolve(collection& facts)
     {
-        auto seconds = get_uptime();
+        auto seconds = get_uptime(facts);
         if (seconds < 0) {
             return;
         }

--- a/lib/src/facts/solaris/uptime_resolver.cc
+++ b/lib/src/facts/solaris/uptime_resolver.cc
@@ -1,3 +1,6 @@
+#include <facter/facts/collection.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/fact.hpp>
 #include <internal/facts/solaris/uptime_resolver.hpp>
 #include <internal/util/solaris/k_stat.hpp>
 #include <sys/sysinfo.h>
@@ -10,21 +13,28 @@ using namespace facter::util::solaris;
 
 namespace facter { namespace facts { namespace solaris {
 
-    int64_t uptime_resolver::get_uptime()
+    int64_t uptime_resolver::get_uptime(collection& facts)
     {
-        try {
-            k_stat ks;
-            auto kv = ks[make_pair("unix", "system_misc")];
-            auto time_at_boot_in_sec = kv[0].value<unsigned long>("boot_time");
+        // If the current zone is 'global', we can use kstat. If not, kstat will return the uptime of the machine, not
+        // the uptime of the current zone. Facter's historical behavior has been to return uptime matching 'uptime',
+        // which means the uptime of the current zone. So if not 'global', use POSIX behavior i.e. call 'uptime'.
+        auto current_zone = facts.get<string_value>(fact::zonename);
+        if (current_zone && current_zone->value() == "global") {
+            try {
+                k_stat ks;
+                auto kv = ks[make_pair("unix", "system_misc")];
+                auto time_at_boot_in_sec = kv[0].value<unsigned long>("boot_time");
 
-            system_clock::time_point atboot{seconds(time_at_boot_in_sec)};
-            system_clock::time_point now{system_clock::now()};
-            seconds uptime{duration_cast<seconds>(now - atboot)};
-            return uptime.count();
-        } catch (kstat_exception&)
-        {
-            return posix::uptime_resolver::get_uptime();
+                system_clock::time_point atboot{seconds(time_at_boot_in_sec)};
+                system_clock::time_point now{system_clock::now()};
+                seconds uptime{duration_cast<seconds>(now - atboot)};
+                return uptime.count();
+            } catch (kstat_exception&) {
+                // Ignore kstat exceptions and defer to POSIX uptime.
+            }
         }
+
+        return posix::uptime_resolver::get_uptime(facts);
     }
 
 }}}  // namespace facter::facts::solaris

--- a/lib/src/facts/windows/uptime_resolver.cc
+++ b/lib/src/facts/windows/uptime_resolver.cc
@@ -31,7 +31,7 @@ namespace facter { namespace facts { namespace windows {
         return ptime(from_undelimited_string(iso_date), time_duration(hour, min, sec));
     }
 
-    int64_t uptime_resolver::get_uptime()
+    int64_t uptime_resolver::get_uptime(collection& facts)
     {
         auto vals = _wmi->query(wmi::operatingsystem, {wmi::lastbootuptime, wmi::localdatetime});
         if (vals.empty()) {

--- a/lib/tests/facts/resolvers/uptime_resolver.cc
+++ b/lib/tests/facts/resolvers/uptime_resolver.cc
@@ -14,7 +14,7 @@ using namespace facter::testing;
 struct test_less_than_day_resolver : uptime_resolver
 {
  protected:
-    virtual int64_t get_uptime() override
+    virtual int64_t get_uptime(collection& facts) override
     {
         // 13 hours, 35 minutes, 6 seconds
         return (13 * 60 * 60) + (35 * 60) + 6;
@@ -24,7 +24,7 @@ struct test_less_than_day_resolver : uptime_resolver
 struct test_one_day_resolver : uptime_resolver
 {
  protected:
-    virtual int64_t get_uptime() override
+    virtual int64_t get_uptime(collection& facts) override
     {
         // 1 day, 2 hours, 12 minutes, 22 seconds
         return (1 * 24 * 60 * 60) + (2 * 60 * 60) + (12 * 60) + 22;
@@ -34,7 +34,7 @@ struct test_one_day_resolver : uptime_resolver
 struct test_more_than_day_resolver : uptime_resolver
 {
  protected:
-    virtual int64_t get_uptime() override
+    virtual int64_t get_uptime(collection& facts) override
     {
         // 3 day, 4 hours, 19 minutes, 45 seconds
         return (3 * 24 * 60 * 60) + (4 * 60 * 60) + (19 * 60) + 45;

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -335,7 +335,7 @@ protected:
 struct uptime_resolver : resolvers::uptime_resolver
 {
 protected:
-    virtual int64_t get_uptime() override
+    virtual int64_t get_uptime(collection& facts) override
     {
         return 1;
     }


### PR DESCRIPTION
On Solaris zones - besides the default `global` zone - uptime in Facter
3 was inaccurate compared to Facter 2. This seems to reflect a bug in
Solaris related to querying kstat for uptime.

If not in the `global` zone on Solaris, call `uptime` to get the uptime
rather than using `kstat`.