### PR TITLE
(maint) Sign packages with new signing key

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -4,7 +4,7 @@ packaging_repo: 'packaging'
 deb_build_mirrors:
   - deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main
 packager: 'puppetlabs'
-gpg_key: '4BD6EC30'
+gpg_key: '7F438280EF8D349F'
 
 # These are the build targets used by the packaging repo. Uncomment to allow use.
 #final_mocks: 'pl-el-5-x86_64 pl-el-5-i386 pl-el-6-x86_64 pl-el-6-i386 pl-el-7-x86_64'


### PR DESCRIPTION
This commit updates the key used to signed packages with the automation
in the packaging repo. We are shipping a new gpg key for all publicly
available packages, so this is a part of that effort.