### PR TITLE
FACT-1439 Facter detecting only enabled network card

### DIFF
--- a/lib/facter/util/ip/windows.rb
+++ b/lib/facter/util/ip/windows.rb
@@ -43,7 +43,7 @@ class Facter::Util::IP::Windows
     interface_names = []
 
     network_adapter_configurations.map do |nic|
-      Facter::Util::WMI.execquery("SELECT * FROM Win32_NetworkAdapter WHERE Index = #{nic.Index} AND NetEnabled = TRUE").each do |sub_nic|
+      Facter::Util::WMI.execquery("SELECT * FROM Win32_NetworkAdapter WHERE Index = #{nic.Index}").each do |sub_nic|
         interface_names << sub_nic.NetConnectionId unless sub_nic.NetConnectionId.nil? or sub_nic.NetConnectionId.empty?
       end
     end


### PR DESCRIPTION
Changing the way facter list NIC on Windows. Get rid of the NetEnabled statement so that every NIC are listed, even the disabled.
modified :         lib/facter/util/ip/windows.rb