### PR TITLE
(FACT-1244) Correctly report Xen Dom0 vs DomU

### DIFF
--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -117,6 +117,11 @@ namespace facter { namespace facts { namespace linux {
                 return true;
             }
             // Take the first line that isn't an error/warning
+            // unless it's "xen", in which case we expect a second
+            // line with more useful information
+            if (line == "xen") {
+                return true;
+            }
             value = move(line);
             return false;
         });


### PR DESCRIPTION
Previously, our virt-what reader would return the first line of output
it found. For cases where the machine is Xen, however, this first line
is simple "xen", with Dom0 or DomU information being provided
after. In that case we want to skip the first line and move on to the
detailed hypervisor info.