### PR TITLE
(FACT-1339) Prevent swap warnings on OpenBSD.

### DIFF
--- a/lib/facter/util/memory.rb
+++ b/lib/facter/util/memory.rb
@@ -150,7 +150,7 @@ module Facter::Memory
     when /AIX/i
       (Facter.value(:id) == "root") ? Facter::Core::Execution.exec('swap -l 2>/dev/null') : nil
     when /OpenBSD/i
-      Facter::Core::Execution.exec('swapctl -s')
+      Facter::Core::Execution.exec('swapctl -s 2>/dev/null')
     when /FreeBSD/i
       Facter::Core::Execution.exec('swapinfo -k')
     when /Darwin/i

--- a/spec/unit/memory_spec.rb
+++ b/spec/unit/memory_spec.rb
@@ -179,7 +179,7 @@ describe "Memory facts" do
       Facter.fact(:kernel).stubs(:value).returns("OpenBSD")
 
       swapusage = "total: 4080510 512-blocks allocated, 461832 used, 3618678 available"
-      Facter::Core::Execution.stubs(:exec).with('swapctl -s').returns(swapusage)
+      Facter::Core::Execution.stubs(:exec).with('swapctl -s 2>/dev/null').returns(swapusage)
 
       Facter::Core::Execution.stubs(:exec).with('vmstat').returns(my_fixture_read('openbsd-vmstat'))
 


### PR DESCRIPTION
When no swap device is configured, prevents from showing the following message on OpenBSD:
```
swapctl: no swap devices configured
```