### PR TITLE
(FACT-549) Implement serial number resolution for AIX

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -112,6 +112,7 @@ if (AIX)
         "src/facts/aix/networking_resolver.cc"
         "src/facts/aix/operating_system_resolver.cc"
         "src/facts/aix/processor_resolver.cc"
+        "src/facts/aix/serial_number_resolver.cc"
     )
 
     set(LIBFACTER_PLATFORM_LIBRARIES

--- a/lib/inc/internal/facts/aix/serial_number_resolver.hpp
+++ b/lib/inc/internal/facts/aix/serial_number_resolver.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file
+ * Declares the AIX serial number fact resolver.
+ */
+#pragma once
+
+#include <facter/facts/resolver.hpp>
+
+namespace facter { namespace facts { namespace aix {
+
+    /**
+     * Responsible for resolving serial number fact.
+     */
+    struct serial_number_resolver : resolver
+    {
+         /*
+          * Constructs the serial_number_resolver.
+          */
+         serial_number_resolver();
+
+         /**
+          * Called to resolve all the facts the resolver is responsible for.
+          * @param facts The fact collection that is resolving facts.
+          */
+         virtual void resolve(collection& facts) override;
+    };
+}}}  // namespace facter::facts::aix

--- a/lib/src/facts/aix/collection.cc
+++ b/lib/src/facts/aix/collection.cc
@@ -4,6 +4,7 @@
 #include <internal/facts/aix/networking_resolver.hpp>
 #include <internal/facts/aix/operating_system_resolver.hpp>
 #include <internal/facts/aix/processor_resolver.hpp>
+#include <internal/facts/aix/serial_number_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
@@ -18,6 +19,7 @@ namespace facter { namespace facts {
         add(make_shared<aix::networking_resolver>());
         add(make_shared<aix::operating_system_resolver>());
         add(make_shared<aix::processor_resolver>());
+        add(make_shared<aix::serial_number_resolver>());
         add(make_shared<posix::ssh_resolver>());
         add(make_shared<posix::identity_resolver>());
         add(make_shared<posix::timezone_resolver>());

--- a/lib/src/facts/aix/serial_number_resolver.cc
+++ b/lib/src/facts/aix/serial_number_resolver.cc
@@ -1,0 +1,43 @@
+#include <internal/facts/aix/serial_number_resolver.hpp>
+#include <internal/util/aix/odm.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/util/regex.hpp>
+#include <boost/regex.hpp>
+
+#include <sys/cfgodm.h>
+
+using namespace std;
+using namespace facter::util::aix;
+using namespace leatherman::util;
+
+namespace facter { namespace facts { namespace aix {
+
+    serial_number_resolver::serial_number_resolver() :
+        resolver(
+            "AIX serial number",
+            {
+                fact::serial_number,
+            })
+    {
+    }
+
+    void serial_number_resolver::resolve(collection& facts) {
+        auto cu_at_query = odm_class<CuAt>::open("CuAt").query("name=sys0 and attribute=systemid");
+        auto result = *cu_at_query.begin();
+
+        // the ODM returns a string of the form "IBM,XXSERIAL#". We
+        // need to strip the "IBM,XX" from the start ofthis, and keep
+        // only the 7 actual serial number bytes.
+        const auto regex = boost::regex("^IBM,\\d\\d(.+)");
+        string serial;
+        if (re_search(string(result.value), regex, &serial)) {
+             facts.add(fact::serial_number, make_value<string_value>(move(serial)));
+        } else {
+            LOG_DEBUG("Could not retrieve serial number: sys0 systemid did not match the expected format");
+        }
+    }
+
+}}}  // namespace facter::facts::aix


### PR DESCRIPTION
On other platforms, the serial number is queried via DMI. There is no DMI on AIX, so we have a custom resolver here to get that information.