### PR TITLE
(FACT-1024) Fix AWS EC2 Gzip userdata

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -46,7 +46,14 @@ Facter.define_fact(:ec2_userdata) do
     end
 
     setcode do
-      @querier.fetch
+      userdata = @querier.fetch
+      begin
+        Facter::Util::Normalization.normalize_string(userdata)
+      rescue Facter::Util::Normalization::NormalizationError => e
+        Facter.debug("Failed to read ec2 userdata: #{e.message}")
+        userdata = nil
+      end
+      userdata
     end
   end
 end


### PR DESCRIPTION
This patch is for the 2.x branch of facter. It fixes when the AWS EC2 User Data are Gzip and can't be read directly.

Error message :
`Fact resolution fact='ec2_userdata', resolution='rest' resolved to an invalid value: String`

Jira ticket : https://tickets.puppetlabs.com/browse/FACT-1024