### PR TITLE
(FACT-1476) fix CI failure

### DIFF
--- a/acceptance/tests/ticket_1429_facter_with_strict_flag.rb
+++ b/acceptance/tests/ticket_1429_facter_with_strict_flag.rb
@@ -2,9 +2,7 @@ test_name 'ticket FACT-1476 - C98098 facter cli with --strict flag'
 
 agents.each do |host|
   step 'facter should return exit code 0 for querying non-existing-fact without --strict flag'
-  on(host, facter('-p non-existing-fact')) do |result|
-    assert_match(/WARN\s+puppetlabs\.facter\s+-\s+skipping external facts for/, result.stderr, 'Unexpected error was detected!')
-  end
+  on(host, facter('-p non-existing-fact'))
 
   step 'facter should return exit code 1 for querying non-existing-fact with --strict flag'
   on(host, facter('-p non-existing-fact --strict'), :acceptable_exit_codes => 1) do |result|


### PR DESCRIPTION
Jenkins slave doesn't output warning when querying a non-exiting-fact in the test case:
Test line: tests/ticket_1429_facter_with_strict_flag.rb:6

https://jenkins.puppetlabs.com/view/puppet-agent/view/master/view/facter/job/platform_facter_intn-van-sys_master/SLAVE_LABEL=beaker,TEST_TARGET=ubuntu1404-64a/71/consoleFull