### PR TITLE
(FACT-1043) Fix virtual fact on Openstack Windows instances

### DIFF
--- a/lib/inc/facter/facts/vm.hpp
+++ b/lib/inc/facter/facts/vm.hpp
@@ -54,6 +54,11 @@ namespace facter { namespace facts {
         constexpr static char const* gce = "gce";
 
         /**
+         * The name for OpenStack-hosted virtual machine, when OpenStack defines the machine type.
+         */
+        constexpr static char const* openstack = "openstack";
+
+        /**
          * The name for Xen privileged domain virtual machine.
          */
         constexpr static char const* xen_privileged = "xen0";

--- a/lib/src/facts/windows/virtualization_resolver.cc
+++ b/lib/src/facts/windows/virtualization_resolver.cc
@@ -28,6 +28,7 @@ namespace facter { namespace facts { namespace windows {
             make_tuple("KVM",               string(vm::kvm)),
             make_tuple("Bochs",             string(vm::bochs)),
             make_tuple("Google",            string(vm::gce)),
+            make_tuple("OpenStack",         string(vm::openstack)),
         };
 
         auto vals = _wmi->query(wmi::computersystem, {wmi::manufacturer, wmi::model});


### PR DESCRIPTION
On OpenStack infrastructure, the machine model can be defined as
OpenStack, as in
```
PS > Get-WmiObject -Class Win32_ComputerSystem
Domain              : ######
Manufacturer        : OpenStack Foundation
Model               : OpenStack Nova
Name                : ######
PrimaryOwnerName    : ######
TotalPhysicalMemory : 6442033152
```

Without this change, Facter will incorrectly report this machine as
non-virtual. Change it to report as virtual, with the VM type set to
`openstack`.