### PR TITLE
(FACT-1172) Convert libblkid data the same way blkid does.

### DIFF
--- a/lib/inc/internal/facts/linux/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/linux/filesystem_resolver.hpp
@@ -14,6 +14,14 @@ namespace facter { namespace facts { namespace linux {
      */
     struct filesystem_resolver : resolvers::filesystem_resolver
     {
+        /**
+         * Converts a string using the same format as blkid's "safe_print" function.
+         * The format uses M-<char> (higher than 128) and ^<char> (control character), while escaping quotes and backslashes.
+         * @param value The value to convert.
+         * @return Returns the converted value.
+         */
+        static std::string safe_convert(char const* value);
+
      protected:
         /**
          * Collects the DMI data.

--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -27,6 +27,30 @@ using boost::bad_lexical_cast;
 
 namespace facter { namespace facts { namespace linux {
 
+    string filesystem_resolver::safe_convert(char const* value)
+    {
+        string result;
+
+        if (value) {
+            while (*value) {
+                unsigned char c = static_cast<unsigned char>(*value);
+                if (c >= 128) {
+                    result += "M-";
+                    c -= 128;
+                }
+                if (c < 32 || c == 0xf7) {
+                    result += '^';
+                    c ^= 0x40;
+                } else if (c == '"' || c == '\\') {
+                    result += '\\';
+                }
+                result += static_cast<char>(c);
+                ++value;
+            }
+        }
+        return result;
+    }
+
     filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)
     {
         data result;
@@ -214,7 +238,7 @@ namespace facter { namespace facts { namespace linux {
                         if (!ptr) {
                             continue;
                         }
-                        (*ptr) = value;
+                        (*ptr) = safe_convert(value);
                     }
                     blkid_tag_iterate_end(it);
                 }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_TESTS_PLATFORM_SOURCES
         "facts/linux/dmi_resolver.cc"
+        "facts/linux/filesystem_resolver.cc"
         "util/bsd/scoped_ifaddrs.cc"
     )
 endif()

--- a/lib/tests/facts/linux/filesystem_resolver.cc
+++ b/lib/tests/facts/linux/filesystem_resolver.cc
@@ -1,0 +1,13 @@
+#include <catch.hpp>
+#include <internal/facts/linux/filesystem_resolver.hpp>
+
+using namespace std;
+using namespace facter::facts::linux;
+
+SCENARIO("blkid output with non-printable ASCII characters") {
+    REQUIRE(filesystem_resolver::safe_convert("") == "");
+    REQUIRE(filesystem_resolver::safe_convert("hello") == "hello");
+    REQUIRE(filesystem_resolver::safe_convert("\"hello\"") == "\\\"hello\\\"");
+    REQUIRE(filesystem_resolver::safe_convert("\\hello\\") == "\\\\hello\\\\");
+    REQUIRE(filesystem_resolver::safe_convert("i am \xE0\xB2\xA0\x5F\xE0\xB2\xA0") == "i am M-`M-2M- _M-`M-2M- ");
+}


### PR DESCRIPTION
libblkid is returning invalid UTF-8 sequences from certain block devices
containing invalid data.  This results in a master being unable to serialize
node facts because Facter gives back the data containing the invalid sequences.

The blkid utility that Facter 2.x relied on to gather block device information
such as UUIDs and labels converts non-printable ASCII characters into a format
used by other UNIX utilities.  This replicates that format so that it maintains
backwards compatibility and eliminates the potential for invalid UTF-8 byte
sequences.