### PR TITLE
(FACT-1465) Use @ip_regex for validating network address facts

### DIFF
--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected in Debian 6 and 7"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Debian 6 and 7.
@@ -68,14 +70,14 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => @ip_regex,
+                          "networking.ip"       => @ip_regex,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                           "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected in Fedora 20, 21, and 22"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Fedora 20, 21, and 22.
@@ -49,14 +51,14 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => @ip_regex,
+                          "networking.ip"       => @ip_regex,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                           "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected in Mac OS X 10.9 and 10.10"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Mac OS X 10.9 and 10.10
@@ -62,14 +64,14 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => @ip_regex,
+                          "networking.ip"       => @ip_regex,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                           "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected in Solaris 10 and 11"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Solaris 10 and 11.
@@ -64,7 +66,7 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.ip"       => @ip_regex,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
@@ -72,7 +74,7 @@ agents.each do |agent|
 
   # Our SPARC testing platforms don't use DHCP
   if os_architecture == 'i86pc'
-    expected_networking["networking.dhcp"] = /10\.\d+\.\d+\.\d+/
+    expected_networking["networking.dhcp"] = @ip_regex
   end
 
   expected_networking.each do |fact, value|
@@ -85,9 +87,9 @@ agents.each do |agent|
 
   step "Ensure bindings for the primary networking interface are present."
   expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
+                        "networking.interfaces.#{primary_interface}.bindings.0.address" => @ip_regex,
                         "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
+                        "networking.interfaces.#{primary_interface}.bindings.0.network" => @ip_regex,
                       }
   expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected in Ubuntu"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in all supported Ubuntu versions.
@@ -83,14 +85,14 @@ agents.each do |agent|
 
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
   expected_networking = {
-                          "networking.dhcp"     => /(?:10|192)\.\d+\.\d+\.\d+/,
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => @ip_regex,
+                          "networking.ip"       => @ip_regex,
                           "networking.ip6"      => /[a-f0-9]+:+/,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
                           "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                           "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
                         }
 

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -1,5 +1,7 @@
 test_name "Facts should resolve as expected on Windows platforms"
 
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected on Windows platforms.
@@ -61,12 +63,12 @@ agents.each do |agent|
   step "Ensure the Networking fact resolves with reasonable values for at least one interface"
 
   expected_networking = {
-                          "networking.dhcp"     => /10\.\d+\.\d+\.\d+/,
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
+                          "networking.dhcp"     => @ip_regex,
+                          "networking.ip"       => @ip_regex,
                           "networking.mac"      => /[a-f0-9]{2}:/,
                           "networking.mtu"      => /\d+/,
                           "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
+                          "networking.network"  => @ip_regex,
                         }
 
   expected_networking.each do |fact, value|


### PR DESCRIPTION
Prior to this fix, many architecture specific fact tests were verifying
ip addresses and netmasks were in the 10.x.x.x range.  This cause ubuntu.rb
to fail when the dhcp server address was 192.x.x.x instead.  After this fix,
all network addresses are validated using the same regex pattern as used in
sles.rb, which matches any and only valid IPv4 addresses.  See also 
https://github.com/puppetlabs/facter/pull/1378