### PR TITLE
(FACT-1338) Resolve weird pthread dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ include(options)
 
 # We use program_options, system, filesystem, date_time, and regex directly.
 find_package(Boost 1.54 REQUIRED COMPONENTS program_options system filesystem date_time regex)
+# date_time and regex need threads on some platforms, and find_package Boost only includes
+# pthreads if you require the Boost.Thread component.
+find_package(Threads)
 
 find_package(Ruby 1.9)
 

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -17,6 +17,11 @@ include_directories(
 )
 
 add_executable(facter ${FACTER_SOURCES})
-target_link_libraries(facter libfacter ${Boost_PROGRAM_OPTIONS_LIBRARY} ${LEATHERMAN_UTIL_LIB} ${LEATHERMAN_NOWIDE_LIB})
+target_link_libraries(facter libfacter
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${LEATHERMAN_UTIL_LIB}
+    ${LEATHERMAN_NOWIDE_LIB}
+    ${CMAKE_THREAD_LIBS_INIT} # fix until Leatherman switches to private dependencies
+)
 
 leatherman_install(facter)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -299,6 +299,7 @@ target_link_libraries(libfacter PRIVATE
     ${OPENSSL_LIBRARIES}
     ${YAMLCPP_LIBRARIES}
     ${CURL_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 symbol_exports(libfacter "${CMAKE_CURRENT_LIST_DIR}/inc/facter/export.h")

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ target_link_libraries(libfacter_test
     ${OPENSSL_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
     ${CURL_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
 )
 
 # Generate a file containing the path to the fixtures


### PR DESCRIPTION
AIX shows a dependency on `.pthread_cancel` from `libboost_date_time`,
which is now included in linking the `facter` binary from
`leatherman_util`. Other links succeed because they include
`libboost_thread`, bringing in a dependency on pthread.

Explicitly depend on pthread everywhere until LTH-81 is resolved.
Resolving LTH-81 exposes an implicit dependency of `libboost_date_time`
and `libboost_regex` on pthread on some platforms that's not fulfilled
by `find_package(Boost)`, so the libfacter and libfacter_test
dependencies on pthread will be permanent.