### PR TITLE
(FACT-1406) Fix filesystem resolver for large disks and 32-bit Linux & BSD

### DIFF
--- a/lib/src/facts/bsd/filesystem_resolver.cc
+++ b/lib/src/facts/bsd/filesystem_resolver.cc
@@ -37,8 +37,10 @@ namespace facter { namespace facts { namespace bsd {
             point.name = fs.f_mntonname;
             point.device = fs.f_mntfromname;
             point.filesystem = fs.f_fstypename;
-            point.size = fs.f_bsize * fs.f_blocks;
-            point.available = fs.f_bsize * fs.f_bfree;
+            point.size = (static_cast<uint64_t>(fs.f_bsize)
+                          * static_cast<uint64_t>(fs.f_blocks));
+            point.available = (static_cast<uint64_t>(fs.f_bsize)
+                               * static_cast<uint64_t>(fs.f_bfree));
             point.options = to_options(fs);
             result.mountpoints.emplace_back(move(point));
 

--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -106,8 +106,10 @@ namespace facter { namespace facts { namespace linux {
 
             struct statfs stats;
             if (statfs(ptr->mnt_dir, &stats) != -1) {
-                point.size = stats.f_frsize * stats.f_blocks;
-                point.available = stats.f_frsize * stats.f_bfree;
+                point.size = (static_cast<uint64_t>(stats.f_frsize)
+                              * static_cast<uint64_t>(stats.f_blocks));
+                point.available = (static_cast<uint64_t>(stats.f_frsize)
+                                   * static_cast<uint64_t>(stats.f_bfree));
             }
 
             result.mountpoints.emplace_back(move(point));


### PR DESCRIPTION
On 32-bit OSs, the statfs structure contain 32-bit fields, requiring casts to 64-bit values when calculating total size and available bytes