### PR TITLE
(FACT-1317) Fix string values that look like booleans

### DIFF
--- a/acceptance/tests/verify_facts.rb
+++ b/acceptance/tests/verify_facts.rb
@@ -29,7 +29,7 @@ def validate_fact(name, node, fact_value, hidden)
               # YAML-CPP seems to drop the decimal whenever it feels like it, so just match Int too.
               fact_value.is_a? Float or fact_value.is_a? Integer or fact_value.to_s =~ /^(\.inf|\.nan|-\.inf)$/
             when 'string'
-              fact_value.is_a? String or fact_value.is_a? TrueValue or fact_value.is_a? FalseValue
+              fact_value.is_a? String
             when 'ip'
               fact_value.is_a? String and fact_value =~ @ip_pattern
             when 'ip6'

--- a/lib/src/util/string.cc
+++ b/lib/src/util/string.cc
@@ -1,4 +1,5 @@
 #include <facter/util/string.hpp>
+#include <boost/regex.hpp>
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
@@ -111,6 +112,13 @@ namespace facter { namespace util {
     {
         // Empty strings should be quoted
         if (str.empty()) {
+            return true;
+        }
+
+        // Taken from http://yaml.org/type/bool.html.
+        // The string would be interpreted as a boolean, so quote it.
+        static boost::regex yaml_bool("y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF");
+        if (boost::regex_match(str, yaml_bool)) {
             return true;
         }
 

--- a/lib/tests/facts/string_value.cc
+++ b/lib/tests/facts/string_value.cc
@@ -230,4 +230,41 @@ SCENARIO("using a string fact value") {
             }
         }
     }
+
+    GIVEN("a boolean value") {
+        for (auto literal : {string("true"), string("false"), string("yes"), string("no")}) {
+            auto value = string_value(literal);
+
+            WHEN("serialized to JSON") {
+                THEN("it should have the same value") {
+                    json_value json;
+                    json_allocator allocator;
+                    value.to_json(allocator, json);
+                    REQUIRE(json.IsString());
+                    REQUIRE(json.GetString() == literal);
+                }
+            }
+            WHEN("serialized to YAML") {
+                THEN("it should be quoted") {
+                    Emitter emitter;
+                    value.write(emitter);
+                    REQUIRE(string(emitter.c_str()) == "\""+literal+"\"");
+                }
+            }
+            WHEN("serialized to text with quotes") {
+                THEN("it should be quoted") {
+                    ostringstream stream;
+                    value.write(stream);
+                    REQUIRE(stream.str() == "\""+literal+"\"");
+                }
+            }
+            WHEN("serialized to text without quotes") {
+                THEN("it should not be quoted") {
+                    ostringstream stream;
+                    value.write(stream, false);
+                    REQUIRE(stream.str() == literal);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
YAML will read boolean strings as boolean types. When the schema states
the Fact type is a string, we should ensure it's read as a string by
YAML parsers. Quote any boolean literal representation in a
string_value.

Also fix a prior mistake in the verify_facts acceptance test, which no
longer needs to check for boolean classes for a string.