### PR TITLE
(FACT-1341) Ensure facter handles unicode in search

### DIFF
--- a/lib/spec/unit/facter_spec.rb
+++ b/lib/spec/unit/facter_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'spec_helper'
 
 Facter.on_message do |level, message|
@@ -90,6 +91,22 @@ describe Facter do
     it 'should set external search paths' do
       Facter.search_external(['foo', 'bar', 'baz'])
       expect(Facter.search_external_path).to eq(['foo', 'bar', 'baz'])
+    end
+
+    it 'should find encoded search paths' do
+      snowman_path = File.expand_path('../../../lib/tests/fixtures/facts/external/zö', File.dirname(__FILE__))
+      encoded_path = snowman_path.encode("Windows-1252")
+      Facter.search(encoded_path)
+      expect(Facter.search_path).to eq([snowman_path])
+      expect(Facter.value('snowman_fact')).to eq('olaf')
+    end
+
+    it 'should find encoded external search paths' do
+      snowman_path = File.expand_path('../../../lib/tests/fixtures/facts/external/zö', File.dirname(__FILE__))
+      encoded_path = snowman_path.encode("Windows-1252")
+      Facter.search_external([encoded_path])
+      expect(Facter.search_external_path).to eq([snowman_path])
+      expect(Facter.value('snowman_fact')).to eq('olaf')
     end
 
     it 'should support stubbing for confine testing' do

--- a/lib/tests/fixtures/facts/external/zö/facts.rb
+++ b/lib/tests/fixtures/facts/external/zö/facts.rb
@@ -1,0 +1,3 @@
+Facter.add "snowman_fact" do
+  setcode { "olaf" }
+end

--- a/lib/tests/fixtures/facts/external/zö/facts.txt
+++ b/lib/tests/fixtures/facts/external/zö/facts.txt
@@ -1,0 +1,1 @@
+snowman_fact=olaf


### PR DESCRIPTION
Prior to this commit, there was no test to make sure that facter
will not throw and unhandled exception when a path contains
unicode characters in Windows. The fix for this bug was actually
merged into leatherman, but we want to ensure that the issue does
not occur in facter by adding a test.