### PR TITLE
(FACT-1175) Get Solaris 10 acceptance tests passing

### DIFF
--- a/acceptance/.gitignore
+++ b/acceptance/.gitignore
@@ -8,3 +8,4 @@ id_rsa-acceptance.pub
 preserved_config.yaml
 merged_options.rb
 junit
+tmp

--- a/acceptance/config/nodes/pe/solaris-10-64a
+++ b/acceptance/config/nodes/pe/solaris-10-64a
@@ -1,0 +1,12 @@
+HOSTS:
+  agent:
+    roles:
+      - agent
+    platform: solaris-10-x86_64
+    hypervisor: vcloud
+    template: solaris-10-x86_64
+CONFIG:
+  datastore: instance0
+  resourcepool: delivery/Quality Assurance/FOSS/Dynamic
+  folder: Delivery/Quality Assurance/FOSS/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -14,6 +14,8 @@ when /windows/
   ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
 when /osx/
   ruby_platform = /x86_64-darwin[\d.]+/
+when /solaris/
+  ruby_platform = /i386-solaris[\d.]+/
 else
   if agent['ruby_arch']
     ruby_platform = agent['ruby_arch'] == 'x64' ? 'x86_64-linux' : /i(4|6)86-linux/

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -1,0 +1,94 @@
+test_name "Facts should resolve as expected in Solaris 10"
+
+#
+# This test is intended to ensure that facts specific to an OS configuration
+# resolve as expected in Solaris 10.
+#
+# Facts tested: os, processors, networking, identity, kernel
+#
+
+confine :to, :platform => /solaris-10/
+
+agents.each do |agent|
+  os_version = '10'
+  os_kernel = /Generic_\d+-\d+/
+
+  step "Ensure the OS fact resolves as expected"
+  expected_os = {
+                  'os.architecture'         => 'i86pc',
+                  'os.family'               => 'Solaris',
+                  'os.hardware'             => 'i86pc',
+                  'os.name'                 => 'Solaris',
+                  'os.release.full'         => /#{os_version}_u\d+/,
+                  'os.release.major'        => os_version,
+                  'os.release.minor'        => /\d+/,
+                }
+
+  expected_os.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Processors fact resolves with reasonable values"
+  expected_processors = {
+                          'processors.count'         => /[1-9]/,
+                          'processors.physicalcount' => /[1-9]/,
+                          'processors.isa'           => /i386/,
+                          'processors.models'        => /"Intel\(r\).*"/
+                        }
+
+  expected_processors.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+
+  expected_networking = {
+                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.mac"      => /[a-f0-9]{2}:/,
+                          "networking.mtu"      => /\d+/,
+                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+                        }
+
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  refute_empty(primary_interface)
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings = {
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
+                      }
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the identity fact resolves as expected"
+  expected_identity = {
+                        'identity.gid'   => '0',
+                        'identity.group' => 'root',
+                        'identity.uid'   => '0',
+                        'identity.user'  => 'root'
+                      }
+
+  expected_identity.each do |fact, value|
+    assert_equal(value, fact_on(agent, fact))
+  end
+
+  step "Ensure the kernel fact resolves as expected"
+  expected_kernel = {
+                      'kernel'           => 'SunOS',
+                      'kernelrelease'    => '5.10',
+                      'kernelversion'    => os_kernel,
+                      'kernelmajversion' => os_kernel
+                    }
+
+  expected_kernel.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+end

--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -3,8 +3,10 @@ confine :except, :platform => 'windows'
 agents.each do |host|
   step 'set an invalid value for locale and run facter'
   result = on host, 'LANG=ABCD facter facterversion'
-  fail_test 'facter did not warn about the locale' unless
-    result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
+  if host['platform'] !~ /solaris/
+    fail_test 'facter did not warn about the locale' unless
+      result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
+  end
   fail_test 'facter did not continue running' unless
     result.stdout =~ /^\d+\.\d+\.\d+$/
 end

--- a/acceptance/tests/verify_facts.rb
+++ b/acceptance/tests/verify_facts.rb
@@ -32,7 +32,8 @@ def validate_fact(name, node, fact_value, hidden)
               # YAML.load will automatically convert timestamp values to a Fixnum
               # so relax validation for uptime related facts
               #   YAML.load('foo: 1:23') => {"foo"=>4980}
-              fact_value.is_a? String or (fact_value.is_a? Fixnum and name =~ /.*uptime/)
+              # It also converts zfs_featurenumbers to a number, even though it's a comma-separated list.
+              fact_value.is_a? String or ((fact_value.is_a? Fixnum or fact_value.is_a? Bignum) and (name =~ /.*uptime/ or name =~ /.+_featurenumbers/))
             when 'ip'
               fact_value.is_a? String and fact_value =~ @ip_pattern
             when 'ip6'


### PR DESCRIPTION
Can be tested with `rake ci:test:aio SHA=bd98fdd74b51eba26a76dcb2fd2d3afc0fc3596c CONFIG=config/nodes/pe/solaris-10-64a SUITE_VERSION=1.2.3.230.gbd98fdd`, using Beaker from `MikaelSmith:feat/master/BKR-470`.