### PR TITLE
(FACT-1288) Bump leatherman and use `leatherman_install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,11 +101,6 @@ add_definitions(${LEATHERMAN_DEFINITIONS})
 
 # Include vendor libraries
 set(RAPIDJSON_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/vendor/rapidjson-0.11/include")
-if (WIN32)
-    # We disabled installing Boost.Nowide; add back the library we use.
-    # CMake doesn't allow install targets in a different directory, so get the file.
-    install(FILES ${CMAKE_BINARY_DIR}/bin/libnowide.dll DESTINATION bin)
-endif()
 
 # Build against our leatherman tooling
 set(LEATHERMAN_USE_LOCALE TRUE)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:
-  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DBOOST_NOWIDE_SKIP_TESTS=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" .
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" .
   - ps: mingw32-make -j2
 
 test_script:

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -19,4 +19,4 @@ include_directories(
 add_executable(facter ${FACTER_SOURCES})
 target_link_libraries(facter libfacter ${Boost_PROGRAM_OPTIONS_LIBRARY} ${LEATHERMAN_UTIL_LIB} ${LEATHERMAN_NOWIDE_LIB})
 
-install(TARGETS facter DESTINATION bin)
+leatherman_install(facter)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -312,7 +312,7 @@ elseif (WIN32)
     add_definitions("-Dlibfacter_EXPORTS")
 endif()
 
-install(TARGETS libfacter DESTINATION ${LIBFACTER_INSTALL_DESTINATION})
+leatherman_install(libfacter)
 install(DIRECTORY inc/facter DESTINATION include)
 
 # Always generate facter.rb and spec_helper.rb, as they might be used in packaging


### PR DESCRIPTION
Update to the latest Leatherman, and use `leatherman_install` to install
targets. Linking `libfacter.bundle` now explicitly points to `lib`.

Also picks up static libnowide.