### PR TITLE
(FACT-1395) Load RtlGetVersion from ntdll.dll

### DIFF
--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -273,7 +273,7 @@ module Facter::Util::Windows::Process
   # NTSTATUS RtlGetVersion(
   #   _Out_ PRTL_OSVERSIONINFOW lpVersionInformation
   # );
-  ffi_lib [FFI::CURRENT_PROCESS, 'ntoskrnl.exe']
+  ffi_lib [FFI::CURRENT_PROCESS, :ntdll]
   attach_function :RtlGetVersion, [:pointer], :int32
 
   # C++ int is a signed 32-bit integer


### PR DESCRIPTION
 - Previously, we were hooking ntoskrnl.exe for the function
   RtlGetVersion.  As it turns out, `ntoskrnl.exe` appears in both
   c:\windows\system32 and c:\windows\sysWOW64 in a local dev
   environment, but this is not always the case.  In CI environments,
   `ntoskrnl.exe` may not always be present - in particular, 32-bit
   processes are failing to load it in a 64-bit OS.

   However, every process loads `ntdll.dll`, which also exports
   RtlGetVersion.

   Change the ffi_lib definition to use that library instead.