### PR TITLE
(maint) Update pinned Beaker version to 2.22

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem "beaker", "~> 2.19"
+gem "beaker", "~> 2.22"
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 


### PR DESCRIPTION
This commit updates the pinned Beaker version to
2.22 to support changes to the puppet-agent
package name and PE repo structure for Mac OS X.