### PR TITLE
(FACT-1431) Enable curl on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ SET(LEATHERMAN_COMPONENTS locale catch nowide logging util file_util dynamic_lib
 
 # We look for curl early, because whether or not we link to the leatherman curl library
 # is dependant on whether or not we find curl on the system.
-if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux") OR WIN32) AND NOT WITHOUT_CURL)
+if ((("${CMAKE_SYSTEM_NAME}" MATCHES "Linux|OpenBSD") OR WIN32) AND NOT WITHOUT_CURL)
     find_package(CURL)
     if (CURL_FOUND)
         add_definitions(-DUSE_CURL)


### PR DESCRIPTION
No need to disable curl on OpenBSD when it builds fine.