### PR TITLE
(FACT-1286) Only return files, never directories

### DIFF
--- a/lib/facter/core/execution/posix.rb
+++ b/lib/facter/core/execution/posix.rb
@@ -11,11 +11,11 @@ class Facter::Core::Execution::Posix < Facter::Core::Execution::Base
 
   def which(bin)
     if absolute_path?(bin)
-      return bin if File.executable?(bin)
+      return bin if File.executable?(bin) and File.file?(bin)
     else
       search_paths.each do |dir|
         dest = File.join(dir, bin)
-        return dest if File.executable?(dest)
+        return dest if File.executable?(dest) and File.file?(dest)
       end
     end
     nil

--- a/spec/unit/core/execution/posix_spec.rb
+++ b/spec/unit/core/execution/posix_spec.rb
@@ -16,6 +16,7 @@ describe Facter::Core::Execution::Posix, :unless => Facter::Util::Config.is_wind
 
     context "and provided with an absolute path" do
       it "should return the binary if executable" do
+        File.expects(:file?).with('/opt/foo').returns true
         File.expects(:executable?).with('/opt/foo').returns true
         subject.which('/opt/foo').should == '/opt/foo'
       end
@@ -24,12 +25,21 @@ describe Facter::Core::Execution::Posix, :unless => Facter::Util::Config.is_wind
         File.expects(:executable?).with('/opt/foo').returns false
         subject.which('/opt/foo').should be_nil
       end
+
+      it "should return nil if the binary is not a file" do
+        File.expects(:file?).with('/opt/foo').returns false
+        File.expects(:executable?).with('/opt/foo').returns true
+        subject.which('/opt/foo').should be_nil
+      end
     end
 
     context "and not provided with an absolute path" do
       it "should return the absolute path if found" do
+        File.expects(:file?).with('/bin/foo').never
         File.expects(:executable?).with('/bin/foo').returns false
+        File.expects(:file?).with('/sbin/foo').returns true
         File.expects(:executable?).with('/sbin/foo').returns true
+        File.expects(:file?).with('/usr/sbin/foo').never
         File.expects(:executable?).with('/usr/sbin/foo').never
         subject.which('foo').should == '/sbin/foo'
       end


### PR DESCRIPTION
Without this patch 'Facter::Util::Resolution.which' will return a
directory if a directory with a matching name is found earlier in the
PATH than a executable file with a matching name.

This patch ensures that 'Facter::Util::Resolution.which' will only
return items which are files.