### PR TITLE
(maint) Run Valgrind on Facter (w/o Ruby)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - libboost-locale1.55-dev
       - libboost-chrono1.55-dev
       - libblkid1
+      - valgrind
 
 before_install:
   # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -60,6 +60,10 @@ else
   bundle install --gemfile=lib/Gemfile
   make test ARGS=-V
 
+  if [ ${TRAVIS_TARGET} == DEBUG ]; then
+    valgrind --error-exitcode=1 ./bin/facter --no-ruby
+  fi
+
   # Make sure installation succeeds
   make DESTDIR=$USERDIR install
 


### PR DESCRIPTION
Runs Valgrind against Facter in Travis, with errors causing a failure.
Doesn't use Ruby, as Ruby messes with the stack in ways that don't work
with Valgrind.