### PR TITLE
(FACT-1426) Add s390x support for acceptance

### DIFF
--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -28,9 +28,9 @@ when /huaweios/
     ruby_platform = /powerpc-linux/
 else
   if agent['ruby_arch']
-    ruby_platform = agent['ruby_arch'] == 'x64' ? 'x86_64-linux' : /i(4|6)86-linux/
+    ruby_platform = agent['ruby_arch'] == 'x64' ? 'x86_64-linux' : /(i486|i686|s390x)-linux/
   else
-    ruby_platform = agent['platform'] =~ /64/ ? 'x86_64-linux' : /i(4|6)86-linux/
+    ruby_platform = agent['platform'] =~ /64/ ? 'x86_64-linux' : /(i486|i686|s390x)-linux/
   end
 end
 

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -21,9 +21,15 @@ agents.each do |agent|
   if agent['platform'] =~ /x86_64/
     os_arch     = 'x86_64'
     os_hardware = 'x86_64'
+    processor_model_pattern = 'Intel\(R\)'
+  elsif agent['platform'] =~ /s390x/
+    os_arch     = 's390x'
+    os_hardware = 's390x'
+    processor_model_pattern = '' # s390x does not populate a model value in /proc/cpuinfo
   else
     os_arch     = 'i386'
     os_hardware = 'i686'
+    processor_model_pattern = 'Intel\(R\)'
   end
 
   step "Ensure the OS fact resolves as expected"
@@ -48,7 +54,7 @@ agents.each do |agent|
                           'processors.count'         => /[1-9]/,
                           'processors.physicalcount' => /[1-9]/,
                           'processors.isa'           => os_hardware,
-                          'processors.models'        => /"Intel\(R\).*"/
+                          'processors.models'        => /#{processor_model_pattern}/
                         }
 
   expected_processors.each do |fact, value|

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -9,6 +9,8 @@ test_name "Facts should resolve as expected in SLES 10, 11 and 12"
 
 confine :to, :platform => /sles-10|sles-11|sles-12/
 
+@ip_regex = /^([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\.([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){3}$/
+
 agents.each do |agent|
   if agent['platform'] =~ /sles-10/
     os_version = '10'
@@ -64,13 +66,13 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => @ip_regex,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                           "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 


### PR DESCRIPTION
This commit modifies the ruby and sles acceptance tests to accommodate
support for the s390x architecture on the zlinux platform.