### PR TITLE
(FACT-1294) Use relative path in facter.rb

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -307,13 +307,8 @@ symbol_exports(libfacter "${CMAKE_CURRENT_LIST_DIR}/inc/facter/export.h")
 leatherman_install(libfacter)
 install(DIRECTORY inc/facter DESTINATION include)
 
-# Always generate facter.rb and spec_helper.rb, as they might be used in packaging
+# Always generate spec_helper.rb, as they might be used in packaging
 # and testing on another machine.
-configure_file (
-    "facter.rb.in"
-    "${CMAKE_BINARY_DIR}/lib/facter.rb"
-)
-
 # Generate a file for ruby testing
 configure_file (
     "spec_helper.rb.in"
@@ -343,6 +338,12 @@ else()
 endif()
 
 if(RUBY_VENDORDIR)
+    file(RELATIVE_PATH LIBFACTER_INSTALL_RELATIVE ${RUBY_VENDORDIR} ${CMAKE_INSTALL_PREFIX})
+    configure_file (
+        "facter.rb.in"
+        "${CMAKE_BINARY_DIR}/lib/facter.rb"
+    )
+
     message(STATUS "\"make install\" will install facter.rb to ${RUBY_VENDORDIR}")
     install(FILES ${CMAKE_BINARY_DIR}/lib/facter.rb DESTINATION ${RUBY_VENDORDIR})
 

--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -27,14 +27,8 @@ module Facter
   else
     # Simply require libfacter.so; this will define all of the Facter API
     begin
-      # This is a cmake pre-processor check.  On *nix it will end up '' == '1'
-      # On windows, where we want the changes it will be '1' == '1'
-      if '${WIN32}' == '1'
-        facter_root = File.expand_path("#{File.dirname(__FILE__)}/..")
-        ENV['PATH'] = "#{File.join(facter_root, 'bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
-        ENV['FACTERDIR'] ||= facter_root
-      end
-      require "#{ENV['FACTERDIR'] || '${CMAKE_INSTALL_PREFIX}'}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
+      facter_dir = File.join(File.expand_path("#{File.dirname(__FILE__)}"), '${LIBFACTER_INSTALL_RELATIVE}')
+      require "#{ENV['FACTERDIR'] || facter_dir}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
     rescue LoadError
       raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
     end


### PR DESCRIPTION
Change `facter.rb` to always use a relative path to find libfacter, based
on the relative path of the install location of facter.rb and
CMAKE_INSTALL_PREFIX. This fixes libfacter lookup when doing `make
install` on a Windows machine, and removes hard-coding the MSI layout.