### PR TITLE
(FACT-1277) Add puppetversion to `facter -p`

### DIFF
--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -15,9 +15,16 @@ static const char load_puppet[] =
 "require 'puppet'\n"
 "Puppet.initialize_settings\n"
 "unless $LOAD_PATH.include?(Puppet[:libdir])\n"
-"    $LOAD_PATH << Puppet[:libdir]\n"
+"  $LOAD_PATH << Puppet[:libdir]\n"
 "end\n"
 "Facter.reset\n"
+"if Puppet.respond_to? :initialize_facts\n"
+"  Puppet.initialize_facts\n"
+"else\n"
+"  Facter.add(:puppetversion) do\n"
+"    setcode { Puppet.version.to_s }\n"
+"  end\n"
+"end\n"
 "Facter.search_external([Puppet[:pluginfactdest]])";
 
 namespace facter { namespace ruby {


### PR DESCRIPTION
When `facter -p` was restored to Facter 3, the `puppetversion` fact was
overlooked. It was moved to Puppet, but the code path we call to
initialize `facter -p` doesn't set it up. Explicitly set it by calling
`Puppet.version`, with support for a Puppet helper to be setup in
PUP-5508 to future-proof `facter -p` for new core Puppet facts.