### PR TITLE
(maint) Acceptance - fix File.exists? in Rakefile

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -94,7 +94,7 @@ EOS
   tests_opt = "--tests=#{tests}" if tests
 
   target = ENV['TEST_TARGET']
-  if config and File.exists(config)
+  if config and File.exists?(config)
     config_opt = "--hosts=#{config}"
   elsif target
     cli = BeakerHostGenerator::CLI.new([target, '--disable-default-role', '--osinfo-version', '1'])


### PR DESCRIPTION
This commit fixes a typo in the File.exists? method in the
acceptance test Rakefile.

[skip ci]