### PR TITLE
(FACT-1448) Add acceptance test to ensure json handles bools

### DIFF
--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -14,7 +14,7 @@ extend Facter::Acceptance::UserFactUtils
 content = <<EOM
 Facter.add('structured_fact') do
   setcode do
-    { "foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }
+    { "foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3", "true" => true, "false" => false }
   end
 end
 EOM
@@ -35,7 +35,7 @@ agents.each do |agent|
   step "Agent #{agent}: retrieve output using the --json option"
   on(agent, facter("--custom-dir '#{custom_dir}' --json structured_fact")) do
     begin
-      expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3"}})
+      expected = JSON.pretty_generate({"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3", "true" => true, "false" => false}})
       assert_equal(expected, stdout.chomp, "JSON output does not match expected output")
     rescue
       fail_test "Couldn't parse output as JSON"


### PR DESCRIPTION
On macOS (at least), json output converts all boolean values to true.