### PR TITLE
(FACT-1488) Add git pack config on Windows

### DIFF
--- a/acceptance/setup/common/00_EnvSetup.rb
+++ b/acceptance/setup/common/00_EnvSetup.rb
@@ -46,6 +46,9 @@ hosts.each do |host|
                  '1.9.3-x86'
                end
 
+    on host, 'mkdir .git'
+    on host, 'cmd /c git config pack.windowMemory 10m'
+    on host, 'cmd /c git config pack.packSizeLimit 20m'
     install_from_git(host, "/opt/puppet-git-repos",
                     :name => 'puppet-win32-ruby',
                     :path => build_giturl('puppet-win32-ruby'),


### PR DESCRIPTION
This commit adds git configuration values for pack memory usage.
Prior to this commit cloning the `puppet-win32-ruby` repo failed on
Window 2003.

This change is a belt and suspenders attempt to mitigate the failure
mentioned above. The packing issue should be addressed on the git
remote server side.