### PR TITLE
(FACT-1362) Add platform identification for HuaweiOS

### DIFF
--- a/lib/inc/facter/facts/os.hpp
+++ b/lib/inc/facter/facts/os.hpp
@@ -185,6 +185,10 @@ namespace facter { namespace facts {
          * The AristaEOS operating system.
          */
         constexpr static char const* arista_eos = "AristaEOS";
+       /**
+        * The HuaweiOS operating system.
+        */
+        constexpr static char const* huawei = "HuaweiOS";
     };
 
 }}

--- a/lib/inc/internal/facts/linux/release_file.hpp
+++ b/lib/inc/internal/facts/linux/release_file.hpp
@@ -111,6 +111,10 @@ namespace facter { namespace facts { namespace linux {
          * Release file for AristaEOS.
          */
         constexpr static char const* arista_eos = "/etc/Eos-release";
+        /**
+         * Release file for HuaweiOS.
+         */
+        constexpr static char const* huawei = "/etc/huawei-release";
     };
 
 }}}  // namespace facter::facts::linux

--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -46,6 +46,10 @@ namespace facter { namespace facts { namespace linux {
     {
         // Check for Debian variants
         bs::error_code ec;
+        if (is_regular_file(release_file::huawei, ec)) {
+          return os::huawei;
+        }
+
         if (is_regular_file(release_file::debian, ec)) {
             if (distro_id == os::ubuntu || distro_id == os::linux_mint) {
                 return distro_id;
@@ -206,6 +210,7 @@ namespace facter { namespace facts { namespace linux {
             { string(os::oracle_enterprise_linux),  string(os_family::redhat) },
             { string(os::amazon),                   string(os_family::redhat) },
             { string(os::xen_server),               string(os_family::redhat) },
+            { string(os::huawei),                   string(os_family::debian) },
             { string(os::linux_mint),               string(os_family::debian) },
             { string(os::ubuntu),                   string(os_family::debian) },
             { string(os::debian),                   string(os_family::debian) },
@@ -273,6 +278,12 @@ namespace facter { namespace facts { namespace linux {
         // Alpine uses the entire contents of the release file as the version
         if (value.empty() && name == os::alpine) {
             value = lth_file::read(release_file::alpine);
+            boost::trim_right(value);
+        }
+
+        // HuaweiOS uses the entire contents of the release file as the version
+        if (value.empty() && name == os::huawei) {
+            value = lth_file::read(release_file::huawei);
             boost::trim_right(value);
         }
 


### PR DESCRIPTION
HuaweiOS runs as an LXC container based on Debian 8 with some
modifications (for example, it uses Debian sysv instead of
systemd). It still uses apt and dpkg for package management.

The firmware version is a long string stored in
/etc/huawei-release which does not follow semver, but looks
like "V100R006C00SPC300B188", so we just pass along this
version information without further parsing.

So the os.name we're using is "HuaweiOS", and os.family is
"Debian"

Confirmed on the target that the output from 'facter os' is:
```
{
  architecture => "ppc",
  family => "Debian",
  hardware => "ppc",
  name => "HuaweiOS",
  release => {
    full => "V100R006C00SPC300B188",
    major => "V100R006C00SPC300B188"
  },
  selinux => {
    enabled => false
  }
}
```