### PR TITLE
(FACT-918) Fix virtualization facts on SPARC

### DIFF
--- a/lib/src/facts/solaris/virtualization_resolver.cc
+++ b/lib/src/facts/solaris/virtualization_resolver.cc
@@ -26,14 +26,14 @@ namespace facter { namespace facts { namespace solaris {
             return vm::zone;
         }
 
-        auto arch = facts.get<string_value>(fact::architecture);
-        if (!arch) {
+        auto isa = facts.get<string_value>(fact::hardware_isa);
+        if (!isa) {
             return {};
         }
 
         string guest_of;
 
-        if (arch->value() == "i86pc") {
+        if (isa->value() == "i386") {
             static map<boost::regex, string> virtual_map = {
                 {boost::regex("VMware"),     string(vm::vmware)},
                 {boost::regex("VirtualBox"), string(vm::virtualbox)},
@@ -62,7 +62,7 @@ namespace facter { namespace facts { namespace solaris {
             } catch (timeout_exception const&) {
                 LOG_WARNING("execution of prtdiag has timed out after %1% seconds.", timeout);
             }
-        } else if (arch->value() == "sparc") {
+        } else if (isa->value() == "sparc") {
             // Uses hints from
             // http://serverfault.com/questions/153179/how-to-find-out-if-a-solaris-machine-is-virtualized-or-not
             // interface stability is uncommited. Should we use it?


### PR DESCRIPTION
Virtualization facts checked architecture, which can be i86pc or sunv4,
but was expecting sparc rather than sunv4. Use hardware_isa, which will
be i386 or sparc and less likely to change than architecture.