### PR TITLE
(FACT-1238) Respect fully-qualified hostnames if specified.

### DIFF
--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -118,7 +118,7 @@ namespace facter { namespace facts { namespace posix {
                     result.domain.assign(parts[1].begin(), parts[1].end());
                     return false;
                 }
-                if (parts[0] == boost::as_literal("search")) {
+                if (search.empty() && parts[0] == boost::as_literal("search")) {
                     // Found a "search" entry, but keep looking for other domain entries
                     // We use the first search domain as the domain.
                     search.assign(parts[1].begin(), parts[1].end());


### PR DESCRIPTION
Facter 2.x would respect any hostname that was already fully-qualified.  A
hostname of 'foo.bar.com' would be split into a hostname of 'foo' and a domain
of 'bar.com'. No further attempt to resolve the FQDN would take place.

Facter 3 always used fallback logic of attempting to resolve the hostname to a
FQDN and looking through `resolv.conf` for domains.  This should only occur if
the system hostname is not already fully-qualified.

This is to say, if the users have configured their machine hostnames to be
fully-qualified, Facter should respect that.