### PR TITLE
(FACT-1405) Properly compare ip route flags

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -145,7 +145,7 @@ namespace facter { namespace facts { namespace linux {
 
             // remove trailing "onlink" or "pervasive" flags
             while (parts.size() > 0) {
-                auto last_token = parts.back();
+                std::string last_token(parts.back().begin(), parts.back().end());
                 if (last_token == "onlink" || last_token == "pervasive")
                     parts.pop_back();
                 else


### PR DESCRIPTION
Previously, we were attempting to compare a string::iterator range
with a const char* C-string via an iterator comparison, treating the
C-string as a "range". This does not work, because when treated as a
range the c-string includes the null byte, while the string iterator
pair does not. This means the ranges are unequal even if they contain
the same character data.

This converts the iterator range to a string before comparison, so
that we use std::string::operator== for the comparison.