### PR TITLE
(FACT-1313) Acceptance - sleep after hostname

### DIFF
--- a/acceptance/tests/ticket_1238_hostname_fqdn.rb
+++ b/acceptance/tests/ticket_1238_hostname_fqdn.rb
@@ -14,6 +14,7 @@ agents.each do |agent|
 
   step 'set hostname as fqdn' do
     on(agent, "hostname #{fqdn}")
+    sleep 1 # on Solaris 11 hostname returns before the hostname is updated
   end
 
   step 'validate facter honors fqdn' do


### PR DESCRIPTION
On Solaris 11, the hostname command returns before the system
has set the new hostname. This commit adds a sleep statement
to allow the hostname value to be updated on the system before
validating that facter can retrieve the expected fqdn.

[skip ci]