### PR TITLE
(FACT-1482) Add mountpoints fact entries for tmpfs-mounted filesystems

### DIFF
--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -75,9 +75,10 @@ namespace facter { namespace facts { namespace linux {
         char buffer[4096];
         while (mntent *ptr = getmntent_r(file, &entry, buffer, sizeof(buffer))) {
             string device = ptr->mnt_fsname;
+            string mtype = ptr->mnt_type;
 
-            // Skip over anything that doesn't map to a device
-            if (!boost::starts_with(device, "/dev/")) {
+            // Skip over anything that doesn't map to a device and is not tmpfs
+            if (!boost::starts_with(device, "/dev/") && mtype != "tmpfs") {
                 continue;
             }
 


### PR DESCRIPTION
This change updates code that previously filtered-out all non-device
entries, now allowing tmpfs.