### PR TITLE
(FACT-1248) Mark serialnumber as hidden on AIX

### DIFF
--- a/lib/src/facts/aix/serial_number_resolver.cc
+++ b/lib/src/facts/aix/serial_number_resolver.cc
@@ -34,7 +34,7 @@ namespace facter { namespace facts { namespace aix {
         const auto regex = boost::regex("^IBM,\\d\\d(.+)");
         string serial;
         if (re_search(string(result.value), regex, &serial)) {
-             facts.add(fact::serial_number, make_value<string_value>(move(serial)));
+            facts.add(fact::serial_number, make_value<string_value>(move(serial), true));
         } else {
             LOG_DEBUG("Could not retrieve serial number: sys0 systemid did not match the expected format");
         }


### PR DESCRIPTION
AIX does not use the DMI resolver, and instead has its own
implementation of the serial number fact. That fact is supposed to be
hidden, and since AIX has its own resolver we need to explicitly hide
the value in AIX