### PR TITLE
(FACT-1348) Remove usage of the Win32-Security gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 platform(*mingw) do
   gem 'ffi', '~> 1.9.5', :require => false
   gem 'win32-dir', '~> 0.4.8', :require => false
+  # Use of the win32-security gem is deprecated
   gem 'win32-security', '~> 0.2.5', :require => false
 end
 

--- a/lib/facter/util/windows.rb
+++ b/lib/facter/util/windows.rb
@@ -1,0 +1,8 @@
+module Facter::Util::Windows
+  if Facter::Util::Config.is_windows?
+    require 'facter/util/windows/api_types'
+    require 'facter/util/windows/error'
+    require 'facter/util/windows/user'
+    require 'facter/util/windows/process'
+  end
+end

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -1,0 +1,106 @@
+require 'ffi'
+
+module Facter::Util::Windows::ApiTypes
+  module ::FFI
+    WIN32_FALSE = 0
+
+    # standard Win32 error codes
+    ERROR_SUCCESS = 0
+  end
+
+  module ::FFI::Library
+    # Wrapper method for attach_function + private
+    def attach_function_private(*args)
+      attach_function(*args)
+      private args[0]
+    end
+  end
+
+  class ::FFI::Pointer
+    NULL_HANDLE = 0
+
+    def read_win32_bool
+      # BOOL is always a 32-bit integer in Win32
+      # some Win32 APIs return 1 for true, while others are non-0
+      read_int32 != FFI::WIN32_FALSE
+    end
+    #
+    alias_method :read_dword, :read_uint32
+
+    def read_handle
+      type_size == 4 ? read_uint32 : read_uint64
+    end
+
+    def read_wide_string(char_length, dst_encoding = Encoding::UTF_8)
+      # char_length is number of wide chars (typically excluding NULLs), *not* bytes
+      str = get_bytes(0, char_length * 2).force_encoding('UTF-16LE')
+      str.encode(dst_encoding)
+    end
+
+    def read_win32_local_pointer(&block)
+      ptr = nil
+      begin
+        ptr = read_pointer
+        yield ptr
+      ensure
+        if ptr && ! ptr.null?
+          if FFI::WIN32::LocalFree(ptr.address) != FFI::Pointer::NULL_HANDLE
+            Puppet.debug "LocalFree memory leak"
+          end
+        end
+      end
+
+      # ptr has already had LocalFree called, so nothing to return
+      nil
+    end
+  end
+  # FFI Types
+  # https://github.com/ffi/ffi/wiki/Types
+
+  # Windows - Common Data Types
+  # https://msdn.microsoft.com/en-us/library/cc230309.aspx
+
+  # Windows Data Types
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
+
+  FFI.typedef :uint32, :dword
+  FFI.typedef :uintptr_t, :handle
+
+  # pointer in FFI is platform specific
+  # NOTE: for API calls with reserved lpvoid parameters, pass a FFI::Pointer::NULL
+  FFI.typedef :pointer, :lpcvoid
+  FFI.typedef :pointer, :lpvoid
+  FFI.typedef :pointer, :lpdword
+  FFI.typedef :pointer, :pdword
+  FFI.typedef :pointer, :phandle
+  FFI.typedef :pointer, :pbool
+
+  # FFI bool can be only 1 byte at times,
+  # Win32 BOOL is a signed int, and is always 4 bytes, even on x64
+  # https://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
+  FFI.typedef :int32, :win32_bool
+
+  # 8 bits per byte
+  FFI.typedef :uchar, :byte
+  FFI.typedef :uint16, :wchar
+
+  module ::FFI::WIN32
+    extend ::FFI::Library
+
+    ffi_convention :stdcall
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa366730(v=vs.85).aspx
+    # HLOCAL WINAPI LocalFree(
+    #   _In_  HLOCAL hMem
+    # );
+    ffi_lib :kernel32
+    attach_function :LocalFree, [:handle], :handle
+
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724211(v=vs.85).aspx
+    # BOOL WINAPI CloseHandle(
+    #   _In_  HANDLE hObject
+    # );
+    ffi_lib :kernel32
+    attach_function_private :CloseHandle, [:handle], :win32_bool
+  end
+end

--- a/lib/facter/util/windows/error.rb
+++ b/lib/facter/util/windows/error.rb
@@ -1,0 +1,85 @@
+require 'facter/util/windows'
+
+# represents an error resulting from a Win32 error code
+class Facter::Util::Windows::Error < RuntimeError
+  require 'ffi'
+  extend FFI::Library
+
+  attr_reader :code
+  attr_reader :original
+
+  # NOTE: FFI.errno only works properly when prior Win32 calls have been made
+  # through FFI bindings.  Calls made through Win32API do not have their error
+  # codes captured by FFI.errno
+  def initialize(message, code = FFI.errno, original = nil)
+    @original = original
+    super(message + ":  #{self.class.format_error_code(code)}")
+
+    @code = code
+  end
+
+  # Helper method that wraps FormatMessage that returns a human readable string.
+  def self.format_error_code(code)
+    # specifying 0 will look for LANGID in the following order
+    # 1.Language neutral
+    # 2.Thread LANGID, based on the thread's locale value
+    # 3.User default LANGID, based on the user's default locale value
+    # 4.System default LANGID, based on the system default locale value
+    # 5.US English
+    dwLanguageId = 0
+    flags = FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_ARGUMENT_ARRAY |
+        FORMAT_MESSAGE_IGNORE_INSERTS |
+        FORMAT_MESSAGE_MAX_WIDTH_MASK
+    error_string = ''
+
+    # this pointer actually points to a :lpwstr (pointer) since we're letting Windows allocate for us
+    FFI::MemoryPointer.new(:pointer, 1) do |buffer_ptr|
+      length = FormatMessageW(flags, FFI::Pointer::NULL, code, dwLanguageId,
+                              buffer_ptr, 0, FFI::Pointer::NULL)
+
+      if length == FFI::WIN32_FALSE
+        # can't raise same error type here or potentially recurse infinitely
+        raise Facter::Error.new("FormatMessageW could not format code #{code}")
+      end
+
+      # returns an FFI::Pointer with autorelease set to false, which is what we want
+      buffer_ptr.read_win32_local_pointer do |wide_string_ptr|
+        if wide_string_ptr.null?
+          raise Facter::Error.new("FormatMessageW failed to allocate buffer for code #{code}")
+        end
+
+        error_string = wide_string_ptr.read_wide_string(length)
+      end
+    end
+
+    error_string
+  end
+
+  ERROR_FILE_NOT_FOUND      = 2
+  ERROR_ACCESS_DENIED       = 5
+
+  FORMAT_MESSAGE_ALLOCATE_BUFFER   = 0x00000100
+  FORMAT_MESSAGE_IGNORE_INSERTS    = 0x00000200
+  FORMAT_MESSAGE_FROM_SYSTEM       = 0x00001000
+  FORMAT_MESSAGE_ARGUMENT_ARRAY    = 0x00002000
+  FORMAT_MESSAGE_MAX_WIDTH_MASK    = 0x000000FF
+
+  ffi_convention :stdcall
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351(v=vs.85).aspx
+  # DWORD WINAPI FormatMessage(
+  #   _In_      DWORD dwFlags,
+  #   _In_opt_  LPCVOID lpSource,
+  #   _In_      DWORD dwMessageId,
+  #   _In_      DWORD dwLanguageId,
+  #   _Out_     LPTSTR lpBuffer,
+  #   _In_      DWORD nSize,
+  #   _In_opt_  va_list *Arguments
+  # );
+  # NOTE: since we're not preallocating the buffer, use a :pointer for lpBuffer
+  ffi_lib :kernel32
+  attach_function_private :FormatMessageW,
+                          [:dword, :lpcvoid, :dword, :dword, :pointer, :dword, :pointer], :dword
+end

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -1,0 +1,236 @@
+require 'facter/util/windows'
+require 'ffi'
+
+module Facter::Util::Windows::Process
+  extend FFI::Library
+
+  def get_current_process
+    # this pseudo-handle does not require closing per MSDN docs
+    GetCurrentProcess()
+  end
+  module_function :get_current_process
+
+  def open_process_token(handle, desired_access, &block)
+    token_handle = nil
+    begin
+      FFI::MemoryPointer.new(:handle, 1) do |token_handle_ptr|
+        result = OpenProcessToken(handle, desired_access, token_handle_ptr)
+        if result == FFI::WIN32_FALSE
+          raise Facter::Util::Windows::Error.new(
+              "OpenProcessToken(#{handle}, #{desired_access.to_s(8)}, #{token_handle_ptr})")
+        end
+
+        yield token_handle = token_handle_ptr.read_handle
+      end
+
+      token_handle
+    ensure
+      FFI::WIN32.CloseHandle(token_handle) if token_handle
+    end
+
+    # token_handle has had CloseHandle called against it, so nothing to return
+    nil
+  end
+  module_function :open_process_token
+
+  def get_token_information(token_handle, token_information, &block)
+    # to determine buffer size
+    FFI::MemoryPointer.new(:dword, 1) do |return_length_ptr|
+      result = GetTokenInformation(token_handle, token_information, nil, 0, return_length_ptr)
+      return_length = return_length_ptr.read_dword
+
+      if return_length <= 0
+        raise Facter::Util::Windows::Error.new(
+            "GetTokenInformation(#{token_handle}, #{token_information}, nil, 0, #{return_length_ptr})")
+      end
+
+      # re-call API with properly sized buffer for all results
+      FFI::MemoryPointer.new(return_length) do |token_information_buf|
+        result = GetTokenInformation(token_handle, token_information,
+                                     token_information_buf, return_length, return_length_ptr)
+
+        if result == FFI::WIN32_FALSE
+          raise Facter::Util::Windows::Error.new(
+              "GetTokenInformation(#{token_handle}, #{token_information}, #{token_information_buf}, " +
+                  "#{return_length}, #{return_length_ptr})")
+        end
+
+        yield token_information_buf
+      end
+    end
+
+    # GetTokenInformation buffer has been cleaned up by this point, nothing to return
+    nil
+  end
+  module_function :get_token_information
+
+  def parse_token_information_as_token_elevation(token_information_buf)
+    TOKEN_ELEVATION.new(token_information_buf)
+  end
+  module_function :parse_token_information_as_token_elevation
+
+  TOKEN_QUERY = 0x0008
+  # Returns whether or not the owner of the current process is running
+  # with elevated security privileges.
+  #
+  # Only supported on Windows Vista or later.
+  #
+  def elevated_security?
+    # default / pre-Vista
+    elevated = false
+    handle = nil
+
+    begin
+      handle = get_current_process
+      open_process_token(handle, TOKEN_QUERY) do |token_handle|
+        get_token_information(token_handle, :TokenElevation) do |token_info|
+          token_elevation = parse_token_information_as_token_elevation(token_info)
+          # TokenIsElevated member of the TOKEN_ELEVATION struct
+          elevated = token_elevation[:TokenIsElevated] != 0
+        end
+      end
+
+      elevated
+    rescue Facter::Util::Windows::Error => e
+      raise e if e.code != ERROR_NO_SUCH_PRIVILEGE
+    ensure
+      FFI::WIN32.CloseHandle(handle) if handle
+    end
+  end
+  module_function :elevated_security?
+
+  def windows_major_version
+    ver = 0
+
+    FFI::MemoryPointer.new(OSVERSIONINFO.size) do |os_version_ptr|
+      os_version = OSVERSIONINFO.new(os_version_ptr)
+      os_version[:dwOSVersionInfoSize] = OSVERSIONINFO.size
+
+      result = GetVersionExW(os_version_ptr)
+
+      if result == FFI::WIN32_FALSE
+        raise Facter::Util::Windows::Error.new("GetVersionEx failed")
+      end
+
+      ver = os_version[:dwMajorVersion]
+    end
+
+    ver
+  end
+  module_function :windows_major_version
+
+  def supports_elevated_security?
+    windows_major_version >= 6
+  end
+  module_function :supports_elevated_security?
+
+  ffi_convention :stdcall
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx
+  # HANDLE WINAPI GetCurrentProcess(void);
+  ffi_lib :kernel32
+  attach_function_private :GetCurrentProcess, [], :handle
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379295(v=vs.85).aspx
+  # BOOL WINAPI OpenProcessToken(
+  #   _In_   HANDLE ProcessHandle,
+  #   _In_   DWORD DesiredAccess,
+  #   _Out_  PHANDLE TokenHandle
+  # );
+  ffi_lib :advapi32
+  attach_function_private :OpenProcessToken,
+                          [:handle, :dword, :phandle], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379626(v=vs.85).aspx
+  TOKEN_INFORMATION_CLASS = enum(
+      :TokenUser, 1,
+      :TokenGroups,
+      :TokenPrivileges,
+      :TokenOwner,
+      :TokenPrimaryGroup,
+      :TokenDefaultDacl,
+      :TokenSource,
+      :TokenType,
+      :TokenImpersonationLevel,
+      :TokenStatistics,
+      :TokenRestrictedSids,
+      :TokenSessionId,
+      :TokenGroupsAndPrivileges,
+      :TokenSessionReference,
+      :TokenSandBoxInert,
+      :TokenAuditPolicy,
+      :TokenOrigin,
+      :TokenElevationType,
+      :TokenLinkedToken,
+      :TokenElevation,
+      :TokenHasRestrictions,
+      :TokenAccessInformation,
+      :TokenVirtualizationAllowed,
+      :TokenVirtualizationEnabled,
+      :TokenIntegrityLevel,
+      :TokenUIAccess,
+      :TokenMandatoryPolicy,
+      :TokenLogonSid,
+      :TokenIsAppContainer,
+      :TokenCapabilities,
+      :TokenAppContainerSid,
+      :TokenAppContainerNumber,
+      :TokenUserClaimAttributes,
+      :TokenDeviceClaimAttributes,
+      :TokenRestrictedUserClaimAttributes,
+      :TokenRestrictedDeviceClaimAttributes,
+      :TokenDeviceGroups,
+      :TokenRestrictedDeviceGroups,
+      :TokenSecurityAttributes,
+      :TokenIsRestricted,
+      :MaxTokenInfoClass
+  )
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/bb530717(v=vs.85).aspx
+  # typedef struct _TOKEN_ELEVATION {
+  #   DWORD TokenIsElevated;
+  # } TOKEN_ELEVATION, *PTOKEN_ELEVATION;
+  class TOKEN_ELEVATION < FFI::Struct
+    layout :TokenIsElevated, :dword
+  end
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446671(v=vs.85).aspx
+  # BOOL WINAPI GetTokenInformation(
+  #   _In_       HANDLE TokenHandle,
+  #   _In_       TOKEN_INFORMATION_CLASS TokenInformationClass,
+  #   _Out_opt_  LPVOID TokenInformation,
+  #   _In_       DWORD TokenInformationLength,
+  #   _Out_      PDWORD ReturnLength
+  # );
+  ffi_lib :advapi32
+  attach_function_private :GetTokenInformation,
+                          [:handle, TOKEN_INFORMATION_CLASS, :lpvoid, :dword, :pdword ], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724834%28v=vs.85%29.aspx
+  # typedef struct _OSVERSIONINFO {
+  #   DWORD dwOSVersionInfoSize;
+  #   DWORD dwMajorVersion;
+  #   DWORD dwMinorVersion;
+  #   DWORD dwBuildNumber;
+  #   DWORD dwPlatformId;
+  #   TCHAR szCSDVersion[128];
+  # } OSVERSIONINFO;
+  class OSVERSIONINFO < FFI::Struct
+    layout(
+        :dwOSVersionInfoSize, :dword,
+        :dwMajorVersion, :dword,
+        :dwMinorVersion, :dword,
+        :dwBuildNumber, :dword,
+        :dwPlatformId, :dword,
+        :szCSDVersion, [:wchar, 128]
+    )
+  end
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451(v=vs.85).aspx
+  # BOOL WINAPI GetVersionEx(
+  #   _Inout_  LPOSVERSIONINFO lpVersionInfo
+  # );
+  ffi_lib :kernel32
+  attach_function_private :GetVersionExW,
+                          [:pointer], :win32_bool
+end

--- a/lib/facter/util/windows/user.rb
+++ b/lib/facter/util/windows/user.rb
@@ -1,0 +1,180 @@
+require 'facter/util/windows'
+require 'ffi'
+
+module Facter::Util::Windows::User
+  extend FFI::Library
+
+  def admin?
+    elevated_supported = Facter::Util::Windows::Process.supports_elevated_security?
+
+    # if Vista or later, check for unrestricted process token
+    return Facter::Util::Windows::Process.elevated_security? if elevated_supported
+
+    # otherwise 2003 or less
+    check_token_membership
+  end
+  module_function :admin?
+
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/ee207397(v=vs.85).aspx
+  SECURITY_MAX_SID_SIZE = 68
+
+  def check_token_membership
+    is_admin = false
+    FFI::MemoryPointer.new(:byte, SECURITY_MAX_SID_SIZE) do |sid_pointer|
+      FFI::MemoryPointer.new(:dword, 1) do |size_pointer|
+        size_pointer.write_uint32(SECURITY_MAX_SID_SIZE)
+
+        if CreateWellKnownSid(:WinBuiltinAdministratorsSid, FFI::Pointer::NULL, sid_pointer, size_pointer) == FFI::WIN32_FALSE
+          raise Facter::Util::Windows::Error.new("Failed to create administrators SID")
+        end
+      end
+
+      if IsValidSid(sid_pointer) == FFI::WIN32_FALSE
+        raise RuntimeError,"Invalid SID"
+      end
+
+      FFI::MemoryPointer.new(:win32_bool, 1) do |ismember_pointer|
+        if CheckTokenMembership(FFI::Pointer::NULL_HANDLE, sid_pointer, ismember_pointer) == FFI::WIN32_FALSE
+          raise Facter::Util::Windows::Error.new("Failed to check membership")
+        end
+
+        # Is administrators SID enabled in calling thread's access token?
+        is_admin = ismember_pointer.read_win32_bool
+      end
+    end
+
+    is_admin
+  end
+  module_function :check_token_membership
+
+  ffi_convention :stdcall
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa376389(v=vs.85).aspx
+  # BOOL WINAPI CheckTokenMembership(
+  #   _In_opt_  HANDLE TokenHandle,
+  #   _In_      PSID SidToCheck,
+  #   _Out_     PBOOL IsMember
+  # );
+  ffi_lib :advapi32
+  attach_function_private :CheckTokenMembership,
+                          [:handle, :pointer, :pbool], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379650(v=vs.85).aspx
+  WELL_KNOWN_SID_TYPE = enum(
+      :WinNullSid                                   , 0,
+      :WinWorldSid                                  , 1,
+      :WinLocalSid                                  , 2,
+      :WinCreatorOwnerSid                           , 3,
+      :WinCreatorGroupSid                           , 4,
+      :WinCreatorOwnerServerSid                     , 5,
+      :WinCreatorGroupServerSid                     , 6,
+      :WinNtAuthoritySid                            , 7,
+      :WinDialupSid                                 , 8,
+      :WinNetworkSid                                , 9,
+      :WinBatchSid                                  , 10,
+      :WinInteractiveSid                            , 11,
+      :WinServiceSid                                , 12,
+      :WinAnonymousSid                              , 13,
+      :WinProxySid                                  , 14,
+      :WinEnterpriseControllersSid                  , 15,
+      :WinSelfSid                                   , 16,
+      :WinAuthenticatedUserSid                      , 17,
+      :WinRestrictedCodeSid                         , 18,
+      :WinTerminalServerSid                         , 19,
+      :WinRemoteLogonIdSid                          , 20,
+      :WinLogonIdsSid                               , 21,
+      :WinLocalSystemSid                            , 22,
+      :WinLocalServiceSid                           , 23,
+      :WinNetworkServiceSid                         , 24,
+      :WinBuiltinDomainSid                          , 25,
+      :WinBuiltinAdministratorsSid                  , 26,
+      :WinBuiltinUsersSid                           , 27,
+      :WinBuiltinGuestsSid                          , 28,
+      :WinBuiltinPowerUsersSid                      , 29,
+      :WinBuiltinAccountOperatorsSid                , 30,
+      :WinBuiltinSystemOperatorsSid                 , 31,
+      :WinBuiltinPrintOperatorsSid                  , 32,
+      :WinBuiltinBackupOperatorsSid                 , 33,
+      :WinBuiltinReplicatorSid                      , 34,
+      :WinBuiltinPreWindows2000CompatibleAccessSid  , 35,
+      :WinBuiltinRemoteDesktopUsersSid              , 36,
+      :WinBuiltinNetworkConfigurationOperatorsSid   , 37,
+      :WinAccountAdministratorSid                   , 38,
+      :WinAccountGuestSid                           , 39,
+      :WinAccountKrbtgtSid                          , 40,
+      :WinAccountDomainAdminsSid                    , 41,
+      :WinAccountDomainUsersSid                     , 42,
+      :WinAccountDomainGuestsSid                    , 43,
+      :WinAccountComputersSid                       , 44,
+      :WinAccountControllersSid                     , 45,
+      :WinAccountCertAdminsSid                      , 46,
+      :WinAccountSchemaAdminsSid                    , 47,
+      :WinAccountEnterpriseAdminsSid                , 48,
+      :WinAccountPolicyAdminsSid                    , 49,
+      :WinAccountRasAndIasServersSid                , 50,
+      :WinNTLMAuthenticationSid                     , 51,
+      :WinDigestAuthenticationSid                   , 52,
+      :WinSChannelAuthenticationSid                 , 53,
+      :WinThisOrganizationSid                       , 54,
+      :WinOtherOrganizationSid                      , 55,
+      :WinBuiltinIncomingForestTrustBuildersSid     , 56,
+      :WinBuiltinPerfMonitoringUsersSid             , 57,
+      :WinBuiltinPerfLoggingUsersSid                , 58,
+      :WinBuiltinAuthorizationAccessSid             , 59,
+      :WinBuiltinTerminalServerLicenseServersSid    , 60,
+      :WinBuiltinDCOMUsersSid                       , 61,
+      :WinBuiltinIUsersSid                          , 62,
+      :WinIUserSid                                  , 63,
+      :WinBuiltinCryptoOperatorsSid                 , 64,
+      :WinUntrustedLabelSid                         , 65,
+      :WinLowLabelSid                               , 66,
+      :WinMediumLabelSid                            , 67,
+      :WinHighLabelSid                              , 68,
+      :WinSystemLabelSid                            , 69,
+      :WinWriteRestrictedCodeSid                    , 70,
+      :WinCreatorOwnerRightsSid                     , 71,
+      :WinCacheablePrincipalsGroupSid               , 72,
+      :WinNonCacheablePrincipalsGroupSid            , 73,
+      :WinEnterpriseReadonlyControllersSid          , 74,
+      :WinAccountReadonlyControllersSid             , 75,
+      :WinBuiltinEventLogReadersGroup               , 76,
+      :WinNewEnterpriseReadonlyControllersSid       , 77,
+      :WinBuiltinCertSvcDComAccessGroup             , 78,
+      :WinMediumPlusLabelSid                        , 79,
+      :WinLocalLogonSid                             , 80,
+      :WinConsoleLogonSid                           , 81,
+      :WinThisOrganizationCertificateSid            , 82,
+      :WinApplicationPackageAuthoritySid            , 83,
+      :WinBuiltinAnyPackageSid                      , 84,
+      :WinCapabilityInternetClientSid               , 85,
+      :WinCapabilityInternetClientServerSid         , 86,
+      :WinCapabilityPrivateNetworkClientServerSid   , 87,
+      :WinCapabilityPicturesLibrarySid              , 88,
+      :WinCapabilityVideosLibrarySid                , 89,
+      :WinCapabilityMusicLibrarySid                 , 90,
+      :WinCapabilityDocumentsLibrarySid             , 91,
+      :WinCapabilitySharedUserCertificatesSid       , 92,
+      :WinCapabilityEnterpriseAuthenticationSid     , 93,
+      :WinCapabilityRemovableStorageSid             , 94
+  )
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446585(v=vs.85).aspx
+  # BOOL WINAPI CreateWellKnownSid(
+  #   _In_       WELL_KNOWN_SID_TYPE WellKnownSidType,
+  #   _In_opt_   PSID DomainSid,
+  #   _Out_opt_  PSID pSid,
+  #   _Inout_    DWORD *cbSid
+  # );
+  ffi_lib :advapi32
+  attach_function_private :CreateWellKnownSid,
+                          [WELL_KNOWN_SID_TYPE, :pointer, :pointer, :lpdword], :win32_bool
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379151(v=vs.85).aspx
+  # BOOL WINAPI IsValidSid(
+  #   _In_  PSID pSid
+  # );
+  ffi_lib :advapi32
+  attach_function_private :IsValidSid,
+                          [:pointer], :win32_bool
+end

--- a/lib/facter/util/windows_root.rb
+++ b/lib/facter/util/windows_root.rb
@@ -1,7 +1,7 @@
-require 'win32/security'
+require 'facter/util/windows'
 
 module Facter::Util::Root
   def self.root?
-    Win32::Security.elevated_security?
+    Facter::Util::Windows::User.admin?
   end
 end

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -1,0 +1,59 @@
+#! /usr/bin/env ruby
+
+require 'spec_helper'
+
+describe "Facter::Util::Windows::User", :if => Facter::Util::Config.is_windows? do
+  describe "2003 without UAC" do
+    before :each do
+      Facter::Util::Windows::Process.stubs(:windows_major_version).returns(5)
+    end
+
+    it "should be an admin if user's token contains the Administrators SID" do
+      Facter::Util::Windows::User.expects(:check_token_membership).returns(true)
+      Facter::Util::Windows::Process.expects(:elevated_security?).never
+
+      expect(Facter::Util::Windows::User).to be_admin
+    end
+
+    it "should not be an admin if user's token doesn't contain the Administrators SID" do
+      Facter::Util::Windows::User.expects(:check_token_membership).returns(false)
+      Facter::Util::Windows::Process.expects(:elevated_security?).never
+
+      expect(Facter::Util::Windows::User).not_to be_admin
+    end
+
+    it "should raise an exception if we can't check token membership" do
+      Facter::Util::Windows::User.expects(:check_token_membership).raises(Facter::Util::Windows::Error, "Access denied.")
+      Facter::Util::Windows::Process.expects(:elevated_security?).never
+
+      expect { Facter::Util::Windows::User.admin? }.to raise_error(Facter::Util::Windows::Error, /Access denied./)
+    end
+  end
+
+  describe "2008 with UAC" do
+    before :each do
+      Facter::Util::Windows::Process.stubs(:windows_major_version).returns(6)
+    end
+
+    it "should be an admin if user is running with elevated privileges" do
+      Facter::Util::Windows::Process.stubs(:elevated_security?).returns(true)
+      Facter::Util::Windows::User.expects(:check_token_membership).never
+
+      expect(Facter::Util::Windows::User).to be_admin
+    end
+
+    it "should not be an admin if user is not running with elevated privileges" do
+      Facter::Util::Windows::Process.stubs(:elevated_security?).returns(false)
+      Facter::Util::Windows::User.expects(:check_token_membership).never
+
+      expect(Facter::Util::Windows::User).not_to be_admin
+    end
+
+    it "should raise an exception if the process fails to open the process token" do
+      Facter::Util::Windows::Process.stubs(:elevated_security?).raises(Facter::Util::Windows::Error, "Access denied.")
+      Facter::Util::Windows::User.expects(:check_token_membership).never
+
+      expect { Facter::Util::Windows::User.admin? }.to raise_error(Facter::Util::Windows::Error, /Access denied./)
+    end
+  end
+end


### PR DESCRIPTION
The Win32-Security gem uses API calls which taget the ANSI implementation
instead of Wide String.  Puppet will remove its requirement for the gem
as part of PUP-5735 however Facter still had a dependency on the gem.
This commit
- Ports the required code from Puppet into Facter for the windows root
  fact.  This required the following classes and files to be ported into
  Facter;
  - Puppet::Util::Windows
  - Puppet::Util::Windows::User
  - Puppet::Util::Windows::Process
  - Puppet::Util::Windows::Error
  - Puppet::Util::Windows::ApiTypes
  - Various FFI extensions
- Ported the applicable integration tests from Puppet to Facter.  No
  additional unit or acceptance tests were applicable for porting