### PR TITLE
(FACT-1395) Fix FFI load of ntoskrnl.exe

### DIFF
--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -273,7 +273,7 @@ module Facter::Util::Windows::Process
   # NTSTATUS RtlGetVersion(
   #   _Out_ PRTL_OSVERSIONINFOW lpVersionInformation
   # );
-  ffi_lib 'ntoskrnl.exe'
+  ffi_lib [FFI::CURRENT_PROCESS, 'ntoskrnl.exe']
   attach_function :RtlGetVersion, [:pointer], :int32
 
   # C++ int is a signed 32-bit integer


### PR DESCRIPTION
 - The ffi_lib call is failing under certain circumstances in testing
   - in particular, a failure has been observed on Windows 2008 x64
   running 32-bit Ruby 1.9.3 with Facter 1.9.5.

   Attempts to reproduce the problem have been unsuccessful, but in
   such cases, the error reported is:

   Could not open library 'ntoskrnl.exe':
   The specified module could not be found. (LoadError)

 - FFI supports a special loading mechanism that will access a
   currently loaded module.  Since Ruby always loads `ntoskrnl.exe`,
   this should remove any issues in FFI around finding modules based
   on searching load path, and should always use the correct
   bitness automatically.