### PR TITLE
(FACT-1413) Fix fact precedence and resolution order

### DIFF
--- a/acceptance/tests/external_facts/fact_precedence.rb
+++ b/acceptance/tests/external_facts/fact_precedence.rb
@@ -1,0 +1,63 @@
+test_name "Fact precedence and resolution order (external & custom facts)"
+
+require 'facter/acceptance/user_fact_utils'
+extend Facter::Acceptance::UserFactUtils
+
+# Use a static external fact
+ext_fact = "test: 'EXTERNAL'"
+
+# Generate custom fact dynamically
+def cust_fact(*args)
+  <<-EOM
+  Facter.add('test') do
+    setcode {'CUSTOM'}
+    #{args.empty? ? '':args.join('\n')}
+  end
+  EOM
+end
+
+agents.each do |agent|
+  # Shared directory for external and custom facts
+  facts_dir = agent.tmpdir('facts.d')
+  ext_fact_path = "#{facts_dir}/test.yaml"
+  cust_fact_path = "#{facts_dir}/test.rb"
+
+  step "Agent #{agent}: create facts directory (#{facts_dir})"
+  on(agent, "rm -rf #{facts_dir}")
+  on(agent, "mkdir -p #{facts_dir}")
+
+  # Custom fact with no external fact should resolve to CUSTOM
+  step "Agent #{agent}: create and resolve a custom fact"
+  create_remote_file(agent, cust_fact_path, cust_fact)
+  on(agent, facter("--external-dir=#{facts_dir} --custom-dir=#{facts_dir} test"))
+  assert_equal("CUSTOM", stdout.chomp)
+
+  # Adding external fact should give precedence to the EXTERNAL fact
+  step "Agent #{agent}: create and resolve an external fact"
+  create_remote_file(agent, ext_fact_path, ext_fact)
+  on(agent, facter("--external-dir=#{facts_dir} --custom-dir=#{facts_dir} test"))
+  assert_equal("EXTERNAL", stdout.chomp)
+
+  # Custom fact with weight > 10000 should give precedence to the CUSTOM fact
+  step "Agent #{agent}: resolve a custom fact with weight of 10001"
+  create_remote_file(agent, cust_fact_path, cust_fact("has_weight 10001"))
+  on(agent, facter("--external-dir=#{facts_dir} --custom-dir=#{facts_dir} test"))
+  assert_equal("CUSTOM", stdout.chomp)
+
+  # Custom fact with weight <= 10000 should give precedence to the EXTERNAL fact
+  step "Agent #{agent}: resolve a custom fact with weight of 10000"
+  create_remote_file(agent, cust_fact_path, cust_fact("has_weight 10000"))
+  on(agent, facter("--external-dir=#{facts_dir} --custom-dir=#{facts_dir} test"))
+  assert_equal("EXTERNAL", stdout.chomp)
+
+  # Custom fact with a confine should give precedence to the EXTERNAL fact
+  # (from FACT-1413)
+  step "Agent #{agent}: resolve a custom fact with a confine"
+  create_remote_file(agent, cust_fact_path, cust_fact("confine :kernel=>'linux'"))
+  on(agent, facter("--external-dir=#{facts_dir} --custom-dir=#{facts_dir} test"))
+  assert_equal("EXTERNAL", stdout.chomp)
+
+  teardown do
+    on(agent, "rm -rf #{facts_dir}")
+  end
+end

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -290,6 +290,13 @@ int main(int argc, char **argv)
         collection facts;
         facts.add_default_facts(ruby);
 
+        // Add the environment facts
+        facts.add_environment_facts();
+
+        if (ruby && !vm["no-custom-facts"].as<bool>()) {
+            facter::ruby::load_custom_facts(facts, vm.count("puppet"), custom_directories);
+        }
+
         if (!vm["no-external-facts"].as<bool>()) {
           string inside_facter;
           environment::get("INSIDE_FACTER", inside_facter);
@@ -301,13 +308,6 @@ int main(int argc, char **argv)
             environment::set("INSIDE_FACTER", "true");
             facts.add_external_facts(external_directories);
           }
-        }
-
-        // Add the environment facts
-        facts.add_environment_facts();
-
-        if (ruby && !vm["no-custom-facts"].as<bool>()) {
-            facter::ruby::load_custom_facts(facts, vm.count("puppet"), custom_directories);
         }
 
         // Output the facts

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -46,6 +46,11 @@ namespace facter { namespace facts {
     struct LIBFACTER_EXPORT collection
     {
         /**
+         * Inherent "has_weight" value for external facts.
+         */
+        constexpr static size_t external_fact_weight = 10000;
+
+        /**
          * Constructs a fact collection.
          */
         collection();
@@ -100,6 +105,21 @@ namespace facter { namespace facts {
          * @param value The value of the fact.
          */
         void add(std::string name, std::unique_ptr<value> value);
+
+        /**
+         * Adds a custom fact to the fact collection.
+         * @param name The name of the fact.
+         * @param value The value of the fact.
+         * @param weight The weight of the fact.
+         */
+        void add_custom(std::string name, std::unique_ptr<value> value, size_t weight);
+
+        /**
+         * Adds an external fact to the fact collection.
+         * @param name The name of the fact.
+         * @param value The value of the fact.
+         */
+        void add_external(std::string name, std::unique_ptr<value> value);
 
         /**
          * Adds external facts to the fact collection.

--- a/lib/inc/facter/facts/value.hpp
+++ b/lib/inc/facter/facts/value.hpp
@@ -56,7 +56,8 @@ namespace facter { namespace facts {
          * @param hidden True if the fact is hidden from output by default or false if not.
          */
         value(bool hidden = false) :
-            _hidden(hidden)
+            _hidden(hidden),
+            _weight(0)
         {
         }
 
@@ -73,6 +74,7 @@ namespace facter { namespace facts {
         value(value&& other)
         {
             _hidden = other._hidden;
+            _weight = other._weight;
         }
 
         /**
@@ -84,6 +86,7 @@ namespace facter { namespace facts {
         value& operator=(value&& other)
         {
             _hidden = other._hidden;
+            _weight = other._weight;
             return *this;
         }
 
@@ -94,6 +97,24 @@ namespace facter { namespace facts {
         bool hidden() const
         {
             return _hidden;
+        }
+
+        /**
+         * Gets the weight of the fact.
+         * @return Returns the weight of the fact.
+         */
+        size_t weight() const
+        {
+            return _weight;
+        }
+
+        /**
+         * Sets the weight of the fact.
+         * @param weight The weight of the fact.
+         */
+        void weight(size_t weight)
+        {
+            _weight = weight;
         }
 
         /**
@@ -124,6 +145,7 @@ namespace facter { namespace facts {
         value& operator=(value const&) = delete;
 
         bool _hidden;
+        size_t _weight;
     };
 
     /**

--- a/lib/inc/internal/ruby/fact.hpp
+++ b/lib/inc/internal/ruby/fact.hpp
@@ -102,6 +102,7 @@ namespace facter { namespace ruby {
         std::vector<leatherman::ruby::VALUE> _resolutions;
         bool _resolved;
         bool _resolving;
+        size_t _weight;
     };
 
 }}  // namespace facter::ruby

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -117,7 +117,25 @@ namespace facter { namespace facts {
             return;
         }
 
+        // keep existing value if it has a larger weight value
+        if (old_value && old_value->weight() > value->weight())
+            return;
+
         _facts[move(name)] = move(value);
+    }
+
+    void collection::add_custom(string name, unique_ptr<value> value, size_t weight)
+    {
+        if (value)
+            value->weight(weight);
+        add(move(name), move(value));
+    }
+
+    void collection::add_external(string name, unique_ptr<value> value)
+    {
+        if (value)
+            value->weight(external_fact_weight);
+        add(move(name), move(value));
     }
 
     bool collection::add_external_facts_dir(vector<unique_ptr<external::resolver>> const& resolvers, string const& dir, bool warn)

--- a/lib/src/facts/external/execution_resolver.cc
+++ b/lib/src/facts/external/execution_resolver.cc
@@ -41,7 +41,7 @@ namespace facter { namespace facts { namespace external {
                     // Add as a string fact
                     string fact = line.substr(0, pos);
                     boost::to_lower(fact);
-                    facts.add(move(fact), make_value<string_value>(line.substr(pos+1)));
+                    facts.add_external(move(fact), make_value<string_value>(line.substr(pos+1)));
                     return true;
                 },
                 [&](string const& line) {

--- a/lib/src/facts/external/json_resolver.cc
+++ b/lib/src/facts/external/json_resolver.cc
@@ -147,7 +147,7 @@ namespace facter { namespace facts { namespace external {
                     throw external::external_fact_exception("expected non-empty key in object.");
                 }
                 boost::to_lower(_key);
-                _facts.add(move(_key), move(val));
+                _facts.add_external(move(_key), move(val));
                 return;
             }
 

--- a/lib/src/facts/external/text_resolver.cc
+++ b/lib/src/facts/external/text_resolver.cc
@@ -29,7 +29,7 @@ namespace facter { namespace facts { namespace external {
             // Add as a string fact
             string fact = line.substr(0, pos);
             boost::to_lower(fact);
-            facts.add(move(fact), make_value<string_value>(line.substr(pos+1)));
+            facts.add_external(move(fact), make_value<string_value>(line.substr(pos+1)));
             return true;
         })) {
             throw external_fact_exception("file could not be opened.");

--- a/lib/src/facts/external/windows/powershell_resolver.cc
+++ b/lib/src/facts/external/windows/powershell_resolver.cc
@@ -70,7 +70,7 @@ namespace facter { namespace facts { namespace external {
                     // Add as a string fact
                     string fact = line.substr(0, pos);
                     boost::to_lower(fact);
-                    facts.add(move(fact), make_value<string_value>(line.substr(pos+1)));
+                    facts.add_external(move(fact), make_value<string_value>(line.substr(pos+1)));
                     return true;
                 },
                 [&](string const& line) {

--- a/lib/src/facts/external/yaml_resolver.cc
+++ b/lib/src/facts/external/yaml_resolver.cc
@@ -65,7 +65,7 @@ namespace facter { namespace facts { namespace external {
         } else if (map_parent) {
             map_parent->add(string(name), move(val));
         } else {
-            facts.add(boost::to_lower_copy(name), move(val));
+            facts.add_external(boost::to_lower_copy(name), move(val));
         }
     }
 

--- a/lib/src/ruby/resolution.cc
+++ b/lib/src/ruby/resolution.cc
@@ -183,9 +183,14 @@ namespace facter { namespace ruby {
     {
         auto const& ruby = api::instance();
 
+        int64_t val = ruby.rb_num2ll(value);
+        if (val < 0) {
+            ruby.rb_raise(*ruby.rb_eTypeError, "expected a non-negative value for has_weight (not %lld)", val);
+        }
+
         auto instance = ruby.to_native<resolution>(self);
         instance->_has_weight = true;
-        instance->_weight = (ruby.num2size_t(value));
+        instance->_weight = static_cast<size_t>(val);
         return self;
     }
 


### PR DESCRIPTION
This change formalizes fact precedence and resolution order when there are
multiple top-level facts with the same name, and it fixes application of the
"has_weight" field from custom facts. With this change, fact precedence
with default weights is as follows:

* external fact (highest precendence)
* custom fact
* environment fact
* core fact (lowest precedence)

To align with Facter 2.x behavior, external facts are assigned an inherent
weight of 10000. Therefore, a custom fact with "has_weight" >= 10001 will
override an external fact with the same name. Also, preserving existing
Facter behavior, a custom fact with a "has_weight" of 0 will be overriden
by an environment or core fact with the same name.

Also, this commit adds a check and error message for negative "has_weight"
values. Previously, these were silently cast to large unsigned numbers. 