### PR TITLE
(maint) Install a recent version of xgettext for Travis build

### DIFF
--- a/scripts/travis_target.sh
+++ b/scripts/travis_target.sh
@@ -14,9 +14,17 @@ elif [ ${TRAVIS_TARGET} == DOXYGEN ]; then
   # grab a pre-built doxygen 1.8.7 from s3
   wget https://s3.amazonaws.com/kylo-pl-bucket/doxygen_install.tar.bz2
   tar xjvf doxygen_install.tar.bz2 --strip 1 -C $USERDIR
-elif [ ${TRAVIS_TARGET} == DEBUG ]; then
-  # Install coveralls.io update utility
-  pip install --user cpp-coveralls
+elif [[ ${TRAVIS_TARGET} == DEBUG || ${TRAVIS_TARGET} == RELEASE ]]; then
+  # Prepare for generating FACTER.pot and ensure it happens every time.
+  # Ensure this happens before calling CMake.
+  wget https://s3.amazonaws.com/kylo-pl-bucket/gettext-0.19.6_install.tar.bz2
+  tar xjf gettext-0.19.6_install.tar.bz2 --strip 1 -C $USERDIR
+  rm -f locales/FACTER.pot
+
+  if [ ${TRAVIS_TARGET} == DEBUG ]; then
+    # Install coveralls.io update utility
+    pip install --user cpp-coveralls
+  fi
 fi
 
 # Generate build files


### PR DESCRIPTION
Older versions of xgettext do not support the "--add-location=file" option.