### PR TITLE
(FACT-1457) Spike an access layer around cpp-hocon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND NOT WITHOUT_BLKID)
     find_package(BLKID)
 endif()
 
+find_package(CPPHOCON REQUIRED)
 
 if (NOT WITHOUT_JRUBY AND NOT WIN32)
     find_package(JNI)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,12 @@ install:
   - ps: wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$pwd\leatherman.7z"
   - ps: 7z.exe x leatherman.7z -oC:\tools | FIND /V "ing "
 
+  - git clone https://github.com/puppetlabs/cpp-hocon.git
+  - cd cpp-hocon
+  - ps: cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_58_0-x86_64_mingw-w64_4.8.3_win32_seh" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_min    gw-w64_4.8.3_win32_seh" -DCURL_STATIC=ON -DBOOST_STATIC=ON -Wno-dev .
+  - ps: mingw32-make install
+  - cd ..
+
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:

--- a/cmake/FindCPPHOCON.cmake
+++ b/cmake/FindCPPHOCON.cmake
@@ -1,0 +1,6 @@
+include(FindDependency)
+find_dependency(CPPHOCON DISPLAY "cpp-hocon" HEADERS "hocon/config.hpp" LIBRARIES "libcpp-hocon.a")
+
+include(FeatureSummary)
+set_package_properties(CPPHOCON PROPERTIES DESCRIPTION "A C++ parser for the HOCON configuration language" URL "https://github.com/puppetlabs/cpp-hocon")
+set_package_properties(CPPHOCON PROPERTIES TYPE REQUIRED PURPOSE "Allows parsing of the Facter config file.")

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
 
 add_executable(facter ${FACTER_SOURCES})
 target_link_libraries(facter libfacter
+    ${Boost_THREAD_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${LEATHERMAN_UTIL_LIB}
     ${LEATHERMAN_NOWIDE_LIB}

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -1,6 +1,7 @@
 #include <facter/version.h>
 #include <facter/logging/logging.hpp>
 #include <facter/facts/collection.hpp>
+#include <facter/config/config.hpp>
 #include <facter/ruby/ruby.hpp>
 #include <leatherman/util/environment.hpp>
 #include <leatherman/util/scope_exit.hpp>
@@ -26,6 +27,7 @@
 using namespace std;
 using namespace facter::facts;
 using namespace facter::logging;
+using namespace facter::config;
 using leatherman::util::environment;
 namespace po = boost::program_options;
 
@@ -110,8 +112,16 @@ int main(int argc, char **argv)
         // Setup logging
         setup_logging(boost::nowide::cerr);
 
+        auto conf = config::instance("/etc/puppetlabs/facter/facter.conf");
+
         vector<string> external_directories;
+        if (conf.has_setting("global.external-dir")) {
+            external_directories.emplace_back(conf.get_setting<string>("global.external-dir"));
+        }
         vector<string> custom_directories;
+        if (conf.has_setting("global.custom-dir")) {
+            custom_directories.emplace_back(conf.get_setting<string>("global.custom-dir"));
+        }
 
         // Build a list of options visible on the command line
         // Keep this list sorted alphabetically

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -273,6 +273,7 @@ include_directories(
     ${YAMLCPP_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
     ${LEATHERMAN_INCLUDE_DIRS}
+    ${CPPHOCON_INCLUDE_DIRS}
 )
 
 link_directories(
@@ -280,6 +281,7 @@ link_directories(
     ${OPENSSL_LIBRARY_DIRS}
     ${YAMLCPP_LIBRARY_DIRS}
     ${CURL_LIBRARY_DIRS}
+    ${CPPHOCON_LIBRARY_DIRS}
 )
 
 # Add the library target without a prefix (name already has the 'lib') and use '.so' for all platforms (Ruby extension file extension)
@@ -297,7 +299,7 @@ endif()
 
 # Link in additional libraries
 target_link_libraries(libfacter PRIVATE
-    cpp-hocon
+    ${CPPHOCON_LIBRARIES}
     ${LIBFACTER_PLATFORM_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
     ${Boost_LIBRARIES}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -72,6 +72,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/ruby/simple_resolution.cc"
     "src/util/scoped_file.cc"
     "src/util/string.cc"
+    "src/config/config.cc"
 )
 
 # Set the POSIX sources if on a POSIX platform
@@ -296,6 +297,7 @@ endif()
 
 # Link in additional libraries
 target_link_libraries(libfacter PRIVATE
+    cpp-hocon
     ${LIBFACTER_PLATFORM_LIBRARIES}
     ${LEATHERMAN_LIBRARIES}
     ${Boost_LIBRARIES}

--- a/lib/inc/facter/config/config.hpp
+++ b/lib/inc/facter/config/config.hpp
@@ -1,0 +1,64 @@
+/**
+ * @file
+ * Declares functions for accessing the Facter configuration file.
+ */
+#pragma once
+
+#include "../export.h"
+#include <hocon/config.hpp>
+
+namespace facter { namespace config {
+
+    class LIBFACTER_EXPORT config {
+        public:
+            /**
+             * Creates a config object from the file at the provided path,
+             * which wraps a cpp-hocon config object. This config
+             * can be queried for specific settings.
+             * @param file_path the full path to the config file
+             */
+            static config instance(std::string const& file_path);
+
+            /**
+             * Reloads all the settings from the configuration file.
+             * @param file_path the full path to the config file
+             */
+            void reload_from_file(std::string const& file_path);
+
+            /**
+             * Checks whether the specified setting is present in the config file.
+             * @param setting_path dot-separated path to the desired setting
+             * @return true if the setting appears in the file, false otherwise
+             */
+            bool has_setting(std::string const& setting_path);
+
+            /**
+             * Returns an item of type T representing the value of the setting at the given path.
+             * Throws an exception if the setting value is of the wrong type, or if the setting does not exist.
+             * @param setting_path dot-separated path to the desired setting
+             * @return the value of the setting
+             */
+            template<typename T>
+            T get_setting(std::string const& setting_path) {
+                return boost::get<T>(_config->get_any_ref(setting_path));
+            }
+
+            /**
+             * Returns a list of items of type T representing the value of the list setting at the given path.
+             * Throws an exception if the setting does not exist or if the list is of the wrong type or not homogeneous.
+             * @param setting_path dot-separated path to the desired setting
+             * @return a list of the values in the setting
+             */
+            template<typename T>
+            std::vector<T> get_list_setting(std::string const& setting_path) {
+                return _config->get_homogeneous_unwrapped_list<T>(setting_path);
+            }
+
+        private:
+            config(hocon::shared_config hocon_conf);
+
+            hocon::shared_config _config;
+    };
+
+}}  // namespace facter::config
+

--- a/lib/inc/facter/config/config.hpp
+++ b/lib/inc/facter/config/config.hpp
@@ -9,6 +9,9 @@
 
 namespace facter { namespace config {
 
+    /**
+     * Singleton wrapper class for the HOCON object representing the Facter config file.
+     */
     class LIBFACTER_EXPORT config {
         public:
             /**
@@ -16,6 +19,7 @@ namespace facter { namespace config {
              * which wraps a cpp-hocon config object. This config
              * can be queried for specific settings.
              * @param file_path the full path to the config file
+             * @return a singleton access point for the config file
              */
             static config instance(std::string const& file_path);
 

--- a/lib/src/config/config.cc
+++ b/lib/src/config/config.cc
@@ -1,0 +1,23 @@
+#include <facter/config/config.hpp>
+
+using namespace std;
+
+namespace facter { namespace config {
+
+    config::config(hocon::shared_config hocon_conf) : _config(hocon_conf) { }
+
+    config config::instance(string const& file_path) {
+        static config conf(hocon::config::parse_file_any_syntax(file_path)->resolve());
+        return conf;
+    }
+
+    void config::reload_from_file(std::string const& file_path) {
+        _config = hocon::config::parse_file_any_syntax(file_path)->resolve();
+    }
+
+    bool config::has_setting(string const& setting_path) {
+        return _config->has_path(setting_path);
+    }
+
+}}  // namespace facter::config
+

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -118,6 +118,7 @@ include_directories(
 
 add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc> ${LIBFACTER_TESTS_COMMON_SOURCES} ${LIBFACTER_TESTS_PLATFORM_SOURCES} ${LIBFACTER_TESTS_CATEGORY_SOURCES})
 target_link_libraries(libfacter_test
+    cpp-hocon
     ${POSIX_TESTS_LIBRARIES}
     ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
     ${YAMLCPP_LIBRARIES}

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -19,6 +19,7 @@ elif [ ${TRAVIS_TARGET} == DEBUG ]; then
   pip install --user cpp-coveralls
 fi
 
+
 # Generate build files
 if [ ${TRAVIS_TARGET} == COMMITS ]; then
   shopt -s nocasematch
@@ -55,6 +56,15 @@ elif [ ${TRAVIS_TARGET} == DOXYGEN ]; then
 elif [ ${TRAVIS_TARGET} == CPPCHECK ]; then
   make cppcheck
 else
+  # clone and install cpp-hocon
+  git clone https://github.com/puppetlabs/cpp-hocon.git
+  cd cpp-hocon
+  mkdir build
+  cd build
+  cmake ..
+  make install
+  cd ..
+
   make -j2
 
   # Install the bundle before testing

--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -62,8 +62,9 @@ else
   mkdir build
   cd build
   cmake ..
-  make install
-  cd ..
+  make DESTDIR=$USERDIR install
+  cd ../..
+  export PATH=$USERDIR:$PATH
 
   make -j2
 


### PR DESCRIPTION
This is a proof of concept for configuring facter via a HOCON config
file. It currently assumes that file is located at
/etc/puppetlabs/facter/facter.conf.

It adds a class for wrapping the calls to cpp-hocon and presenting
a simple API for accessing settings.

Since I don't know exactly what our requirements are, this is a generic initial draft. Looking for feedback!