### PR TITLE
Specify deprecation in the hidden fact note.

### DIFF
--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -11,7 +11,7 @@
 ## `<%= name %>`
 
 <% if schema['hidden'] -%>
-This fact is hidden in Facter's command-line output.
+This unstructured fact is deprecated and hidden in Facter's command-line output.
 
 <% end -%>
 **Type:** <%= schema['type'] %>
@@ -25,7 +25,6 @@ This fact is hidden in Facter's command-line output.
 
 <%= schema['elements'].map{|name, info| format_fact_element(name, info)}.join('') %>
 <% end -%>
-
 <% if schema['resolution'] -%>
 **Resolution:**
 

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -326,9 +326,7 @@ env_windows_installdir:
     type: string
     description: Return the path of the directory in which Puppet was installed.
     resolution: |
-      Windows: This fact is specific to the Windows MSI generated environment, and is
-        set using the `environment.bat` script that configures the runtime environment
-        for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
+      Windows: This fact is specific to the Windows MSI generated environment, and is set using the `environment.bat` script that configures the runtime environment for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information.
     caveats: |
       This fact is specific to Windows, and will not resolve on any other platform.
 


### PR DESCRIPTION
As in [`puppet-docs` PR 551](https://github.com/puppetlabs/puppet-docs/pull/551), make sure the docs generator specifies that we're hiding facts because they're unstructured and deprecated.

Also, fix an issue causing a paragraph in `env_windows_installer` to show up as an unordered list.