### PR TITLE
(FACT-1282) Populate interface bindings from routing table

### DIFF
--- a/lib/inc/internal/facts/linux/networking_resolver.hpp
+++ b/lib/inc/internal/facts/linux/networking_resolver.hpp
@@ -20,6 +20,13 @@ namespace facter { namespace facts { namespace linux {
     {
      protected:
         /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+
+        /**
          * Determines if the given sock address is a link layer address.
          * @param addr The socket address to check.
          * @returns Returns true if the socket address is a link layer address or false if it is not.
@@ -47,6 +54,24 @@ namespace facter { namespace facts { namespace linux {
          * @return Returns the primary interface or empty string if one could not be determined.
          */
         virtual std::string get_primary_interface() const override;
+
+     private:
+        struct route {
+            // In actuality routes are a destination associated with a
+            // bunch of key-value pairs, but we only require a couple
+            // of those values for our processing of network devices.
+            std::string destination;
+            std::string interface;
+            std::string source;
+        };
+
+        void read_routing_table();
+        void populate_from_routing_table(data&) const;
+        template <typename appender>
+        void associate_src_with_iface(const route&, data&, appender) const;
+
+        std::vector<route> routes4;
+        std::vector<route> routes6;
     };
 
 }}}  // namespace facter::facts::linux


### PR DESCRIPTION
Previously, we only populated interface bindings directly from the IPs
that were set on that interface. It's possible, though, that an
interface doesn't have a direct IP binding, but instead only has a
'source' parameter on a route that sends outgoing traffic through that
interface. This happens when incoming and outgoing traffic is split
between two interfaces.

This patch queries the source parameter of routes, and treats them as
additional bindings on the interfaces referenced in the routing table.

This retargets #1279 to stable