### PR TITLE
(FACT-1485) Fix Amazon Linux version facts

### DIFF
--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -251,6 +251,7 @@ namespace facter { namespace facts { namespace linux {
     {
         // Map of release files that contain a "release X.X.X" on the first line
         static map<string, string> const release_files = {
+                { string(os::amazon),                   string(release_file::amazon) },
                 { string(os::centos),                   string(release_file::redhat) },
                 { string(os::redhat),                   string(release_file::redhat) },
                 { string(os::scientific),               string(release_file::redhat) },
@@ -367,11 +368,6 @@ namespace facter { namespace facts { namespace linux {
             if (exec.success) {
                 re_search(exec.output, boost::regex("VMware ESX .*?(\\d.*)"), &value);
             }
-        }
-
-        // For Amazon, use the distro release
-        if (value.empty() && name == os::amazon) {
-            return distro_release;
         }
 
         return value;


### PR DESCRIPTION
Facter 2 previously reported the Amazon Linux release version, rather
than an underlying RedHat version. Fix Facter 3 to do the same.
