### PR TITLE
(maint) Skip check for locale warning on OS X

### DIFF
--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -3,7 +3,7 @@ confine :except, :platform => 'windows'
 agents.each do |host|
   step 'set an invalid value for locale and run facter'
   result = on host, 'LANG=ABCD facter facterversion'
-  if host['platform'] !~ /solaris|aix|cumulus|osx/
+  if host['platform'] !~ /solaris|aix|cumulus|osx|cisco/
     fail_test 'facter did not warn about the locale' unless
       result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
   end

--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -3,7 +3,7 @@ confine :except, :platform => 'windows'
 agents.each do |host|
   step 'set an invalid value for locale and run facter'
   result = on host, 'LANG=ABCD facter facterversion'
-  if host['platform'] !~ /solaris|aix|cumulus/
+  if host['platform'] !~ /solaris|aix|cumulus|osx/
     fail_test 'facter did not warn about the locale' unless
       result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
   end


### PR DESCRIPTION
i18n work in Leatherman 0.4.0 introduced using Boost.Locale to generate
locales on platforms besides Windows. For OS X, this has a side-effect
that an exception is no longer thrown if a bad locale is set. Add OS X
to the list of platforms we don't check for a warning when a bad locale
is set.