### PR TITLE
(FACT-1402) check also upper case letter in virtual kvm lspci check

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -160,7 +160,7 @@ Facter.add("virtual") do
       next "xenhvm"     if lines.any? {|l| l =~ /XenSource/ }
       next "hyperv"     if lines.any? {|l| l =~ /Microsoft Corporation Hyper-V/ }
       next "gce"        if lines.any? {|l| l =~ /Class 8007: Google, Inc/ }
-      next "kvm"        if lines.any? {|l| l =~ /virtio/i }
+      next "kvm"        if lines.any? {|l| l =~ /[Vv]irtio/i }
     end
 
     # Parse dmidecode


### PR DESCRIPTION
If virtual = kvm should be detected, the virtual facter just triggers for lower case and is not able to catch up for example "00:03.0 Ethernet controller: Red Hat, Inc Virtio network device"