### PR TITLE
(FACT-909) Add Solaris 10 fallback if kstat_read fails

### DIFF
--- a/lib/src/util/solaris/k_stat.cc
+++ b/lib/src/util/solaris/k_stat.cc
@@ -30,13 +30,14 @@ namespace facter { namespace util { namespace solaris {
     {
         kstat_t* kp = kstat_lookup(ctrl, const_cast<char*>(module.c_str()), instance, name.empty() ? nullptr : const_cast<char *>(name.c_str()));
         if (kp == nullptr) {
-            throw kstat_exception("kstat_lookup failed m:" + module + " i:" + to_string(instance) + " n:" + name + " err:" + strerror(errno));
+            throw kstat_exception("kstat_lookup of module " + module + "/" + to_string(instance) + "/" + name
+                    + " failed:" + string(strerror(errno)) + " (" + to_string(errno) + ")");
         }
 
         vector<k_stat_entry> arr;
         while (kp) {
             if (kstat_read(ctrl, kp, 0) == -1) {
-                throw kstat_exception("kstat_read failed");
+                throw kstat_exception("kstat_read failed: " + string(strerror(errno)) + " (" + to_string(errno) + ")");
             }
 
             bool insert = true;


### PR DESCRIPTION
`kstat_read` fails in some Solaris 10 SPARC environments with an EACCES
error. Add a fallback to invoke `kstat` for processor facts if the read
failed.