### PR TITLE
(FACT-1221) Add fallback for resolving total and free memory on SPARC

### DIFF
--- a/lib/src/facts/solaris/memory_resolver.cc
+++ b/lib/src/facts/solaris/memory_resolver.cc
@@ -1,8 +1,8 @@
 #include <internal/facts/solaris/memory_resolver.hpp>
 #include <internal/util/solaris/k_stat.hpp>
-#include <leatherman/file_util/file.hpp>
 #include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <sys/sysinfo.h>
 #include <sys/sysconfig.h>
@@ -11,6 +11,8 @@
 
 using namespace std;
 using namespace facter::util::solaris;
+using namespace leatherman::execution;
+using namespace leatherman::util;
 
 namespace facter { namespace facts { namespace solaris {
 
@@ -18,57 +20,72 @@ namespace facter { namespace facts { namespace solaris {
     {
         data result;
 
-        const long page_size = sysconf(_SC_PAGESIZE);
-        const long max_dev_size = PATH_MAX;
+        const uint64_t page_size = sysconf(_SC_PAGESIZE);
+        const auto max_dev_size = PATH_MAX;
+
         try {
             k_stat ks;
             auto ke = ks[make_pair("unix", "system_pages")][0];
             result.mem_total = ke.value<ulong_t>("physmem") * page_size;
             result.mem_free = ke.value<ulong_t>("pagesfree") * page_size;
-
-            // Swap requires a little more effort. See
-            // https://community.oracle.com/thread/1951228?start=0&tstart=0
-            // http://www.brendangregg.com/K9Toolkit/swapinfo
-            int num = 0;
-            if ((num = swapctl(SC_GETNSWP,  0)) == -1) {
-                LOG_DEBUG("swapctl failed: %1% (%2%): swap information is unavailable", strerror(errno), errno);
-                return result;
-            }
-            if (num == 0) {
-                // no swap devices configured
-                return result;
-            }
-
-            // swap devices can be added online. So add one extra.
-            num++;
-
-            vector<char> buffer(num * sizeof(swapent_t) + sizeof(swaptbl_t));
-            vector<vector<char>> str_table(num);
-
-            swaptbl_t* swaps = reinterpret_cast<swaptbl_t*>(buffer.data());
-            swaps->swt_n = num;
-
-            for (int i = 0; i < num; i++) {
-                str_table[i].resize(max_dev_size);
-                swaps->swt_ent[i].ste_path = str_table[i].data();
-            }
-
-            if (swapctl(SC_LIST, swaps) == -1) {
-                LOG_DEBUG("swapctl with SC_LIST failed: %1% (%2%): swap information is unavailable", strerror(errno), errno);
-                return result;
-            }
-
-            for (int i = 0; i < num; i++) {
-                result.swap_free += swaps->swt_ent[i].ste_free;
-                result.swap_total += swaps->swt_ent[i].ste_pages;
-            }
-
-            result.swap_free *= page_size;
-            result.swap_total *= page_size;
-            return result;
         } catch (kstat_exception &ex) {
-            LOG_DEBUG("memory facts unavailable (%1%)", ex.what());
-            return {};
+            LOG_DEBUG("failed to read memory facts from kstat api: %1%.", ex.what());
+
+            uint64_t physmem, pagesfree;
+
+            static boost::regex physmem_rx("^\\s*physmem\\s+(.+)$");
+            static boost::regex pagesfree_rx("^\\s*pagesfree\\s+(\\d+)$");
+
+            each_line("/usr/bin/kstat", {"-m", "unix", "-n", "system_pages"}, [&] (string& line) {
+                if (re_search(line, physmem_rx, &physmem)) {
+                    result.mem_total = physmem * page_size;
+                } else if (re_search(line, pagesfree_rx, &pagesfree)) {
+                    result.mem_free = pagesfree * page_size;
+                }
+                return result.mem_total == 0 || result.mem_free == 0;
+            });
         }
+
+        // Swap requires a little more effort. See
+        // https://community.oracle.com/thread/1951228?start=0&tstart=0
+        // http://www.brendangregg.com/K9Toolkit/swapinfo
+        int num = 0;
+        if ((num = swapctl(SC_GETNSWP,  0)) == -1) {
+            LOG_DEBUG("swapctl failed: %1% (%2%): swap information is unavailable", strerror(errno), errno);
+            return result;
+        }
+        if (num == 0) {
+            // no swap devices configured
+            return result;
+        }
+
+        // swap devices can be added online. So add one extra.
+        num++;
+
+        vector<char> buffer(num * sizeof(swapent_t) + sizeof(swaptbl_t));
+        vector<vector<char>> str_table(num);
+
+        swaptbl_t* swaps = reinterpret_cast<swaptbl_t*>(buffer.data());
+        swaps->swt_n = num;
+
+        for (int i = 0; i < num; i++) {
+            str_table[i].resize(max_dev_size);
+            swaps->swt_ent[i].ste_path = str_table[i].data();
+        }
+
+        if (swapctl(SC_LIST, swaps) == -1) {
+            LOG_DEBUG("swapctl with SC_LIST failed: %1% (%2%): swap information is unavailable", strerror(errno), errno);
+            return result;
+        }
+
+        for (int i = 0; i < num; i++) {
+            result.swap_free += swaps->swt_ent[i].ste_free;
+            result.swap_total += swaps->swt_ent[i].ste_pages;
+        }
+
+        result.swap_free *= page_size;
+        result.swap_total *= page_size;
+
+        return result;
     }
 }}}  // namespace facter::facts::solaris

--- a/lib/src/facts/solaris/processor_resolver.cc
+++ b/lib/src/facts/solaris/processor_resolver.cc
@@ -54,9 +54,9 @@ namespace facter { namespace facts { namespace solaris {
     processor_resolver::data processor_resolver::collect_data(collection& facts)
     {
         auto result = posix::processor_resolver::collect_data(facts);
-        unordered_set<int> chips;
 
         try {
+            unordered_set<int> chips;
             k_stat kc;
             auto kv = kc["cpu_info"];
             for (auto const& ke : kv) {
@@ -70,15 +70,14 @@ namespace facter { namespace facts { namespace solaris {
                         result.speed = static_cast<int64_t>(ke.value<uint64_t>("current_clock_Hz"));
                     }
                 } catch (kstat_exception& ex) {
-                    LOG_DEBUG("failed to read processor data: %1%.", ex.what());
+                    LOG_DEBUG("failed to read processor data entry: %1%.", ex.what());
                 }
             }
             result.physical_count = chips.size();
         } catch (kstat_exception& ex) {
-            LOG_DEBUG("failed to read processor data: %1%.", ex.what());
-        }
+            LOG_DEBUG("failed to read processor data from kstat api: %1%.", ex.what());
 
-        if (chips.empty()) {
+            unordered_set<int> chips;
             string brand;
             int32_t chip_id;
             int64_t current_clock_hz;


### PR DESCRIPTION
On Solaris SPARC in our LDoms, kstat_read fails similar to FACT-909. Add a fallback to use when it fails, where we call kstat directly.

