### PR TITLE
(FACT-1428) Add DMI facts for FreeBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -196,6 +196,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/bsd/networking_resolver.cc"
         "src/facts/bsd/uptime_resolver.cc"
         "src/facts/freebsd/processor_resolver.cc"
+        "src/facts/freebsd/dmi_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")

--- a/lib/inc/internal/facts/freebsd/dmi_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/dmi_resolver.hpp
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * Declares the FreeBSD Desktop Management Interface (DMI) fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/dmi_resolver.hpp"
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving DMI facts.
+     */
+    struct dmi_resolver : resolvers::dmi_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+
+     private:
+        static std::string kenv_lookup(const char* file);
+    };
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -3,6 +3,7 @@
 #include <internal/facts/bsd/uptime_resolver.hpp>
 #include <internal/facts/glib/load_average_resolver.hpp>
 #include <internal/facts/freebsd/processor_resolver.hpp>
+#include <internal/facts/freebsd/dmi_resolver.hpp>
 #include <internal/facts/posix/identity_resolver.hpp>
 #include <internal/facts/posix/kernel_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
@@ -24,6 +25,7 @@ namespace facter { namespace facts {
         add(make_shared<posix::timezone_resolver>());
         add(make_shared<glib::load_average_resolver>());
         add(make_shared<freebsd::processor_resolver>());
+        add(make_shared<freebsd::dmi_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/freebsd/dmi_resolver.cc
+++ b/lib/src/facts/freebsd/dmi_resolver.cc
@@ -1,0 +1,36 @@
+#include <internal/facts/freebsd/dmi_resolver.hpp>
+#include <leatherman/logging/logging.hpp>
+
+#include <kenv.h>
+
+using namespace std;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    dmi_resolver::data dmi_resolver::collect_data(collection& facts)
+    {
+        data result;
+        result.bios_vendor = kenv_lookup("smbios.bios.vendor");
+        result.bios_version = kenv_lookup("smbios.bios.version");
+        result.bios_release_date = kenv_lookup("smbios.bios.reldate");
+        result.uuid = kenv_lookup("smbios.system.uuid");
+        result.serial_number = kenv_lookup("smbios.planar.serial");
+        result.product_name = kenv_lookup("smbios.system.product");
+        result.manufacturer = kenv_lookup("smbios.system.maker");
+
+        return result;
+    }
+
+    string dmi_resolver::kenv_lookup(const char* file)
+    {
+        char buffer[100] = {};
+
+        LOG_DEBUG("kenv lookup for %s", file);
+        if (kenv(KENV_GET, file, buffer, sizeof(buffer) - 1) == -1) {
+            LOG_WARNING("kenv lookup for %1% failed: %2% (%3%)", file, strerror(errno), errno);
+            return "";
+        }
+        return buffer;
+    }
+
+} } }  // namespace facter::facts::freebsd


### PR DESCRIPTION
DMI facts were missing in FreeBSD. Now back!

```
{
  bios => {
    release_date => "12/01/2006",
    vendor => "innotek GmbH",
    version => "VirtualBox"
  },
  manufacturer => "innotek GmbH",
  product => {
    name => "VirtualBox",
    serial_number => "0",
    uuid => "813498a1-4327-4796-a5d0-93f2f69f7328"
  }
}
```