### PR TITLE
(FACT-1181) Don't try to match exact Ruby version in acceptance

### DIFF
--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -24,7 +24,7 @@ else
   end
 end
 
-ruby_version = '2.1.6'
+ruby_version = /2\.\d+\.\d+/
 expected_ruby = {
                   'ruby.platform' => ruby_platform,
                   'ruby.sitedir'  => /\/site_ruby/,


### PR DESCRIPTION
Previously, we were looking for the exact Ruby version '2.1.6'
as the value of the ruby_version fact, which caused breakage
when we updated our Ruby version. This commit updates this test
to check the fact against a more general regex which ensures
that the fact resembles a version string in the 2 series.