### PR TITLE
(FACT-1243) Add Scientific/Oracle to el acceptance

### DIFF
--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -40,7 +40,7 @@ agents.each do |agent|
                   'os.architecture'         => os_arch,
                   'os.family'               => 'RedHat',
                   'os.hardware'             => os_hardware,
-                  'os.name'                 => /(RedHat|CentOS)/,
+                  'os.name'                 => /(RedHat|CentOS|Scientific|Oracle)/,
                   'os.release.full'         => /#{os_version}\.\d(\.\d)?/,
                   'os.release.major'        => os_version,
                   'os.release.minor'        => /\d/,


### PR DESCRIPTION
This commit adds Scientific and Oracle to the accepted pattern
of os.name values for the `acceptance/test/facts/el.rb` test.

Prior to this commit, this test would fail On Scientific Linux
and Oracle Linux due to the fact that the `os.name` value did
not match the available values.