### PR TITLE
(FACT-1416) Use the -c flag when calling zoneadm for Solaris zone facts

### DIFF
--- a/lib/src/facts/solaris/zone_resolver.cc
+++ b/lib/src/facts/solaris/zone_resolver.cc
@@ -19,9 +19,9 @@ namespace facter { namespace facts { namespace solaris {
           result.current_zone_name = exec.output;
         }
 
-        static boost::regex zone_pattern("(\\d+):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*)");
+        static boost::regex zone_pattern("(\\d+|-):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*):([^:]*)");
 
-        each_line("/usr/sbin/zoneadm", {"list", "-p"}, [&](string& line) {
+        each_line("/usr/sbin/zoneadm", {"list", "-cp"}, [&](string& line) {
             zone z;
             if (re_search(line, zone_pattern, &z.id, &z.name, &z.status, &z.path, &z.uuid, &z.brand, &z.ip_type)) {
                 result.zones.emplace_back(move(z));


### PR DESCRIPTION
Previously, Facter called zoneadm using only the -p flag when
querying the system for zones, which excluded non-running zones.
This is a breaking change from Facter 2, where Facter reported
all zones.

This commit updates the zone resolver to use the -c flag when
calling zoneadm, as we did in Facter 2. In addition, the zone
regex has been modified to match a '-' at the beginning of a
zone entry, as is the output for non-running zones.