### PR TITLE
(FACT-1418) Replaces COM moniker call for Nano Server support

### DIFF
--- a/lib/facter/util/wmi.rb
+++ b/lib/facter/util/wmi.rb
@@ -2,7 +2,10 @@ module Facter::Util::WMI
   class << self
     def connect(uri = wmi_resource_uri)
       require 'win32ole'
-      WIN32OLE.connect(uri)
+      #WIN32OLE.connect(uri)
+      swbem = WIN32OLE.new("WbemScripting.SWbemLocator")
+      # TODO: parse wmi_resource_uri to extract host and namespace
+      swbem.ConnectServer(".", "root\\cimv2")
     end
 
     def wmi_resource_uri( host = '.' )


### PR DESCRIPTION
This patch fixes the lack for COM monikers support on Windows Nano Server while retaining API call compatibility.
