### PR TITLE
(FACT-380) Use default gateway device for `ipaddress` fact on linux

### DIFF
--- a/lib/facter/ipaddress.rb
+++ b/lib/facter/ipaddress.rb
@@ -3,7 +3,9 @@
 # Purpose: Return the main IP address for a host.
 #
 # Resolution:
-#   On the Unixes does an ifconfig, and returns the first non 127.0.0.0/8
+#   On Linux and AIX, it examines the routing table and uses the IP address
+#   of the default interface.
+#   On other Unixes does an ifconfig, and returns the first non 127.0.0.0/8
 #   subnetted IP it finds.
 #   On Windows, it attempts to use the socket library and resolve the machine's
 #   hostname via DNS.
@@ -28,15 +30,10 @@ Facter.add(:ipaddress) do
   confine :kernel => :linux
   setcode do
     ip = nil
-    output = Facter::Util::IP.exec_ifconfig(["2>/dev/null"])
-    if output
-      regexp = /inet (?:addr:)?([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/
-      output.split("\n").each do |line|
-        match = regexp.match(line)
-        if match and not /^127\./.match(match[1])
-          ip = match[1]
-          break
-        end
+    File.read("/proc/net/route").split("\n").each do |line|
+      parts = line.split()
+      if parts[1] == "00000000"
+        ip ||= Facter.value("ipaddress_#{parts[0]}".intern)
       end
     end
     ip


### PR DESCRIPTION
Previously, Facter would treat whichever device was first in `ifconfig` as the default device. This kinda-sorta-works in a world where "first ethernet device" is your default, and there are no devices alphabetically before "e".

The new version of the code will check `/proc/net/route` and use the IP address of whichever interface provides the default route.