### PR TITLE
DO NOT MERGE (FACT-1344) Acceptance - Replace TrueValue/FalseValue

### DIFF
--- a/acceptance/tests/verify_facts.rb
+++ b/acceptance/tests/verify_facts.rb
@@ -29,7 +29,7 @@ def validate_fact(name, node, fact_value, hidden)
               # YAML-CPP seems to drop the decimal whenever it feels like it, so just match Int too.
               fact_value.is_a? Float or fact_value.is_a? Integer or fact_value.to_s =~ /^(\.inf|\.nan|-\.inf)$/
             when 'string'
-              fact_value.is_a? String or fact_value.is_a? TrueValue or fact_value.is_a? FalseValue
+              fact_value.is_a? String or fact_value.is_a? TrueClass or fact_value.is_a? FalseClass
             when 'ip'
               fact_value.is_a? String and fact_value =~ @ip_pattern
             when 'ip6'


### PR DESCRIPTION
This commit replaces occurrences of the constants `TrueValue` and
`FalseValue` with `TrueClass` and `FalseClass` respectively.

The previous constants were not recognized as ruby or beaker
constants and resulted in a `NameError` exception when triggered
by the acceptance test.

[skip ci]