### PR TITLE
(maint) Fix networking.dhcp fact in ubuntu.rb for ubuntu-10.04.

### DIFF
--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -83,7 +83,7 @@ agents.each do |agent|
 
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
   expected_networking = {
-                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => /(?:10|192)\.\d+\.\d+\.\d+/,
                           "networking.ip"       => /10\.\d+\.\d+\.\d+/,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,


### PR DESCRIPTION
The acceptance test facts/ubuntu.rb assumes the ip address in the
networking.dhcp fact begins with '10.'  On ubuntu-10.04, this is not always
the case.  This fix allows ip addresses beginning with '192.' as well as '10.'.