### PR TITLE
(FACT-1389) Fix acceptance test on systems with Ruby installed

### DIFF
--- a/acceptance/tests/load_libfacter.rb
+++ b/acceptance/tests/load_libfacter.rb
@@ -9,7 +9,8 @@ agents.each do |agent|
     path = '/usr/local/bin:/bin:/usr/bin'
   end
 
-  on agent, "env PATH='#{path}:#{agent['privatebindir']}' ruby '#{facter_loader}'" do
+  # Ensure privatebindir comes first so we get the correct Ruby version.
+  on agent, "env PATH='#{agent['privatebindir']}:#{path}' ruby '#{facter_loader}'" do
     assert_empty stdout
     assert_empty stderr
   end


### PR DESCRIPTION
Previously the path to find Ruby was setup with system paths first, so
we would find any system Ruby installed. That caused the test to fail
when that Ruby is 1.8.7. Fix to find the puppet-agent Ruby instead.

[skip ci]