### PR TITLE
(FACT-911, FACT-915) Fix dmi facts on sparc

### DIFF
--- a/lib/src/facts/solaris/dmi_resolver.cc
+++ b/lib/src/facts/solaris/dmi_resolver.cc
@@ -74,11 +74,17 @@ namespace facter { namespace facts { namespace solaris {
                 }
                 return true;
             });
+
             bool success;
             string output, none;
             tie(success, output, none) = execute("/usr/sbin/uname", {"-a"});
             if (success) {
                 re_search(output, boost::regex(".* sun\\d[vu] sparc SUNW,(.*)"), &result.product_name);
+            }
+
+            tie(success, output, none) = execute("/usr/sbin/sneep");
+            if (success) {
+                result.serial_number = output;
             }
         }
         return result;


### PR DESCRIPTION
Fixes implementation of the manufacturer and productname facts, and adds the serialnumber fact.