### PR TITLE
(FACT-1289) fix detection of a virtualbox guest

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -256,6 +256,8 @@ Facter.add("virtual") do
         'xenu'
       when /ibm_systemz/i
         'zlinux'
+      when /virtualbox/i
+        'virtualbox'
       else
         output.to_s.split("\n").last
       end

--- a/spec/unit/virtual_spec.rb
+++ b/spec/unit/virtual_spec.rb
@@ -410,6 +410,7 @@ describe "Virtual fact" do
         'xen-dom0' => 'xen0',
         'xen-domU' => 'xenu',
         'ibm_systemz' => 'zlinux',
+        "virtualbox\nkvm" => 'virtualbox',
       }
 
       virt_what_map.each do |input,output|


### PR DESCRIPTION
A virtualbox guest on top of a KVM hypervisor gets reported as kvm,
as we only look at the last line of virt-what's output. We need
to be more specific here.