### PR TITLE
(FACT-1392) Avoid locale failures in corrupted environments

### DIFF
--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -54,10 +54,13 @@ namespace facter { namespace logging {
         try {
             setup_logging_internal(os);
         } catch (exception const&) {
+            log(level::warning, "locale environment variables were bad; continuing with LANG=C LC_ALL=C");
+
             for (auto var : lc_vars) {
                 environment::clear(var);
             }
             environment::set("LANG", "C");
+            environment::set("LC_ALL", "C");
             try {
                 setup_logging_internal(os);
             } catch (exception const& e) {
@@ -70,7 +73,6 @@ namespace facter { namespace logging {
                 // be taken to alert the user.
                 throw locale_error(e.what());
             }
-            log(level::warning, "locale environment variables were bad; continuing with LANG=C");
         }
     }
 


### PR DESCRIPTION
On puppet-dev, someone observed issues running Facter when all locale
variables were set to UTF-8 but their environment had no locale files
for UTF-8. Facter's fallback to LANG=C appeared to be insufficient.

Add a stronger fallback of LC_ALL=C, as done in
https://github.com/puppetlabs/puppet/blob/4.4.1/lib/puppet/util/execution.rb#L282-L286,
to ensure only the C locale is used.