### PR TITLE
(FACT-959) Incorrect processor counts on Windows

### DIFF
--- a/lib/facter/processors/os.rb
+++ b/lib/facter/processors/os.rb
@@ -112,7 +112,7 @@ module Facter
         # get each physical processor
         Facter::Util::WMI.execquery("select * from Win32_Processor").each do |proc|
           # not supported before 2008
-          if proc.respond_to?(:NumberOfLogicalProcessors)
+          if proc.ole_respond_to?(:NumberOfLogicalProcessors)
             processor_num = proc.NumberOfLogicalProcessors
           else
             processor_num = 1

--- a/spec/unit/processors/os_spec.rb
+++ b/spec/unit/processors/os_spec.rb
@@ -221,6 +221,7 @@ describe Facter::Processors::Windows do
       before :each do
         proc = stubs 'proc'
         proc.stubs(:Name).returns("Intel(R)    Celeron(R)   processor")
+        proc.stubs(:ole_respond_to?).with(:NumberOfLogicalProcessors).returns(false)
         load(Array.new(2, proc))
       end
 
@@ -235,6 +236,7 @@ describe Facter::Processors::Windows do
       before :each do
         proc = stubs 'proc'
         proc.stubs(:NumberOfLogicalProcessors).returns(2)
+        proc.stubs(:ole_respond_to?).with(:NumberOfLogicalProcessors).returns(true)
         proc.stubs(:Name).returns("Intel(R)    Celeron(R)   processor")
         load(Array.new(2, proc))
       end


### PR DESCRIPTION
Facter is showing the CPU socket count on processorcount fact which
should be the the logical count and not the physical count (which is
already represented by the physicalprocessorcount fact).

Apparently it is a bug in the
proc.respond_to?(:NumberOfLogicalProcessors) which always returns
false since the NumberOfLogicalProcessors is not a regular method but
an OLE method. Therefore it should use the ole_respond_to? method
(WIN32OLE class).