### PR TITLE
(FACT-1448) Fix json output to correctly print booleans from custom facts

### DIFF
--- a/lib/src/ruby/ruby_value.cc
+++ b/lib/src/ruby/ruby_value.cc
@@ -71,7 +71,7 @@ namespace facter { namespace ruby {
             return;
         }
         if (ruby.is_false(value)) {
-            json.SetBool(true);
+            json.SetBool(false);
             return;
         }
         if (ruby.is_string(value) || ruby.is_symbol(value)) {


### PR DESCRIPTION
Fixes a typo in the ruby_value::to_json method that was converting all booleans to true.