### PR TITLE
(FACT-1230) Disable attempting to use locales on AIX

### DIFF
--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -12,7 +12,7 @@ static void setup_logging_internal(ostream& os)
 {
     // Initialize boost filesystem's locale to a UTF-8 default.
     // Logging gets setup the same way via the default 2nd argument.
-#if !defined(__sun) || !defined(__GNUC__)
+#if (!defined(__sun) && !defined(_AIX)) || !defined(__GNUC__)
     // Locale support in GCC on Solaris is busted, so skip it.
     boost::filesystem::path::imbue(leatherman::locale::get_locale());
 #endif


### PR DESCRIPTION
Much as in solaris, the libstdc++ support for locales on AIX is... bad. We shouldn't even bother.