### PR TITLE
(FACT-1419) Use string comparison for `privileged` in tests

### DIFF
--- a/acceptance/tests/facts/aix.rb
+++ b/acceptance/tests/facts/aix.rb
@@ -86,7 +86,7 @@ agents.each do |agent|
                         'identity.group'      => 'system',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -106,7 +106,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -116,7 +116,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -87,7 +87,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -100,7 +100,7 @@ agents.each do |agent|
                         'identity.group'      => 'wheel',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -95,7 +95,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -99,7 +99,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -111,7 +111,7 @@ agents.each do |agent|
                         'identity.group'      => 'root',
                         'identity.uid'        => '0',
                         'identity.user'       => 'root',
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -78,7 +78,7 @@ agents.each do |agent|
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.user'       => /.*\\cyg_server/,
-                        'identity.privileged' => true
+                        'identity.privileged' => 'true'
                       }
 
   expected_identity.each do |fact, value|


### PR DESCRIPTION
The `identity` fact output is grabbed by running `facter` and grabbing
stdout, so we'll always be comparing against a string. Change to
expecting a string rather than a boolean.