### PR TITLE
(FACT-1232) Be more specific in the regex when parsing the oslevel data cache

### DIFF
--- a/lib/src/facts/aix/kernel_resolver.cc
+++ b/lib/src/facts/aix/kernel_resolver.cc
@@ -13,7 +13,7 @@ using namespace std;
 namespace lth_file = leatherman::file_util;
 
 static std::string parse_rml_cache() {
-    const auto regex = boost::regex("(\\d+-\\d+-\\d+)_SP.*Service Pack");
+    const auto regex = boost::regex("^(\\d\\d-\\d+-\\d+)_SP.*Service Pack");
     string result;
     lth_file::each_line("/tmp/.oslevel.datafiles/.oslevel.rml.cache", [&](string& line) {
         string value;


### PR DESCRIPTION
On AIX 5.3, there are service pack entries that do not match our expected format. This was causing bad output from facter. The new regex causes us to ignore those entries.