### PR TITLE
(maint) Prepare for Catch 1.4

### DIFF
--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -42,6 +42,7 @@ using namespace std;
 using namespace facter::facts;
 using namespace leatherman::util;
 using namespace facter::testing;
+using Catch::Matchers::AnyOf;
 
 // For every base resolver, implement a resolver that outputs the minimum values to pass schema validation
 // We don't care about the actual data in the facts, only that it conforms to the schema


### PR DESCRIPTION
Leatherman updated to Catch 1.4. In it, AnyOf is no longer put into the
root namespace. It didn't change namespaces however, so explicitly
include it so we have code that works with Catch 1.0-1.4.