### PR TITLE
(FACT-1222) Update OS release regex for SPARC Solaris 10

### DIFF
--- a/lib/src/facts/solaris/operating_system_resolver.cc
+++ b/lib/src/facts/solaris/operating_system_resolver.cc
@@ -54,7 +54,7 @@ namespace facter { namespace facts { namespace solaris {
          to be resolved further using the `pkg info kernel` command (TODO).
          */
 
-        static boost::regex regexp_s10("Solaris \\d+ \\d+/\\d+ s(\\d+)x_u(\\d+)wos_");
+        static boost::regex regexp_s10("Solaris \\d+ \\d+/\\d+ s(\\d+)\\S_u(\\d+)wos_");
         static boost::regex regexp_s11("Solaris (\\d+)[.](\\d+)");
         static boost::regex regexp_s11b("Solaris (\\d+) ");
         lth_file::each_line("/etc/release", [&](string& line) {


### PR DESCRIPTION
SPARC and X86 Solaris systems contain slightly different
release strings in /etc/release. They differ by a single
character, where SPARC uses the letter 's' and X86 uses
the letter 'x'. This commit relaxes the regex used to grab
this string so as to be compatible with both architectures.