### PR TITLE
(FACT-1277) Ensure Puppet external facts are loaded

### DIFF
--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -18,14 +18,14 @@ static const char load_puppet[] =
 "  $LOAD_PATH << Puppet[:libdir]\n"
 "end\n"
 "Facter.reset\n"
+"Facter.search_external([Puppet[:pluginfactdest]])\n"
 "if Puppet.respond_to? :initialize_facts\n"
 "  Puppet.initialize_facts\n"
 "else\n"
 "  Facter.add(:puppetversion) do\n"
 "    setcode { Puppet.version.to_s }\n"
 "  end\n"
-"end\n"
-"Facter.search_external([Puppet[:pluginfactdest]])";
+"end\n";
 
 namespace facter { namespace ruby {
 


### PR DESCRIPTION
The external facts path needs to be registered before doing anything to
resolve facts - such as call `Facter.add`. Otherwise that path will not
be used to resolve facts. Register `pluginfactdest` before adding core
Puppet facts.