### PR TITLE
(FACT-1280) Enable setting aio_agent_version during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ if (FACTER_RUBY)
     message(STATUS "Fixing lookup for libruby to ${FACTER_RUBY_PATH}")
 endif()
 
+set(AIO_AGENT_VERSION "" CACHE STRING "Creates an aio_agent_version fact with the specified value.")
+if (AIO_AGENT_VERSION)
+    add_definitions(-DAIO_AGENT_VERSION="${AIO_AGENT_VERSION}")
+    message(STATUS "Adding fact aio_agent_version=${AIO_AGENT_VERSION}")
+endif()
+
 enable_testing()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -21,6 +21,12 @@
 #
 # Please keep the facts in alphabetical order.
 
+aio_agent_version:
+    type: string
+    description: Return the version of the puppet-agent package that installed facter.
+    resolution: |
+        All platforms: use the compile-time enabled version definition.
+
 architecture:
     type: string
     hidden: true

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -571,6 +571,9 @@ namespace facter { namespace facts {
     void collection::add_common_facts(bool include_ruby_facts)
     {
         add("facterversion", make_value<string_value>(LIBFACTER_VERSION));
+#ifdef AIO_AGENT_VERSION
+        add("aio_agent_version", make_value<string_value>(AIO_AGENT_VERSION));
+#endif
 
         if (include_ruby_facts) {
             add(make_shared<resolvers::ruby_resolver>());

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -427,6 +427,7 @@ void add_all_facts(collection& facts)
 {
     facts.add("env_windows_installdir", make_value<string_value>("C:\\Program Files\\Some\\Path"));
     facts.add("facterversion", make_value<string_value>("version"));
+    facts.add("aio_agent_version", make_value<string_value>(""));
     facts.add(make_shared<augeas_resolver>());
     facts.add(make_shared<disk_resolver>());
     facts.add(make_shared<dmi_resolver>());


### PR DESCRIPTION
Adds a new CMake option to create an aio_agent_version fact. This allows
AIO builds to set the package version during compilation.