### PR TITLE
(FACT-918) Fix up Solaris SPARC virtual facts

### DIFF
--- a/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
@@ -43,10 +43,10 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Gets the product name which is matched against a list of known
          * hypervisors.
-         * @param facts The fact collection that is resolving facts.
+         * @param product_name The product_name fact to match against.
          * @return Returns the hypervisor product name if matched.
          */
-        static std::string get_product_name_vm(collection& facts);
+        static std::string get_product_name_vm(std::string const& product_name);
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -60,7 +60,10 @@ namespace facter { namespace facts { namespace linux {
 
         // Next check the DMI product name for the VM
         if (value.empty()) {
-            value = get_product_name_vm(facts);
+            auto product_name = facts.get<string_value>(fact::product_name);
+            if (product_name) {
+                value = get_product_name_vm(product_name->value());
+            }
         }
 
         // Lastly, resort to lspci to look for hardware related to certain VMs

--- a/lib/src/facts/openbsd/virtualization_resolver.cc
+++ b/lib/src/facts/openbsd/virtualization_resolver.cc
@@ -14,9 +14,12 @@ namespace facter { namespace facts { namespace openbsd {
 
     string virtualization_resolver::get_hypervisor(collection& facts)
     {
-        string value = get_product_name_vm(facts);
+        auto product_name = facts.get<string_value>(fact::product_name);
+        if (product_name) {
+            return get_product_name_vm(product_name->value());
+        }
 
-        return value;
+        return {};
     }
 
 } } }  // namespace facter::facts::openbsd

--- a/lib/src/facts/resolvers/virtualization_resolver.cc
+++ b/lib/src/facts/resolvers/virtualization_resolver.cc
@@ -45,7 +45,7 @@ namespace facter { namespace facts { namespace resolvers {
         return hypervisors.count(hypervisor) == 0;
     }
 
-    string virtualization_resolver::get_product_name_vm(collection& facts)
+    string virtualization_resolver::get_product_name_vm(string const& product_name)
     {
         static vector<tuple<string, string>> vms = {
             make_tuple("VMware",            string(vm::vmware)),
@@ -59,15 +59,8 @@ namespace facter { namespace facts { namespace resolvers {
             make_tuple("Bochs",             string(vm::bochs)),
         };
 
-        auto product_name = facts.get<string_value>(fact::product_name);
-        if (!product_name) {
-            return {};
-        }
-
-        auto const& value = product_name->value();
-
         for (auto const& vm : vms) {
-            if (value.find(get<0>(vm)) != string::npos) {
+            if (product_name.find(get<0>(vm)) != string::npos) {
                 return get<1>(vm);
             }
         }


### PR DESCRIPTION
Reviewing the implementation here compared to the Facter 2.x
implementation, all the methods attempted on Solaris i386 appear to
apply. So re-enable those methods, as well as using the ldom facts to
identify when in an LDom.