### PR TITLE
(FACT-1272) Add tooling for facts POT file

### DIFF
--- a/lib/schema/core_facts.pot
+++ b/lib/schema/core_facts.pot
@@ -1,0 +1,2017 @@
+# CORE FACTS SCHEMA
+# Copyright (C) 2016 Puppet, LLC
+# This file is distributed under the same license as the FACTER package.
+# FIRST AUTHOR <docs@puppet.com>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FACTER \n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+
+#. aio_agent_version description
+msgid "Return the version of the puppet-agent package that installed facter."
+msgstr ""
+
+#. aio_agent_version resolution
+msgid "All platforms: use the compile-time enabled version definition."
+msgstr ""
+
+#. architecture description
+msgid "Return the operating system's hardware architecture."
+msgstr ""
+
+#. architecture resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the OS hardware architecture."
+msgstr ""
+
+#. architecture resolution
+msgid "Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware architecture."
+msgstr ""
+
+#. architecture caveats
+msgid "Linux: Debian, Gentoo, kFreeBSD, and Ubuntu use "amd64" for "x86_64" and Gentoo uses "x86" for "i386"."
+msgstr ""
+
+#. augeas description
+msgid "Return information about augeas."
+msgstr ""
+
+#. augeas resolution
+msgid "All platforms: query augparse for augeas metadata."
+msgstr ""
+
+#. augeasversion description
+msgid "Return the version of augeas."
+msgstr ""
+
+#. augeasversion resolution
+msgid "All platforms: query augparse for the augeas version."
+msgstr ""
+
+#. blockdevices description
+msgid "Return a comma-separated list of block devices."
+msgstr ""
+
+#. blockdevices resolution
+msgid "Linux: parse the contents of `/sys/block/<device>/`."
+msgstr ""
+
+#. blockdevices resolution
+msgid "Solaris: use the `kstat` function to query disk information."
+msgstr ""
+
+#. blockdevices caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. blockdevice_<devicename>_model description
+msgid "Return the model name of block devices attached to the system."
+msgstr ""
+
+#. blockdevice_<devicename>_model resolution
+msgid "Linux: parse the contents of `/sys/block/<device>/device/model` to retrieve the model name/number for a device."
+msgstr ""
+
+#. blockdevice_<devicename>_model resolution
+msgid "Solaris: use the `kstat` function to query disk information."
+msgstr ""
+
+#. blockdevice_<devicename>_model caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. blockdevice_<devicename>_size description
+msgid "Return the size of a block device in bytes."
+msgstr ""
+
+#. blockdevice_<devicename>_size resolution
+msgid "Linux: parse the contents of `/sys/block/<device>/size` to receive the size (multiplying by 512 to correct for blocks-to-bytes)."
+msgstr ""
+
+#. blockdevice_<devicename>_size resolution
+msgid "Solaris: use the `kstat` function to query disk information."
+msgstr ""
+
+#. blockdevice_<devicename>_size caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. blockdevice_<devicename>_vendor description
+msgid "Return the vendor name of block devices attached to the system."
+msgstr ""
+
+#. blockdevice_<devicename>_vendor resolution
+msgid "Linux: parse the contents of `/sys/block/<device>/device/vendor` to retrieve the vendor for a device."
+msgstr ""
+
+#. blockdevice_<devicename>_vendor resolution
+msgid "Solaris: use the `kstat` function to query disk information."
+msgstr ""
+
+#. blockdevice_<devicename>_vendor caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. bios_release_date description
+msgid "Return the release date of the system BIOS."
+msgstr ""
+
+#. bios_release_date resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/bios_date` to retrieve the system BIOS release date."
+msgstr ""
+
+#. bios_release_date resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system BIOS release date."
+msgstr ""
+
+#. bios_release_date caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. bios_vendor description
+msgid "Return the vendor of the system BIOS."
+msgstr ""
+
+#. bios_vendor resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/bios_vendor` to retrieve the system BIOS vendor."
+msgstr ""
+
+#. bios_vendor resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system BIOS vendor."
+msgstr ""
+
+#. bios_vendor caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. bios_version description
+msgid "Return the version of the system BIOS."
+msgstr ""
+
+#. bios_version resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/bios_version` to retrieve the system BIOS version."
+msgstr ""
+
+#. bios_version resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system BIOS version."
+msgstr ""
+
+#. bios_version caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. boardassettag description
+msgid "Return the system board asset tag."
+msgstr ""
+
+#. boardassettag resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/board_asset_tag` to retrieve the system board asset tag."
+msgstr ""
+
+#. boardassettag caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. boardmanufacturer description
+msgid "Return the system board manufacturer."
+msgstr ""
+
+#. boardmanufacturer resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/board_vendor` to retrieve the system board manufacturer."
+msgstr ""
+
+#. boardmanufacturer caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. boardproductname description
+msgid "Return the system board product name."
+msgstr ""
+
+#. boardproductname resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/board_name` to retrieve the system board product name."
+msgstr ""
+
+#. boardproductname caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. boardserialnumber description
+msgid "Return the system board serial number."
+msgstr ""
+
+#. boardserialnumber resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/board_serial` to retrieve the system board serial number."
+msgstr ""
+
+#. boardserialnumber caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. chassisassettag description
+msgid "Return the system chassis asset tag."
+msgstr ""
+
+#. chassisassettag resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/chassis_asset_tag` to retrieve the system chassis asset tag."
+msgstr ""
+
+#. chassisassettag resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system chassis asset tag."
+msgstr ""
+
+#. chassisassettag caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. chassistype description
+msgid "Return the system chassis type."
+msgstr ""
+
+#. chassistype resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/chassis_type` to retrieve the system chassis type."
+msgstr ""
+
+#. chassistype resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system chassis type."
+msgstr ""
+
+#. chassistype caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. dhcp_servers description
+msgid "Return the DHCP servers for the system."
+msgstr ""
+
+#. dhcp_servers resolution
+msgid "Linux: parse `dhclient` lease files or use the `dhcpcd` utility to retrieve the DHCP servers."
+msgstr ""
+
+#. dhcp_servers resolution
+msgid "Mac OSX: use the `ipconfig` utility to retrieve the DHCP servers."
+msgstr ""
+
+#. dhcp_servers resolution
+msgid "Solaris: use the `dhcpinfo` utility to retrieve the DHCP servers."
+msgstr ""
+
+#. dhcp_servers resolution
+msgid "Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the DHCP servers."
+msgstr ""
+
+#. disks description
+msgid "Return the disk (block) devices attached to the system."
+msgstr ""
+
+#. disks resolution
+msgid "Linux: parse the contents of `/sys/block/<device>/`."
+msgstr ""
+
+#. disks resolution
+msgid "Solaris: use the `kstat` function to query disk information."
+msgstr ""
+
+#. disks caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. dmi description
+msgid "Return the system management information."
+msgstr ""
+
+#. dmi resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/` to retrieve system management information."
+msgstr ""
+
+#. dmi resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve system management information."
+msgstr ""
+
+#. dmi resolution
+msgid "Solaris: use the `smbios`, `prtconf`, and `uname` utilities to retrieve system management information."
+msgstr ""
+
+#. dmi resolution
+msgid "Windows: use WMI to retrieve system management information."
+msgstr ""
+
+#. dmi caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. domain description
+msgid "Return the network domain of the system."
+msgstr ""
+
+#. domain resolution
+msgid "POSIX platforms: use the `getaddrinfo` function to retrieve the network domain."
+msgstr ""
+
+#. domain resolution
+msgid "Windows: query the registry to retrieve the network domain; falls back to the primary interface's domain if not set in the registry."
+msgstr ""
+
+#. ec2_metadata description
+msgid "Return the Amazon Elastic Compute Cloud (EC2) instance metadata."
+msgstr ""
+
+#. ec2_metadata description
+msgid "Please see the [EC2 instance metadata documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the contents of this fact."
+msgstr ""
+
+#. ec2_metadata resolution
+msgid "EC2: query the EC2 metadata endpoint and parse the response."
+msgstr ""
+
+#. ec2_metadata caveats
+msgid "All platforms: `libfacter` must be built with `libcurl` support."
+msgstr ""
+
+#. ec2_userdata description
+msgid "Return the Amazon Elastic Compute Cloud (EC2) instance user data."
+msgstr ""
+
+#. ec2_userdata description
+msgid "Please see the [EC2 instance user data documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the contents of this fact."
+msgstr ""
+
+#. ec2_userdata resolution
+msgid "EC2: query the EC2 user data endpoint and parse the response."
+msgstr ""
+
+#. ec2_userdata caveats
+msgid "All platforms: `libfacter` must be built with `libcurl` support."
+msgstr ""
+
+#. env_windows_installdir description
+msgid "Return the path of the directory in which Puppet was installed."
+msgstr ""
+
+#. env_windows_installdir resolution
+msgid "Windows: This fact is specific to the Windows MSI generated environment, and is"
+msgstr ""
+
+#. env_windows_installdir resolution
+msgid "  set using the `environment.bat` script that configures the runtime environment"
+msgstr ""
+
+#. env_windows_installdir resolution
+msgid "  for all Puppet executables. Please see [the original commit in the puppet_for_the_win repo](https://github.com/puppetlabs/puppet_for_the_win/commit/0cc32c1a09550c13d725b200d3c0cc17d93ec262) for more information."
+msgstr ""
+
+#. env_windows_installdir caveats
+msgid "This fact is specific to Windows, and will not resolve on any other platform."
+msgstr ""
+
+#. facterversion description
+msgid "Return the version of facter."
+msgstr ""
+
+#. facterversion resolution
+msgid "All platforms: use the built-in version of libfacter."
+msgstr ""
+
+#. filesystems description
+msgid "Return the usable file systems for block or disk devices."
+msgstr ""
+
+#. filesystems resolution
+msgid "Linux: parse the contents of `/proc/filesystems` to retrieve the usable file systems."
+msgstr ""
+
+#. filesystems resolution
+msgid "Mac OSX: use the `getfsstat` function to retrieve the usable file systems."
+msgstr ""
+
+#. filesystems resolution
+msgid "Solaris: use the `sysdef` utility to retrieve the usable file systems."
+msgstr ""
+
+#. filesystems caveats
+msgid "Linux: The proc file system must be mounted."
+msgstr ""
+
+#. filesystems caveats
+msgid "Mac OSX: The usable file systems is limited to the file system of mounted devices."
+msgstr ""
+
+#. fqdn description
+msgid "Return the fully qualified domain name (FQDN) of the system."
+msgstr ""
+
+#. fqdn resolution
+msgid "POSIX platforms: use the `getaddrinfo` function to retrieve the FQDN or use host and domain names."
+msgstr ""
+
+#. fqdn resolution
+msgid "Windows: use the host and domain names to build the FQDN."
+msgstr ""
+
+#. gce description
+msgid "Return the Google Compute Engine (GCE) metadata."
+msgstr ""
+
+#. gce description
+msgid "Please see the [GCE metadata documentation](https://cloud.google.com/compute/docs/metadata) for the contents of this fact."
+msgstr ""
+
+#. gce resolution
+msgid "GCE: query the GCE metadata endpoint and parse the response."
+msgstr ""
+
+#. gce caveats
+msgid "All platforms: `libfacter` must be built with `libcurl` support."
+msgstr ""
+
+#. gid description
+msgid "Return the group identifier (GID) of the user running facter."
+msgstr ""
+
+#. gid resolution
+msgid "POSIX platforms: use the `getegid` fuction to retrieve the group identifier."
+msgstr ""
+
+#. hardwareisa description
+msgid "Return the hardware instruction set architecture (ISA)."
+msgstr ""
+
+#. hardwareisa resolution
+msgid "POSIX platforms: use `uname` to retrieve the hardware ISA."
+msgstr ""
+
+#. hardwareisa resolution
+msgid "Windows: use WMI to retrieve the hardware ISA."
+msgstr ""
+
+#. hardwaremodel description
+msgid "Return the operating system's hardware model."
+msgstr ""
+
+#. hardwaremodel resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the OS hardware model."
+msgstr ""
+
+#. hardwaremodel resolution
+msgid "Windows: use the `GetNativeSystemInfo` function to retrieve the OS hardware model."
+msgstr ""
+
+#. hostname description
+msgid "Return the host name of the system."
+msgstr ""
+
+#. hostname resolution
+msgid "POSIX platforms: use the `gethostname` function to retrieve the host name"
+msgstr ""
+
+#. hostname resolution
+msgid "Windows: use the `GetComputerNameExW` function to retrieve the host name."
+msgstr ""
+
+#. id description
+msgid "Return the user identifier (UID) of the user running facter."
+msgstr ""
+
+#. id resolution
+msgid "POSIX platforms: use the `geteuid` fuction to retrieve the user identifier."
+msgstr ""
+
+#. identity description
+msgid "Return the identity information of the user running facter."
+msgstr ""
+
+#. identity resolution
+msgid "POSIX platforms: use the `getegid`, `getpwuid_r`, `geteuid`, and `getgrgid_r` functions to retrieve the identity information; use the result of the `geteuid() == 0` test as the value of the privileged element"
+msgstr ""
+
+#. identity resolution
+msgid "Windows: use the `GetUserNameExW` function to retrieve the identity information; use the `GetTokenInformation` to get the current process token elevation status and use it as the value of the privileged element on versions of Windows supporting the token elevation, on older versions of Windows use the `CheckTokenMembership` to test whether the well known local Administrators group SID is enabled in the current thread impersonation token and use the test result as the value of the privileged element"
+msgstr ""
+
+#. interfaces description
+msgid "Return the comma-separated list of network interface names."
+msgstr ""
+
+#. interfaces resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface names."
+msgstr ""
+
+#. interfaces resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface names."
+msgstr ""
+
+#. interfaces resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface names."
+msgstr ""
+
+#. interfaces resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface names."
+msgstr ""
+
+#. ipaddress description
+msgid "Return the IPv4 address for the default network interface."
+msgstr ""
+
+#. ipaddress resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6 description
+msgid "Return the IPv6 address for the default network interface."
+msgstr ""
+
+#. ipaddress6 resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6 resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6 resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6 resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6_<interface> description
+msgid "Return the IPv6 address for a network interface."
+msgstr ""
+
+#. ipaddress6_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress6_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress_<interface> description
+msgid "Return the IPv4 address for a network interface."
+msgstr ""
+
+#. ipaddress_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. ipaddress_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. is_virtual description
+msgid "Return whether or not the host is a virtual machine."
+msgstr ""
+
+#. is_virtual resolution
+msgid "Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine status."
+msgstr ""
+
+#. is_virtual resolution
+msgid "Mac OSX: use the system profiler to retrieve virtual machine status."
+msgstr ""
+
+#. is_virtual resolution
+msgid "Solaris: use the `zonename` utility to retrieve virtual machine status."
+msgstr ""
+
+#. is_virtual resolution
+msgid "Windows: use WMI to retrieve virtual machine status."
+msgstr ""
+
+#. kernel description
+msgid "Return the kernel's name."
+msgstr ""
+
+#. kernel resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the kernel name."
+msgstr ""
+
+#. kernel resolution
+msgid "Windows: use the value of `windows` for all Windows versions."
+msgstr ""
+
+#. kernelmajversion description
+msgid "Return the kernel's major version."
+msgstr ""
+
+#. kernelmajversion resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the kernel's major version."
+msgstr ""
+
+#. kernelmajversion resolution
+msgid "Windows: use the file version of `kernel32.dll` to retrieve the kernel's major version."
+msgstr ""
+
+#. kernelrelease description
+msgid "Return the kernel's release."
+msgstr ""
+
+#. kernelrelease resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the kernel's release."
+msgstr ""
+
+#. kernelrelease resolution
+msgid "Windows: use the file version of `kernel32.dll` to retrieve the kernel's release."
+msgstr ""
+
+#. kernelversion description
+msgid "Return the kernel's version."
+msgstr ""
+
+#. kernelversion resolution
+msgid "POSIX platforms: use the `uname` function to retrieve the kernel's version."
+msgstr ""
+
+#. kernelversion resolution
+msgid "Windows: use the file version of `kernel32.dll` to retrieve the kernel's version."
+msgstr ""
+
+#. ldom description
+msgid "Return Solaris LDom information from the `virtinfo` utility."
+msgstr ""
+
+#. ldom resolution
+msgid "Solaris: use the `virtinfo` utility to retrieve LDom information."
+msgstr ""
+
+#. ldom_<name> description
+msgid "Return Solaris LDom information."
+msgstr ""
+
+#. ldom_<name> resolution
+msgid "Solaris: use the `virtinfo` utility to retrieve LDom information."
+msgstr ""
+
+#. load_averages description
+msgid "Return the load average over the last 1, 5 and 15 minutes."
+msgstr ""
+
+#. load_averages resolution
+msgid "POSIX platforms: use `getloadavg` function to retrieve the system load averages."
+msgstr ""
+
+#. lsbdistcodename description
+msgid "Return the Linux Standard Base (LSB) distribution code name."
+msgstr ""
+
+#. lsbdistcodename resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB distribution code name."
+msgstr ""
+
+#. lsbdistcodename caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbdistdescription description
+msgid "Return the Linux Standard Base (LSB) distribution description."
+msgstr ""
+
+#. lsbdistdescription resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB distribution description."
+msgstr ""
+
+#. lsbdistdescription caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbdistid description
+msgid "Return the Linux Standard Base (LSB) distribution identifier."
+msgstr ""
+
+#. lsbdistid resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB distribution identifier."
+msgstr ""
+
+#. lsbdistid caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbdistrelease description
+msgid "Return the Linux Standard Base (LSB) distribution release."
+msgstr ""
+
+#. lsbdistrelease resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB distribution release."
+msgstr ""
+
+#. lsbdistrelease caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbmajdistrelease description
+msgid "Return the Linux Standard Base (LSB) major distribution release."
+msgstr ""
+
+#. lsbmajdistrelease resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB major distribution release."
+msgstr ""
+
+#. lsbmajdistrelease caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbminordistrelease description
+msgid "Return the Linux Standard Base (LSB) minor distribution release."
+msgstr ""
+
+#. lsbminordistrelease resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB minor distribution release."
+msgstr ""
+
+#. lsbminordistrelease caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. lsbrelease description
+msgid "Return the Linux Standard Base (LSB) release."
+msgstr ""
+
+#. lsbrelease resolution
+msgid "Linux: use the `lsb_release` utility to retrieve the LSB release."
+msgstr ""
+
+#. lsbrelease caveats
+msgid "Linux: Requires that the `lsb_release` utility be installed."
+msgstr ""
+
+#. macaddress description
+msgid "Return the MAC address for the default network interface."
+msgstr ""
+
+#. macaddress resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress_<interface> description
+msgid "Return the MAC address for a network interface."
+msgstr ""
+
+#. macaddress_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface address."
+msgstr ""
+
+#. macaddress_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface address."
+msgstr ""
+
+#. macosx_buildversion description
+msgid "Return the Mac OSX build version."
+msgstr ""
+
+#. macosx_buildversion resolution
+msgid "Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX build version."
+msgstr ""
+
+#. macosx_productname description
+msgid "Return the Mac OSX product name."
+msgstr ""
+
+#. macosx_productname resolution
+msgid "Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product name."
+msgstr ""
+
+#. macosx_productversion description
+msgid "Return the Mac OSX product version."
+msgstr ""
+
+#. macosx_productversion resolution
+msgid "Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product version."
+msgstr ""
+
+#. macosx_productversion_major description
+msgid "Return the Mac OSX product major version."
+msgstr ""
+
+#. macosx_productversion_major resolution
+msgid "Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product major version."
+msgstr ""
+
+#. macosx_productversion_minor description
+msgid "Return the Mac OSX product minor version."
+msgstr ""
+
+#. macosx_productversion_minor resolution
+msgid "Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product minor version."
+msgstr ""
+
+#. manufacturer description
+msgid "Return the system manufacturer."
+msgstr ""
+
+#. manufacturer resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/sys_vendor` to retrieve the system manufacturer."
+msgstr ""
+
+#. manufacturer resolution
+msgid "Solaris: use the `prtconf` utility to retrieve the system manufacturer."
+msgstr ""
+
+#. manufacturer resolution
+msgid "Windows: use WMI to retrieve the system manufacturer."
+msgstr ""
+
+#. manufacturer caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. memory description
+msgid "Return the system memory information."
+msgstr ""
+
+#. memory resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the system memory information."
+msgstr ""
+
+#. memory resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the system memory information."
+msgstr ""
+
+#. memory resolution
+msgid "Solaris: use the `kstat` function to retrieve the system memory information."
+msgstr ""
+
+#. memory resolution
+msgid "Windows: use the `GetPerformanceInfo` function to retrieve the system memory information."
+msgstr ""
+
+#. memoryfree description
+msgid "Return the display size of the free system memory (e.g. "1 GiB")."
+msgstr ""
+
+#. memoryfree resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree resolution
+msgid "Solaris: use the `kstat` function to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree resolution
+msgid "Windows: use the `GetPerformanceInfo` function to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree_mb description
+msgid "Return the size of the free system memory, in mebibytes."
+msgstr ""
+
+#. memoryfree_mb resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree_mb resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree_mb resolution
+msgid "Solaris: use the `kstat` function to retrieve the free system memory."
+msgstr ""
+
+#. memoryfree_mb resolution
+msgid "Windows: use the `GetPerformanceInfo` function to retrieve the free system memory."
+msgstr ""
+
+#. memorysize description
+msgid "Return the display size of the total system memory (e.g. "1 GiB")."
+msgstr ""
+
+#. memorysize resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory."
+msgstr ""
+
+#. memorysize resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the total system memory."
+msgstr ""
+
+#. memorysize resolution
+msgid "Solaris: use the `kstat` function to retrieve the total system memory."
+msgstr ""
+
+#. memorysize resolution
+msgid "Windows: use the `GetPerformanceInfo` function to retrieve the total system memory."
+msgstr ""
+
+#. memorysize_mb description
+msgid "Return the size of the total system memory, in mebibytes."
+msgstr ""
+
+#. memorysize_mb resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory."
+msgstr ""
+
+#. memorysize_mb resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the total system memory."
+msgstr ""
+
+#. memorysize_mb resolution
+msgid "Solaris: use the `kstat` function to retrieve the total system memory."
+msgstr ""
+
+#. memorysize_mb resolution
+msgid "Windows: use the `GetPerformanceInfo` function to retrieve the total system memory."
+msgstr ""
+
+#. mountpoints description
+msgid "Return the current mount points of the system."
+msgstr ""
+
+#. mountpoints resolution
+msgid "Linux: use the `setmntent` function to retrieve the mount points."
+msgstr ""
+
+#. mountpoints resolution
+msgid "Mac OSX: use the `getfsstat` function to retrieve the mount points."
+msgstr ""
+
+#. mountpoints resolution
+msgid "Solaris: parse the contents of `/etc/mnttab` to retrieve the mount points."
+msgstr ""
+
+#. mtu_<interface> description
+msgid "Return the Maximum Transmission Unit (MTU) for a network interface."
+msgstr ""
+
+#. mtu_<interface> resolution
+msgid "Linux: use the `ioctl` function to retrieve the network interface MTU."
+msgstr ""
+
+#. mtu_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface MTU."
+msgstr ""
+
+#. mtu_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface MTU."
+msgstr ""
+
+#. mtu_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface MTU."
+msgstr ""
+
+#. netmask description
+msgid "Return the IPv4 netmask for the default network interface."
+msgstr ""
+
+#. netmask resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask resolution
+msgid "Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6 description
+msgid "Return the IPv6 netmask for the default network interface."
+msgstr ""
+
+#. netmask6 resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6 resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6 resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6 resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6 caveats
+msgid "Windows Server 2003: IPv6 netmasks are not supported."
+msgstr ""
+
+#. netmask6_<interface> description
+msgid "Return the IPv6 netmask for a network interface."
+msgstr ""
+
+#. netmask6_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask6_<interface> caveats
+msgid "Windows Server 2003: IPv6 netmasks are not supported."
+msgstr ""
+
+#. netmask_<interface> description
+msgid "Return the IPv4 netmask for a network interface."
+msgstr ""
+
+#. netmask_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface netmask."
+msgstr ""
+
+#. netmask_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` (Windows Server 2003: `GetAdaptersInfo`) function to retrieve the network interface netmask."
+msgstr ""
+
+#. network description
+msgid "Return the IPv4 network for the default network interface."
+msgstr ""
+
+#. network resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface network."
+msgstr ""
+
+#. network resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network."
+msgstr ""
+
+#. network6 description
+msgid "Return the IPv6 network for the default network interface."
+msgstr ""
+
+#. network6 resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network6 resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network6 resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface network."
+msgstr ""
+
+#. network6 resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network."
+msgstr ""
+
+#. network6_<interface> description
+msgid "Return the IPv6 network for a network interface."
+msgstr ""
+
+#. network6_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network6_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network6_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface network."
+msgstr ""
+
+#. network6_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network."
+msgstr ""
+
+#. network_<interface> description
+msgid "Return the IPv4 network for a network interface."
+msgstr ""
+
+#. network_<interface> resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network_<interface> resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interface network."
+msgstr ""
+
+#. network_<interface> resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interface network."
+msgstr ""
+
+#. network_<interface> resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interface network."
+msgstr ""
+
+#. networking description
+msgid "Return the networking information for the system."
+msgstr ""
+
+#. networking resolution
+msgid "Linux: use the `getifaddrs` function to retrieve the network interfaces."
+msgstr ""
+
+#. networking resolution
+msgid "Mac OSX: use the `getifaddrs` function to retrieve the network interfaces."
+msgstr ""
+
+#. networking resolution
+msgid "Solaris: use the `ioctl` function to retrieve the network interfaces."
+msgstr ""
+
+#. networking resolution
+msgid "Windows: use the `GetAdaptersAddresses` function to retrieve the network interfaces."
+msgstr ""
+
+#. networking caveats
+msgid "Windows Server 2003: the `GetAdaptersInfo` function is used for DHCP and netmask lookup. This function does not support IPv6 netmasks."
+msgstr ""
+
+#. operatingsystem description
+msgid "Return the name of the operating system."
+msgstr ""
+
+#. operatingsystem resolution
+msgid "All platforms: default to the kernel name."
+msgstr ""
+
+#. operatingsystem resolution
+msgid "Linux: use various release files in `/etc` to retrieve the OS name."
+msgstr ""
+
+#. operatingsystemmajrelease description
+msgid "Return the major release of the operating system."
+msgstr ""
+
+#. operatingsystemmajrelease resolution
+msgid "All platforms: default to the major version of the kernel release."
+msgstr ""
+
+#. operatingsystemmajrelease resolution
+msgid "Linux: parse the contents of release files in `/etc` to retrieve the OS major release."
+msgstr ""
+
+#. operatingsystemmajrelease resolution
+msgid "Solaris: parse the contents of `/etc/release` to retrieve the OS major release."
+msgstr ""
+
+#. operatingsystemmajrelease resolution
+msgid "Windows: use WMI to retrieve the OS major release."
+msgstr ""
+
+#. operatingsystemmajrelease caveats
+msgid "Linux: for Ubuntu, the major release is X.Y (e.g. "10.4")."
+msgstr ""
+
+#. operatingsystemrelease description
+msgid "Return the release of the operating system."
+msgstr ""
+
+#. operatingsystemrelease resolution
+msgid "All platforms: default to the kernel release."
+msgstr ""
+
+#. operatingsystemrelease resolution
+msgid "Linux: parse the contents of release files in `/etc` to retrieve the OS release."
+msgstr ""
+
+#. operatingsystemrelease resolution
+msgid "Solaris: parse the contents of `/etc/release` to retrieve the OS release."
+msgstr ""
+
+#. operatingsystemrelease resolution
+msgid "Windows: use WMI to retrieve the OS release."
+msgstr ""
+
+#. os description
+msgid "Return information about the host operating system."
+msgstr ""
+
+#. os resolution
+msgid "Linux: use the `lsb_release` utility and parse the contents of release files in `/etc` to retrieve the OS information."
+msgstr ""
+
+#. os resolution
+msgid "OSX: use the `sw_vers` utility to retrieve the OS information."
+msgstr ""
+
+#. os resolution
+msgid "Solaris: parse the contents of `/etc/release` to retrieve the OS information."
+msgstr ""
+
+#. os resolution
+msgid "Windows: use WMI to retrieve the OS information."
+msgstr ""
+
+#. osfamily description
+msgid "Return the family of the operating system."
+msgstr ""
+
+#. osfamily resolution
+msgid "All platforms: default to the kernel name."
+msgstr ""
+
+#. osfamily resolution
+msgid "Linux: map various Linux distributions to their base distribution (e.g. Ubuntu is a "Debian" distro)."
+msgstr ""
+
+#. osfamily resolution
+msgid "Solaris: map various Solaris-based operating systems to the "Solaris" family."
+msgstr ""
+
+#. osfamily resolution
+msgid "Windows: use "windows" as the family name."
+msgstr ""
+
+#. partitions description
+msgid "Return the disk partitions of the system."
+msgstr ""
+
+#. partitions resolution
+msgid "Linux: use `libblkid` to retrieve the disk partitions."
+msgstr ""
+
+#. partitions caveats
+msgid "Linux: `libfacter` must be built with `libblkid` support."
+msgstr ""
+
+#. path description
+msgid "Return the PATH environment variable."
+msgstr ""
+
+#. path resolution
+msgid "All platforms: retrieve the value of the PATH environment variable."
+msgstr ""
+
+#. physicalprocessorcount description
+msgid "Return the count of physical processors."
+msgstr ""
+
+#. physicalprocessorcount resolution
+msgid "Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of physical processors."
+msgstr ""
+
+#. physicalprocessorcount resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the count of physical processors."
+msgstr ""
+
+#. physicalprocessorcount resolution
+msgid "Solaris: use the `kstat` function to retrieve the count of physical processors."
+msgstr ""
+
+#. physicalprocessorcount resolution
+msgid "Windows: use WMI to retrieve the count of physical processors."
+msgstr ""
+
+#. physicalprocessorcount caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. processor<N> description
+msgid "Return the model string of processor N."
+msgstr ""
+
+#. processor<N> resolution
+msgid "Linux: parse the contents of `/proc/cpuinfo` to retrieve the processor model string."
+msgstr ""
+
+#. processor<N> resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the processor model string."
+msgstr ""
+
+#. processor<N> resolution
+msgid "Solaris: use the `kstat` function to retrieve the processor model string."
+msgstr ""
+
+#. processor<N> resolution
+msgid "Windows: use WMI to retrieve the processor model string."
+msgstr ""
+
+#. processorcount description
+msgid "Return the count of logical processors."
+msgstr ""
+
+#. processorcount resolution
+msgid "Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the count of logical processors."
+msgstr ""
+
+#. processorcount resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the count of logical processors."
+msgstr ""
+
+#. processorcount resolution
+msgid "Solaris: use the `kstat` function to retrieve the count of logical processors."
+msgstr ""
+
+#. processorcount resolution
+msgid "Windows: use WMI to retrieve the count of logical processors."
+msgstr ""
+
+#. processorcount caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. processors description
+msgid "Return information about the system's processors."
+msgstr ""
+
+#. processors resolution
+msgid "Linux: parse the contents `/sys/devices/system/cpu/` and `/proc/cpuinfo` to retrieve the processor information."
+msgstr ""
+
+#. processors resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the processor information."
+msgstr ""
+
+#. processors resolution
+msgid "Solaris: use the `kstat` function to retrieve the processor information."
+msgstr ""
+
+#. processors resolution
+msgid "Windows: use WMI to retrieve the processor information."
+msgstr ""
+
+#. productname description
+msgid "Return the system product name."
+msgstr ""
+
+#. productname resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product name."
+msgstr ""
+
+#. productname resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the system product name."
+msgstr ""
+
+#. productname resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system product name."
+msgstr ""
+
+#. productname resolution
+msgid "Windows: use WMI to retrieve the system product name."
+msgstr ""
+
+#. productname caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. ruby description
+msgid "Return information about the Ruby loaded by facter."
+msgstr ""
+
+#. ruby resolution
+msgid "All platforms: Use `RbConfig`, `RUBY_PLATFORM`, and `RUBY_VERSION` to retrieve information about Ruby."
+msgstr ""
+
+#. ruby caveats
+msgid "All platforms: facter must be able to locate `libruby`."
+msgstr ""
+
+#. rubyplatform description
+msgid "Return the platform Ruby was built for."
+msgstr ""
+
+#. rubyplatform resolution
+msgid "All platforms: use `RUBY_PLATFORM` from the Ruby loaded by facter."
+msgstr ""
+
+#. rubyplatform caveats
+msgid "All platforms: facter must be able to locate `libruby`."
+msgstr ""
+
+#. rubysitedir description
+msgid "Return the path to Ruby's site library directory."
+msgstr ""
+
+#. rubysitedir resolution
+msgid "All platforms: use `RbConfig` from the Ruby loaded by facter."
+msgstr ""
+
+#. rubysitedir caveats
+msgid "All platforms: facter must be able to locate `libruby`."
+msgstr ""
+
+#. rubyversion description
+msgid "Return the version of Ruby."
+msgstr ""
+
+#. rubyversion resolution
+msgid "All platforms: use `RUBY_VERSION` from the Ruby loaded by facter."
+msgstr ""
+
+#. rubyversion caveats
+msgid "All platforms: facter must be able to locate `libruby`."
+msgstr ""
+
+#. selinux description
+msgid "Return whether Security-Enhanced Linux (SELinux) is enabled."
+msgstr ""
+
+#. selinux resolution
+msgid "Linux: parse the contents of `/proc/self/mounts` to determine if SELinux is enabled."
+msgstr ""
+
+#. selinux_config_mode description
+msgid "Return the configured Security-Enhanced Linux (SELinux) mode."
+msgstr ""
+
+#. selinux_config_mode resolution
+msgid "Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux mode."
+msgstr ""
+
+#. selinux_config_policy description
+msgid "Return the configured Security-Enhanced Linux (SELinux) policy."
+msgstr ""
+
+#. selinux_config_policy resolution
+msgid "Linux: parse the contents of `/etc/selinux/config` to retrieve the configured SELinux policy."
+msgstr ""
+
+#. selinux_current_mode description
+msgid "Return the current Security-Enhanced Linux (SELinux) mode."
+msgstr ""
+
+#. selinux_current_mode resolution
+msgid "Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode."
+msgstr ""
+
+#. selinux_enforced description
+msgid "Return whether Security-Enhanced Linux (SELinux) is enforced."
+msgstr ""
+
+#. selinux_enforced resolution
+msgid "Linux: parse the contents of `<mountpoint>/enforce` to retrieve the current SELinux mode."
+msgstr ""
+
+#. selinux_policyversion description
+msgid "Return the Security-Enhanced Linux (SELinux) policy version."
+msgstr ""
+
+#. selinux_policyversion resolution
+msgid "Linux: parse the contents of `<mountpoint>/policyvers` to retrieve the SELinux policy version."
+msgstr ""
+
+#. serialnumber description
+msgid "Return the system product serial number."
+msgstr ""
+
+#. serialnumber resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/product_name` to retrieve the system product serial number."
+msgstr ""
+
+#. serialnumber resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system product serial number."
+msgstr ""
+
+#. serialnumber resolution
+msgid "Windows: use WMI to retrieve the system product serial number."
+msgstr ""
+
+#. serialnumber caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. solaris_zones description
+msgid "Return information about Solaris zones."
+msgstr ""
+
+#. solaris_zones resolution
+msgid "Solaris: use the `zoneadm` and `zonename` utilities to retrieve information about the Solaris zones."
+msgstr ""
+
+#. sp_<name> description
+msgid "Return Mac OSX system profiler information."
+msgstr ""
+
+#. sp_<name> resolution
+msgid "Mac OSX: use the `system_profiler` utility to retrieve system profiler information."
+msgstr ""
+
+#. ssh description
+msgid "Return SSH public keys and fingerprints."
+msgstr ""
+
+#. ssh resolution
+msgid "POSIX platforms: parse SSH public key files and derive fingerprints."
+msgstr ""
+
+#. ssh caveats
+msgid "POSIX platforms: facter must be built with OpenSSL support."
+msgstr ""
+
+#. ssh<algorithm>key description
+msgid "Return the SSH public key for the algorithm."
+msgstr ""
+
+#. ssh<algorithm>key resolution
+msgid "POSIX platforms: parse SSH public key files."
+msgstr ""
+
+#. ssh<algorithm>key caveats
+msgid "POSIX platforms: facter must be built with OpenSSL support."
+msgstr ""
+
+#. sshfp_<algorithm> description
+msgid "Return the SSH fingerprints for the algorithm's public key."
+msgstr ""
+
+#. sshfp_<algorithm> resolution
+msgid "POSIX platforms: derive the SHA1 and SHA256 fingerprints; delimit with a new line character."
+msgstr ""
+
+#. sshfp_<algorithm> caveats
+msgid "POSIX platforms: facter must be built with OpenSSL support."
+msgstr ""
+
+#. swapencrypted description
+msgid "Return whether or not the swap is encrypted."
+msgstr ""
+
+#. swapencrypted resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve swap encryption status."
+msgstr ""
+
+#. swapfree description
+msgid "Return the display size of the free swap memory (e.g. "1 GiB")."
+msgstr ""
+
+#. swapfree resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory."
+msgstr ""
+
+#. swapfree resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the free swap memory."
+msgstr ""
+
+#. swapfree resolution
+msgid "Solaris: use the `swapctl` function to retrieve the free swap memory."
+msgstr ""
+
+#. swapfree_mb description
+msgid "Return the size of the free swap memory, in mebibytes."
+msgstr ""
+
+#. swapfree_mb resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory."
+msgstr ""
+
+#. swapfree_mb resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the free swap memory."
+msgstr ""
+
+#. swapfree_mb resolution
+msgid "Solaris: use the `swapctl` function to retrieve the free swap memory."
+msgstr ""
+
+#. swapsize description
+msgid "Return the display size of the total swap memory (e.g. "1 GiB")."
+msgstr ""
+
+#. swapsize resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory."
+msgstr ""
+
+#. swapsize resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the total swap memory."
+msgstr ""
+
+#. swapsize resolution
+msgid "Solaris: use the `swapctl` function to retrieve the total swap memory."
+msgstr ""
+
+#. swapsize_mb description
+msgid "Return the size of the total swap memory, in mebibytes."
+msgstr ""
+
+#. swapsize_mb resolution
+msgid "Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory."
+msgstr ""
+
+#. swapsize_mb resolution
+msgid "Mac OSX: use the `sysctl` function to retrieve the total swap memory."
+msgstr ""
+
+#. swapsize_mb resolution
+msgid "Solaris: use the `swapctl` function to retrieve the total swap memory."
+msgstr ""
+
+#. system32 description
+msgid "Return the path to the System32 directory on Windows."
+msgstr ""
+
+#. system32 resolution
+msgid "Windows: use the `SHGetFolderPath` function to retrieve the path to the System32 directory."
+msgstr ""
+
+#. system_profiler description
+msgid "Return information from the Mac OSX system profiler."
+msgstr ""
+
+#. system_profiler resolution
+msgid "Mac OSX: use the `system_profiler` utility to retrieve system profiler information."
+msgstr ""
+
+#. system_uptime description
+msgid "Return the system uptime information."
+msgstr ""
+
+#. system_uptime resolution
+msgid "Linux: use the `sysinfo` function to retrieve the system uptime."
+msgstr ""
+
+#. system_uptime resolution
+msgid "POSIX platforms: use the `uptime` utility to retrieve the system uptime."
+msgstr ""
+
+#. system_uptime resolution
+msgid "Solaris: use the `kstat` function to retrieve the system uptime."
+msgstr ""
+
+#. system_uptime resolution
+msgid "Windows: use WMI to retrieve the system uptime."
+msgstr ""
+
+#. timezone description
+msgid "Return the system timezone."
+msgstr ""
+
+#. timezone resolution
+msgid "POSIX platforms: use the `localtime_r` function to retrieve the system timezone."
+msgstr ""
+
+#. timezone resolution
+msgid "Windows: use the `localtime_s` function to retrieve the system timezone."
+msgstr ""
+
+#. uptime description
+msgid "Return the system uptime."
+msgstr ""
+
+#. uptime resolution
+msgid "Linux: use the `sysinfo` function to retrieve the system uptime."
+msgstr ""
+
+#. uptime resolution
+msgid "POSIX platforms: use the `uptime` utility to retrieve the system uptime."
+msgstr ""
+
+#. uptime resolution
+msgid "Solaris: use the `kstat` function to retrieve the system uptime."
+msgstr ""
+
+#. uptime resolution
+msgid "Windows: use WMI to retrieve the system uptime."
+msgstr ""
+
+#. uptime_days description
+msgid "Return the system uptime days."
+msgstr ""
+
+#. uptime_days resolution
+msgid "Linux: use the `sysinfo` function to retrieve the system uptime days."
+msgstr ""
+
+#. uptime_days resolution
+msgid "POSIX platforms: use the `uptime` utility to retrieve the system uptime days."
+msgstr ""
+
+#. uptime_days resolution
+msgid "Solaris: use the `kstat` function to retrieve the system uptime days."
+msgstr ""
+
+#. uptime_days resolution
+msgid "Windows: use WMI to retrieve the system uptime days."
+msgstr ""
+
+#. uptime_hours description
+msgid "Return the system uptime hours."
+msgstr ""
+
+#. uptime_hours resolution
+msgid "Linux: use the `sysinfo` function to retrieve the system uptime hours."
+msgstr ""
+
+#. uptime_hours resolution
+msgid "POSIX platforms: use the `uptime` utility to retrieve the system uptime hours."
+msgstr ""
+
+#. uptime_hours resolution
+msgid "Solaris: use the `kstat` function to retrieve the system uptime hours."
+msgstr ""
+
+#. uptime_hours resolution
+msgid "Windows: use WMI to retrieve the system uptime hours."
+msgstr ""
+
+#. uptime_seconds description
+msgid "Return the system uptime seconds."
+msgstr ""
+
+#. uptime_seconds resolution
+msgid "Linux: use the `sysinfo` function to retrieve the system uptime seconds."
+msgstr ""
+
+#. uptime_seconds resolution
+msgid "POSIX platforms: use the `uptime` utility to retrieve the system uptime seconds."
+msgstr ""
+
+#. uptime_seconds resolution
+msgid "Solaris: use the `kstat` function to retrieve the system uptime seconds."
+msgstr ""
+
+#. uptime_seconds resolution
+msgid "Windows: use WMI to retrieve the system uptime seconds."
+msgstr ""
+
+#. uuid description
+msgid "Return the system product unique identifier."
+msgstr ""
+
+#. uuid resolution
+msgid "Linux: parse the contents of `/sys/class/dmi/id/product_uuid` to retrieve the system product unique identifier."
+msgstr ""
+
+#. uuid resolution
+msgid "Solaris: use the `smbios` utility to retrieve the system product unique identifier."
+msgstr ""
+
+#. uuid caveats
+msgid "Linux: kernel 2.6+ is required due to the reliance on sysfs."
+msgstr ""
+
+#. virtual description
+msgid "Return the hypervisor name for virtual machines or "physical" for physical machines."
+msgstr ""
+
+#. virtual resolution
+msgid "Linux: use procfs or utilities such as `vmware` and `virt-what` to retrieve virtual machine name."
+msgstr ""
+
+#. virtual resolution
+msgid "Mac OSX: use the system profiler to retrieve virtual machine name."
+msgstr ""
+
+#. virtual resolution
+msgid "Solaris: use the `zonename` utility to retrieve virtual machine name."
+msgstr ""
+
+#. virtual resolution
+msgid "Windows: use WMI to retrieve virtual machine name."
+msgstr ""
+
+#. xen description
+msgid "Return metadata for the Xen hypervisor."
+msgstr ""
+
+#. xen resolution
+msgid "POSIX platforms: use `/usr/lib/xen-common/bin/xen-toolstack` to locate xen admin commands if available, otherwise fallback to `/usr/sbin/xl` or `/usr/sbin/xm`. Use the found command to execute the `list` query."
+msgstr ""
+
+#. xen caveats
+msgid "POSIX platforms: confined to Xen privileged virtual machines."
+msgstr ""
+
+#. xendomains description
+msgid "Return a list of comma-separated active Xen domain names."
+msgstr ""
+
+#. xendomains resolution
+msgid "POSIX platforms: see the `xen` structured fact."
+msgstr ""
+
+#. xendomains caveats
+msgid "POSIX platforms: confined to Xen privileged virtual machines."
+msgstr ""
+
+#. zfs_featurenumbers description
+msgid "Return the comma-delimited feature numbers for ZFS."
+msgstr ""
+
+#. zfs_featurenumbers resolution
+msgid "Solaris: use the `zfs` utility to retrieve the feature numbers for ZFS"
+msgstr ""
+
+#. zfs_featurenumbers caveats
+msgid "Solaris: the `zfs` utility must be present."
+msgstr ""
+
+#. zfs_version description
+msgid "Return the version for ZFS."
+msgstr ""
+
+#. zfs_version resolution
+msgid "Solaris: use the `zfs` utility to retrieve the version for ZFS"
+msgstr ""
+
+#. zfs_version caveats
+msgid "Solaris: the `zfs` utility must be present."
+msgstr ""
+
+#. zone_<name>_brand description
+msgid "Return the brand for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_brand resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the brand for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_brand caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_iptype description
+msgid "Return the IP type for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_iptype resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the IP type for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_iptype caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_name description
+msgid "Return the name for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_name resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the name for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_name caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_uuid description
+msgid "Return the unique identifier for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_uuid resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the unique identifier for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_uuid caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_id description
+msgid "Return the zone identifier for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_id resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the zone identifier for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_id caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_path description
+msgid "Return the zone path for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_path resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the zone path for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_path caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zone_<name>_status description
+msgid "Return the zone state for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_status resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the zone state for the Solaris zone."
+msgstr ""
+
+#. zone_<name>_status caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zonename description
+msgid "Return the name of the current Solaris zone."
+msgstr ""
+
+#. zonename resolution
+msgid "Solaris: use the `zonename` utility to retrieve the current zone name."
+msgstr ""
+
+#. zonename caveats
+msgid "Solaris: the `zonename` utility must be present."
+msgstr ""
+
+#. zones description
+msgid "Return the count of Solaris zones."
+msgstr ""
+
+#. zones resolution
+msgid "Solaris: use the `zoneadm` utility to retrieve the count of Solaris zones."
+msgstr ""
+
+#. zones caveats
+msgid "Solaris: the `zoneadm` utility must be present."
+msgstr ""
+
+#. zpool_featurenumbers description
+msgid "Return the comma-delimited feature numbers for ZFS storage pools."
+msgstr ""
+
+#. zpool_featurenumbers resolution
+msgid "Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools"
+msgstr ""
+
+#. zpool_featurenumbers caveats
+msgid "Solaris: the `zpool` utility must be present."
+msgstr ""
+
+#. zpool_version description
+msgid "Return the version for ZFS storage pools."
+msgstr ""
+
+#. zpool_version resolution
+msgid "Solaris: use the `zpool` utility to retrieve the version for ZFS storage pools"
+msgstr ""
+
+#. zpool_version caveats
+msgid "Solaris: the `zpool` utility must be present."
+msgstr ""
+

--- a/lib/schema/translation_tooling.rb
+++ b/lib/schema/translation_tooling.rb
@@ -1,0 +1,67 @@
+require 'yaml'
+
+fact_schema = YAML.load_file(File.join(File.dirname(__FILE__), "facter.yaml"))
+facts = []
+
+fact_schema.each do |fact|
+  fact_name = fact[0]
+  fact_details = fact[1]
+
+  fact_data = {:name => fact_name,
+               :description => fact_details['description'],
+               :resolution => fact_details['resolution'],
+               :caveats => fact_details['caveats']}
+
+  facts << fact_data
+end
+
+File.open(File.join(File.dirname(__FILE__), "core_facts.pot"), 'w') do |file|
+  file.puts <<-HEADER
+# CORE FACTS SCHEMA
+# Copyright (C) 2016 Puppet, LLC
+# This file is distributed under the same license as the FACTER package.
+# FIRST AUTHOR <docs@puppet.com>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: FACTER \\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\\n"
+"POT-Creation-Date: \\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: \\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\\n"
+\n
+  HEADER
+
+  facts.each do |fact|
+    if fact[:description]
+      descriptions = fact[:description].split("\n")
+
+      descriptions.each do |string|
+        file.puts "#. #{fact[:name]} description\nmsgid \"#{string}\"\nmsgstr \"\"\n\n"
+      end
+    end
+
+    if fact[:resolution]
+      resolutions = fact[:resolution].split("\n")
+
+      resolutions.each do |string|
+        file.puts "#. #{fact[:name]} resolution\nmsgid \"#{string}\"\nmsgstr \"\"\n\n"
+      end
+    end
+
+    if fact[:caveats]
+      caveats = fact[:caveats].split("\n")
+
+      caveats.each do |string|
+        file.puts "#. #{fact[:name]} caveats\nmsgid \"#{string}\"\nmsgstr \"\"\n\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to support the translation of information about core facts,
add a ruby script which takes the fact.yaml file and generates a POT
file with the important strings so they can be translated.