### PR TITLE
(maint) Fix doxygen warning

### DIFF
--- a/lib/inc/internal/facts/linux/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/linux/filesystem_resolver.hpp
@@ -16,7 +16,7 @@ namespace facter { namespace facts { namespace linux {
     {
         /**
          * Converts a string using the same format as blkid's "safe_print" function.
-         * The format uses M-<char> (higher than 128) and ^<char> (control character), while escaping quotes and backslashes.
+         * The format uses M-\<char> (higher than 128) and ^\<char> (control character), while escaping quotes and backslashes.
          * @param value The value to convert.
          * @return Returns the converted value.
          */


### PR DESCRIPTION
A commit to stable generated a doxygen warning that wasn't caught by the
CI on master before merging master upper to stable. This commit resolves
the warning.