### PR TITLE
(FACT-1254) Allow dot syntax to query ruby facts

### DIFF
--- a/lib/inc/facter/ruby/ruby.hpp
+++ b/lib/inc/facter/ruby/ruby.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../facts/collection.hpp"
+#include "../facts/value.hpp"
 #include "../export.h"
 #include <vector>
 #include <string>
@@ -39,6 +40,16 @@ namespace facter { namespace ruby {
      * @param paths The paths to search for custom facts.
      */
     LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, std::vector<std::string> const& paths = {});
+
+    /**
+     * Traverses a ruby fact and returns a new value based on the
+     * query segments passed in the range.
+     * @param value The original value to query
+     * @param segment The beginning of the query segment range
+     * @param end The end of the query segment range
+     * @return Returns a pointer to the value queried, or nullptr if it does not exist.
+     */
+    LIBFACTER_EXPORT facts::value const* lookup(facts::value const* value, std::vector<std::string>::iterator segment, std::vector<std::string>::iterator end);
 
     /**
      * Uninitialize Ruby integration in Facter.

--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -1,8 +1,11 @@
 #include <facter/ruby/ruby.hpp>
 #include <facter/logging/logging.hpp>
 #include <internal/ruby/module.hpp>
+#include <internal/ruby/ruby_value.hpp>
 #include <leatherman/ruby/api.hpp>
 #include <leatherman/logging/logging.hpp>
+
+#include <algorithm>
 
 using namespace std;
 using namespace facter::facts;
@@ -53,6 +56,73 @@ namespace facter { namespace ruby {
     void load_custom_facts(collection& facts, vector<string> const& paths)
     {
          load_custom_facts(facts, false, paths);
+    }
+
+    value const* lookup(value const* value, vector<string>::iterator segment, vector<string>::iterator end) {
+        auto rb_value = dynamic_cast<ruby_value const*>(value);
+        if (!rb_value) {
+             return nullptr;
+        }
+
+        // Check for a cached lookup
+        auto key = accumulate(segment, end, string{}, [](const string& a, const string& b) -> string {
+                 if (b.find(".") != string::npos) {
+                     return a+".\""+b+"\"";
+                 } else {
+                     return a+"."+b;
+                 }
+             });
+        auto child_value = rb_value->child(key);
+        if (child_value) {
+            return child_value;
+        }
+
+        auto val = rb_value->value();  // now we're in ruby land
+        api& ruby = api::instance();
+
+        for (; segment != end; ++segment) {
+            if (ruby.is_array(val)) {
+                long index;
+                try {
+                    index = stol(*segment);
+                } catch (logic_error&) {
+                    LOG_DEBUG("cannot lookup an array element with \"%1%\": expected an integral value.", *segment);
+                    return nullptr;
+                }
+                if (index < 0) {
+                    LOG_DEBUG("cannot lookup an array element with \"%1%\": expected a non-negative value.", *segment);
+                    return nullptr;
+                }
+                long length = ruby.array_len(val);
+                if (0 == length) {
+                    LOG_DEBUG("cannot lookup an array element with \"%1%\": the array is empty.", *segment);
+                    return nullptr;
+                }
+
+                if (index >= length) {
+                    LOG_DEBUG("cannot lookup an array element with \"%1%\": expected an integral value between 0 and %2% (inclusive).", *segment, length - 1);
+                    return nullptr;
+                }
+
+                val = ruby.rb_ary_entry(val, index);
+            } else if (ruby.is_hash(val)) {
+                // if we're anything but an array, we look up by name
+                auto key = ruby.utf8_value(*segment);
+                auto result = ruby.rb_hash_lookup(val, key);
+                if (ruby.is_nil(result)) {
+                    // We also want to try looking up as a symbol
+                    key = ruby.to_symbol(*segment);
+                    result = ruby.rb_hash_lookup(val, key);
+                }
+                val = result;
+            } else {
+                LOG_DEBUG("cannot lookup element \"%1%\": container is not an array or hash", *segment);
+            }
+            if (ruby.is_nil(val)) {
+                return nullptr;
+            }
+        }
+        return rb_value->wrap_child(val, move(key));
     }
 
     void uninitialize()

--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -272,4 +272,17 @@ namespace facter { namespace ruby {
         emitter << Null;
     }
 
+    ruby_value const* ruby_value::wrap_child(VALUE child, string key) const {
+        return _children.emplace(move(key), std::unique_ptr<ruby_value>(new ruby_value(child))).first->second.get();
+    }
+
+    ruby_value const* ruby_value::child(const string& key) const {
+        auto child = _children.find(key);
+        if (child != end(_children)) {
+            return child->second.get();
+        } else {
+            return nullptr;
+        }
+    }
+
 }}  // namespace facter::ruby

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -271,11 +271,17 @@ SCENARIO("custom facts written in Ruby") {
         THEN("the value is an array") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "[\n  1,\n  true,\n  false,\n  \"foo\",\n  12.4,\n  [\n    1\n  ],\n  {\n    foo => \"bar\"\n  }\n]");
         }
+        THEN("the members of the fact can be queried") {
+            REQUIRE(ruby_value_to_string(facts.query<ruby_value>("foo.5.0")) == "1");
+        }
     }
     GIVEN("a fact that resolves to a hash value") {
         REQUIRE(load_custom_fact("hash_fact.rb", facts));
         THEN("the value is a hash") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "{\n  int => 1,\n  bool_true => true,\n  bool_false => false,\n  double => 12.34,\n  string => \"foo\",\n  array => [\n    1,\n    2,\n    3\n  ]\n}");
+        }
+        THEN("the members of the fact can be queried") {
+            REQUIRE(ruby_value_to_string(facts.query<ruby_value>("foo.array.1")) == "2");
         }
     }
     GIVEN("a fact that resolves using Facter.value") {


### PR DESCRIPTION
Previously, the dot syntax could not query ruby facts, since they were
opaque to the facter collection.

This commit updates the collection code to recognize when it has
encountered a ruby value during dot lookup, and passes the value and
the remaining query segments to the facter::ruby code to finish the
query.