### PR TITLE
(FACT-1402) check also upper case letter in virtual kvm lspci check

### DIFF
--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -237,7 +237,7 @@ namespace facter { namespace facts { namespace linux {
             make_tuple(boost::regex("XenSource"),                     string(vm::xen_hardware)),
             make_tuple(boost::regex("Microsoft Corporation Hyper-V"), string(vm::hyperv)),
             make_tuple(boost::regex("Class 8007: Google, Inc"),       string(vm::gce)),
-            make_tuple(boost::regex("virtio", boost::regex::icase),   string(vm::kvm)),
+            make_tuple(boost::regex("[Vv]irtio", boost::regex::icase),   string(vm::kvm)),
         };
 
         string value;


### PR DESCRIPTION
If virtual = kvm should be detected, the virtual facter just triggers for lower case and is not able to catch up for example "00:03.0 Ethernet controller: Red Hat, Inc Virtio network device"