### PR TITLE
(FACT-1235) Fix output of negative numbers returned by custom facts.

### DIFF
--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -87,7 +87,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            json.SetInt64(ruby.rb_num2ulong(value));
+            json.SetInt64(ruby.rb_num2long(value));
             return;
         }
         if (ruby.is_float(value)) {
@@ -156,7 +156,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            os << ruby.rb_num2ulong(value);
+            os << ruby.rb_num2long(value);
             return;
         }
         if (ruby.is_float(value)) {
@@ -242,7 +242,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            emitter << ruby.rb_num2ulong(value);
+            emitter << ruby.rb_num2long(value);
             return;
         }
         if (ruby.is_float(value)) {

--- a/lib/tests/fixtures/ruby/negative_number.rb
+++ b/lib/tests/fixtures/ruby/negative_number.rb
@@ -1,0 +1,5 @@
+Facter.add(:foo) do
+    setcode do
+        -101
+    end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -607,4 +607,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "true");
         }
     }
+    GIVEN("a fact that returns a negative number") {
+        REQUIRE(load_custom_fact("negative_number.rb", facts));
+        THEN("the value should be output as a signed value") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "-101");
+        }
+    }
 }


### PR DESCRIPTION
rb_num2ulong was being called when outputting a Ruby value in JSON, YAML, or to
the console.  This resulted in an underflow when the value was negative and the
value was displayed as a large positive value.

The fix is to instead call rb_num2long which returns a signed version.