### PR TITLE
(FACT-1489 & 1490) Framework for fact blocking within resolvers

### DIFF
--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -52,8 +52,9 @@ namespace facter { namespace facts {
 
         /**
          * Constructs a fact collection.
+         * @param blocklist A list of facts that should not be collected.
          */
-        collection();
+        collection(std::set<std::string> blocklist = std::set<std::string>());
 
         /**
          * Destructor for fact collection.
@@ -270,6 +271,7 @@ namespace facter { namespace facts {
         std::list<std::shared_ptr<resolver>> _resolvers;
         std::multimap<std::string, std::shared_ptr<resolver>> _resolver_map;
         std::list<std::shared_ptr<resolver>> _pattern_resolvers;
+        std::set<std::string> _blocklist;
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/facter/facts/resolver.hpp
+++ b/lib/inc/facter/facts/resolver.hpp
@@ -107,8 +107,16 @@ namespace facter { namespace facts {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) = 0;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist = std::set<std::string>()) = 0;
+
+    protected:
+        /**
+         * Logs a message that collection of the specified fact has been blocked.
+         * @param fact_name The name of the blocked fact
+         */
+        static void log_fact_blockage(std::string fact_name);
 
      private:
         std::string _name;

--- a/lib/inc/facter/util/config.hpp
+++ b/lib/inc/facter/util/config.hpp
@@ -38,6 +38,13 @@ namespace facter { namespace util { namespace config {
     LIBFACTER_EXPORT void load_cli_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
 
     /**
+     * Loads the "blocklist" section of the config file into the settings map.
+     * @param hocon_config the config object representing the parsed config file
+     * @param vm the key-value map in which to store the settings
+     */
+    LIBFACTER_EXPORT void load_fact_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
+
+    /**
      * Returns a schema of the valid global options that can appear in the config file.
      * @return names, values, and descriptions of global Facter options
      */
@@ -48,4 +55,10 @@ namespace facter { namespace util { namespace config {
      * @return names, values, and descriptions of command line options
      */
     LIBFACTER_EXPORT boost::program_options::options_description cli_config_options();
+
+    /**
+     * Returns a schema for options dealing with block fact collection.
+     * @return names, values, and descriptions of fact blocking config options
+     */
+    LIBFACTER_EXPORT boost::program_options::options_description fact_config_options();
 }}}  // namespace facter::util::config

--- a/lib/inc/internal/facts/aix/serial_number_resolver.hpp
+++ b/lib/inc/internal/facts/aix/serial_number_resolver.hpp
@@ -21,7 +21,8 @@ namespace facter { namespace facts { namespace aix {
          /**
           * Called to resolve all the facts the resolver is responsible for.
           * @param facts The fact collection that is resolving facts.
+          * @param blocklist A list of facts that should not be collected.
           */
-         virtual void resolve(collection& facts) override;
+         virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
     };
 }}}  // namespace facter::facts::aix

--- a/lib/inc/internal/facts/bsd/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/bsd/filesystem_resolver.hpp
@@ -19,9 +19,10 @@ namespace facter { namespace facts { namespace bsd {
         /**
          * Collects the file system data.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          * @return Returns the file system data.
          */
-        virtual data collect_data(collection& facts) override;
+        virtual data collect_data(collection& facts, std::set<std::string> const& blocklist) override;
 
      private:
         static std::vector<std::string> to_options(struct statfs const& fs);

--- a/lib/inc/internal/facts/linux/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/linux/filesystem_resolver.hpp
@@ -26,9 +26,10 @@ namespace facter { namespace facts { namespace linux {
         /**
          * Collects the DMI data.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          * @return Returns the DMI data.
          */
-        virtual data collect_data(collection& facts) override;
+        virtual data collect_data(collection& facts, std::set<std::string> const& blocklist) override;
 
      private:
         void collect_mountpoint_data(data& result);

--- a/lib/inc/internal/facts/resolvers/augeas_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/augeas_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/disk_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/disk_resolver.hpp
@@ -24,8 +24,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/dmi_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/dmi_resolver.hpp
@@ -29,8 +29,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/ec2_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ec2_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
@@ -25,8 +25,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
@@ -158,9 +158,10 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Collects the file system data.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          * @return Returns the file system data.
          */
-        virtual data collect_data(collection& facts) = 0;
+        virtual data collect_data(collection& facts, std::set<std::string> const& blocklist) = 0;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/gce_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/gce_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/identity_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/identity_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/kernel_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/kernel_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/ldom_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ldom_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
         protected:
             /**

--- a/lib/inc/internal/facts/resolvers/load_average_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/load_average_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
     protected:
         /**

--- a/lib/inc/internal/facts/resolvers/memory_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/memory_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/networking_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/networking_resolver.hpp
@@ -47,8 +47,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
         /**
          * Parses the major and minor OS release versions for Linux distros.

--- a/lib/inc/internal/facts/resolvers/path_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/path_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/processor_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/processor_resolver.hpp
@@ -24,8 +24,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/ruby_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ruby_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/ssh_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ssh_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/system_profiler_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/system_profiler_resolver.hpp
@@ -21,8 +21,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/timezone_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/timezone_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/uptime_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
@@ -22,8 +22,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/xen_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/xen_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/zfs_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zfs_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/zone_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zone_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
@@ -23,8 +23,9 @@ namespace facter { namespace facts { namespace resolvers {
         /**
          * Called to resolve all facts the resolver is responsible for.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          */
-        virtual void resolve(collection& facts) override;
+        virtual void resolve(collection& facts, std::set<std::string> const& blocklist) override;
 
      protected:
         /**

--- a/lib/inc/internal/facts/solaris/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/filesystem_resolver.hpp
@@ -19,7 +19,7 @@ namespace facter { namespace facts { namespace solaris {
          * @param facts The fact collection that is resolving facts.
          * @return Returns the file system data.
          */
-        virtual data collect_data(collection& facts) override;
+        virtual data collect_data(collection& facts, std::set<std::string> const& blocklist) override;
 
      private:
         void collect_mountpoint_data(data& result);

--- a/lib/inc/internal/facts/solaris/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/solaris/filesystem_resolver.hpp
@@ -17,6 +17,7 @@ namespace facter { namespace facts { namespace solaris {
         /**
          * Collects the file system data.
          * @param facts The fact collection that is resolving facts.
+         * @param blocklist A list of facts that should not be collected.
          * @return Returns the file system data.
          */
         virtual data collect_data(collection& facts, std::set<std::string> const& blocklist) override;

--- a/lib/src/facts/aix/serial_number_resolver.cc
+++ b/lib/src/facts/aix/serial_number_resolver.cc
@@ -24,7 +24,7 @@ namespace facter { namespace facts { namespace aix {
     {
     }
 
-    void serial_number_resolver::resolve(collection& facts) {
+    void serial_number_resolver::resolve(collection& facts, set<string> const& blocklist) {
         auto cu_at_query = odm_class<CuAt>::open("CuAt").query("name=sys0 and attribute=systemid");
         auto result = *cu_at_query.begin();
 

--- a/lib/src/facts/bsd/filesystem_resolver.cc
+++ b/lib/src/facts/bsd/filesystem_resolver.cc
@@ -1,3 +1,4 @@
+#include <facter/facts/fact.hpp>
 #include <internal/facts/bsd/filesystem_resolver.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <facter/util/string.hpp>
@@ -10,9 +11,16 @@ using namespace facter::util;
 
 namespace facter { namespace facts { namespace bsd {
 
-    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)
+    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts, set<string> const& blocklist)
     {
         data result;
+
+        if (blocklist.count(fact::mountpoints) || blocklist.count(fact::filesystems)) {
+            // since these both come from the same data collection path, blocking one blocks the other
+            log_fact_blockage(fact::mountpoints);
+            log_fact_blockage(fact::filesystems);
+            return result;
+        }
 
         // First get the count of file systems
         int count = getfsstat(nullptr, 0, MNT_NOWAIT);

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -34,7 +34,7 @@ using namespace leatherman::file_util;
 
 namespace facter { namespace facts {
 
-    collection::collection()
+    collection::collection(set<string> blocklist) : _blocklist(move(blocklist))
     {
         // This needs to be defined here since we use incomplete types in the header
     }
@@ -56,6 +56,7 @@ namespace facter { namespace facts {
             _resolvers = std::move(other._resolvers);
             _resolver_map = std::move(other._resolver_map);
             _pattern_resolvers = std::move(other._pattern_resolvers);
+            _blocklist = std::move(other._blocklist);
         }
         return *this;
     }
@@ -313,7 +314,7 @@ namespace facter { namespace facts {
             auto resolver = _resolvers.front();
             remove(resolver);
             LOG_DEBUG("resolving %1% facts.", resolver->name());
-            resolver->resolve(*this);
+            resolver->resolve(*this, _blocklist);
         }
     }
 

--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -1,3 +1,4 @@
+#include <facter/facts/fact.hpp>
 #include <internal/facts/linux/filesystem_resolver.hpp>
 #include <internal/util/scoped_file.hpp>
 #include <leatherman/file_util/file.hpp>
@@ -53,12 +54,26 @@ namespace facter { namespace facts { namespace linux {
         return result;
     }
 
-    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)
+    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts, set<string> const& blocklist)
     {
         data result;
-        collect_mountpoint_data(result);
-        collect_filesystem_data(result);
-        collect_partition_data(result);
+        if (blocklist.count(fact::mountpoints)) {
+            LOG_DEBUG("collection of %1% fact has been blocked", fact::mountpoints);
+        } else {
+            collect_mountpoint_data(result);
+        }
+
+        if (blocklist.count(fact::filesystems)) {
+            LOG_DEBUG("collection of %1% fact has been blocked", fact::filesystems);
+        } else {
+            collect_filesystem_data(result);
+        }
+
+        if (blocklist.count(fact::partitions)) {
+            LOG_DEBUG("collection of %1% fact has been blocked", fact::partitions);
+        } else {
+            collect_partition_data(result);
+        }
         return result;
     }
 

--- a/lib/src/facts/resolver.cc
+++ b/lib/src/facts/resolver.cc
@@ -28,6 +28,10 @@ namespace facter { namespace facts {
         }
     }
 
+    void resolver::log_fact_blockage(string fact_name) {
+        LOG_DEBUG("collection of %1% fact has been blocked", fact_name);
+    }
+
     resolver::~resolver()
     {
         // This needs to be defined here since we use incomplete types in the header

--- a/lib/src/facts/resolvers/augeas_resolver.cc
+++ b/lib/src/facts/resolvers/augeas_resolver.cc
@@ -40,7 +40,7 @@ namespace facter { namespace facts { namespace resolvers {
         return value;
     }
 
-    void augeas_resolver::resolve(collection& facts)
+    void augeas_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto version = get_version();
         if (version.empty()) {

--- a/lib/src/facts/resolvers/disk_resolver.cc
+++ b/lib/src/facts/resolvers/disk_resolver.cc
@@ -23,7 +23,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void disk_resolver::resolve(collection& facts)
+    void disk_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/dmi_resolver.cc
+++ b/lib/src/facts/resolvers/dmi_resolver.cc
@@ -70,7 +70,7 @@ namespace facter { namespace facts { namespace resolvers {
         return "Unknown";
     }
 
-    void dmi_resolver::resolve(collection& facts)
+    void dmi_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
         auto dmi = make_value<map_value>();

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -107,7 +107,7 @@ namespace facter { namespace facts { namespace resolvers {
     }
 #endif
 
-    void ec2_resolver::resolve(collection& facts)
+    void ec2_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
 #ifndef USE_CURL
         LOG_INFO("EC2 facts are unavailable: facter was built without libcurl support.");

--- a/lib/src/facts/resolvers/filesystem_resolver.cc
+++ b/lib/src/facts/resolvers/filesystem_resolver.cc
@@ -23,7 +23,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void filesystem_resolver::resolve(collection& facts)
+    void filesystem_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/filesystem_resolver.cc
+++ b/lib/src/facts/resolvers/filesystem_resolver.cc
@@ -25,7 +25,7 @@ namespace facter { namespace facts { namespace resolvers {
 
     void filesystem_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
-        auto data = collect_data(facts);
+        auto data = collect_data(facts, blocklist);
 
         // Populate the mountpoints fact
         if (!data.mountpoints.empty()) {

--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -221,7 +221,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void gce_resolver::resolve(collection& facts)
+    void gce_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto virtualization = facts.get<string_value>(fact::virtualization);
         if (!virtualization || virtualization->value() != vm::gce) {

--- a/lib/src/facts/resolvers/identity_resolver.cc
+++ b/lib/src/facts/resolvers/identity_resolver.cc
@@ -19,7 +19,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void identity_resolver::resolve(collection &facts)
+    void identity_resolver::resolve(collection &facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/kernel_resolver.cc
+++ b/lib/src/facts/resolvers/kernel_resolver.cc
@@ -20,7 +20,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void kernel_resolver::resolve(collection& facts)
+    void kernel_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
         if (!data.name.empty()) {

--- a/lib/src/facts/resolvers/ldom_resolver.cc
+++ b/lib/src/facts/resolvers/ldom_resolver.cc
@@ -22,7 +22,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void ldom_resolver::resolve(collection& facts)
+    void ldom_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/load_average_resolver.cc
+++ b/lib/src/facts/resolvers/load_average_resolver.cc
@@ -18,7 +18,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void load_average_resolver::resolve(collection& facts)
+    void load_average_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         /* Get the load averages */
         auto averages = get_load_averages();

--- a/lib/src/facts/resolvers/memory_resolver.cc
+++ b/lib/src/facts/resolvers/memory_resolver.cc
@@ -28,7 +28,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void memory_resolver::resolve(collection& facts)
+    void memory_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         data result = collect_data(facts);
 

--- a/lib/src/facts/resolvers/networking_resolver.cc
+++ b/lib/src/facts/resolvers/networking_resolver.cc
@@ -44,7 +44,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void networking_resolver::resolve(collection& facts)
+    void networking_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -47,7 +47,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void operating_system_resolver::resolve(collection& facts)
+    void operating_system_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/path_resolver.cc
+++ b/lib/src/facts/resolvers/path_resolver.cc
@@ -14,7 +14,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void path_resolver::resolve(collection& facts)
+    void path_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         string path_val;
         if (environment::get("PATH", path_val)) {

--- a/lib/src/facts/resolvers/processor_resolver.cc
+++ b/lib/src/facts/resolvers/processor_resolver.cc
@@ -26,7 +26,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void processor_resolver::resolve(collection& facts)
+    void processor_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/ruby_resolver.cc
+++ b/lib/src/facts/resolvers/ruby_resolver.cc
@@ -92,7 +92,7 @@ namespace facter { namespace facts { namespace resolvers {
         return rb_data;
     }
 
-    void ruby_resolver::resolve(collection& facts)
+    void ruby_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto rb_data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/ssh_resolver.cc
+++ b/lib/src/facts/resolvers/ssh_resolver.cc
@@ -24,7 +24,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void ssh_resolver::resolve(collection& facts)
+    void ssh_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/system_profiler_resolver.cc
+++ b/lib/src/facts/resolvers/system_profiler_resolver.cc
@@ -39,7 +39,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void system_profiler_resolver::resolve(collection& facts)
+    void system_profiler_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/timezone_resolver.cc
+++ b/lib/src/facts/resolvers/timezone_resolver.cc
@@ -3,6 +3,8 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/scalar_value.hpp>
 
+using namespace std;
+
 namespace facter { namespace facts { namespace resolvers {
 
     timezone_resolver::timezone_resolver() :
@@ -14,7 +16,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void timezone_resolver::resolve(collection& facts)
+    void timezone_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto timezone = get_timezone();
         if (timezone.empty()) {

--- a/lib/src/facts/resolvers/uptime_resolver.cc
+++ b/lib/src/facts/resolvers/uptime_resolver.cc
@@ -22,7 +22,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void uptime_resolver::resolve(collection& facts)
+    void uptime_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto seconds = get_uptime();
         if (seconds < 0) {

--- a/lib/src/facts/resolvers/virtualization_resolver.cc
+++ b/lib/src/facts/resolvers/virtualization_resolver.cc
@@ -20,7 +20,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void virtualization_resolver::resolve(collection& facts)
+    void virtualization_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto hypervisor = get_hypervisor(facts);
 

--- a/lib/src/facts/resolvers/xen_resolver.cc
+++ b/lib/src/facts/resolvers/xen_resolver.cc
@@ -27,7 +27,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void xen_resolver::resolve(collection& facts)
+    void xen_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         // Confine to fact virtual == xen0
         auto virt = facts.get<string_value>(fact::virtualization);

--- a/lib/src/facts/resolvers/zfs_resolver.cc
+++ b/lib/src/facts/resolvers/zfs_resolver.cc
@@ -23,7 +23,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void zfs_resolver::resolve(collection& facts)
+    void zfs_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/zone_resolver.cc
+++ b/lib/src/facts/resolvers/zone_resolver.cc
@@ -31,7 +31,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void zone_resolver::resolve(collection& facts)
+    void zone_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/resolvers/zpool_resolver.cc
+++ b/lib/src/facts/resolvers/zpool_resolver.cc
@@ -23,7 +23,7 @@ namespace facter { namespace facts { namespace resolvers {
     {
     }
 
-    void zpool_resolver::resolve(collection& facts)
+    void zpool_resolver::resolve(collection& facts, set<string> const& blocklist)
     {
         auto data = collect_data(facts);
 

--- a/lib/src/facts/solaris/filesystem_resolver.cc
+++ b/lib/src/facts/solaris/filesystem_resolver.cc
@@ -1,3 +1,4 @@
+#include <facter/facts/fact.hpp>
 #include <internal/facts/solaris/filesystem_resolver.hpp>
 #include <internal/util/solaris/k_stat.hpp>
 #include <internal/util/scoped_file.hpp>
@@ -23,11 +24,21 @@ using namespace boost::filesystem;
 
 namespace facter { namespace facts { namespace solaris {
 
-    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)
+    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts, set<string> const& blocklist)
     {
         data result;
-        collect_mountpoint_data(result);
-        collect_filesystem_data(result);
+
+        if (blocklist.count(fact::mountpoints)) {
+            log_fact_blockage(fact::mountpoints);
+        } else {
+            collect_mountpoint_data(result);
+        }
+
+        if (blocklist.count(fact::filesystems)) {
+            log_fact_blockage(fact::mountpoints);
+        } else {
+            collect_filesystem_data(result);
+        }
         return result;
     }
 

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -30,11 +30,18 @@ namespace facter { namespace util { namespace config {
         }
     }
 
+    void load_fact_settings(shared_config hocon_config, po::variables_map& vm) {
+        if (hocon_config && hocon_config->has_path("facts")) {
+            auto fact_settings = hocon_config->get_object("facts")->to_config();
+            po::store(hocon::program_options::parse_hocon<char>(fact_settings, fact_config_options(), false), vm);
+        }
+    }
+
     po::options_description global_config_options() {
         po::options_description global_options("");
         global_options.add_options()
-            ("custom-dir", po::value<vector<string>>(), "A directory or list of directories to use for custom facts.")
-            ("external-dir", po::value<vector<string>>(), "A directory or list of directories to use for external facts.")
+            ("custom-dir", po::value<vector<string>>(), "A directory to use for custom facts.")
+            ("external-dir", po::value<vector<string>>(), "A directory to use for external facts.")
             ("no-custom-facts", po::value<bool>()->default_value(false), "Disables custom facts.")
             ("no-external-facts", po::value<bool>()->default_value(false), "Disables external facts.")
             ("no-ruby", po::value<bool>()->default_value(false), "Disables loading Ruby, facts requiring Ruby, and custom facts.");
@@ -49,5 +56,12 @@ namespace facter { namespace util { namespace config {
             ("trace", po::value<bool>()->default_value(false), "Enable backtraces for custom facts.")
             ("verbose", po::value<bool>()->default_value(false), "Enable verbose (info) output.");
         return cli_options;
+    }
+
+    po::options_description fact_config_options() {
+        po::options_description fact_settings("");
+        fact_settings.add_options()
+            ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
+        return fact_settings;
     }
 }}}  // namespace facter::util::config;

--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -19,7 +19,7 @@ struct simple_resolver : facter::facts::resolver
     {
     }
 
-    virtual void resolve(collection& facts) override
+    virtual void resolve(collection& facts, set<string> const& blocklist) override
     {
         facts.add("foo", make_value<string_value>("bar"));
     }
@@ -31,7 +31,7 @@ struct multi_resolver : facter::facts::resolver
     {
     }
 
-    virtual void resolve(collection& facts) override
+    virtual void resolve(collection& facts, set<string> const& blocklist) override
     {
         facts.add("foo", make_value<string_value>("bar"));
         facts.add("bar", make_value<string_value>("foo"));

--- a/lib/tests/facts/resolvers/filesystem_resolver.cc
+++ b/lib/tests/facts/resolvers/filesystem_resolver.cc
@@ -47,7 +47,7 @@ struct test_filesystem_resolver : filesystem_resolver
     }
 
  protected:
-    virtual data collect_data(collection& facts) override
+    virtual data collect_data(collection& facts, set<string> const& blocklist) override
     {
         data result;
         result.mountpoints = move(mountpoints);

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -99,7 +99,7 @@ struct dmi_resolver : resolvers::dmi_resolver
 struct filesystem_resolver : resolvers::filesystem_resolver
 {
  protected:
-    virtual data collect_data(collection& facts) override
+    virtual data collect_data(collection& facts, set<string> const& blocklist) override
     {
         data result;
 


### PR DESCRIPTION
This adds an argument to the `resolve` method of each resolver, allowing a blocklist to be passed into the method. Since we have decided to support blocking of individual top-level facts, and not all resolvers map cleanly to these chunks, it was necessary to have each resolve method handle the list according to its implementation.

As an example of what this might look like, I have implemented the blocking of facts associated with the `filesystem_resolver`, which is an example of a resolver that deals with multiple top-level facts.

I would like to be able to test this blocking functionality, but I can't seem to find any tests that verify the behavior of this resolver. Is it unfeasible to test? If not, what would be the best approach to add these tests?