### PR TITLE
(FACT-1361) Create networking fact acceptance test

### DIFF
--- a/acceptance/tests/facts/aix.rb
+++ b/acceptance/tests/facts/aix.rb
@@ -52,34 +52,6 @@ agents.each do |agent|
     assert_match(value, fact_on(agent, fact))
   end
 
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.ip"       => /10\.\d+\.\d+\.\d+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.network"  => /10\.\d+\.\d+\.\d+/,
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                      }
-  expected_bindings.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
   step "Ensure the identity fact resolves as expected"
   expected_identity = {
                         'identity.gid'        => '0',

--- a/acceptance/tests/facts/debian.rb
+++ b/acceptance/tests/facts/debian.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected in Debian 6 and 7"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Debian 6, 7 and 8.
@@ -64,41 +62,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.dhcp"     => @ip_regex,
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/el.rb
+++ b/acceptance/tests/facts/el.rb
@@ -10,8 +10,6 @@ test_name "Facts should resolve as expected in EL 4, 5, 6 and 7"
 # Don't test on RedHat 4, as is does not include yum (See BKR-512)
 confine :to, :platform => /el-[5-7]|centos-[4-7]/
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 agents.each do |agent|
   # TODO: It might be time to start abstracting all of this logic away as more versions are continually added.
   case agent['platform']
@@ -81,40 +79,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/fedora.rb
+++ b/acceptance/tests/facts/fedora.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected in Fedora 20, 21, and 22"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Fedora 20, 21, and 22.
@@ -45,41 +43,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.dhcp"     => @ip_regex,
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected in Mac OS X 10.9 and 10.10"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Mac OS X 10.9 and 10.10
@@ -58,41 +56,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.dhcp"     => @ip_regex,
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -1,0 +1,80 @@
+test_name 'FACT-1361 - C59029 networking facts should be fully populated'
+
+#
+# This test is intended to ensure that networking facts resolves
+# as expected in AIO across supported platforms.
+#
+
+skip_test "Networking fact test is confined to AIO" if @options[:type] != 'aio'
+
+@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
+expected_networking = {
+    "networking.dhcp"     => @ip_regex,
+    "networking.ip"       => @ip_regex,
+    "networking.ip6"      => /[a-f0-9]+:+/,
+    "networking.mac"      => /[a-f0-9]{2}:/,
+    "networking.mtu"      => /\d+/,
+    "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
+    "networking.netmask6" => /[a-f0-9]+:/,
+    "networking.network"  => @ip_regex,
+    "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
+}
+
+agents.each do |agent|
+
+  step "Ensure a primary networking interface was determined."
+  primary_interface = fact_on(agent, 'networking.primary')
+  refute_empty(primary_interface)
+
+  expected_bindings = {
+      "\"networking.interfaces.#{primary_interface}.bindings.0.address\"" => /\d+\.\d+\.\d+\.\d+/,
+      "\"networking.interfaces.#{primary_interface}.bindings.0.netmask\"" => /\d+\.\d+\.\d+\.\d+/,
+      "\"networking.interfaces.#{primary_interface}.bindings.0.network\"" => /\d+\.\d+\.\d+\.\d+/,
+      "\"networking.interfaces.#{primary_interface}.bindings6.0.address\"" => /[a-f0-9:]+/,
+      "\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"" => /[a-f0-9:]+/,
+      "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
+  }
+
+  case agent['platform']
+    when /solaris/, /eos/
+      #remove the invalid networking facts on aix and solaris
+      expected_networking.delete("networking.ip6")
+      expected_networking.delete("networking.netmask6")
+      expected_networking.delete("networking.network6")
+
+      #remove invalid bindings for the primary networking interface on AIX and Solaris
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+
+    when /sparc/, /aix/, /cisco/
+      #remove the invalid networking facts on SPARC or AIX
+      #Our SPARC testing platforms don't use DHCP
+      expected_networking.delete("networking.dhcp")
+      expected_networking.delete("networking.ip6")
+      expected_networking.delete("networking.netmask6")
+      expected_networking.delete("networking.network6")
+
+      #remove invalid bindings for the primary networking interface on SPARC or AIX
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+
+    when /sles/
+      #some sles VMs do not have networking.dhcp
+      expected_networking.delete("networking.dhcp")
+
+  end
+
+  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+  expected_networking.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+  step "Ensure bindings for the primary networking interface are present."
+  expected_bindings.each do |fact, value|
+    assert_match(value, fact_on(agent, fact))
+  end
+
+end

--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -1,80 +1,79 @@
-test_name 'FACT-1361 - C59029 networking facts should be fully populated'
+test_name 'FACT-1361 - C59029 networking facts should be fully populated' do
 
 #
 # This test is intended to ensure that networking facts resolves
-# as expected in AIO across supported platforms.
+# as expected across supported platforms.
 #
 
-skip_test "Networking fact test is confined to AIO" if @options[:type] != 'aio'
+  @ip_regex       = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+  @netmask_regex  = /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
-expected_networking = {
-    "networking.dhcp"     => @ip_regex,
-    "networking.ip"       => @ip_regex,
-    "networking.ip6"      => /[a-f0-9]+:+/,
-    "networking.mac"      => /[a-f0-9]{2}:/,
-    "networking.mtu"      => /\d+/,
-    "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-    "networking.netmask6" => /[a-f0-9]+:/,
-    "networking.network"  => @ip_regex,
-    "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-}
-
-agents.each do |agent|
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  expected_bindings = {
-      "\"networking.interfaces.#{primary_interface}.bindings.0.address\"" => /\d+\.\d+\.\d+\.\d+/,
-      "\"networking.interfaces.#{primary_interface}.bindings.0.netmask\"" => /\d+\.\d+\.\d+\.\d+/,
-      "\"networking.interfaces.#{primary_interface}.bindings.0.network\"" => /\d+\.\d+\.\d+\.\d+/,
-      "\"networking.interfaces.#{primary_interface}.bindings6.0.address\"" => /[a-f0-9:]+/,
-      "\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"" => /[a-f0-9:]+/,
-      "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
+  expected_networking = {
+      "networking.dhcp"     => @ip_regex,
+      "networking.ip"       => @ip_regex,
+      "networking.ip6"      => /[a-f0-9]+:+/,
+      "networking.mac"      => /[a-f0-9]{2}:/,
+      "networking.mtu"      => /\d+/,
+      "networking.netmask"  => @netmask_regex,
+      "networking.netmask6" => /[a-f0-9]+:/,
+      "networking.network"  => @ip_regex,
+      "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
   }
 
-  case agent['platform']
-    when /solaris/, /eos/
-      #remove the invalid networking facts on aix and solaris
-      expected_networking.delete("networking.ip6")
-      expected_networking.delete("networking.netmask6")
-      expected_networking.delete("networking.network6")
+  agents.each do |agent|
+    step "Ensure a primary networking interface was determined."
+    primary_interface = fact_on(agent, 'networking.primary')
+    refute_empty(primary_interface)
 
-      #remove invalid bindings for the primary networking interface on AIX and Solaris
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+    expected_bindings = {
+        "\"networking.interfaces.#{primary_interface}.bindings.0.address\"" => @ip_regex,
+        "\"networking.interfaces.#{primary_interface}.bindings.0.netmask\"" => @netmask_regex,
+        "\"networking.interfaces.#{primary_interface}.bindings.0.network\"" => @ip_regex,
+        "\"networking.interfaces.#{primary_interface}.bindings6.0.address\"" => /[a-f0-9:]+/,
+        "\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"" => /[a-f0-9:]+/,
+        "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
+    }
 
-    when /sparc/, /aix/, /cisco/
-      #remove the invalid networking facts on SPARC or AIX
-      #Our SPARC testing platforms don't use DHCP
-      expected_networking.delete("networking.dhcp")
-      expected_networking.delete("networking.ip6")
-      expected_networking.delete("networking.netmask6")
-      expected_networking.delete("networking.network6")
+    case agent['platform']
+      when /solaris/, /eos/
+        #remove the invalid networking facts on Solaris or Arista
+        expected_networking.delete("networking.ip6")
+        expected_networking.delete("networking.netmask6")
+        expected_networking.delete("networking.network6")
 
-      #remove invalid bindings for the primary networking interface on SPARC or AIX
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+        #remove invalid bindings for the primary networking interface on AIX and Solaris
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
 
-    when /sles/
-      #some sles VMs do not have networking.dhcp
-      expected_networking.delete("networking.dhcp")
+      when /sparc/, /aix/, /cisco/
+        #remove the invalid networking facts on SPARC, AIX, or Cisco
+        #Our SPARC testing platforms don't use DHCP
+        expected_networking.delete("networking.dhcp")
+        expected_networking.delete("networking.ip6")
+        expected_networking.delete("networking.netmask6")
+        expected_networking.delete("networking.network6")
 
-  end
+        #remove invalid bindings for the primary networking interface on SPARC or AIX
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
 
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
+      when /sles/
+        #some sles VMs do not have networking.dhcp
+        expected_networking.delete("networking.dhcp")
 
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
+    end
+
+    step "Ensure the Networking fact resolves with reasonable values for at least one interface"
+    expected_networking.each do |fact, value|
+      assert_match(value, fact_on(agent, fact))
+    end
+
+    step "Ensure bindings for the primary networking interface are present."
+    expected_bindings.each do |fact, value|
+      assert_match(value, fact_on(agent, fact))
+    end
   end
 
 end

--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -21,59 +21,61 @@ test_name 'FACT-1361 - C59029 networking facts should be fully populated' do
   }
 
   agents.each do |agent|
-    step "Ensure a primary networking interface was determined."
-    primary_interface = fact_on(agent, 'networking.primary')
-    refute_empty(primary_interface)
+    step "Ensure a primary networking interface was determined" do
+      primary_interface = fact_on(agent, 'networking.primary')
+      refute_empty(primary_interface)
 
-    expected_bindings = {
-        "\"networking.interfaces.#{primary_interface}.bindings.0.address\"" => @ip_regex,
-        "\"networking.interfaces.#{primary_interface}.bindings.0.netmask\"" => @netmask_regex,
-        "\"networking.interfaces.#{primary_interface}.bindings.0.network\"" => @ip_regex,
-        "\"networking.interfaces.#{primary_interface}.bindings6.0.address\"" => /[a-f0-9:]+/,
-        "\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"" => /[a-f0-9:]+/,
-        "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
-    }
+      expected_bindings = {
+          "\"networking.interfaces.#{primary_interface}.bindings.0.address\"" => @ip_regex,
+          "\"networking.interfaces.#{primary_interface}.bindings.0.netmask\"" => @netmask_regex,
+          "\"networking.interfaces.#{primary_interface}.bindings.0.network\"" => @ip_regex,
+          "\"networking.interfaces.#{primary_interface}.bindings6.0.address\"" => /[a-f0-9:]+/,
+          "\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"" => /[a-f0-9:]+/,
+          "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
+      }
 
-    case agent['platform']
-      when /solaris/, /eos/
-        #remove the invalid networking facts on Solaris or Arista
-        expected_networking.delete("networking.ip6")
-        expected_networking.delete("networking.netmask6")
-        expected_networking.delete("networking.network6")
+      case agent['platform']
+        when /solaris/, /eos/
+          #remove the invalid networking facts on Solaris or Arista
+          expected_networking.delete("networking.ip6")
+          expected_networking.delete("networking.netmask6")
+          expected_networking.delete("networking.network6")
 
-        #remove invalid bindings for the primary networking interface on AIX and Solaris
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+          #remove invalid bindings for the primary networking interface on AIX and Solaris
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
 
-      when /sparc/, /aix/, /cisco/
-        #remove the invalid networking facts on SPARC, AIX, or Cisco
-        #Our SPARC testing platforms don't use DHCP
-        expected_networking.delete("networking.dhcp")
-        expected_networking.delete("networking.ip6")
-        expected_networking.delete("networking.netmask6")
-        expected_networking.delete("networking.network6")
+        when /sparc/, /aix/, /cisco/
+          #remove the invalid networking facts on SPARC, AIX, or Cisco
+          #Our SPARC testing platforms don't use DHCP
+          expected_networking.delete("networking.dhcp")
+          expected_networking.delete("networking.ip6")
+          expected_networking.delete("networking.netmask6")
+          expected_networking.delete("networking.network6")
 
-        #remove invalid bindings for the primary networking interface on SPARC or AIX
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+          #remove invalid bindings for the primary networking interface on SPARC or AIX
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+          expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
 
-      when /sles/
-        #some sles VMs do not have networking.dhcp
-        expected_networking.delete("networking.dhcp")
+        when /sles/
+          #some sles VMs do not have networking.dhcp
+          expected_networking.delete("networking.dhcp")
 
+      end
     end
 
-    step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-    expected_networking.each do |fact, value|
-      assert_match(value, fact_on(agent, fact))
+    step "Ensure the Networking fact resolves with reasonable values for at least one interface" do
+      expected_networking.each do |fact, value|
+        assert_match(value, fact_on(agent, fact))
+      end
     end
 
-    step "Ensure bindings for the primary networking interface are present."
-    expected_bindings.each do |fact, value|
-      assert_match(value, fact_on(agent, fact))
+    step "Ensure bindings for the primary networking interface are present" do
+      expected_bindings.each do |fact, value|
+        assert_match(value, fact_on(agent, fact))
+      end
     end
   end
-
 end

--- a/acceptance/tests/facts/sles.rb
+++ b/acceptance/tests/facts/sles.rb
@@ -9,8 +9,6 @@ test_name "Facts should resolve as expected in SLES 10, 11 and 12"
 
 confine :to, :platform => /sles-10|sles-11|sles-12/
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 agents.each do |agent|
   if agent['platform'] =~ /sles-10/
     os_version = '10'
@@ -60,40 +58,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/solaris.rb
+++ b/acceptance/tests/facts/solaris.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected in Solaris 10 and 11"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in Solaris 10 and 11.
@@ -60,38 +58,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.ip"       => @ip_regex,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                        }
-
-  # Our SPARC testing platforms don't use DHCP
-  if os_architecture == 'i86pc'
-    expected_networking["networking.dhcp"] = @ip_regex
-  end
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => @ip_regex,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => @ip_regex,
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected in Ubuntu"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected in all supported Ubuntu versions.
@@ -80,40 +78,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-  expected_networking = {
-                          "networking.dhcp"     => @ip_regex,
-                          "networking.ip"       => @ip_regex,
-                          "networking.ip6"      => /[a-f0-9]+:+/,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.netmask6" => /[a-f0-9]+:/,
-                          "networking.network"  => @ip_regex,
-                          "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.#{primary_interface}.bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings.0.network" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.address" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.netmask" => /[a-f0-9:]+/,
-                        "networking.interfaces.#{primary_interface}.bindings6.0.network" => /[a-f0-9:]+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -1,7 +1,5 @@
 test_name "Facts should resolve as expected on Windows platforms"
 
-@ip_regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-
 #
 # This test is intended to ensure that facts specific to an OS configuration
 # resolve as expected on Windows platforms.
@@ -57,35 +55,6 @@ agents.each do |agent|
                         }
 
   expected_processors.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure the Networking fact resolves with reasonable values for at least one interface"
-
-  expected_networking = {
-                          "networking.dhcp"     => @ip_regex,
-                          "networking.ip"       => @ip_regex,
-                          "networking.mac"      => /[a-f0-9]{2}:/,
-                          "networking.mtu"      => /\d+/,
-                          "networking.netmask"  => /\d+\.\d+\.\d+\.\d+/,
-                          "networking.network"  => @ip_regex,
-                        }
-
-  expected_networking.each do |fact, value|
-    assert_match(value, fact_on(agent, fact))
-  end
-
-  step "Ensure a primary networking interface was determined."
-  primary_interface = fact_on(agent, 'networking.primary')
-  refute_empty(primary_interface)
-
-  step "Ensure bindings for the primary networking interface are present."
-  expected_bindings = {
-                        "networking.interfaces.\"#{primary_interface}\".bindings.0.address" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.\"#{primary_interface}\".bindings.0.netmask" => /\d+\.\d+\.\d+\.\d+/,
-                        "networking.interfaces.\"#{primary_interface}\".bindings.0.network" => /\d+\.\d+\.\d+\.\d+/
-                      }
-  expected_bindings.each do |fact, value|
     assert_match(value, fact_on(agent, fact))
   end
 


### PR DESCRIPTION
Prior to this PR, networking facts were verified in each individual test cases in acceptance/tests/facts/<platform>.rb

This PR pulls out the networking portion of all the tests in acceptance/tests/facts into new acceptance test, acceptance/tests/facts/networking_facts.rb

This will also help to test networking facts in many more platforms in puppet-agent CI, instead of being confined to only 9 platforms in acceptance/tests/facts