### PR TITLE
(docs) Split the facts reference into "modern" and "legacy" sections. 

### DIFF
--- a/lib/docs/generate.rb
+++ b/lib/docs/generate.rb
@@ -9,8 +9,17 @@ require 'ostruct'
 PATH_TO_SCHEMA = File.join(File.dirname(__FILE__), '../schema/facter.yaml')
 PATH_TO_TEMPLATE = File.join(File.dirname(__FILE__), 'template.erb')
 
-scope = OpenStruct.new({
-  :facts => YAML.load_file(PATH_TO_SCHEMA)
-})
+schema = YAML.load_file(PATH_TO_SCHEMA)
 
-puts ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-').result(scope.instance_eval {binding})
+def format_facts(fact_hash)
+  scope = OpenStruct.new({
+    :facts => fact_hash
+  })
+
+  ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-').result(scope.instance_eval {binding})
+end
+
+print "## Modern Facts\n\n"
+print format_facts(schema.reject {|name, info| info['hidden'] == true})
+print "## Legacy Facts\n\n"
+print format_facts(schema.reject {|name, info| info['hidden'].nil? || info['hidden'] == false})

--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -11,7 +11,7 @@
 ## `<%= name %>`
 
 <% if schema['hidden'] -%>
-This fact is hidden in Facter's command-line output.
+This legacy fact is hidden by default in Facter's command-line output.
 
 <% end -%>
 **Type:** <%= schema['type'] %>

--- a/lib/docs/template.erb
+++ b/lib/docs/template.erb
@@ -8,7 +8,7 @@
   end
 -%>
 <% facts.each do |name, schema| -%>
-## `<%= name %>`
+### `<%= name %>`
 
 <% if schema['hidden'] -%>
 This legacy fact is hidden by default in Facter's command-line output.


### PR DESCRIPTION
This came out of some discussion in chat, where some people wanted to emphasize even more heavily that Puppet Labs would prefer that people use the new structured facts. 

I'm expecting we'll go back and forth a bit on wording, but wanted to get this up there to show it's really pretty easy to do. 