### PR TITLE
DO NOT MERGE (PE-14501) add superuser flag to the identity fact

### DIFF
--- a/acceptance/tests/facts/aix.rb
+++ b/acceptance/tests/facts/aix.rb
@@ -82,10 +82,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'system',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'system',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -102,10 +102,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -112,10 +112,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -83,11 +83,13 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
+
 
   expected_identity.each do |fact, value|
     assert_equal(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -96,11 +96,13 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'wheel',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'wheel',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
+
 
   expected_identity.each do |fact, value|
     assert_equal(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -91,11 +91,13 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
+
 
   expected_identity.each do |fact, value|
     assert_equal(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -95,11 +95,13 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
+
 
   expected_identity.each do |fact, value|
     assert_equal(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -107,11 +107,13 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'       => '0',
+                        'identity.group'     => 'root',
+                        'identity.uid'       => '0',
+                        'identity.user'      => 'root',
+                        'identity.superuser' => true
                       }
+
 
   expected_identity.each do |fact, value|
     assert_equal(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -77,7 +77,8 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.user'   => /.*\\cyg_server/,
+                        'identity.user'      => /.*\\cyg_server/,
+                        'identity.superuser' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/lib/inc/internal/facts/resolvers/identity_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/identity_resolver.hpp
@@ -51,6 +51,14 @@ namespace facter { namespace facts { namespace resolvers {
              * Stores the name of the user's primary group.
              */
             std::string group_name;
+
+            /**
+             * Stores whether the user is a superuser (a user
+             * with the UID of 0 on *NIX systems or a member
+             * of the local Administrators group on Windows)
+             * or not.
+             */
+            boost::optional<bool> superuser;
         };
 
         /**

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -416,8 +416,8 @@ identity:
     type: map
     description: Return the identity information of the user running facter.
     resolution: |
-        POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information.
-        Windows: use the `GetUserNameExW` function to retrieve the identity information.
+        POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information; use the result of the UID == 0 test as the value of the superuser element
+        Windows: use the `GetUserNameExW` function to retrieve the identity information; use the `GetTokenInformation` to get the current process token elevation status and use it as the value of the superuser element on version of Windows supporting the token elevation, on older Windows versions use `CheckTokenMembership` to test whether the well known local Administrators SID is enabled in the current thread impersonation token and use the test result as the value of the superuser element
     elements:
         gid:
             type: integer
@@ -431,6 +431,9 @@ identity:
         user:
             type: string
             description: The user name of the user running facter.
+        superuser:
+            type: boolean
+            description: True if facter runs with superuser priviliges or false if not.
 
 interfaces:
     type: string

--- a/lib/src/facts/posix/identity_resolver.cc
+++ b/lib/src/facts/posix/identity_resolver.cc
@@ -34,6 +34,7 @@ namespace facter { namespace facts { namespace posix {
         } else {
             result.user_id = static_cast<int64_t>(uid);
             result.user_name = pwd.pw_name;
+            result.superuser = (uid == 0);
         }
 
         buffer_size = sysconf(_SC_GETGR_R_SIZE_MAX);

--- a/lib/src/facts/resolvers/identity_resolver.cc
+++ b/lib/src/facts/resolvers/identity_resolver.cc
@@ -38,6 +38,9 @@ namespace facter { namespace facts { namespace resolvers {
         if (data.group_id) {
             identity->add("gid", make_value<integer_value>(*data.group_id));
         }
+        if (data.superuser) {
+            identity->add("superuser", make_value<boolean_value>(*data.superuser));
+        }
 
         if (!identity->empty()) {
             facts.add(fact::identity, move(identity));

--- a/lib/tests/facts/resolvers/identity_resolver.cc
+++ b/lib/tests/facts/resolvers/identity_resolver.cc
@@ -30,6 +30,7 @@ struct test_identity_resolver : identity_resolver
         result.group_name = "foo";
         result.user_id = 456;
         result.user_name = "bar";
+        result.superuser = false;
         return result;
     }
 };
@@ -47,7 +48,7 @@ SCENARIO("using the identity resolver") {
         THEN("a structured fact is added") {
             auto identity = facts.get<map_value>(fact::identity);
             REQUIRE(identity);
-            REQUIRE(identity->size() == 4u);
+            REQUIRE(identity->size() == 5u);
 
             auto name = identity->get<string_value>("group");
             REQUIRE(name);
@@ -64,6 +65,10 @@ SCENARIO("using the identity resolver") {
             id = identity->get<integer_value>("uid");
             REQUIRE(id);
             REQUIRE(id->value() == 456);
+
+            auto superuser = identity->get<boolean_value>("superuser");
+            REQUIRE(superuser);
+            REQUIRE(superuser->value() == false);
         }
         THEN("flat facts are added") {
             auto name = facts.get<string_value>(fact::gid);

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -139,6 +139,7 @@ struct identity_resolver : resolvers::identity_resolver
         result.group_name = "group";
         result.user_id = 456;
         result.user_name = "user";
+        result.superuser = false;
         return result;
     }
 };


### PR DESCRIPTION
This commit adds the `superuser` flag as another attribute of the `identity` structured fact.

It is a boolean flag which is set to `true` if the facter process runs with UID of 0 on *NIX systems or with the privileges of the local Administrators group on Windows. Under any other circumstances the flag is set to `false`.