### PR TITLE
(FACT-1254) Fix compilation with Clang

### DIFF
--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -5,7 +5,7 @@
 #include <leatherman/ruby/api.hpp>
 #include <leatherman/logging/logging.hpp>
 
-#include <algorithm>
+#include <numeric>
 
 using namespace std;
 using namespace facter::facts;


### PR DESCRIPTION
`std::accumulate` lives in the `numeric` header, but GCC includes that
from the `algorithm` header. Clang is more strict, so switch to
including `numeric`.