### PR TITLE
(FACT-1379) Query original hardware address for bonded interfaces

### DIFF
--- a/lib/inc/internal/facts/linux/networking_resolver.hpp
+++ b/lib/inc/internal/facts/linux/networking_resolver.hpp
@@ -69,6 +69,7 @@ namespace facter { namespace facts { namespace linux {
         void populate_from_routing_table(data&) const;
         template <typename appender>
         void associate_src_with_iface(const route&, data&, appender) const;
+        std::string get_bond_master(const std::string& name) const;
 
         std::vector<route> routes4;
         std::vector<route> routes6;


### PR DESCRIPTION
The list of interfaces on Linux contains the bonded mac, but previous
version of Facter reported the original hardware mac in this
case. This restores the behavior of querying the system for bonded
devices and retrieving the original mac.