### PR TITLE
(MAINT) Unbreak after leatherman split in cc1245ab

### DIFF
--- a/lib/src/facts/openbsd/memory_resolver.cc
+++ b/lib/src/facts/openbsd/memory_resolver.cc
@@ -1,5 +1,5 @@
 #include <internal/facts/openbsd/memory_resolver.hpp>
-#include <facter/execution/execution.hpp>
+#include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <sys/types.h>
 #include <sys/param.h>
@@ -9,8 +9,7 @@
 #include <unistd.h>
 
 using namespace std;
-using namespace facter::execution;
-using namespace facter::util;
+using namespace leatherman::execution;
 
 namespace facter { namespace facts { namespace openbsd {
 

--- a/lib/src/facts/openbsd/networking_resolver.cc
+++ b/lib/src/facts/openbsd/networking_resolver.cc
@@ -1,6 +1,6 @@
 #include <internal/facts/openbsd/networking_resolver.hpp>
 #include <internal/util/bsd/scoped_ifaddrs.hpp>
-#include <facter/execution/execution.hpp>
+#include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/algorithm/string.hpp>
 #include <sys/sockio.h>
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace facter::util;
 using namespace facter::util::bsd;
-using namespace facter::execution;
+using namespace leatherman::execution;
 
 namespace facter { namespace facts { namespace openbsd {
 

--- a/lib/src/facts/openbsd/virtualization_resolver.cc
+++ b/lib/src/facts/openbsd/virtualization_resolver.cc
@@ -3,12 +3,12 @@
 #include <facter/facts/collection.hpp>
 #include <facter/facts/fact.hpp>
 #include <facter/facts/vm.hpp>
-#include <facter/execution/execution.hpp>
+#include <leatherman/execution/execution.hpp>
 #include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace facter::facts;
-using namespace facter::execution;
+using namespace leatherman::execution;
 
 namespace facter { namespace facts { namespace openbsd {
 


### PR DESCRIPTION
While (finally) updating facter to 3.1 on OpenBSD I noticed that the OpenBSD facts weren't adjusted yet for the split-off leatherman.