### PR TITLE
(maint) Fix Facter API to export scalar_value<T>.

### DIFF
--- a/lib/inc/facter/facts/scalar_value.hpp
+++ b/lib/inc/facter/facts/scalar_value.hpp
@@ -19,7 +19,7 @@ namespace facter { namespace facts {
      * @tparam T The underlying scalar type.
      */
     template <typename T>
-    struct scalar_value : value
+    struct LIBFACTER_EXPORT scalar_value : value
     {
         /**
          * Constructs a scalar_value.


### PR DESCRIPTION
Missing an export declaration on `scalar_value<T>`.  This prevents Facter
from exporting needed type info on Linux.