### PR TITLE
(FACT-799) Add os.major fact to AIX resolver

### DIFF
--- a/lib/src/facts/aix/operating_system_resolver.cc
+++ b/lib/src/facts/aix/operating_system_resolver.cc
@@ -46,6 +46,13 @@ namespace facter { namespace facts { namespace aix {
     {
         // Default to the base implementation
         auto result = posix::operating_system_resolver::collect_data(facts);
+
+        // on AIX, major version is hyphen-delimited. The base
+        // resolver can't figure this out for us.
+        vector<string> tokens;
+        boost::split(tokens, result.release, boost::is_any_of("-"));
+        result.major = tokens[0];
+
         result.architecture = getattr("proc0", "type");
         result.hardware = getattr("sys0", "modelname");
 


### PR DESCRIPTION
Previously, cfacter did not have an os.major fact. If we go way back,
facter 2 used the full os.release fact for its os.major fact. Based on
this ticket, the right answer is probably what we have here.