### PR TITLE
(FACT-780) Prevent Puppet from altering Facter logging with -p.

### DIFF
--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -33,8 +33,9 @@ namespace facter { namespace ruby {
          * Constructs the Ruby Facter module.
          * @param facts The collection of facts to populate.
          * @param paths The search paths for loading custom facts.
+         * @param logging_hooks True if the logging hooks should be defined in the Facter API or false if not.
          */
-        module(facter::facts::collection& facts, std::vector<std::string> const& paths = {});
+        module(facter::facts::collection& facts, std::vector<std::string> const& paths = {}, bool logging_hooks = true);
 
         /**
          * Destructs the Facter module.

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -161,7 +161,7 @@ namespace facter { namespace ruby {
 
     map<VALUE, module*> module::_instances;
 
-    module::module(collection& facts, vector<string> const& paths) :
+    module::module(collection& facts, vector<string> const& paths, bool logging_hooks) :
         _collection(facts),
         _loaded_all(false)
     {
@@ -219,9 +219,7 @@ namespace facter { namespace ruby {
         ruby.rb_define_singleton_method(_self, "warn", RUBY_METHOD_FUNC(ruby_warn), 1);
         ruby.rb_define_singleton_method(_self, "warnonce", RUBY_METHOD_FUNC(ruby_warnonce), 1);
         ruby.rb_define_singleton_method(_self, "log_exception", RUBY_METHOD_FUNC(ruby_log_exception), -1);
-        ruby.rb_define_singleton_method(_self, "debugging", RUBY_METHOD_FUNC(ruby_set_debugging), 1);
         ruby.rb_define_singleton_method(_self, "debugging?", RUBY_METHOD_FUNC(ruby_get_debugging), 0);
-        ruby.rb_define_singleton_method(_self, "trace", RUBY_METHOD_FUNC(ruby_set_trace), 1);
         ruby.rb_define_singleton_method(_self, "trace?", RUBY_METHOD_FUNC(ruby_get_trace), 0);
         ruby.rb_define_singleton_method(_self, "flush", RUBY_METHOD_FUNC(ruby_flush), 0);
         ruby.rb_define_singleton_method(_self, "list", RUBY_METHOD_FUNC(ruby_list), 0);
@@ -234,7 +232,14 @@ namespace facter { namespace ruby {
         ruby.rb_define_singleton_method(_self, "search_path", RUBY_METHOD_FUNC(ruby_search_path), 0);
         ruby.rb_define_singleton_method(_self, "search_external", RUBY_METHOD_FUNC(ruby_search_external), 1);
         ruby.rb_define_singleton_method(_self, "search_external_path", RUBY_METHOD_FUNC(ruby_search_external_path), 0);
-        ruby.rb_define_singleton_method(_self, "on_message", RUBY_METHOD_FUNC(ruby_on_message), 0);
+
+        // Only define these if requested to do so
+        // This prevents consumers of Facter from altering the logging behavior
+        if (logging_hooks) {
+            ruby.rb_define_singleton_method(_self, "debugging", RUBY_METHOD_FUNC(ruby_set_debugging), 1);
+            ruby.rb_define_singleton_method(_self, "trace", RUBY_METHOD_FUNC(ruby_set_trace), 1);
+            ruby.rb_define_singleton_method(_self, "on_message", RUBY_METHOD_FUNC(ruby_on_message), 0);
+        }
 
         // Define the execution module
         ruby.rb_define_singleton_method(execution, "which", RUBY_METHOD_FUNC(ruby_which), 1);

--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -38,7 +38,7 @@ namespace facter { namespace ruby {
     void load_custom_facts(collection& facts, bool initialize_puppet, vector<string> const& paths)
     {
         api& ruby = api::instance();
-        module mod(facts, {});
+        module mod(facts, {}, !initialize_puppet);
         if (initialize_puppet) {
             try {
                 ruby.eval(load_puppet);


### PR DESCRIPTION
When the `-p` option is given to Facter, Facter loads and initializes Puppet.
However, part of the Puppet initialization is to alter Facter's logging
behavior to better integrate it with Puppet's output.

When Puppet is loaded by Facter, this is undesirable behavior as by default
this will cause no further output from Facter other than printing the facts.

To fix this, this change only defines the methods that Puppet consumes to alter
Facter's logging behavior if the `-p` option was not specified.  Puppet already
checks for these methods being present before consuming them.