### PR TITLE
(FACT-1385) (FACT-1364) BigNum and FixedNum fix ups on Windows 

### DIFF
--- a/lib/src/ruby/chunk.cc
+++ b/lib/src/ruby/chunk.cc
@@ -60,7 +60,7 @@ namespace facter { namespace ruby {
                     ruby.rb_gc_register_address(&values[0]);
                 } else if (ruby.is_array(_dependencies)) {
                     // Resize the vector now to ensure it is fully allocated before registering with GC
-                    values.resize(static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(_dependencies, ruby.rb_intern("size"), 0))), ruby.nil_value());
+                    values.resize(ruby.num2size_t(ruby.rb_funcall(_dependencies, ruby.rb_intern("size"), 0)), ruby.nil_value());
                     for (auto& v : values) {
                         ruby.rb_gc_register_address(&v);
                     }

--- a/lib/src/ruby/fact.cc
+++ b/lib/src/ruby/fact.cc
@@ -210,7 +210,7 @@ namespace facter { namespace ruby {
                 } else if (key_id == weight_id) {
                     // Handle the weight option
                     has_weight = true;
-                    weight = static_cast<size_t>(ruby.rb_num2ulong(value));
+                    weight = ruby.num2size_t(value);
                 } else if (key_id == timeout_id) {
                     // Ignore timeout as it isn't supported
                     static bool timeout_warning = true;

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -843,7 +843,7 @@ namespace facter { namespace ruby {
             uint32_t timeout = 0;
             volatile VALUE timeout_option = ruby.rb_hash_lookup(argv[1], ruby.to_symbol("timeout"));
             if (ruby.is_fixednum(timeout_option)) {
-                timeout = static_cast<uint32_t>(ruby.rb_num2ulong(timeout_option));
+                timeout = ruby.num2size_t(timeout_option);
             }
 
             // Get the on_fail option (defaults to :raise)

--- a/lib/src/ruby/resolution.cc
+++ b/lib/src/ruby/resolution.cc
@@ -185,7 +185,7 @@ namespace facter { namespace ruby {
 
         auto instance = ruby.to_native<resolution>(self);
         instance->_has_weight = true;
-        instance->_weight = static_cast<size_t>(ruby.rb_num2ulong(value));
+        instance->_weight = (ruby.num2size_t(value));
         return self;
     }
 

--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -81,7 +81,7 @@ namespace facter { namespace ruby {
                 temp = ruby.rb_funcall(value, ruby.rb_intern("to_s"), 0);
             }
 
-            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0)));
+            size_t size = ruby.num2size_t(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0));
             char const* str = ruby.rb_string_value_ptr(&temp);
             json.SetString(str, size, allocator);
             return;
@@ -96,7 +96,7 @@ namespace facter { namespace ruby {
         }
         if (ruby.is_array(value)) {
             json.SetArray();
-            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(value, ruby.rb_intern("size"), 0)));
+            size_t size = ruby.num2size_t(ruby.rb_funcall(value, ruby.rb_intern("size"), 0));
             json.Reserve(size, allocator);
 
             ruby.array_for_each(value, [&](VALUE element) {
@@ -143,7 +143,7 @@ namespace facter { namespace ruby {
                 temp = ruby.rb_funcall(value, ruby.rb_intern("to_s"), 0);
             }
 
-            size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0)));
+            size_t size = ruby.num2size_t(ruby.rb_funcall(temp, ruby.rb_intern("bytesize"), 0));
             char const* str = ruby.rb_string_value_ptr(&temp);
 
             if (quoted) {
@@ -164,7 +164,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_array(value)) {
-            auto size = ruby.rb_num2ulong(ruby.rb_funcall(value, ruby.rb_intern("size"), 0));
+            auto size = ruby.num2size_t(ruby.rb_funcall(value, ruby.rb_intern("size"), 0));
             if (size == 0) {
                 os << "[]";
                 return;
@@ -188,7 +188,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_hash(value)) {
-            auto size = ruby.rb_num2ulong(ruby.rb_funcall(value, ruby.rb_intern("size"), 0));
+            auto size = ruby.num2size_t(ruby.rb_funcall(value, ruby.rb_intern("size"), 0));
             if (size == 0) {
                 os << "{}";
                 return;
@@ -207,7 +207,7 @@ namespace facter { namespace ruby {
                     key = ruby.rb_funcall(key, ruby.rb_intern("to_s"), 0);
                 }
 
-                size_t size = static_cast<size_t>(ruby.rb_num2ulong(ruby.rb_funcall(key, ruby.rb_intern("bytesize"), 0)));
+                size_t size = ruby.num2size_t(ruby.rb_funcall(key, ruby.rb_intern("bytesize"), 0));
                 char const* str = ruby.rb_string_value_ptr(&key);
 
                 fill_n(ostream_iterator<char>(os), level * 2, ' ');

--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -86,8 +86,8 @@ namespace facter { namespace ruby {
             json.SetString(str, size, allocator);
             return;
         }
-        if (ruby.is_fixednum(value)) {
-            json.SetInt64(ruby.rb_num2long(value));
+        if (ruby.is_fixednum(value) || ruby.is_bignum(value)) {
+            json.SetInt64(ruby.rb_num2ll(value));
             return;
         }
         if (ruby.is_float(value)) {
@@ -155,8 +155,8 @@ namespace facter { namespace ruby {
             }
             return;
         }
-        if (ruby.is_fixednum(value)) {
-            os << ruby.rb_num2long(value);
+        if (ruby.is_fixednum(value) || ruby.is_bignum(value)) {
+            os << ruby.rb_num2ll(value);
             return;
         }
         if (ruby.is_float(value)) {
@@ -241,8 +241,8 @@ namespace facter { namespace ruby {
             emitter << str;
             return;
         }
-        if (ruby.is_fixednum(value)) {
-            emitter << ruby.rb_num2long(value);
+        if (ruby.is_fixednum(value) || ruby.is_bignum(value)) {
+            emitter << ruby.rb_num2ll(value);
             return;
         }
         if (ruby.is_float(value)) {


### PR DESCRIPTION
This pull request addresses two Facter tickets. The first is FACT-1385 which
involved updating Facter so that our tests which relied on the rb_num2long
returning a long did not fail on Windows with Ruby 2.2.

The second is FACT-1364, which involved updating the printing methods
in Facter to recognize integers larger than 64-bits and display them
properly.

Both these changes rely on the new release of Leatherman.