### PR TITLE
(FACT-1240) Remove dependency on buggy RapidJSON pooled allocator.

### DIFF
--- a/lib/inc/facter/facts/array_value.hpp
+++ b/lib/inc/facter/facts/array_value.hpp
@@ -82,7 +82,7 @@ namespace facter { namespace facts {
          * @param allocator The allocator to use for creating the JSON value.
          * @param value The returned JSON value.
          */
-        virtual void to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const override;
+        virtual void to_json(json_allocator& allocator, json_value& value) const override;
 
         /**
          * Gets the element at the given index.

--- a/lib/inc/facter/facts/map_value.hpp
+++ b/lib/inc/facter/facts/map_value.hpp
@@ -84,7 +84,7 @@ namespace facter { namespace facts {
          * @param allocator The allocator to use for creating the JSON value.
          * @param value The returned JSON value.
          */
-        virtual void to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const override;
+        virtual void to_json(json_allocator& allocator, json_value& value) const override;
 
         /**
          * Gets the value in the map of the given name.

--- a/lib/inc/facter/facts/scalar_value.hpp
+++ b/lib/inc/facter/facts/scalar_value.hpp
@@ -62,7 +62,7 @@ namespace facter { namespace facts {
          * @param allocator The allocator to use for creating the JSON value.
          * @param value The returned JSON value.
          */
-        virtual void to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const override;
+        virtual void to_json(json_allocator& allocator, json_value& value) const override;
 
         /**
          * Gets the underlying scalar value.
@@ -103,13 +103,13 @@ namespace facter { namespace facts {
 
     // Declare the specializations for JSON output
     template <>
-    void scalar_value<std::string>::to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const;
+    void scalar_value<std::string>::to_json(json_allocator& allocator, json_value& value) const;
     template <>
-    void scalar_value<int64_t>::to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const;
+    void scalar_value<int64_t>::to_json(json_allocator& allocator, json_value& value) const;
     template <>
-    void scalar_value<bool>::to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const;
+    void scalar_value<bool>::to_json(json_allocator& allocator, json_value& value) const;
     template <>
-    void scalar_value<double>::to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const;
+    void scalar_value<double>::to_json(json_allocator& allocator, json_value& value) const;
 
     // Declare the specializations for YAML output
     template <>

--- a/lib/inc/facter/facts/value.hpp
+++ b/lib/inc/facter/facts/value.hpp
@@ -18,11 +18,9 @@ namespace YAML {
 // Forward delcare needed rapidjson classes.
 namespace rapidjson {
     class CrtAllocator;
-    template <typename BaseAllocator> class MemoryPoolAllocator;
     template <typename Encoding, typename Allocator> class GenericValue;
+    template <typename Encoding, typename Allocator, typename StackAllocator> class GenericDocument;
     template<typename CharType> struct UTF8;
-    typedef GenericValue<UTF8<char>, MemoryPoolAllocator<CrtAllocator>> Value;
-    typedef MemoryPoolAllocator<CrtAllocator> Allocator;
 }
 
 extern "C" {
@@ -33,6 +31,19 @@ extern "C" {
 }
 
 namespace facter { namespace facts {
+
+    /**
+     * Typedef for RapidJSON allocator.
+     */
+    typedef typename rapidjson::CrtAllocator json_allocator;
+    /**
+     * Typedef for RapidJSON value.
+     */
+    typedef typename rapidjson::GenericValue<rapidjson::UTF8<char>, json_allocator> json_value;
+    /**
+     * Typedef for RapidJSON document.
+     */
+    typedef typename rapidjson::GenericDocument<rapidjson::UTF8<char>, json_allocator, json_allocator> json_document;
 
     /**
      * Base class for values.
@@ -90,7 +101,7 @@ namespace facter { namespace facts {
          * @param allocator The allocator to use for creating the JSON value.
          * @param value The returned JSON value.
          */
-        virtual void to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const = 0;
+        virtual void to_json(json_allocator& allocator, json_value& value) const = 0;
 
         /**
           * Writes the value to the given stream.

--- a/lib/inc/internal/ruby/ruby_value.hpp
+++ b/lib/inc/internal/ruby/ruby_value.hpp
@@ -55,7 +55,7 @@ namespace facter { namespace ruby {
          * @param allocator The allocator to use for creating the JSON value.
          * @param value The returned JSON value.
          */
-        virtual void to_json(rapidjson::Allocator& allocator, rapidjson::Value& value) const override;
+        virtual void to_json(facts::json_allocator& allocator, facts::json_value& value) const override;
 
         /**
           * Writes the value to the given stream.
@@ -80,7 +80,7 @@ namespace facter { namespace ruby {
         leatherman::ruby::VALUE value() const;
 
      private:
-        static void to_json(leatherman::ruby::api const& ruby, leatherman::ruby::VALUE value, rapidjson::Allocator& allocator, rapidjson::Value& json);
+        static void to_json(leatherman::ruby::api const& ruby, leatherman::ruby::VALUE value, facts::json_allocator& allocator, facts::json_value& json);
         static void write(leatherman::ruby::api const& ruby, leatherman::ruby::VALUE value, std::ostream& os, bool quoted, unsigned int level);
         static void write(leatherman::ruby::api const& ruby, leatherman::ruby::VALUE value, YAML::Emitter& emitter);
 

--- a/lib/src/facts/array_value.cc
+++ b/lib/src/facts/array_value.cc
@@ -53,13 +53,13 @@ namespace facter { namespace facts {
         }
     }
 
-    void array_value::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void array_value::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetArray();
         value.Reserve(_elements.size(), allocator);
 
         for (auto const& element : _elements) {
-            rapidjson::Value child;
+            json_value child;
             element->to_json(allocator, child);
             value.PushBack(child, allocator);
         }

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -477,7 +477,7 @@ namespace facter { namespace facts {
 
     void collection::write_json(ostream& stream, set<string> const& queries, bool show_legacy)
     {
-        Document document;
+        json_document document;
         document.SetObject();
 
         auto builder = ([&](string const& key, value const* val) {
@@ -485,7 +485,7 @@ namespace facter { namespace facts {
             if (!show_legacy && queries.empty() && val && val->hidden()) {
                 return;
             }
-            rapidjson::Value value;
+            json_value value;
             if (val) {
                 val->to_json(document.GetAllocator(), value);
             } else {

--- a/lib/src/facts/map_value.cc
+++ b/lib/src/facts/map_value.cc
@@ -64,12 +64,12 @@ namespace facter { namespace facts {
         return it->second.get();
     }
 
-    void map_value::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void map_value::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetObject();
 
         for (auto const& kvp : _elements) {
-            rapidjson::Value child;
+            json_value child;
             kvp.second->to_json(allocator, child);
             value.AddMember(rapidjson::StringRef(kvp.first.c_str(), kvp.first.size()), std::move(child), allocator);
         }

--- a/lib/src/facts/scalar_value.cc
+++ b/lib/src/facts/scalar_value.cc
@@ -12,25 +12,25 @@ using namespace YAML;
 namespace facter { namespace facts {
 
     template <>
-    void scalar_value<string>::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void scalar_value<string>::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetString(_value.c_str(), _value.size());
     }
 
     template <>
-    void scalar_value<int64_t>::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void scalar_value<int64_t>::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetInt64(_value);
     }
 
     template <>
-    void scalar_value<bool>::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void scalar_value<bool>::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetBool(_value);
     }
 
     template <>
-    void scalar_value<double>::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void scalar_value<double>::to_json(json_allocator& allocator, json_value& value) const
     {
         value.SetDouble(_value);
     }

--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -39,7 +39,7 @@ namespace facter { namespace ruby {
         return *this;
     }
 
-    void ruby_value::to_json(Allocator& allocator, rapidjson::Value& value) const
+    void ruby_value::to_json(json_allocator& allocator, json_value& value) const
     {
         auto const& ruby = api::instance();
         to_json(ruby, _value, allocator, value);
@@ -64,7 +64,7 @@ namespace facter { namespace ruby {
         return _value;
     }
 
-    void ruby_value::to_json(api const& ruby, VALUE value, Allocator& allocator, rapidjson::Value& json)
+    void ruby_value::to_json(api const& ruby, VALUE value, json_allocator& allocator, json_value& json)
     {
         if (ruby.is_true(value)) {
             json.SetBool(true);
@@ -100,9 +100,9 @@ namespace facter { namespace ruby {
             json.Reserve(size, allocator);
 
             ruby.array_for_each(value, [&](VALUE element) {
-                rapidjson::Value e;
-                to_json(ruby, element, allocator, e);
-                json.PushBack(e, allocator);
+                json_value child;
+                to_json(ruby, element, allocator, child);
+                json.PushBack(child, allocator);
                 return true;
             });
             return;
@@ -115,9 +115,9 @@ namespace facter { namespace ruby {
                 if (!ruby.is_string(key)) {
                     key = ruby.rb_funcall(key, ruby.rb_intern("to_s"), 0);
                 }
-                rapidjson::Value e;
-                to_json(ruby, element, allocator, e);
-                json.AddMember(rapidjson::Value(ruby.rb_string_value_ptr(&key), allocator), e, allocator);
+                json_value child;
+                to_json(ruby, element, allocator, child);
+                json.AddMember(json_value(ruby.rb_string_value_ptr(&key), allocator), child, allocator);
                 return true;
             });
             return;

--- a/lib/tests/facts/array_value.cc
+++ b/lib/tests/facts/array_value.cc
@@ -94,19 +94,19 @@ SCENARIO("using an array fact value") {
         }
         WHEN("serialized to JSON") {
             THEN("it should contain the same values") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsArray());
-                REQUIRE(json_value.Size() == 3);
-                REQUIRE(json_value[0u].IsString());
-                REQUIRE(string(json_value[0u].GetString()) == "1");
-                REQUIRE(json_value[1u].IsNumber());
-                REQUIRE(json_value[1u].GetInt64() == 2ll);
-                REQUIRE(json_value[2u].IsArray());
-                REQUIRE(json_value[2u].Size() == 1);
-                REQUIRE(json_value[2u][0u].IsString());
-                REQUIRE(string(json_value[2u][0u].GetString()) == "element");
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsArray());
+                REQUIRE(json.Size() == 3);
+                REQUIRE(json[0u].IsString());
+                REQUIRE(string(json[0u].GetString()) == "1");
+                REQUIRE(json[1u].IsNumber());
+                REQUIRE(json[1u].GetInt64() == 2ll);
+                REQUIRE(json[2u].IsArray());
+                REQUIRE(json[2u].Size() == 1);
+                REQUIRE(json[2u][0u].IsString());
+                REQUIRE(string(json[2u][0u].GetString()) == "element");
             }
         }
         WHEN("serialized to text") {

--- a/lib/tests/facts/boolean_value.cc
+++ b/lib/tests/facts/boolean_value.cc
@@ -15,11 +15,11 @@ SCENARIO("using a boolean fact value") {
         REQUIRE(value.value());
         WHEN("serialized to JSON") {
             THEN("it should serialize as true") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsBool());
-                REQUIRE(json_value.GetBool());
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsBool());
+                REQUIRE(json.GetBool());
             }
         }
         WHEN("serialized to YAML") {
@@ -42,11 +42,11 @@ SCENARIO("using a boolean fact value") {
         REQUIRE_FALSE(value.value());
         WHEN("serialized to JSON") {
             THEN("it should serialize as false") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsBool());
-                REQUIRE_FALSE(json_value.GetBool());
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsBool());
+                REQUIRE_FALSE(json.GetBool());
             }
         }
         WHEN("serialized to YAML") {

--- a/lib/tests/facts/double_value.cc
+++ b/lib/tests/facts/double_value.cc
@@ -16,11 +16,11 @@ SCENARIO("using a double fact value") {
     REQUIRE(value.value() == Approx(42.4242));
     WHEN("serialized to JSON") {
         THEN("it should have the same value") {
-            rapidjson::Value json_value;
-            MemoryPoolAllocator<> allocator;
-            value.to_json(allocator, json_value);
-            REQUIRE(json_value.IsNumber());
-            REQUIRE(json_value.GetDouble() == Approx(42.4242));
+            json_value json;
+            json_allocator allocator;
+            value.to_json(allocator, json);
+            REQUIRE(json.IsNumber());
+            REQUIRE(json.GetDouble() == Approx(42.4242));
         }
     }
     WHEN("serialized to YAML") {

--- a/lib/tests/facts/integer_value.cc
+++ b/lib/tests/facts/integer_value.cc
@@ -16,11 +16,11 @@ SCENARIO("using an integer fact value") {
         REQUIRE(value.value() == expected_value);
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsNumber());
-                REQUIRE(json_value.GetInt64() == expected_value);
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsNumber());
+                REQUIRE(json.GetInt64() == expected_value);
             }
         }
         WHEN("serialized to YAML") {
@@ -44,11 +44,11 @@ SCENARIO("using an integer fact value") {
         REQUIRE(value.value() == expected_value);
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsNumber());
-                REQUIRE(json_value.GetInt64() == expected_value);
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsNumber());
+                REQUIRE(json.GetInt64() == expected_value);
             }
         }
         WHEN("serialized to YAML") {

--- a/lib/tests/facts/map_value.cc
+++ b/lib/tests/facts/map_value.cc
@@ -79,23 +79,23 @@ SCENARIO("using a map fact value") {
         }
         WHEN("serialized to JSON") {
             THEN("it should contain the same values") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsObject());
-                REQUIRE(json_value["string"].IsString());
-                REQUIRE(string(json_value["string"].GetString()) == "hello");
-                REQUIRE(json_value["integer"].IsNumber());
-                REQUIRE(json_value["integer"].GetInt64() == 5);
-                REQUIRE(json_value["array"].IsArray());
-                REQUIRE(json_value["array"].Size() == 2);
-                REQUIRE(json_value["array"][0u].IsString());
-                REQUIRE(string(json_value["array"][0u].GetString()) == "1");
-                REQUIRE(json_value["array"][1u].IsNumber());
-                REQUIRE(json_value["array"][1u].GetInt64() == 2);
-                REQUIRE(json_value["map"].IsObject());
-                REQUIRE(json_value["map"]["foo"].IsString());
-                REQUIRE(string(json_value["map"]["foo"].GetString()) == "bar");
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsObject());
+                REQUIRE(json["string"].IsString());
+                REQUIRE(string(json["string"].GetString()) == "hello");
+                REQUIRE(json["integer"].IsNumber());
+                REQUIRE(json["integer"].GetInt64() == 5);
+                REQUIRE(json["array"].IsArray());
+                REQUIRE(json["array"].Size() == 2);
+                REQUIRE(json["array"][0u].IsString());
+                REQUIRE(string(json["array"][0u].GetString()) == "1");
+                REQUIRE(json["array"][1u].IsNumber());
+                REQUIRE(json["array"][1u].GetInt64() == 2);
+                REQUIRE(json["map"].IsObject());
+                REQUIRE(json["map"]["foo"].IsString());
+                REQUIRE(string(json["map"]["foo"].GetString()) == "bar");
             }
         }
         WHEN("serialized to text") {

--- a/lib/tests/facts/string_value.cc
+++ b/lib/tests/facts/string_value.cc
@@ -31,11 +31,11 @@ SCENARIO("using a string fact value") {
         string_value value("foobar");
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsString());
-                REQUIRE(json_value.GetString() == string("foobar"));
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsString());
+                REQUIRE(json.GetString() == string("foobar"));
             }
         }
         WHEN("serialized to YAML") {
@@ -65,11 +65,11 @@ SCENARIO("using a string fact value") {
         string_value value("fe80::");
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsString());
-                REQUIRE(json_value.GetString() == string("fe80::"));
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsString());
+                REQUIRE(json.GetString() == string("fe80::"));
             }
         }
         WHEN("serialized to YAML") {
@@ -99,11 +99,11 @@ SCENARIO("using a string fact value") {
         string_value value("127.254.3.0");
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsString());
-                REQUIRE(json_value.GetString() == string("127.254.3.0"));
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsString());
+                REQUIRE(json.GetString() == string("127.254.3.0"));
             }
         }
         WHEN("serialized to YAML") {
@@ -133,11 +133,11 @@ SCENARIO("using a string fact value") {
         string_value value("::1");
         WHEN("serialized to JSON") {
             THEN("it should have the same value") {
-                rapidjson::Value json_value;
-                MemoryPoolAllocator<> allocator;
-                value.to_json(allocator, json_value);
-                REQUIRE(json_value.IsString());
-                REQUIRE(json_value.GetString() == string("::1"));
+                json_value json;
+                json_allocator allocator;
+                value.to_json(allocator, json);
+                REQUIRE(json.IsString());
+                REQUIRE(json.GetString() == string("::1"));
             }
         }
         WHEN("serialized to YAML") {


### PR DESCRIPTION
Fix RapidJSON typedefs to allow easy change of the allocators.

Change to the CRT allocator by default as this doesn't work properly on sparc.
This has been performance reviewed and the change to the non-pooled allocator
has resulted in no noticeable change in performance.