### PR TITLE
(maint) Fix building Facter with Leatherman DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ find_package(Leatherman REQUIRED COMPONENTS ${LEATHERMAN_COMPONENTS})
 # we need for finding all our other libraries.
 include(options)
 
-# We use program_options, system, filesystem, date_time, and regex directly. Testing uses thread.
-find_package(Boost 1.54 REQUIRED COMPONENTS program_options system filesystem date_time regex thread)
+# We use program_options, system, filesystem, date_time, and regex directly. Testing uses thread and chrono.
+find_package(Boost 1.54 REQUIRED COMPONENTS program_options system filesystem date_time regex thread chrono)
 # date_time and regex need threads on some platforms, and find_package Boost only includes
 # pthreads if you require the Boost.Thread component.
 find_package(Threads)


### PR DESCRIPTION
On Windows, building Facter with Leatherman shared libraries leaves an
unresolved symbol from chrono. Add the chrono library dependency for
testing.