### PR TITLE
(FACT-1172) Convert libblkid data the same way blkid does.

### DIFF
--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -183,6 +183,35 @@ namespace facter { namespace facts { namespace linux {
 #endif  // USE_BLKID
     }
 
+#ifdef USE_BLKID
+    // This exists as a reimplementation of blkid's "safe_print" function which exists internally to
+    // print values that contain non-ASCII characters.  It will convert non-printable
+    // ASCII characters using the '^' and M- notation.
+    static string safe_convert(char const* value)
+    {
+        string result;
+
+        if (value) {
+            while (*value) {
+                unsigned char c = static_cast<unsigned char>(*value);
+                if (c >= 128) {
+                    result += "M-";
+                    c -= 128;
+                }
+                if (c < 32 || c == 0xf7) {
+                    result += '^';
+                    c ^= 0x40;
+                } else if (c == '"' || c == '\\') {
+                    result += '\\';
+                }
+                result += static_cast<char>(c);
+                ++value;
+            }
+        }
+        return result;
+    }
+#endif
+
     void filesystem_resolver::populate_partition_attributes(partition& part, string const& device_directory, void* cache, map<string, string> const& mountpoints)
     {
 #ifdef USE_BLKID
@@ -214,7 +243,7 @@ namespace facter { namespace facts { namespace linux {
                         if (!ptr) {
                             continue;
                         }
-                        (*ptr) = value;
+                        (*ptr) = safe_convert(value);
                     }
                     blkid_tag_iterate_end(it);
                 }


### PR DESCRIPTION
libblkid is returning invalid UTF-8 sequences from certain block devices
containing invalid data.  This results in a master being unable to serialize
node facts because Facter gives back the data containing the invalid sequences.

The blkid utility that Facter 2.x relied on to gather block device information
such as UUIDs and labels converts non-printable ASCII characters into a format
used by other UNIX utilities.  This replicates that format so that it maintains
backwards compatibility and eliminates the potential for invalid UTF-8 byte
sequences.