### PR TITLE
Support multilib installation on RPM distributions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -241,8 +241,7 @@ endif()
 if (WIN32)
     set(LIBFACTER_INSTALL_DESTINATION bin)
 else()
-    # TODO: lib64 for certain operating systems?
-    set(LIBFACTER_INSTALL_DESTINATION lib)
+    set(LIBFACTER_INSTALL_DESTINATION lib${LIB_SUFFIX})
 endif()
 
 if (JRUBY_SUPPORT)


### PR DESCRIPTION
Major RPM distributions define the CMake variable LIB_SUFFIX to determine
if libraries should be shipped in /usr/lib64 or /usr/lib