### PR TITLE
(FACT-1258) Guard all Ruby callbacks for exceptions

### DIFF
--- a/lib/src/ruby/simple_resolution.cc
+++ b/lib/src/ruby/simple_resolution.cc
@@ -1,7 +1,5 @@
 #include <internal/ruby/simple_resolution.hpp>
 #include <internal/ruby/module.hpp>
-#include <facter/facts/value.hpp>
-#include <facter/facts/scalar_value.hpp>
 #include <leatherman/execution/execution.hpp>
 
 using namespace std;


### PR DESCRIPTION
Ruby doesn't know how to handle C++ exceptions (it's a C program) so we
must catch any C++ exceptions in the ruby_* calls to avoid crashing the
interpreter.