### PR TITLE
(QENG-4186) Restrict mime-types gem for Ruby 1.x

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,6 +10,11 @@ def location_for(place, fake_version = nil)
   end
 end
 
+# mime-types 3 added a dependency on mime-types-data which has a
+# requirement on ruby >= 2. We pin to mime-types 2.99.2 or less on
+# ruby 1.x
+gem 'mime-types', '<=2.99.2', :require => false if RUBY_VERSION =~ /^1\./
+
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || 'git://github.com/puppetlabs/beaker#master')
 gem 'rake', "~> 10.1.0"
 


### PR DESCRIPTION
The mime-types v3+ gem flipped to requiring Ruby >= 2 with
the dependency on mime-types-data. This means when running
beaker against versions of Ruby less than 2, we need to
restrict the mime-types gem to 2.99.2 or less.