### PR TITLE
(FACT-910) Add LDom facts for SPARC system

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -36,6 +36,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/facts/resolvers/gce_resolver.cc"
     "src/facts/resolvers/identity_resolver.cc"
     "src/facts/resolvers/kernel_resolver.cc"
+    "src/facts/resolvers/ldom_resolver.cc"
     "src/facts/resolvers/load_average_resolver.cc"
     "src/facts/resolvers/memory_resolver.cc"
     "src/facts/resolvers/networking_resolver.cc"
@@ -147,6 +148,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
         "src/facts/solaris/zfs_resolver.cc"
         "src/facts/solaris/zone_resolver.cc"
         "src/facts/solaris/zpool_resolver.cc"
+        "src/facts/solaris/ldom_resolver.cc"
         "src/util/solaris/k_stat.cc"
         "src/util/solaris/scoped_kstat.cc"
     )

--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -642,6 +642,11 @@ namespace facter { namespace facts {
          * The fact for Xen domains.
          */
         constexpr static char const* xendomains = "xendomains";
+
+        /**
+         * The structured fact for Solaris LDom facts.
+         */
+        constexpr static char const* ldom = "ldom";
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/internal/facts/resolvers/ldom_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ldom_resolver.hpp
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * Declares the base LDom (Logical Domain) fact resolver.
+ */
+#pragma once
+
+#include <facter/facts/resolver.hpp>
+#include <map>
+
+namespace facter { namespace facts { namespace resolvers {
+
+    /**
+     * Responsible for resolving LDom facts.
+     */
+    struct ldom_resolver : resolver
+    {
+        /**
+         * Constructs the ldom_resolver.
+         */
+        ldom_resolver();
+
+        /**
+         * Called to resolve all facts the resolver is responsible for.
+         * @param facts The fact collection that is resolving facts.
+         */
+        virtual void resolve(collection& facts) override;
+
+        protected:
+            /**
+             * Represents dynamic sub-keys consisting of LDom data.
+             */
+            struct ldom_info
+            {
+                /**
+                 * Stores the top-level name of this category of LDom information.
+                 */
+                std::string key;
+
+                /**
+                 * Stores related LDom information.
+                 */
+                std::map<std::string, std::string> values;
+            };
+
+            /**
+             * Represents the resolver's data.
+             */
+            struct data
+            {
+                /**
+                 * Stores all gathered LDom data.
+                 */
+                std::vector<ldom_info> ldom;
+            };
+
+            /**
+             * Collects the resolver data.
+             * @param facts The fact collection that is resolving facts.
+             * @return Returns the resolver data.
+             */
+            virtual data collect_data(collection& facts) = 0;
+    };
+
+}}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/solaris/ldom_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/ldom_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the ldom fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/ldom_resolver.hpp"
+
+namespace facter { namespace facts { namespace solaris {
+
+    /**
+     * Responsible for resolving ldom facts.
+     */
+    struct ldom_resolver : resolvers::ldom_resolver
+    {
+    protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::solaris

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -515,6 +515,21 @@ kernelversion:
         POSIX platforms: use the `uname` function to retrieve the kernel's version.
         Windows: use the file version of `kernel32.dll` to retrieve the kernel's version.
 
+ldom:
+    type: map
+    description: Return Solaris LDom information from the `virtinfo` utility.
+    resolution: |
+        Solaris: use the `virtinfo` utility to retrieve LDom information.
+    validate: false
+
+ldom_<name>:
+    pattern: ^ldom_.+$
+    hidden: true
+    type: string
+    description: Return Solaris LDom information.
+    resolution: |
+        Solaris: use the `virtinfo` utility to retrieve LDom information.
+
 load_averages:
     type: map
     description: Return the load average over the last 1, 5 and 15 minutes.

--- a/lib/src/facts/resolvers/ldom_resolver.cc
+++ b/lib/src/facts/resolvers/ldom_resolver.cc
@@ -1,0 +1,61 @@
+#include <internal/facts/resolvers/ldom_resolver.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include <iostream>
+
+using namespace std;
+using namespace facter::facts;
+
+namespace facter { namespace facts { namespace resolvers {
+
+    ldom_resolver::ldom_resolver() :
+        resolver(
+            "ldom",
+            {
+                fact::ldom,
+            },
+            {
+                string("^ldom_"),
+            })
+
+    {
+    }
+
+    void ldom_resolver::resolve(collection& facts)
+    {
+        auto data = collect_data(facts);
+
+        if (!data.ldom.empty()) {
+            auto ldom = make_value<map_value>();
+
+            for (auto& sub_key : data.ldom) {
+                if (sub_key.values.size() == 0) {
+                    continue;
+
+                } else if (sub_key.values.size() == 1) {
+                    string key = sub_key.values.begin()->first;
+                    string value = sub_key.values.begin()->second;
+
+                    ldom->add(key, make_value<string_value>(value));
+                    facts.add("ldom_" + key, make_value<string_value>(move(value), true));
+
+                } else {
+                    // If we have multiple sub key values, insert a map into the structured fact to contain them.
+                    auto sub_value = make_value<map_value>();
+
+                    for (auto& kv : sub_key.values) {
+                        sub_value->add(kv.first, make_value<string_value>(kv.second));
+                        facts.add("ldom_" + sub_key.key + "_" + move(kv.first), make_value<string_value>(move(kv.second), true));
+                    }
+
+                    ldom->add(sub_key.key, move(sub_value));
+                }
+            }
+
+            facts.add(fact::ldom, move(ldom));
+        }
+    }
+
+}}}  // namespace facter::facts

--- a/lib/src/facts/solaris/collection.cc
+++ b/lib/src/facts/solaris/collection.cc
@@ -15,6 +15,7 @@
 #include <internal/facts/solaris/zpool_resolver.hpp>
 #include <internal/facts/solaris/zfs_resolver.hpp>
 #include <internal/facts/solaris/zone_resolver.hpp>
+#include <internal/facts/solaris/ldom_resolver.hpp>
 #include <internal/facts/glib/load_average_resolver.hpp>
 #include <internal/facts/posix/xen_resolver.hpp>
 
@@ -44,6 +45,7 @@ namespace facter { namespace facts {
         add(make_shared<solaris::zpool_resolver>());
         add(make_shared<solaris::zfs_resolver>());
         add(make_shared<solaris::zone_resolver>());
+        add(make_shared<solaris::ldom_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/solaris/ldom_resolver.cc
+++ b/lib/src/facts/solaris/ldom_resolver.cc
@@ -1,0 +1,87 @@
+#include <internal/facts/solaris/ldom_resolver.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/util/regex.hpp>
+#include <facter/facts/map_value.hpp>
+#include <boost/algorithm/string.hpp>
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace facter::facts;
+using namespace leatherman::execution;
+using namespace leatherman::util;
+
+namespace facter { namespace facts { namespace solaris {
+
+    ldom_resolver::data ldom_resolver::collect_data(collection& facts)
+    {
+        /*
+           Convert virtinfo parseable output format to array of arrays.
+           DOMAINROLE|impl=LDoms|control=true|io=true|service=true|root=true
+           DOMAINNAME|name=primary
+           DOMAINUUID|uuid=8e0d6ec5-cd55-e57f-ae9f-b4cc050999a4
+           DOMAINCONTROL|name=san-t2k-6
+           DOMAINCHASSIS|serialno=0704RB0280
+
+           For keys containing multiple value such as domain role:
+           ldom_{key}_{subkey} = value
+           Otherwise the fact will simply be:
+           ldom_{key} = value
+        */
+        data result;
+
+        auto isa = facts.get<string_value>(fact::hardware_isa);
+        if (isa && isa->value() != "sparc") {
+            return result;
+        }
+
+        each_line("/usr/sbin/virtinfo", { "-a", "-p" }, [&] (string& line) {
+            if (!re_search(line, boost::regex("^DOMAIN"))) {
+                return true;
+            }
+
+            vector<string> items;
+            boost::split(items, line, boost::is_any_of("|"));
+
+            // The first element is the key, i.e, "domainrole." Subsequent entries are values.
+            if (items.empty()) {
+                return true;
+            } else if (items.size() == 2) {
+                ldom_info ldom_data;
+                string key = items[0];
+                string value = items[1].substr(items[1].find("=") + 1);
+
+                transform(key.begin(), key.end(), key.begin(), ::tolower);
+
+                ldom_data.key = key;
+                ldom_data.values.insert({ key, value });
+                result.ldom.emplace_back(ldom_data);
+            } else {
+                // When there are multiple values to a line, we insert them all in a single sub-map.
+                ldom_info ldom_data;
+                string base_key = items[0];  // Base key is used as top level sub-key in the structured fact
+                transform(base_key.begin(), base_key.end(), base_key.begin(), ::tolower);
+                ldom_data.key = base_key;
+
+                items.erase(items.begin());
+
+                for (string val : items) {
+                    auto pos = val.find("=");
+                    string sub_key = val.substr(0, pos);
+                    string value = val.substr(pos + 1);
+
+                    ldom_data.values.insert({ sub_key, value });
+                }
+
+                result.ldom.emplace_back(ldom_data);
+            }
+            return true;
+        });
+
+        return result;
+    }
+
+}}}  // namespace facter::facts::solaris

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "facts/resolvers/filesystem_resolver.cc"
     "facts/resolvers/identity_resolver.cc"
     "facts/resolvers/kernel_resolver.cc"
+    "facts/resolvers/ldom_resolver.cc"
     "facts/resolvers/memory_resolver.cc"
     "facts/resolvers/networking_resolver.cc"
     "facts/resolvers/operating_system_resolver.cc"

--- a/lib/tests/facts/resolvers/ldom_resolver.cc
+++ b/lib/tests/facts/resolvers/ldom_resolver.cc
@@ -1,0 +1,86 @@
+#include <catch.hpp>
+#include <internal/facts/resolvers/ldom_resolver.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include "../../collection_fixture.hpp"
+
+using namespace std;
+using namespace facter::facts;
+using namespace facter::facts::resolvers;
+using namespace facter::testing;
+
+struct empty_ldom_resolver : ldom_resolver
+{
+ protected:
+    virtual data collect_data(collection& facts) override
+    {
+        data result;
+        return result;
+    }
+};
+
+struct test_ldom_resolver : ldom_resolver
+{
+ protected:
+    virtual data collect_data(collection& facts) override
+    {
+        ldom_info single_value;
+        single_value.key = "domainname";
+        single_value.values.insert({ "domainname", "somedomain"});
+
+        ldom_info multi_value;
+        multi_value.key = "domainrole";
+        multi_value.values.insert({ "impl", "true"});
+        multi_value.values.insert({ "io", "false"});
+
+        data result;
+        result.ldom.emplace_back(single_value);
+        result.ldom.emplace_back(multi_value);
+
+        return result;
+    }
+};
+
+SCENARIO("Using the Solaris LDom resolver") {
+    collection_fixture facts;
+    WHEN("data is not present") {
+        facts.add(make_shared<empty_ldom_resolver>());
+        THEN("no LDom facts should be added") {
+            REQUIRE(facts.size() == 0u);
+        }
+    }
+    WHEN("data is present") {
+        facts.add(make_shared<test_ldom_resolver>());
+        THEN("a structured fact is added") {
+            REQUIRE(facts.size() == 4u);
+            auto ldom = facts.get<map_value>(fact::ldom);
+            REQUIRE(ldom);
+            REQUIRE(ldom->size() == 2u);
+
+            auto sval = ldom->get<string_value>("domainname");
+            REQUIRE(sval);
+            REQUIRE(sval->value() == "somedomain");
+
+            auto mval = ldom->get<map_value>("domainrole");
+            REQUIRE(mval);
+            REQUIRE(mval->size() == 2u);
+        }
+        THEN("flat facts are added") {
+            REQUIRE(facts.size() == 4u);
+            auto sval_2 = facts.get<string_value>("ldom_domainname");
+            REQUIRE(sval_2);
+            REQUIRE(sval_2->value() == "somedomain");
+
+            auto sval_3 = facts.get<string_value>("ldom_domainrole_impl");
+            REQUIRE(sval_3);
+            REQUIRE(sval_3->value() == "true");
+
+            auto sval_4 = facts.get<string_value>("ldom_domainrole_io");
+            REQUIRE(sval_4);
+            REQUIRE(sval_4->value() == "false");
+        }
+    }
+
+}

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -20,6 +20,7 @@
 #include <internal/facts/resolvers/gce_resolver.hpp>
 #include <internal/facts/resolvers/identity_resolver.hpp>
 #include <internal/facts/resolvers/kernel_resolver.hpp>
+#include <internal/facts/resolvers/ldom_resolver.hpp>
 #include <internal/facts/resolvers/load_average_resolver.hpp>
 #include <internal/facts/resolvers/memory_resolver.hpp>
 #include <internal/facts/resolvers/networking_resolver.hpp>
@@ -436,6 +437,8 @@ void add_all_facts(collection& facts)
     facts.add(fact::gce, make_value<map_value>());
     facts.add(make_shared<identity_resolver>());
     facts.add(make_shared<kernel_resolver>());
+    facts.add(fact::ldom, make_value<map_value>());
+    facts.add("ldom_domainname", make_value<string_value>("somedomain", true));
     facts.add(make_shared<load_average_resolver>());
     facts.add(make_shared<memory_resolver>());
     facts.add(make_shared<networking_resolver>());


### PR DESCRIPTION
This commit adds a new structured fact, 'ldom', which contains
all LDom information previously given by the ldom_* flat
facts. These flat facts are also included for backwards compatibility.