### PR TITLE
(FACT-1245) Update tests for AIX

### DIFF
--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -14,6 +14,8 @@ when /windows/
   ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
 when /osx/
   ruby_platform = /x86_64-darwin[\d.]+/
+when /aix/
+  ruby_platform = /powerpc-aix[\d.]+/
 when /solaris/
     if agent['platform'] =~ /sparc/
       ruby_platform = /sparc-solaris[\d.]+/

--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -3,7 +3,7 @@ confine :except, :platform => 'windows'
 agents.each do |host|
   step 'set an invalid value for locale and run facter'
   result = on host, 'LANG=ABCD facter facterversion'
-  if host['platform'] !~ /solaris/
+  if host['platform'] !~ /solaris|aix/
     fail_test 'facter did not warn about the locale' unless
       result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
   end


### PR DESCRIPTION
This commit updates the `facts/ruby.rb` and
`ticket_1123_facter_with_invalid_locale.rb` tests to include
specific criteria for the AIX platform.