### PR TITLE
(maint) Include a versioned blkid so in the LIBARIES list

### DIFF
--- a/cmake/FindBLKID.cmake
+++ b/cmake/FindBLKID.cmake
@@ -1,5 +1,5 @@
 include(FindDependency)
-find_dependency(BLKID DISPLAY "blkid" HEADERS "blkid/blkid.h" LIBRARIES "blkid")
+find_dependency(BLKID DISPLAY "blkid" HEADERS "blkid/blkid.h" LIBRARIES "libblkid.so.1" "blkid")
 
 include(FeatureSummary)
 set_package_properties(BLKID PROPERTIES DESCRIPTION "The library for the Linux blkid utility" URL "http://en.wikipedia.org/wiki/Util-linux")


### PR DESCRIPTION
On el4, libblkid does not include a non-versioned so, and so cmake
prefers the .a file, which causes it to not dynamically link against
libuuid. This commit adds libblkid.so.1 to the library search list, so
that on el4 the versioned so can be found.