### PR TITLE
(FACT-1389) Fix facter.rb regression

### DIFF
--- a/acceptance/tests/load_libfacter.rb
+++ b/acceptance/tests/load_libfacter.rb
@@ -1,0 +1,16 @@
+test_name 'Ruby can load libfacter'
+
+agents.each do |agent|
+  if agent.platform.variant == 'windows'
+    facter_loader = 'C:/Program Files/Puppet Labs/Puppet/facter/lib/facter.rb'
+    path = '/cygdrive/c/Windows/system32:/cygdrive/c/Windows'
+  else
+    facter_loader = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter.rb'
+    path = '/usr/local/bin:/bin:/usr/bin'
+  end
+
+  on agent, "env PATH='#{path}:#{agent['privatebindir']}' ruby '#{facter_loader}'" do
+    assert_empty stdout
+    assert_empty stderr
+  end
+end

--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -27,8 +27,13 @@ module Facter
   else
     # Simply require libfacter.so; this will define all of the Facter API
     begin
-      facter_dir = File.join(File.expand_path("#{File.dirname(__FILE__)}"), '${LIBFACTER_INSTALL_RELATIVE}')
-      require "#{ENV['FACTERDIR'] || facter_dir}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
+      facter_dir = ENV['FACTERDIR'] || File.join(File.expand_path("#{File.dirname(__FILE__)}"), '${LIBFACTER_INSTALL_RELATIVE}')
+      # This is a cmake pre-processor check. On *nix it will end up '' == '1'
+      # On windows, where we want the changes it will be '1' == '1'
+      if '${WIN32}' == '1'
+        ENV['PATH'] = "#{File.join(facter_dir, 'bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+      end
+      require "#{facter_dir}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
     rescue LoadError
       raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
     end


### PR DESCRIPTION
The work for FACT-1294 caused a regression when running Facter from MCO
(as a service), where we try to load facter.rb but Puppet
Labs/facter/bin isn't on the PATH. Previously facter.rb ensured it was
added to the path, but the change in FACT-1294 accidentally dropped that
(as part of an assumption that the next release would be with new MSI
packaging that put ruby.exe and libfacter in the same directory).

Restore setting PATH as part of loading libfacter. Also adds an
acceptance test to avoid further regressions.