### PR TITLE
(FACT-950) Unvendor leatherman

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/leatherman"]
-	path = vendor/leatherman
-	url = https://github.com/puppetlabs/leatherman

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
   # Install dependencies of facter
   - wget https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1_install.tar.bz2
   - tar xjvf yaml-cpp-0.5.1_install.tar.bz2 --strip 1 -C $USERDIR
+  - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz
+  - tar xzvf leatherman.tar.gz -C $USERDIR
 
 script: ./scripts/travis_target.sh
 
@@ -38,6 +40,7 @@ env:
     - PYTHONUSERBASE=$USERDIR
     - PATH=$USERDIR/bin:$PATH
     - LD_LIBRARY_PATH=$USERDIR/lib:$LD_LIBRARY_PATH
+    - LEATHERMAN_VERSION=0.3.4
   matrix:
     - TRAVIS_TARGET=COMMITS
     - TRAVIS_TARGET=DOXYGEN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/vendor/leatherman/cmake")
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     # Allow searching in boxen installed homebrew directories
@@ -40,7 +39,30 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} /opt/boxen/homebrew/include)
 endif()
 
-# Before we find any packages, we want to pull in the common leatherman options, as they can affect commonly-used packages.
+include(FeatureSummary)
+
+SET(LEATHERMAN_COMPONENTS locale catch nowide logging util file_util dynamic_library execution ruby rapidjson)
+
+# We look for curl early, because whether or not we link to the leatherman curl library
+# is dependant on whether or not we find curl on the system.
+if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux") OR WIN32) AND NOT WITHOUT_CURL)
+    find_package(CURL)
+    if (CURL_FOUND)
+        add_definitions(-DUSE_CURL)
+        list(APPEND LEATHERMAN_COMPONENTS curl)
+    endif()
+    set_package_properties(CURL PROPERTIES DESCRIPTION "A free and easy-to-use client-side URL transfer library" URL "http://curl.haxx.se/libcurl/")
+    set_package_properties(CURL PROPERTIES TYPE OPTIONAL PURPOSE "Enables facts that require HTTP.")
+endif()
+
+if (WIN32)
+    list(APPEND LEATHERMAN_COMPONENTS windows)
+endif()
+
+find_package(Leatherman REQUIRED COMPONENTS ${LEATHERMAN_COMPONENTS})
+
+# Now that we have leatherman, we can pulll in its options file, which
+# we need for finding all our other libraries.
 include(options)
 
 # We use program_options, system, filesystem, date_time, and regex directly.
@@ -56,14 +78,6 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND NOT WITHOUT_BLKID)
     find_package(BLKID)
 endif()
 
-if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux") OR WIN32) AND NOT WITHOUT_CURL)
-    find_package(CURL)
-    if (CURL_FOUND)
-        add_definitions(-DUSE_CURL)
-    endif()
-    set_package_properties(CURL PROPERTIES DESCRIPTION "A free and easy-to-use client-side URL transfer library" URL "http://curl.haxx.se/libcurl/")
-    set_package_properties(CURL PROPERTIES TYPE OPTIONAL PURPOSE "Enables facts that require HTTP.")
-endif()
 
 if (NOT WITHOUT_JRUBY AND NOT WIN32)
     find_package(JNI)
@@ -101,25 +115,6 @@ add_definitions(${LEATHERMAN_DEFINITIONS})
 
 # Include vendor libraries
 set(RAPIDJSON_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/vendor/rapidjson-0.11/include")
-
-# Build against our leatherman tooling
-set(LEATHERMAN_USE_LOCALE TRUE)
-set(LEATHERMAN_USE_CATCH TRUE)
-set(LEATHERMAN_USE_NOWIDE TRUE)
-set(LEATHERMAN_USE_LOGGING TRUE)
-set(LEATHERMAN_USE_UTIL TRUE)
-if(CURL_FOUND)
-    set(LEATHERMAN_USE_CURL TRUE)
-endif()
-if(WIN32)
-	set(LEATHERMAN_USE_WINDOWS TRUE)
-endif()
-set(LEATHERMAN_USE_FILE_UTIL TRUE)
-set(LEATHERMAN_USE_DYNAMIC_LIBRARY TRUE)
-set(LEATHERMAN_USE_EXECUTION TRUE)
-set(LEATHERMAN_USE_RUBY TRUE)
-set(LEATHERMAN_USE_RAPIDJSON TRUE)
-add_subdirectory("vendor/leatherman")
 
 #
 # Add cpplint and cppcheck targets

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 3.1.0.{build}
 clone_depth: 10
+environment:
+  LEATHERMAN_VERSION: 0.3.4
 install:
   - git submodule update --init --recursive
 
@@ -15,11 +17,17 @@ install:
   - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\yaml-cpp.7z"
   - ps: 7z.exe x yaml-cpp.7z -oC:\tools | FIND /V "ing  "
 
+  - ps: wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$pwd\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
+  - ps: 7z.exe x "curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
+
+  - ps: wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$pwd\leatherman.7z"
+  - ps: 7z.exe x leatherman.7z -oC:\tools | FIND /V "ing "
+
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh" .
   - ps: mingw32-make -j2
 
 test_script:

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -39,9 +39,9 @@ if [ ${TRAVIS_TARGET} == COMMITS ]; then
   done
   exit 0
 elif [ ${TRAVIS_TARGET} == DEBUG ]; then
-  cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON .
+  cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON -DCMAKE_PREFIX_PATH=$USERDIR .
 else
-  cmake .
+  cmake -DCMAKE_PREFIX_PATH=$USERDIR .
 fi
 
 if [ ${TRAVIS_TARGET} == CPPLINT ]; then


### PR DESCRIPTION
This updates the CMake to assume leatherman needs to be found on the
system, and updates the travis build scripts to use an artifact
provided from a github release.

Merging this will require puppetlabs/leatherman#112, a to-be-released puppet-agent PR for adding the necessary leatherman component there, and an updated tag of leatherman so we'll have a github release and a good baseline for the P-A component