### PR TITLE
(FACT-1375) Only recognize default route with netmask of 0.0.0.0

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -81,7 +81,7 @@ namespace facter { namespace facts { namespace linux {
         lth_file::each_line("/proc/net/route", [&interface](string& line) {
             vector<boost::iterator_range<string::iterator>> parts;
             boost::split(parts, line, boost::is_space(), boost::token_compress_on);
-            if (parts.size() > 1 && parts[1] == boost::as_literal("00000000")
+            if (parts.size() > 7 && parts[1] == boost::as_literal("00000000")
                                  && parts[7] == boost::as_literal("00000000")) {
                 interface.assign(parts[0].begin(), parts[0].end());
                 return false;

--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -81,7 +81,8 @@ namespace facter { namespace facts { namespace linux {
         lth_file::each_line("/proc/net/route", [&interface](string& line) {
             vector<boost::iterator_range<string::iterator>> parts;
             boost::split(parts, line, boost::is_space(), boost::token_compress_on);
-            if (parts.size() > 1 && parts[1] == boost::as_literal("00000000")) {
+            if (parts.size() > 1 && parts[1] == boost::as_literal("00000000")
+                                 && parts[7] == boost::as_literal("00000000")) {
                 interface.assign(parts[0].begin(), parts[0].end());
                 return false;
             }


### PR DESCRIPTION
Without this patch, Facter will recognize any route with a destination
of 0.0.0.0 as a default route, even if that route has a non-0 netmask.
The default route always has a netmask of 0.0.0.0, and should be the
one chosen to determine the primary network interface.