### PR TITLE
(FACT-1385) Fix FixNum interpretation in Ruby 2.2

### DIFF
--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -87,7 +87,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            json.SetInt64(ruby.rb_num2long(value));
+            json.SetInt64(ruby.rb_num2ll(value));
             return;
         }
         if (ruby.is_float(value)) {
@@ -156,7 +156,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            os << ruby.rb_num2long(value);
+            os << ruby.rb_num2ll(value);
             return;
         }
         if (ruby.is_float(value)) {
@@ -242,7 +242,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_fixednum(value)) {
-            emitter << ruby.rb_num2long(value);
+            emitter << ruby.rb_num2ll(value);
             return;
         }
         if (ruby.is_float(value)) {


### PR DESCRIPTION
64-bit Ruby 2.2 on Windows returns a 32-bit integer coerced to a intptr_t
from rb_num2long. Switch to using rb_num2ll instead to get a true 64-bit
integer back.

Ruby's behavior was probably changed to implement the actual `long` type,
which is 32-bit on Windows and 64-bit on other platforms. Our Ruby API
layer still expects it to return a 64-bit type, and doesn't know any
better.