### PR TITLE
(FACT-1395) Use Windows API for Windows version

### DIFF
--- a/lib/facter/kernelrelease.rb
+++ b/lib/facter/kernelrelease.rb
@@ -11,6 +11,7 @@
 # Caveats:
 #
 require 'facter/util/posix'
+require 'facter/util/windows'
 
 Facter.add(:kernelrelease) do
   setcode 'uname -r'
@@ -39,12 +40,6 @@ end
 Facter.add(:kernelrelease) do
   confine :kernel => "windows"
   setcode do
-    require 'facter/util/wmi'
-    version = ""
-    Facter::Util::WMI.execquery("SELECT Version from Win32_OperatingSystem").each do |ole|
-      version = "#{ole.Version}"
-      break
-    end
-    version
+    Facter::Util::Windows::Process.os_version_string
   end
 end

--- a/lib/facter/operatingsystem/windows.rb
+++ b/lib/facter/operatingsystem/windows.rb
@@ -4,33 +4,32 @@ module Facter
   module Operatingsystem
     class Windows < Base
       def get_operatingsystemrelease
-        require 'facter/util/wmi'
+        require 'facter/util/windows'
         result = nil
-        Facter::Util::WMI.execquery("SELECT version, producttype FROM Win32_OperatingSystem").each do |os|
+        Facter::Util::Windows::Process.os_version do |os|
           result =
-            case os.version
-            when /^6\.4/
-              # As of October 2014, there are no Win server releases with kernel 6.4.x.
-              # This case prevents future releases from resolving to nil before we
-              # can update the fact regexes.
-              os.producttype == 1 ? "10" : Facter[:kernelrelease].value
-            when /^6\.3/
-              os.producttype == 1 ? "8.1" : "2012 R2"
-            when /^6\.2/
-              os.producttype == 1 ? "8" : "2012"
-            when /^6\.1/
-              os.producttype == 1 ? "7" : "2008 R2"
-            when /^6\.0/
-              os.producttype == 1 ? "Vista" : "2008"
-            when /^5\.2/
-              if os.producttype == 1
-                "XP"
+            case "#{os[:dwMajorVersion]}.#{os[:dwMinorVersion]}"
+            when '10.0'
+              if os[:dwBuildNumber] == 14300
+                'Nano'
               else
-                begin
-                  os.othertypedescription == "R2" ? "2003 R2" : "2003"
-                rescue NoMethodError
-                  "2003"
-                end
+                os[:wProductType] == 1 ? '10' : Facter[:kernelrelease].value
+              end
+            when '6.3'
+              os[:wProductType] == 1 ? "8.1" : "2012 R2"
+            when '6.2'
+              os[:wProductType] == 1 ? "8" : "2012"
+            when '6.1'
+              os[:wProductType] == 1 ? "7" : "2008 R2"
+            when '6.0'
+              os[:wProductType] == 1 ? "Vista" : "2008"
+            when '5.2'
+              if os[:wProductType] == 1
+                "XP"
+              elsif Facter::Util::Windows::Process.is_2003_r2?
+                "2003 R2"
+              else
+                "2003"
               end
             else
               Facter[:kernelrelease].value

--- a/lib/facter/util/windows.rb
+++ b/lib/facter/util/windows.rb
@@ -1,4 +1,6 @@
 module Facter::Util::Windows
+  module Process; end
+
   if Facter::Util::Config.is_windows?
     require 'facter/util/windows/api_types'
     require 'facter/util/windows/error'

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -75,10 +75,20 @@ module Facter::Util::Windows::ApiTypes
   FFI.typedef :pointer, :phandle
   FFI.typedef :pointer, :pbool
 
+  # any time LONG / ULONG is in a win32 API definition DO NOT USE platform specific width
+  # which is what FFI uses by default
+  # instead create new aliases for these very special cases
+  # NOTE: not a good idea to redefine FFI :ulong since other typedefs may rely on it
+  FFI.typedef :uint32, :win32_ulong
+  FFI.typedef :int32, :win32_long
   # FFI bool can be only 1 byte at times,
   # Win32 BOOL is a signed int, and is always 4 bytes, even on x64
   # https://blogs.msdn.com/b/oldnewthing/archive/2011/03/28/10146459.aspx
   FFI.typedef :int32, :win32_bool
+
+  # NOTE: FFI already defines (u)short as a 16-bit (un)signed like this:
+  # FFI.typedef :uint16, :ushort
+  # FFI.typedef :int16, :short
 
   # 8 bits per byte
   FFI.typedef :uchar, :byte

--- a/spec/unit/kernelrelease_spec.rb
+++ b/spec/unit/kernelrelease_spec.rb
@@ -7,10 +7,7 @@ describe "Kernel release fact" do
   describe "on Windows" do
     before do
       Facter.fact(:kernel).stubs(:value).returns("windows")
-      require 'facter/util/wmi'
-      version = stubs 'version'
-      version.stubs(:Version).returns("test_kernel")
-      Facter::Util::WMI.stubs(:execquery).with("SELECT Version from Win32_OperatingSystem").returns([version])
+      Facter::Util::Windows::Process.stubs(:os_version_string).returns('test_kernel')
     end
 
     it "should return the kernel release" do

--- a/spec/unit/operatingsystem/windows_spec.rb
+++ b/spec/unit/operatingsystem/windows_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'facter/operatingsystem/windows'
 
 describe Facter::Operatingsystem::Windows do
-  require 'facter/util/wmi'
+  require 'facter/util/windows'
   subject { described_class.new }
 
   describe "Operatingsystemrelease fact" do
@@ -11,24 +11,29 @@ describe Facter::Operatingsystem::Windows do
     end
 
     {
-      ['5.2.3790', 1] => "XP",
-      ['6.0.6002', 1] => "Vista",
-      ['6.0.6002', 2] => "2008",
-      ['6.0.6002', 3] => "2008",
-      ['6.1.7601', 1] => "7",
-      ['6.1.7601', 2] => "2008 R2",
-      ['6.1.7601', 3] => "2008 R2",
-      ['6.2.9200', 1] => "8",
-      ['6.2.9200', 2] => "2012",
-      ['6.2.9200', 3] => "2012",
-      ['6.3.9600', 1] => "8.1",
-      ['6.3.9600', 2] => "2012 R2",
-      ['6.3.9600', 3] => "2012 R2",
-      ['6.4.9841', 1] => "10",     # Kernel version for Windows 10 preview. Subject to change.
+      [5,2,3790, 1] => "XP",
+      [6,0,6002, 1] => "Vista",
+      [6,0,6002, 2] => "2008",
+      [6,0,6002, 3] => "2008",
+      [6,1,7601, 1] => "7",
+      [6,1,7601, 2] => "2008 R2",
+      [6,1,7601, 3] => "2008 R2",
+      [6,2,9200, 1] => "8",
+      [6,2,9200, 2] => "2012",
+      [6,2,9200, 3] => "2012",
+      [6,3,9600, 1] => "8.1",
+      [6,3,9600, 2] => "2012 R2",
+      [6,3,9600, 3] => "2012 R2",
+      [10,0,10586, 1] => "10",     # Kernel version for Windows 10
+      [10,0,14300, 2] => "Nano",   # current Nano kernel version
     }.each do |os_values, expected_output|
-      it "should be #{expected_output}  with Version #{os_values[0]}  and ProductType #{os_values[1]}" do
-        os = mock('os', :version => os_values[0], :producttype => os_values[1])
-        Facter::Util::WMI.expects(:execquery).returns([os])
+      it "should be #{expected_output}  with Version #{os_values[0]}.#{os_values[1]}.#{os_values[2]}  and ProductType #{os_values[3]}" do
+        os = stub('os')
+        os.stubs(:[]).with(:dwMajorVersion).returns(os_values[0])
+        os.stubs(:[]).with(:dwMinorVersion).returns(os_values[1])
+        os.stubs(:[]).with(:dwBuildNumber).returns(os_values[2])
+        os.stubs(:[]).with(:wProductType).returns(os_values[3])
+        Facter::Util::Windows::Process.expects(:os_version).yields(os)
         release = subject.get_operatingsystemrelease
         expect(release).to eq expected_output
       end
@@ -39,38 +44,39 @@ describe Facter::Operatingsystem::Windows do
       # which is subject to change. These tests cover any future Windows server
       # releases with a kernel version of 6.4.x, none of which have been released
       # as of October 2014.
-      ['6.4.9841', 2] => "6.4.9841",
-      ['6.4.9841', 3] => "6.4.9841",
+      [10,0,10586, 2] => "10-NewKernel",
+      [10,0,10586, 3] => "10-NewKernel",
     }.each do |os_values, expected_output|
       it "should be the kernel release for unknown future server releases" do
-        Facter.fact(:kernelrelease).stubs(:value).returns("6.4.9841")
-        os = mock('os', :version => os_values[0], :producttype => os_values[1])
-        Facter::Util::WMI.expects(:execquery).returns([os])
+        Facter.fact(:kernelrelease).stubs(:value).returns("10-NewKernel")
+        os = stub('os')
+        os.stubs(:[]).with(:dwMajorVersion).returns(os_values[0])
+        os.stubs(:[]).with(:dwMinorVersion).returns(os_values[1])
+        os.stubs(:[]).with(:dwBuildNumber).returns(os_values[2])
+        os.stubs(:[]).with(:wProductType).returns(os_values[3])
+        Facter::Util::Windows::Process.expects(:os_version).yields(os)
         release = subject.get_operatingsystemrelease
         expect(release).to eq expected_output
       end
     end
 
     {
-      ['5.2.3790', 2, ""]   => "2003",
-      ['5.2.3790', 2, "R2"] => "2003 R2",
-      ['5.2.3790', 3, ""]   => "2003",
-      ['5.2.3790', 3, "R2"] => "2003 R2",
+      [5,2,3790, 2, false]   => "2003",
+      [5,2,3790, 2, true] => "2003 R2",
+      [5,2,3790, 3, false]   => "2003",
+      [5,2,3790, 3, true] => "2003 R2",
     }.each do |os_values, expected_output|
-      it "should be #{expected_output}  with Version #{os_values[0]}  and ProductType #{os_values[1]} and OtherTypeDescription #{os_values[2]}" do
-        os = mock('os', :version => os_values[0], :producttype => os_values[1], :othertypedescription => os_values[2])
-        Facter::Util::WMI.expects(:execquery).returns([os])
+      it "should be #{expected_output}  with Version #{os_values[0]}.#{os_values[1]}.#{os_values[2]} and ProductType #{os_values[3]} and is_2003_r2? #{os_values[4]}" do
+        os = stub('os')
+        os.stubs(:[]).with(:dwMajorVersion).returns(os_values[0])
+        os.stubs(:[]).with(:dwMinorVersion).returns(os_values[1])
+        os.stubs(:[]).with(:dwBuildNumber).returns(os_values[2])
+        os.stubs(:[]).with(:wProductType).returns(os_values[3])
+        Facter::Util::Windows::Process.expects(:is_2003_r2?).returns(os_values[4])
+        Facter::Util::Windows::Process.expects(:os_version).yields(os)
         release = subject.get_operatingsystemrelease
         expect(release).to eq expected_output
       end
-    end
-
-    it "reports '2003' if the WMI method othertypedescription does not exist" do
-      os = mock('os', :version => '5.2.3790', :producttype => 2)
-      os.stubs(:othertypedescription).raises(NoMethodError)
-      Facter::Util::WMI.expects(:execquery).returns([os])
-      release = subject.get_operatingsystemrelease
-      expect(release).to eq "2003"
     end
 
     context "Unknown Windows version" do
@@ -79,8 +85,9 @@ describe Facter::Operatingsystem::Windows do
       end
 
       it "should be kernel version value with unknown values " do
-        os = mock('os', :version => "X.Y.ZZZZ")
-        Facter::Util::WMI.expects(:execquery).returns([os])
+        os = stub('os')
+        os.stubs(:[])
+        Facter::Util::Windows::Process.expects(:os_version).yields(os)
         release = subject.get_operatingsystemrelease
         expect(release).to eq "X.Y.ZZZZ"
       end


### PR DESCRIPTION
- GetVersionEx was historically the way to do this, except that with
   Windows 8.1 it was deprecated.  Depending on how an application is
   built, GetVersionEx may return an unexpected version - for instance
   it returns '6.2.9200' on a Windows 10 machine, when the previous
   WMI query returns '10.0.10586'

   Instead use the kernel call RtlGetVersion from ntoskrnl.exe, which
   returns exactly the same structure as GetVersionEx does, but will
   return the correct versions of the kernel.

- Reimplement the kernelrelease and OS facts so that they no longer use
  WMI. To support Windows 2003 R2, use the function GetSystemMetrics
  which can return a special value when on that OS.

- Add the current Nano build number (though a more appropriate way of
  detecting Nano is probably more appropriate).

- This implementation shaves off about 400ms+ of runtime in some micro
  benchmarks.