### PR TITLE
(maint) Fixes for compiling Facter with GCC 5 on Windows.

### DIFF
--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -40,7 +40,7 @@ namespace facter { namespace facts {
                 return {p.string()};
             }
 
-            LOG_WARNING("error finding COMMON_APPDATA, external facts unavailable: %1%", system_error());
+            LOG_WARNING("error finding COMMON_APPDATA, external facts unavailable: %1%", leatherman::windows::system_error());
         } else {
             auto home = user::home_dir();
             if (!home.empty()) {

--- a/lib/src/facts/windows/identity_resolver.cc
+++ b/lib/src/facts/windows/identity_resolver.cc
@@ -20,14 +20,14 @@ namespace facter { namespace facts { namespace windows {
         auto nameformat = NameSamCompatible;
         GetUserNameExW(nameformat, nullptr, &size);
         if (GetLastError() != ERROR_MORE_DATA) {
-            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", system_error());
+            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", leatherman::windows::system_error());
             return result;
         }
 
         // Use the string as a raw buffer that supports move and ref operations.
         wstring buffer(size, '\0');
         if (!GetUserNameExW(nameformat, &buffer[0], &size)) {
-            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", system_error());
+            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", leatherman::windows::system_error());
             return result;
         }
 

--- a/lib/src/facts/windows/kernel_resolver.cc
+++ b/lib/src/facts/windows/kernel_resolver.cc
@@ -68,7 +68,7 @@ namespace facter { namespace facts { namespace windows {
             result.release = move(*release);
             result.version = result.release;
         } else {
-            LOG_DEBUG("failed to retrieve kernel facts: %1%", system_error());
+            LOG_DEBUG("failed to retrieve kernel facts: %1%", leatherman::windows::system_error());
         }
 
         result.name = os::windows;

--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -40,13 +40,13 @@ namespace facter { namespace facts { namespace windows {
         DWORD size = 0u;
         GetComputerNameExW(nameFormat, nullptr, &size);
         if (GetLastError() != ERROR_MORE_DATA) {
-            LOG_DEBUG("failure resolving hostname: %1%", system_error());
+            LOG_DEBUG("failure resolving hostname: %1%", leatherman::windows::system_error());
             return "";
         }
 
         wstring buffer(size, '\0');
         if (!GetComputerNameExW(nameFormat, &buffer[0], &size)) {
-            LOG_DEBUG("failure resolving hostname: %1%", system_error());
+            LOG_DEBUG("failure resolving hostname: %1%", leatherman::windows::system_error());
             return "";
         }
 
@@ -108,13 +108,13 @@ namespace facter { namespace facts { namespace windows {
             } else if (err == ERROR_BUFFER_OVERFLOW) {
                 pAddresses.resize(outBufLen);
             } else {
-                LOG_DEBUG("failure getting netmask info: %1%", system_error(err));
+                LOG_DEBUG("failure getting netmask info: %1%", leatherman::windows::system_error(err));
                 return {};
             }
         }
 
         if (err != ERROR_SUCCESS) {
-            LOG_DEBUG("failure getting netmask info: %1%", system_error(err));
+            LOG_DEBUG("failure getting netmask info: %1%", leatherman::windows::system_error(err));
             return {};
         }
 
@@ -163,13 +163,13 @@ namespace facter { namespace facts { namespace windows {
             } else if (err == ERROR_BUFFER_OVERFLOW) {
                 pAddresses.resize(outBufLen);
             } else {
-                LOG_DEBUG("failure resolving networking facts: %1%", system_error(err));
+                LOG_DEBUG("failure resolving networking facts: %1%", leatherman::windows::system_error(err));
                 return result;
             }
         }
 
         if (err != ERROR_SUCCESS) {
-            LOG_DEBUG("failure resolving networking facts: %1%", system_error(err));
+            LOG_DEBUG("failure resolving networking facts: %1%", leatherman::windows::system_error(err));
             return result;
         }
 

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -57,7 +57,7 @@ namespace facter { namespace facts { namespace windows {
         // executables can be found.
         TCHAR szPath[MAX_PATH];
         if (!SUCCEEDED(SHGetFolderPath(NULL, CSIDL_WINDOWS, NULL, 0, szPath))) {
-            LOG_DEBUG("error finding SYSTEMROOT: %1%", system_error());
+            LOG_DEBUG("error finding SYSTEMROOT: %1%", leatherman::windows::system_error());
         }
 
         auto pathNative = path(szPath) / "sysnative";

--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -466,7 +466,7 @@ SCENARIO("using the fact collection with a default external fact path") {
             LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/text",
         });
         REQUIRE_FALSE(facts.empty());
-        REQUIRE(facts.size() == 4);
+        REQUIRE(facts.size() == 4u);
         THEN("facts from both directories should be added") {
             REQUIRE(facts.get<string_value>("foo"));
             REQUIRE(facts.get<string_value>("txt_fact1"));

--- a/lib/tests/facts/resolvers/networking_resolver.cc
+++ b/lib/tests/facts/resolvers/networking_resolver.cc
@@ -405,7 +405,7 @@ SCENARIO("using the networking resolver") {
                 REQUIRE(mtu->value() == i);
                 auto bindings = interface->get<array_value>("bindings");
                 REQUIRE(bindings);
-                REQUIRE(bindings->size() == 2);
+                REQUIRE(bindings->size() == 2u);
                 for (size_t binding_index = 0; binding_index < bindings->size(); ++binding_index) {
                     auto interface_num = to_string(binding_index);
                     auto binding = bindings->get<map_value>(binding_index);
@@ -422,7 +422,7 @@ SCENARIO("using the networking resolver") {
                 }
                 bindings = interface->get<array_value>("bindings6");
                 REQUIRE(bindings);
-                REQUIRE(bindings->size() == 2);
+                REQUIRE(bindings->size() == 2u);
                 for (size_t binding_index = 0; binding_index < bindings->size(); ++binding_index) {
                     auto interface_num = to_string(binding_index);
                     auto binding = bindings->get<map_value>(binding_index);


### PR DESCRIPTION
This resolves the ambiguity between `std::system_error` and
`leatherman::windows::system_error`.

Also fixed were two signed/unsigned conversions in the test code.