### PR TITLE
(FACT-1321) Install facter batch files on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,3 +150,8 @@ else()
 endif()
 
 install(FILES ${PROJECT_SOURCE_DIR}/man/man8/facter.8 DESTINATION ${MANDIR})
+if (WIN32)
+  install(FILES ${PROJECT_SOURCE_DIR}/ext/windows/facter.bat DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+  install(FILES ${PROJECT_SOURCE_DIR}/ext/windows/facter_interactive.bat DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+  install(FILES ${PROJECT_SOURCE_DIR}/ext/windows/run_facter_interactive.bat DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+endif()

--- a/ext/windows/facter.bat
+++ b/ext/windows/facter.bat
@@ -1,0 +1,8 @@
+@echo off
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET "PATH=%~dp0;%PATH%"
+)
+facter.exe %*

--- a/ext/windows/facter_interactive.bat
+++ b/ext/windows/facter_interactive.bat
@@ -1,0 +1,6 @@
+@echo off
+SETLOCAL
+echo Running Facter on demand ...
+cd "%~dp0"
+call .\facter.bat %*
+PAUSE

--- a/ext/windows/run_facter_interactive.bat
+++ b/ext/windows/run_facter_interactive.bat
@@ -1,0 +1,9 @@
+@echo Running facter on demand ...
+@echo off
+SETLOCAL
+if exist "%~dp0environment.bat" (
+  call "%~dp0environment.bat" %0 %*
+) else (
+  SET "PATH=%~dp0;%PATH%"
+)
+elevate.exe "%~dp0facter_interactive.bat"


### PR DESCRIPTION
As we switch to building puppet-agent for windows with vanagon, we need
access to resources that currently live in puppet_for_the_win. Though
these resources depend on resources that are made available in
puppet-agent, it makes sense to store these in the project specific
repo.

This takes advantage of `environment.bat` in puppet-agent installed with https://github.com/puppetlabs/puppet-agent/pull/512