### PR TITLE
(FACT-1419) add privileged element to identity fact

### DIFF
--- a/acceptance/tests/facts/aix.rb
+++ b/acceptance/tests/facts/aix.rb
@@ -82,10 +82,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'system',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'system',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -102,10 +102,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -112,10 +112,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -83,10 +83,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -96,10 +96,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'wheel',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'wheel',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -91,10 +91,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -95,10 +95,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -107,10 +107,11 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.gid'   => '0',
-                        'identity.group' => 'root',
-                        'identity.uid'   => '0',
-                        'identity.user'  => 'root'
+                        'identity.gid'        => '0',
+                        'identity.group'      => 'root',
+                        'identity.uid'        => '0',
+                        'identity.user'       => 'root',
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -77,7 +77,8 @@ agents.each do |agent|
 
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
-                        'identity.user'   => /.*\\cyg_server/,
+                        'identity.user'       => /.*\\cyg_server/,
+                        'identity.privileged' => true
                       }
 
   expected_identity.each do |fact, value|

--- a/lib/inc/internal/facts/resolvers/identity_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/identity_resolver.hpp
@@ -51,6 +51,15 @@ namespace facter { namespace facts { namespace resolvers {
              * Stores the name of the user's primary group.
              */
             std::string group_name;
+
+            /**
+             * Stores whether facter is running as a privileged
+             * process: With the effective UID of 0 on *NIX systems
+             * or with elevated privileges on Windows (or with the
+             * local Administrators group privileges on older versions
+             * of windows not supporting privileges elevation).
+             */
+            boost::optional<bool> privileged;
         };
 
         /**

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -416,8 +416,8 @@ identity:
     type: map
     description: Return the identity information of the user running facter.
     resolution: |
-        POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information.
-        Windows: use the `GetUserNameExW` function to retrieve the identity information.
+        POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information; use the result of the `geteuid() == 0` test as the value of the privileged element
+        Windows: use the `GetUserNameExW` function to retrieve the identity information; use the `GetTokenInformation` to get the current process token elevation status and use it as the value of the privileged element on versions of Windows supporting the token elevation, on older versions of Windows use the `CheckTokenMembership` to test whether the well known local Administrators group SID is enabled in the current thread impersonation token and use the test result as the value of the privileged element
     elements:
         gid:
             type: integer
@@ -431,6 +431,9 @@ identity:
         user:
             type: string
             description: The user name of the user running facter.
+        privileged:
+            type: boolean
+            description: True if facter is running as a privileged process or false if not.
 
 interfaces:
     type: string

--- a/lib/src/facts/posix/identity_resolver.cc
+++ b/lib/src/facts/posix/identity_resolver.cc
@@ -34,6 +34,7 @@ namespace facter { namespace facts { namespace posix {
         } else {
             result.user_id = static_cast<int64_t>(uid);
             result.user_name = pwd.pw_name;
+            result.privileged = (uid == 0);
         }
 
         buffer_size = sysconf(_SC_GETGR_R_SIZE_MAX);

--- a/lib/src/facts/resolvers/identity_resolver.cc
+++ b/lib/src/facts/resolvers/identity_resolver.cc
@@ -38,6 +38,9 @@ namespace facter { namespace facts { namespace resolvers {
         if (data.group_id) {
             identity->add("gid", make_value<integer_value>(*data.group_id));
         }
+        if (data.privileged) {
+            identity->add("privileged", make_value<boolean_value>(*data.privileged));
+        }
 
         if (!identity->empty()) {
             facts.add(fact::identity, move(identity));

--- a/lib/src/facts/windows/identity_resolver.cc
+++ b/lib/src/facts/windows/identity_resolver.cc
@@ -1,5 +1,6 @@
 #include <internal/facts/windows/identity_resolver.hpp>
 #include <leatherman/windows/system_error.hpp>
+#include <leatherman/windows/user.hpp>
 #include <leatherman/windows/windows.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/nowide/convert.hpp>
@@ -20,20 +21,26 @@ namespace facter { namespace facts { namespace windows {
         auto nameformat = NameSamCompatible;
         GetUserNameExW(nameformat, nullptr, &size);
         if (GetLastError() != ERROR_MORE_DATA) {
-            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", leatherman::windows::system_error());
+            LOG_DEBUG("failure resolving identity facts: %1%", leatherman::windows::system_error());
             return result;
         }
 
         // Use the string as a raw buffer that supports move and ref operations.
         wstring buffer(size, '\0');
         if (!GetUserNameExW(nameformat, &buffer[0], &size)) {
-            LOG_DEBUG("failure resolving identity facts: %1% (%2%)", leatherman::windows::system_error());
+            LOG_DEBUG("failure resolving identity facts: %1%", leatherman::windows::system_error());
             return result;
         }
 
         // Resize the buffer to the returned string size.
         buffer.resize(size);
         result.user_name = boost::nowide::narrow(buffer);
+
+        // Check whether this thread is running with elevated privileges
+        // (or with the privileges of the local Administrators group on
+        // older versions of Windows not supporting privileges elevation).
+        result.privileged = user::is_admin();
+
         return result;
     }
 }}}  // facter::facts::windows

--- a/lib/tests/facts/resolvers/identity_resolver.cc
+++ b/lib/tests/facts/resolvers/identity_resolver.cc
@@ -30,6 +30,7 @@ struct test_identity_resolver : identity_resolver
         result.group_name = "foo";
         result.user_id = 456;
         result.user_name = "bar";
+        result.privileged = false;
         return result;
     }
 };
@@ -47,7 +48,7 @@ SCENARIO("using the identity resolver") {
         THEN("a structured fact is added") {
             auto identity = facts.get<map_value>(fact::identity);
             REQUIRE(identity);
-            REQUIRE(identity->size() == 4u);
+            REQUIRE(identity->size() == 5u);
 
             auto name = identity->get<string_value>("group");
             REQUIRE(name);
@@ -64,6 +65,10 @@ SCENARIO("using the identity resolver") {
             id = identity->get<integer_value>("uid");
             REQUIRE(id);
             REQUIRE(id->value() == 456);
+
+            auto privileged = identity->get<boolean_value>("privileged");
+            REQUIRE(privileged);
+            REQUIRE(privileged->value() == false);
         }
         THEN("flat facts are added") {
             auto name = facts.get<string_value>(fact::gid);

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -139,6 +139,7 @@ struct identity_resolver : resolvers::identity_resolver
         result.group_name = "group";
         result.user_id = 456;
         result.user_name = "user";
+        result.privileged = false;
         return result;
     }
 };


### PR DESCRIPTION
This commit adds the `privileged` flag as another element of the `identity` structured fact.

It is a boolean flag which is set to `true` if the facter process runs with UID of 0 on *NIX systems or with the privileges of the local Administrators group on Windows. Under any other circumstances the flag is set to `false`.