### PR TITLE
(FACT-1246) Return the first value found in ID_LIKE

### DIFF
--- a/lib/inc/internal/facts/linux/os_cisco.hpp
+++ b/lib/inc/internal/facts/linux/os_cisco.hpp
@@ -57,7 +57,17 @@ namespace facter { namespace facts { namespace linux {
                 return value;
             }
             auto val = _release_info.find("ID_LIKE");
-            return (val != _release_info.end()) ? val->second : std::string();
+            if (val != _release_info.end()) {
+                auto& family = val->second;
+                auto pos = family.find(" ");
+                // If multiple values are found in ID_LIKE, only return the
+                // first one (FACT-1246)
+                if (pos != std::string::npos) {
+                    return family.substr(0, pos);
+                }
+                return family;
+            }
+            return std::string();
         }
 
         /**


### PR DESCRIPTION
The ID_LIKE field may contain a space-separated list of related OS
families. Some Cisco platforms exercise this feature, and when they
do so, we only want to return the first value found.

Tested on the cisco-wrlinux-7 platform with the following release file contents:

/etc/os-release:
ID=wrlinux
NAME=Wind River Linux
VERSION=7.0.0.2
VERSION_ID=7.0.0.2
PRETTY_NAME=Wind River Linux 7.0.0.2
CISCO_RELEASE_INFO=/etc/cisco-release

/etc/cisco-release:
ID=ios_xr
ID_LIKE="cisco-wrlinux wrlinux"
NAME=IOS XR
VERSION="6.0.0.20I"
VERSION_ID=6.0.0.20I
PRETTY_NAME="Cisco IOS XR Software, Version 6.0.0.20I"
HOME_URL=http://www.cisco.com
BUILD_ID="2015-10-22-18-52-49"
CISCO_RELEASE_INFO=/etc/cisco-release

This is the first time I've touched C++ code in years, so please be thorough when explaining any desired refactorings. 