### PR TITLE
(FACT-1257) Fix Facter exception resolving dmi

### DIFF
--- a/lib/src/facts/windows/dmi_resolver.cc
+++ b/lib/src/facts/windows/dmi_resolver.cc
@@ -18,11 +18,19 @@ namespace facter { namespace facts { namespace windows {
         data result;
 
         auto vals = _wmi->query(wmi::computersystemproduct, {wmi::name});
-        result.product_name = wmi::get(vals, wmi::name);
+        if (vals.empty()) {
+            LOG_DEBUG("WMI query returned no results for %1% with value %2%.", wmi::computersystemproduct, wmi::name);
+        } else {
+            result.product_name = wmi::get(vals, wmi::name);
+        }
 
         vals = _wmi->query(wmi::bios, {wmi::manufacturer, wmi::serialnumber});
-        result.serial_number = wmi::get(vals, wmi::serialnumber);
-        result.manufacturer = wmi::get(vals, wmi::manufacturer);
+        if (vals.empty()) {
+            LOG_DEBUG("WMI query returned no results for %1% with values %2% and %3%.", wmi::bios, wmi::serialnumber, wmi::manufacturer);
+        } else {
+            result.serial_number = wmi::get(vals, wmi::serialnumber);
+            result.manufacturer = wmi::get(vals, wmi::manufacturer);
+        }
 
         return result;
     }


### PR DESCRIPTION
When resolving dmi facts on Windows, if WMI is unable to resolve the
Win32_ComputerSystemProduct's Name, Win32_Bios's SerialNumber or
Manufacturer it would previously throw an exception and halt the Facter
run. It will now fail to resolve specific dmi facts without halting
Facter.