### PR TITLE
(FACT-1392) Restore logging after logging is setup

### DIFF
--- a/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
+++ b/acceptance/tests/ticket_1123_facter_with_invalid_locale.rb
@@ -7,7 +7,7 @@ agents.each do |host|
   result = on host, 'LANG=ABCD facter facterversion'
   if host['platform'] !~ /solaris|aix|cumulus|osx/
     fail_test 'facter did not warn about the locale' unless
-      result.stderr.include? 'locale environment variables were bad; continuing with LANG=C'
+      result.stderr.include? 'locale environment variables were bad; continuing with LANG=C LC_ALL=C'
   end
   fail_test 'facter did not continue running' unless
     result.stdout =~ /^\d+\.\d+\.\d+$/

--- a/lib/src/logging/logging.cc
+++ b/lib/src/logging/logging.cc
@@ -54,8 +54,6 @@ namespace facter { namespace logging {
         try {
             setup_logging_internal(os);
         } catch (exception const&) {
-            log(level::warning, "locale environment variables were bad; continuing with LANG=C LC_ALL=C");
-
             for (auto var : lc_vars) {
                 environment::clear(var);
             }
@@ -71,8 +69,12 @@ namespace facter { namespace logging {
                 // Since logging is busted, we raise an exception that
                 // signals to the consumer that a special action must
                 // be taken to alert the user.
-                throw locale_error(e.what());
+                throw locale_error(string("could not initialize logging, even with locale variables reset to LANG=C LC_ALL=C: ")
+                                   + e.what());
             }
+            // We can't log the issue until after logging is setup. Rely on the exception for any other
+            // error reporting.
+            log(level::warning, "locale environment variables were bad; continuing with LANG=C LC_ALL=C");
         }
     }
 


### PR DESCRIPTION
Prior change for FACT-1392 mistakenly moved logging to before logging
can occur, because it hasn't been initialized. Restore it to occur
after.