### PR TITLE
(maint) Fix typo in test

### DIFF
--- a/lib/tests/facts/external/windows/execution_resolver.cc
+++ b/lib/tests/facts/external/windows/execution_resolver.cc
@@ -61,7 +61,7 @@ SCENARIO("resolving external executable facts") {
         }
     }
     GIVEN("a relative path not on PATH") {
-        test_with_relative_path fixture("foo", "bar.bar", "");
+        test_with_relative_path fixture("foo", "bar.bat", "");
         THEN("the file cannot be resolved") {
             REQUIRE_FALSE(resolver.can_resolve("foo/bar.bat"));
         }


### PR DESCRIPTION
Previously the test wasn't testing the right thing, as the name of the
created test file was wrong. Fix the typo to use the same name for
creation and lookup.