### PR TITLE
(FACT-1429) Add `--strict` flag to command line options

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -133,7 +133,8 @@ int main(int argc, char **argv)
             ("trace", "Enable backtraces for custom facts.")
             ("verbose", "Enable verbose (info) output.")
             ("version,v", "Print the version and exit.")
-            ("yaml,y", "Output in YAML format.");
+            ("yaml,y", "Output in YAML format.")
+            ("strict", "Enables more aggressive error reporting.");
 
         // Build a list of "hidden" options that are not visible on the command line
         po::options_description hidden_options("");
@@ -282,7 +283,8 @@ int main(int argc, char **argv)
         }
 
         bool show_legacy = vm.count("show-legacy");
-        facts.write(boost::nowide::cout, fmt, queries, show_legacy);
+        bool strict_errors = vm.count("strict");
+        facts.write(boost::nowide::cout, fmt, queries, show_legacy, strict_errors);
         boost::nowide::cout << endl;
     } catch (locale_error const& e) {
         boost::nowide::cerr << "failed to initialize logging system due to a locale error: " << e.what() << "\n" << endl;

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -187,7 +187,7 @@ namespace facter { namespace facts {
         template <typename T = value>
         T const* query(std::string const& query)
         {
-            return dynamic_cast<T const*>(query_value(query));
+            return dynamic_cast<T const*>(query_value(query, false));
         }
 
         /**
@@ -214,9 +214,10 @@ namespace facter { namespace facts {
          * @param fmt The output format to use.
          * @param queries The set of queries to filter the output to. If empty, all facts will be output.
          * @param show_legacy Show legacy facts when querying all facts.
+         * @param strict_errors Report additional error cases
          * @return Returns the stream being written to.
          */
-        std::ostream& write(std::ostream& stream, format fmt, std::set<std::string> const& queries, bool show_legacy);
+        std::ostream& write(std::ostream& stream, format fmt, std::set<std::string> const& queries, bool show_legacy, bool strict_errors);
 
         /**
          * Resolves all facts in the collection.
@@ -233,11 +234,11 @@ namespace facter { namespace facts {
      private:
         LIBFACTER_NO_EXPORT void resolve_fact(std::string const& name);
         LIBFACTER_NO_EXPORT value const* get_value(std::string const& name);
-        LIBFACTER_NO_EXPORT value const* query_value(std::string const& query);
-        LIBFACTER_NO_EXPORT value const* lookup(value const* value, std::string const& name);
-        LIBFACTER_NO_EXPORT void write_hash(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
-        LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
-        LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy);
+        LIBFACTER_NO_EXPORT value const* query_value(std::string const& query, bool strict_errors);
+        LIBFACTER_NO_EXPORT value const* lookup(value const* value, std::string const& name, bool strict_errors);
+        LIBFACTER_NO_EXPORT void write_hash(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy, bool strict_errors);
+        LIBFACTER_NO_EXPORT void write_json(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy, bool strict_errors);
+        LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy, bool strict_errors);
         LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
         LIBFACTER_NO_EXPORT bool add_external_facts_dir(std::vector<std::unique_ptr<external::resolver>> const& resolvers, std::string const& directory, bool warn);
 

--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -105,17 +105,17 @@ SCENARIO("using the fact collection") {
         WHEN("writing all (hidden) facts") {
             THEN("it should serialize both facts to JSON") {
                 ostringstream ss;
-                facts.write(ss, format::json, set<string>{}, true);
+                facts.write(ss, format::json, set<string>{}, true, false);
                 REQUIRE(ss.str() == "{\n  \"foo\": \"bar\",\n  \"hidden_foo\": \"hidden_bar\"\n}");
             }
             THEN("it should serialize both facts to YAML") {
                 ostringstream ss;
-                facts.write(ss, format::yaml, set<string>{}, true);
+                facts.write(ss, format::yaml, set<string>{}, true, false);
                 REQUIRE(ss.str() == "foo: bar\nhidden_foo: hidden_bar");
             }
             THEN("it should serialize both facts to text") {
                 ostringstream ss;
-                facts.write(ss, format::hash, set<string>{}, true);
+                facts.write(ss, format::hash, set<string>{}, true, false);
                 REQUIRE(ss.str() == "foo => bar\nhidden_foo => hidden_bar");
             }
         }
@@ -139,17 +139,17 @@ SCENARIO("using the fact collection") {
         WHEN("querying hidden facts") {
             THEN("it should serialize both facts to JSON") {
                 ostringstream ss;
-                facts.write(ss, format::json, {"foo", "hidden_foo"}, true);
+                facts.write(ss, format::json, {"foo", "hidden_foo"}, true, false);
                 REQUIRE(ss.str() == "{\n  \"foo\": \"bar\",\n  \"hidden_foo\": \"hidden_bar\"\n}");
             }
             THEN("it should serialize both facts to YAML") {
                 ostringstream ss;
-                facts.write(ss, format::yaml, {"foo", "hidden_foo"}, true);
+                facts.write(ss, format::yaml, {"foo", "hidden_foo"}, true, false);
                 REQUIRE(ss.str() == "foo: bar\nhidden_foo: hidden_bar");
             }
             THEN("it should serialize both facts to text") {
                 ostringstream ss;
-                facts.write(ss, format::hash, {"foo", "hidden_foo"}, true);
+                facts.write(ss, format::hash, {"foo", "hidden_foo"}, true, false);
                 REQUIRE(ss.str() == "foo => bar\nhidden_foo => hidden_bar");
             }
         }


### PR DESCRIPTION
Enabling this flag currently only changes one error code: when a non-existing fact is queried, Facter will return 1 instead of 0 as before.

In the future this flag may enable more detailed error codes for different errors. The discussion thread on what this functionality should look like is here: https://groups.google.com/forum/#!topic/puppet-dev/qtiPcJAtKZw