### PR TITLE
(FACT-1494 & 1498) Acceptance: load search dirs from config in Ruby module

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ cli : {
 ```
 All options are respected when running Facter standalone, while calling Facter from Ruby will only load `external-dir` and `custom-dir`.
 
-The file will be loaded by default from `/etc/puppetlabs/facter/facter.conf` on Unix and `C:\ProgramData\PuppetLabs\facter\facter.conf` on Windows. A different location can be specified using the `--config` command line option.
+The file will be loaded by default from `/etc/puppetlabs/facter/facter.conf` on Unix and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows. A different location can be specified using the `--config` command line option.
 
 Uninstall
 ---------

--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -42,6 +42,20 @@ module Facter
           '.sh'
         end
       end
+
+      # Retrieve the path to default location of facter.conf file.
+      #
+      def get_default_fact_dir(platform, version)
+        if platform =~ /windows/
+          if version < 6.0
+            File.join('C:', 'Documents and Settings', 'All Users', 'Application Data', 'PuppetLabs', 'facter')
+          else
+            File.join('C:', 'ProgramData', 'PuppetLabs', 'facter')
+          end
+        else
+          File.join('/', 'etc', 'puppetlabs', 'facter')
+        end
+      end
     end
   end
 end

--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -47,11 +47,7 @@ module Facter
       #
       def get_default_fact_dir(platform, version)
         if platform =~ /windows/
-          if version < 6.0
-            File.join('C:', 'Documents and Settings', 'All Users', 'Application Data', 'PuppetLabs', 'facter')
-          else
-            File.join('C:', 'ProgramData', 'PuppetLabs', 'facter')
-          end
+          File.join('C:', 'ProgramData', 'PuppetLabs', 'facter', 'etc')
         else
           File.join('/', 'etc', 'puppetlabs', 'facter')
         end

--- a/acceptance/tests/options/config.rb
+++ b/acceptance/tests/options/config.rb
@@ -1,0 +1,26 @@
+# This test is intended to verify that the config file location can be specified
+# via the `--config` flag on the command line.
+test_name "--config command-line option designates the location of the config file" do
+
+  agents.each do |agent|
+    step "Agent #{agent}: create config file" do
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      create_remote_file(agent, config_file, <<-FILE)
+      cli : {
+          debug : true
+      }
+      FILE
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
+      step "setting --config should cause the config file to be loaded from the specified location" do
+        on(agent, facter("--config '#{config_file}'"))
+        assert_match(/DEBUG/, stderr, "Expected debug output on stdout")
+      end
+    end
+
+  end
+end

--- a/acceptance/tests/options/config_file/custom_facts.rb
+++ b/acceptance/tests/options/config_file/custom_facts.rb
@@ -21,10 +21,6 @@ EOM
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, custom_fact_content)
 
-      teardown do
-        on(agent, "rm -f '#{custom_fact}'")
-      end
-
       config_custom = <<EOM
 global : {
     custom-dir : "#{custom_dir}"
@@ -46,6 +42,10 @@ EOM
 
       config_no_custom_file = File.join(config_dir, "no_custom.conf")
       create_remote_file(agent, config_no_custom_file, config_no_custom)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_dir}' '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
 
       step "setting custom-dir in config file should specify location to look for custom facts" do
         on(agent, facter("--config '#{config_custom_file}' custom_fact")) do

--- a/acceptance/tests/options/config_file/debug.rb
+++ b/acceptance/tests/options/config_file/debug.rb
@@ -1,6 +1,9 @@
 # This test is intended to demonstrate that setting the cli.debug field to true
 # causes DEBUG information to be printed to stderr.
 test_name "setting the debug config field to true prints debug info to stderr" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
   config = <<EOM
 cli : {
     debug : true
@@ -9,12 +12,17 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = agent.tmpdir("config_dir")
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
+      on(agent, "mkdir -p '#{config_dir}'")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
       step "debug output should print when config file is loaded" do
-        on(agent, facter("--config '#{config_file}'")) do
+        on(agent, facter("")) do
           assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
         end
       end

--- a/acceptance/tests/options/config_file/default_file_location.rb
+++ b/acceptance/tests/options/config_file/default_file_location.rb
@@ -22,7 +22,7 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -f '#{config_file}'")
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
       end
 
       step "config file should be loaded automatically and turn DEBUG output on" do

--- a/acceptance/tests/options/config_file/external_facts.rb
+++ b/acceptance/tests/options/config_file/external_facts.rb
@@ -36,10 +36,6 @@ EOM
       create_remote_file(agent, ext_fact_custom_dir, content)
       on(agent, "chmod +x '#{ext_fact_factsd}' '#{ext_fact_custom_dir}'")
 
-      teardown do
-        on(agent, "rm -f '#{ext_fact_factsd}' '#{ext_fact_custom_dir}'")
-      end
-
       config_no_ext = <<EOM
 global : {
     no-external-facts : true
@@ -72,6 +68,10 @@ global : {
 EOM
       config_ext_list_file = File.join(config_dir, "ext_list.conf")
       create_remote_file(agent, config_ext_list_file, config_ext_list)
+
+      teardown do
+        on(agent, "rm -rf '#{ext_fact_factsd}' '#{ext_fact_custom_dir}' '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
 
       step "setting no-external-facts to true should disable external facts" do
         on(agent, facter("--config '#{config_no_ext_file}' external_fact")) do

--- a/acceptance/tests/options/config_file/facter_config_file.rb
+++ b/acceptance/tests/options/config_file/facter_config_file.rb
@@ -1,0 +1,73 @@
+# This test is intended to demonstrate that Facter will load a config file
+# saved at the default location without any special command line flags.
+# On *nix, this location is /etc/puppetlabs/facter/facter.conf.
+# On Windows 6.0 or newer, it is C:\ProgramData\PuppetLabs\facter\facter.conf
+# On Windows older than 6.0, it is
+# C:\Documents and Settings\All Users\Application Data\PuppetLabs\facter\facter.conf
+#
+# The test also verifies that facter will search for external facts and custom facts
+# in the directory paths defined with external-dir and custome-dir in the facter.conf file
+test_name "FACT-1494 - C98142 Load facter.conf having external-dir" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    # creat paths for default facter.conf, external-dir, and custom-dir
+    #
+
+    # defaul facter.conf
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_path = "#{facter_conf_default_dir}/facter.conf"
+
+    # external-dir
+    ext_fact_dir1 = agent.tmpdir('ext_fact_dir1')
+    ext_path1     = "#{ext_fact_dir1}/test_ext_fact1.yaml"
+    ext_fact_dir2 = agent.tmpdir('ext_fact_dir2')
+    ext_path2     = "#{ext_fact_dir2}/test_ext_fact2.yaml"
+
+    # custom-dir
+    cust_fact_dir = agent.tmpdir('cust_fact_dir')
+    cust_path     = "#{cust_fact_dir}/custom_fact.rb"
+
+    # create the directories
+    on(agent, "mkdir -p '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'")
+
+    step "Agent #{agent}: create facter.conf, external fact, and custom fact files" do
+
+      create_remote_file(agent, facter_conf_default_path, <<-FILE)
+        global : {
+          external-dir : ["#{ext_fact_dir1}", "#{ext_fact_dir2}"],
+          custom-dir : ["#{cust_fact_dir}"]
+      }
+      FILE
+
+      create_remote_file(agent, ext_path1, <<-FILE)
+        externalfact1: 'This is external fact 1 in #{ext_fact_dir1} directory'
+      FILE
+
+      create_remote_file(agent, ext_path2, <<-FILE)
+        externalfact2: 'This is external fact 2 in #{ext_fact_dir2} directory'
+      FILE
+
+      create_remote_file(agent, cust_path, <<-FILE)
+        Facter.add('customfact') do
+          setcode do
+            'This is a custom fact in #{cust_fact_dir} directory'
+          end
+        end
+      FILE
+    end
+
+    step "config file should be loaded automatically and search all external-dir and custome-dir paths" do
+      on(agent, facter("")) do
+        assert_match(/This is external fact 1 in #{ext_fact_dir1} directory/, stdout, "Expected external fact")
+        assert_match(/This is external fact 2 in #{ext_fact_dir2} directory/, stdout, "Expected external fact")
+        assert_match(/This is a custom fact in #{cust_fact_dir} directory/, stdout, "Expected custom fact")
+      end
+    end
+
+    teardown do
+      on(agent, "rm -rf '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'")
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/load_from_ruby.rb
+++ b/acceptance/tests/options/config_file/load_from_ruby.rb
@@ -1,33 +1,35 @@
-# This test is intended to demonstrate that Facter will load a config file
-# saved at the default location without any special command line flags.
+# This test is intended to demonstrate that Facter's config file will
+# load correctly from the default location when Facter is required from Ruby.
 # On *nix, this location is /etc/puppetlabs/facter/facter.conf.
-# On Windows 6.0 or newer, it is C:\ProgramData\PuppetLabs\facter\facter.conf
-# On Windows older than 6.0, it is
-# C:\Documents and Settings\All Users\Application Data\PuppetLabs\facter\facter.conf
+# On Windows, it is C:\ProgramData\PuppetLabs\facter\etc\facter.conf
 #
 # The test also verifies that facter will search for external facts and custom facts
 # in the directory paths defined with external-dir and custome-dir in the facter.conf file
-test_name "FACT-1494 - C98142 Load facter.conf having external-dir" do
+test_name "config file is loaded when Facter is run from Puppet" do
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    # creat paths for default facter.conf, external-dir, and custom-dir
-    #
+    # create paths for default facter.conf, external-dir, and custom-dir
 
-    # defaul facter.conf
+    # default facter.conf
     facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-    facter_conf_default_path = "#{facter_conf_default_dir}/facter.conf"
+    facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
     # external-dir
     ext_fact_dir1 = agent.tmpdir('ext_fact_dir1')
-    ext_path1     = "#{ext_fact_dir1}/test_ext_fact1.yaml"
+    ext_path1     = File.join(ext_fact_dir1, "test_ext_fact1.yaml")
     ext_fact_dir2 = agent.tmpdir('ext_fact_dir2')
-    ext_path2     = "#{ext_fact_dir2}/test_ext_fact2.yaml"
+    ext_path2     = File.join(ext_fact_dir2, "test_ext_fact2.yaml")
 
     # custom-dir
-    cust_fact_dir = agent.tmpdir('cust_fact_dir')
-    cust_path     = "#{cust_fact_dir}/custom_fact.rb"
+    cust_fact_dir = agent.tmpdir('custom_fact_dir')
+    cust_path     = File.join(cust_fact_dir, "custom_fact.rb")
+
+    teardown do
+      on(agent, "rm -rf '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'",
+          :acceptable_exit_codes => [0,1])
+    end
 
     # create the directories
     on(agent, "mkdir -p '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'")
@@ -58,16 +60,12 @@ test_name "FACT-1494 - C98142 Load facter.conf having external-dir" do
       FILE
     end
 
-    step "config file should be loaded automatically and search all external-dir and custome-dir paths" do
-      on(agent, facter("")) do
+    step "running `puppet facts` should load the config file automatically and search all external-dir and custom-dir paths" do
+      on(agent, puppet('facts')) do
         assert_match(/This is external fact 1 in #{ext_fact_dir1} directory/, stdout, "Expected external fact")
         assert_match(/This is external fact 2 in #{ext_fact_dir2} directory/, stdout, "Expected external fact")
         assert_match(/This is a custom fact in #{cust_fact_dir} directory/, stdout, "Expected custom fact")
       end
-    end
-
-    teardown do
-      on(agent, "rm -rf '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'")
     end
   end
 end

--- a/acceptance/tests/options/config_file/log_level.rb
+++ b/acceptance/tests/options/config_file/log_level.rb
@@ -2,6 +2,9 @@
 # properly. The value of the setting should be a string indicating the
 # logging level.
 test_name "log-level setting can be used to specific logging level" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
   config = <<EOM
 cli : {
     log-level : debug
@@ -10,12 +13,17 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = agent.tmpdir("config_dir")
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
+      on(agent, "mkdir -p '#{config_dir}'")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
       step "log-level set to debug should print DEBUG output to stderr" do
-        on(agent, facter("--config '#{config_file}'")) do
+        on(agent, facter("")) do
           assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
         end
       end

--- a/acceptance/tests/options/config_file/no_ruby.rb
+++ b/acceptance/tests/options/config_file/no_ruby.rb
@@ -21,12 +21,17 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = agent.tmpdir("config_dir")
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
+      on(agent, "mkdir -p '#{config_dir}'")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
       step "no-ruby option should disable Ruby and facts requiring Ruby" do
-        on(agent, facter("--config '#{config_file}' ruby")) do
+        on(agent, facter("ruby")) do
           assert_equal("", stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{stdout.chomp}")
           assert_equal("", stderr.chomp, "Expected no warnings about Ruby on stderr, but got output: #{stderr.chomp}")
         end
@@ -39,7 +44,11 @@ EOM
           custom_fact = File.join(custom_dir, 'custom_fact.rb')
           create_remote_file(agent, custom_fact, custom_fact_content)
 
-          on(agent, facter("--config '#{config_file}' custom_fact", :environment => { 'FACTERLIB' => custom_dir })) do
+          teardown do
+            on(agent, "rm -rf '#{custom_dir}'", :acceptable_exit_codes => [0,1])
+          end
+
+          on(agent, facter("custom_fact", :environment => { 'FACTERLIB' => custom_dir })) do
             assert_equal("", stdout.chomp, "Expected custom fact to be disabled when no-ruby is true, but it resolved as #{stdout.chomp}")
           end
         end

--- a/acceptance/tests/options/config_file/trace.rb
+++ b/acceptance/tests/options/config_file/trace.rb
@@ -26,16 +26,17 @@ EOM
       create_remote_file(agent, custom_fact, erroring_custom_fact)
       on(agent, "chmod +x '#{custom_fact}'")
 
-      teardown do
-        on(agent, "rm -f '#{custom_fact}'")
-      end
-
-      config_dir = agent.tmpdir("config_dir")
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
+      on(agent, "mkdir -p '#{config_dir}'")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{custom_dir}' '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
       step "trace setting should provide a backtrace for a custom fact with errors" do
-        on(agent, facter("--custom-dir '#{custom_dir}' --config '#{config_file}' custom_fact"), :acceptable_exit_codes => [1])
+        on(agent, facter("--custom-dir '#{custom_dir}' custom_fact"), :acceptable_exit_codes => [1])
         assert_match(/backtrace:\s+#{custom_fact}/, stderr, "Expected a backtrace for erroneous custom fact")
       end
     end

--- a/acceptance/tests/options/config_file/verbose.rb
+++ b/acceptance/tests/options/config_file/verbose.rb
@@ -1,6 +1,9 @@
 # This test is intended to demonstrate that setting cli.verbose to true in the 
 # config file causes INFO level logging to output to stderr.
 test_name "verbose config field prints verbose information to stderr" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
   config = <<EOM
 cli : {
     verbose : true
@@ -9,12 +12,17 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = agent.tmpdir("config_dir")
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
+      on(agent, "mkdir -p '#{config_dir}'")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
       step "debug output should print when config file is loaded" do
-        on(agent, facter("--config '#{config_file}'")) do
+        on(agent, facter("")) do
           assert_match(/INFO/, stderr, "Expected stderr to contain verbose (INFO) statements")
         end
       end

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -179,13 +179,7 @@ namespace facter { namespace ruby {
         // Load global settigs from config file
         load_global_settings(load_default_config_file(), _config_file_settings);
 
-        // Initialize custom fact paths
-        vector<string> custom_fact_path = paths;
-        if (_config_file_settings.count("custom-dir")) {
-            auto config_paths = _config_file_settings["custom-dir"].as<vector<string>>();
-            custom_fact_path.insert(custom_fact_path.end(), config_paths.begin(), config_paths.end());
-        }
-        initialize_search_paths(custom_fact_path);
+        initialize_search_paths(paths);
 
         // Register the block for logging callback with the GC
         _on_message_block = ruby.nil_value();
@@ -319,6 +313,12 @@ namespace facter { namespace ruby {
         }
 
         LOG_DEBUG("loading all custom facts.");
+
+        LOG_DEBUG("loading custom fact directories from config file");
+        if (_config_file_settings.count("custom-dir")) {
+            auto config_paths = _config_file_settings["custom-dir"].as<vector<string>>();
+            _search_paths.insert(_search_paths.end(), config_paths.begin(), config_paths.end());
+        }
 
         for (auto const& directory : _search_paths) {
             LOG_DEBUG("searching for custom facts in {1}.", directory);
@@ -798,6 +798,7 @@ namespace facter { namespace ruby {
             });
 
             // Add external path from config file
+            LOG_DEBUG(_("loading external fact directories from config file"));
             if (instance->_config_file_settings.count("external-dir")) {
                 auto config_paths = instance->_config_file_settings["external-dir"].as<vector<string>>();
                 instance->_external_search_paths.insert(instance->_external_search_paths.end(), config_paths.begin(), config_paths.end());


### PR DESCRIPTION
This adds an acceptance test for running Facter within Puppet with a config file providing external and custom fact directories. It also fixes a bug discovered as a result of writing this test, where the specified custom directories were not being added to the search path correctly.

This also refactors some of the existing config file tests to use the default location, as well as adds a test explicitly testing the `--config` command line flag.