### PR TITLE
(FACT-1364) Add test for int value larger than 32-bits

### DIFF
--- a/lib/tests/fixtures/ruby/bignum_fact_value.rb
+++ b/lib/tests/fixtures/ruby/bignum_fact_value.rb
@@ -1,0 +1,5 @@
+Facter.add('bignum_fact') do
+  setcode do
+    12345678901
+  end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -619,4 +619,10 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) == "-101");
         }
     }
+    GIVEN("a fact that returns a number larger than 32-bits") {
+        REQUIRE(load_custom_fact("bignum_fact_value.rb", facts));
+        THEN("the value should be output correctly") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("bignum_fact")) == "12345678901");
+        }
+    }
 }


### PR DESCRIPTION
To ensure that facts with bignum integer values continue to work on
windows, add a test.