### PR TITLE
(FACT-718) Allow blocking resolvers via a list in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,15 @@ cli : {
     verbose   : false,
     log-level : "warn"
 }
+facts : {
+    blocklist : [ "file system", "EC2" ]
+}
 ```
-All options are respected when running Facter standalone, while calling Facter from Ruby will only load `external-dir` and `custom-dir`.
+All options are respected when running Facter standalone, while calling Facter from Ruby will only load `external-dir`, `custom-dir`, and the fact-specific configuration.
 
 The file will be loaded by default from `/etc/puppetlabs/facter/facter.conf` on Unix and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows. A different location can be specified using the `--config` command line option.
+
+Elements in the blocklist are fact groupings which will not be resolved when Facter runs. Valid elements correspond to the `blockgroup` field in the fact schema. If a fact does not have a blockgroup, it cannot be blocked.
 
 Uninstall
 ---------

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -178,6 +178,7 @@ int main(int argc, char **argv)
             if (hocon_conf) {
                 facter::util::config::load_global_settings(hocon_conf, vm);
                 facter::util::config::load_cli_settings(hocon_conf, vm);
+                facter::util::config::load_fact_settings(hocon_conf, vm);
             }
 
             // Check for a help option first before notifying
@@ -277,7 +278,12 @@ int main(int argc, char **argv)
 
         log_queries(queries);
 
-        collection facts;
+        set<string> blocklist;
+        if (vm.count("blocklist")) {
+            auto facts_to_block = vm["blocklist"].as<vector<string>>();
+            blocklist.insert(facts_to_block.begin(), facts_to_block.end());
+        }
+        collection facts(blocklist);
         facts.add_default_facts(ruby);
 
         // Add the environment facts

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -29,6 +29,7 @@ using namespace std;
 using namespace hocon;
 using namespace facter::facts;
 using namespace facter::logging;
+using namespace facter::util::config;
 using leatherman::util::environment;
 namespace po = boost::program_options;
 
@@ -63,7 +64,17 @@ void help(po::options_description& desc)
           "===============\n\n"
           "  facter kernel\n"
           "  facter networking.ip\n"
-          "  facter processors.models.0", desc) << endl;
+          "  facter processors.models.0"
+          "\n"
+          "\n"
+          "Config File\n"
+          "===========\n"
+          "\n"
+          "Contains settings for configuring external and custom fact directories,\n"
+          "setting command line options, and blocking facts.\n"
+          "Loaded by default from {2}.\n"
+          "See man page, README, or docs for more details.",
+          desc, default_config_location()) << endl;
 }
 
 void log_command_line(int argc, char** argv)
@@ -170,15 +181,15 @@ int main(int argc, char **argv)
             hocon::shared_config hocon_conf;
             if (vm.count("config")) {
                 string conf_dir = vm["config"].as<string>();
-                hocon_conf = facter::util::config::load_config_from(conf_dir);
+                hocon_conf = load_config_from(conf_dir);
             } else {
-                hocon_conf = facter::util::config::load_default_config_file();
+                hocon_conf = load_default_config_file();
             }
 
             if (hocon_conf) {
-                facter::util::config::load_global_settings(hocon_conf, vm);
-                facter::util::config::load_cli_settings(hocon_conf, vm);
-                facter::util::config::load_fact_settings(hocon_conf, vm);
+                load_global_settings(hocon_conf, vm);
+                load_cli_settings(hocon_conf, vm);
+                load_fact_settings(hocon_conf, vm);
             }
 
             // Check for a help option first before notifying

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -52,8 +52,9 @@ namespace facter { namespace facts {
 
         /**
          * Constructs a fact collection.
+         * @param blocklist the names of resolvers that should not be resolved
          */
-        collection();
+        collection(std::set<std::string> const& blocklist = {});
 
         /**
          * Destructor for fact collection.
@@ -270,6 +271,7 @@ namespace facter { namespace facts {
         std::list<std::shared_ptr<resolver>> _resolvers;
         std::multimap<std::string, std::shared_ptr<resolver>> _resolver_map;
         std::list<std::shared_ptr<resolver>> _pattern_resolvers;
+        std::set<std::string> _blocklist;
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -262,6 +262,7 @@ namespace facter { namespace facts {
         LIBFACTER_NO_EXPORT void write_yaml(std::ostream& stream, std::set<std::string> const& queries, bool show_legacy, bool strict_errors);
         LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
         LIBFACTER_NO_EXPORT bool add_external_facts_dir(std::vector<std::unique_ptr<external::resolver>> const& resolvers, std::string const& directory, bool warn);
+        LIBFACTER_NO_EXPORT bool try_block(std::shared_ptr<resolver> const& res);
 
         // Platform specific members
         LIBFACTER_NO_EXPORT void add_platform_facts();

--- a/lib/inc/facter/facts/resolver.hpp
+++ b/lib/inc/facter/facts/resolver.hpp
@@ -110,6 +110,12 @@ namespace facter { namespace facts {
          */
         virtual void resolve(collection& facts) = 0;
 
+        /**
+         * Determines if this resolver can be blocked from collecting its facts.
+         * @return Returns true if this resolver can be blocked, false otherwise
+         */
+        virtual bool is_blockable() const;
+
      private:
         std::string _name;
         std::vector<std::string> _names;

--- a/lib/inc/facter/util/config.hpp
+++ b/lib/inc/facter/util/config.hpp
@@ -17,6 +17,12 @@ namespace facter { namespace util { namespace config {
     LIBFACTER_EXPORT hocon::shared_config load_default_config_file();
 
     /**
+     * Returns the default location of the config file.
+     * @return the absolute path to the default config file
+     */
+    LIBFACTER_EXPORT std::string default_config_location();
+
+    /**
      * Parses the contents of the config pile at the specified path.
      * @param config_path the path to the config file
      * @return HOCON config object, or nullptr if no file was found

--- a/lib/inc/facter/util/config.hpp
+++ b/lib/inc/facter/util/config.hpp
@@ -38,6 +38,13 @@ namespace facter { namespace util { namespace config {
     LIBFACTER_EXPORT void load_cli_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
 
     /**
+     * Loads the "blocklist" section of the config file into the settings map.
+     * @param hocon_config the config object representing the parsed config file
+     * @param vm the key-value map in which to store the settings
+     */
+    LIBFACTER_EXPORT void load_fact_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
+
+    /**
      * Returns a schema of the valid global options that can appear in the config file.
      * @return names, values, and descriptions of global Facter options
      */
@@ -48,4 +55,10 @@ namespace facter { namespace util { namespace config {
      * @return names, values, and descriptions of command line options
      */
     LIBFACTER_EXPORT boost::program_options::options_description cli_config_options();
+
+    /**
+     * Returns a schema for options dealing with block fact collection.
+     * @return names, values, and descriptions of fact blocking config options
+     */
+    LIBFACTER_EXPORT boost::program_options::options_description fact_config_options();
 }}}  // namespace facter::util::config

--- a/lib/inc/internal/facts/resolvers/ec2_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ec2_resolver.hpp
@@ -23,6 +23,8 @@ namespace facter { namespace facts { namespace resolvers {
          * @param facts The fact collection that is resolving facts.
          */
         virtual void resolve(collection& facts) override;
+
+        bool is_blockable() const override;
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/filesystem_resolver.hpp
@@ -28,6 +28,7 @@ namespace facter { namespace facts { namespace resolvers {
          */
         virtual void resolve(collection& facts) override;
 
+        bool is_blockable() const override;
      protected:
         /**
          * Represents data about a mountpoint.

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -18,6 +18,7 @@
 #   - caveats (optional): describes any caveats to the fact.
 #   - elements (required for map types): contains the element values of a map value; each element is another entry.
 #   - validate (optional; default: true): true if a map value's elements should be validated or false if not.
+#   - blockgroup (optional): the block group of this fact; if not specified, the fact cannot be blocked
 #
 # Please keep the facts in alphabetical order.
 
@@ -317,6 +318,7 @@ ec2_metadata:
     caveats: |
         All platforms: `libfacter` must be built with `libcurl` support.
     validate: false
+    blockgroup: EC2
 
 ec2_userdata:
     type: string
@@ -327,6 +329,7 @@ ec2_userdata:
         EC2: query the EC2 user data endpoint and parse the response.
     caveats: |
         All platforms: `libfacter` must be built with `libcurl` support.
+    blockgroup: EC2
 
 env_windows_installdir:
     type: string
@@ -354,6 +357,7 @@ filesystems:
     caveats: |
         Linux: The proc file system must be mounted.
         Mac OSX: The usable file systems is limited to the file system of mounted devices.
+    blockgroup: file system
 
 fqdn:
     type: string
@@ -795,6 +799,7 @@ mountpoints:
         Linux: use the `setmntent` function to retrieve the mount points.
         Mac OSX: use the `getfsstat` function to retrieve the mount points.
         Solaris: parse the contents of `/etc/mnttab` to retrieve the mount points.
+    blockgroup: file system
     elements:
         <mountpoint>:
             pattern: .+
@@ -1191,6 +1196,7 @@ partitions:
         Linux: use `libblkid` to retrieve the disk partitions.
     caveats: |
         Linux: `libfacter` must be built with `libblkid` support.
+    blockgroup: file system
     elements:
         <partition>:
             pattern: \w+

--- a/lib/spec/unit/facter_spec.rb
+++ b/lib/spec/unit/facter_spec.rb
@@ -87,21 +87,21 @@ describe Facter do
 
     it 'should set search paths' do
       Facter.search('foo', 'bar', 'baz')
-      expect(Facter.search_path).to eq(['foo', 'bar', 'baz'])
+      expect(Facter.search_path).to include('foo', 'bar', 'baz')
       Facter.reset
       expect(Facter.search_path).to eq([])
     end
 
     it 'should set external search paths' do
       Facter.search_external(['foo', 'bar', 'baz'])
-      expect(Facter.search_external_path).to eq(['foo', 'bar', 'baz'])
+      expect(Facter.search_external_path).to include('foo', 'bar', 'baz')
     end
 
     it 'should find encoded search paths' do
       snowman_path = File.expand_path('../../../lib/tests/fixtures/facts/external/zö', File.dirname(__FILE__))
       encoded_path = snowman_path.encode("Windows-1252")
       Facter.search(encoded_path)
-      expect(Facter.search_path).to eq([snowman_path])
+      expect(Facter.search_path).to include(snowman_path)
       expect(Facter.value('snowman_fact')).to eq('olaf')
     end
 
@@ -109,7 +109,7 @@ describe Facter do
       snowman_path = File.expand_path('../../../lib/tests/fixtures/facts/external/zö', File.dirname(__FILE__))
       encoded_path = snowman_path.encode("Windows-1252")
       Facter.search_external([encoded_path])
-      expect(Facter.search_external_path).to eq([snowman_path])
+      expect(Facter.search_external_path).to include(snowman_path)
       expect(Facter.value('snowman_fact')).to eq('olaf')
     end
 

--- a/lib/src/facts/resolver.cc
+++ b/lib/src/facts/resolver.cc
@@ -98,4 +98,8 @@ namespace facter { namespace facts {
         return _http_langs;
     }
 
+    bool resolver::is_blockable() const
+    {
+        return false;
+    }
 }}  // namespace facter::facts

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -167,4 +167,8 @@ namespace facter { namespace facts { namespace resolvers {
 #endif
     }
 
+    bool ec2_resolver::is_blockable() const {
+        return true;
+    }
+
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/resolvers/filesystem_resolver.cc
+++ b/lib/src/facts/resolvers/filesystem_resolver.cc
@@ -111,4 +111,8 @@ namespace facter { namespace facts { namespace resolvers {
         }
     }
 
+    bool filesystem_resolver::is_blockable() const {
+        return true;
+    }
+
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -49,7 +49,14 @@ namespace facter { namespace ruby {
         require_context()
         {
             // Create a collection and a facter module
-            _facts.reset(new collection());
+            boost::program_options::variables_map vm;
+            load_fact_settings(load_default_config_file(), vm);
+            set<string> blocklist;
+            if (vm.count("blocklist")) {
+                auto facts_to_block = vm["blocklist"].as<vector<string>>();
+                blocklist.insert(facts_to_block.begin(), facts_to_block.end());
+            }
+            _facts.reset(new collection(blocklist));
             _module.reset(new module(*_facts));
 
             // Ruby doesn't have a proper way of notifying extensions that the VM is shutting down

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -30,6 +30,13 @@ namespace facter { namespace util { namespace config {
         }
     }
 
+    void load_fact_settings(shared_config hocon_config, po::variables_map& vm) {
+        if (hocon_config && hocon_config->has_path("facts")) {
+            auto fact_settings = hocon_config->get_object("facts")->to_config();
+            po::store(hocon::program_options::parse_hocon<char>(fact_settings, fact_config_options(), true), vm);
+        }
+    }
+
     po::options_description global_config_options() {
         po::options_description global_options("");
         global_options.add_options()
@@ -49,5 +56,12 @@ namespace facter { namespace util { namespace config {
             ("trace", po::value<bool>()->default_value(false), "Enable backtraces for custom facts.")
             ("verbose", po::value<bool>()->default_value(false), "Enable verbose (info) output.");
         return cli_options;
+    }
+
+    po::options_description fact_config_options() {
+        po::options_description fact_settings("");
+        fact_settings.add_options()
+            ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
+        return fact_settings;
     }
 }}}  // namespace facter::util::config;

--- a/lib/src/util/config/posix/config.cc
+++ b/lib/src/util/config/posix/config.cc
@@ -3,6 +3,10 @@
 namespace facter { namespace util { namespace config {
 
     hocon::shared_config load_default_config_file() {
-        return load_config_from("/etc/puppetlabs/facter/facter.conf");
+        return load_config_from(default_config_location());
+    }
+
+    std::string default_config_location() {
+        return "/etc/puppetlabs/facter/facter.conf";
     }
 }}}  // namespace facter::util::config

--- a/lib/src/util/config/windows/config.cc
+++ b/lib/src/util/config/windows/config.cc
@@ -4,6 +4,11 @@
 namespace facter { namespace util { namespace config {
 
     hocon::shared_config load_default_config_file() {
-        return load_config_from(leatherman::windows::file_util::get_programdata_dir() + "\\PuppetLabs\\facter\\etc\\facter.conf");
+        return load_config_from(default_config_location());
+    }
+
+    std::string default_config_location() {
+        return leatherman::windows::file_util::get_programdata_dir() +
+            "\\PuppetLabs\\facter\\etc\\facter.conf";
     }
 }}}  // namespace facter::util::config

--- a/lib/tests/collection_fixture.cc
+++ b/lib/tests/collection_fixture.cc
@@ -4,6 +4,8 @@ namespace facter { namespace testing {
 
     using namespace std;
 
+    collection_fixture::collection_fixture(set<string> const& blocklist) : collection(blocklist) { }
+
     vector<string> collection_fixture::get_external_fact_directories() const
     {
         return {};

--- a/lib/tests/collection_fixture.hpp
+++ b/lib/tests/collection_fixture.hpp
@@ -8,7 +8,10 @@ namespace facter { namespace testing {
 
     class collection_fixture : public facter::facts::collection
     {
-     protected:
+    public:
+        collection_fixture(std::set<std::string> const& blocklist = std::set<std::string>());
+
+    protected:
         virtual std::vector<std::string> get_external_fact_directories() const override;
     };
 

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -96,6 +96,15 @@ struct dmi_resolver : resolvers::dmi_resolver
     }
 };
 
+struct ec2_resolver : resolvers::ec2_resolver
+{
+    void resolve(collection& facts) override
+    {
+        facts.add(fact::ec2_metadata, make_value<map_value>());
+        facts.add(fact::ec2_userdata, make_value<string_value>("user data"));
+    }
+};
+
 struct filesystem_resolver : resolvers::filesystem_resolver
 {
  protected:
@@ -434,8 +443,7 @@ void add_all_facts(collection& facts)
     facts.add(make_shared<dmi_resolver>());
     facts.add(make_shared<filesystem_resolver>());
     // TODO: refactor the EC2 resolver to use the "collect_data" pattern
-    facts.add(fact::ec2_metadata, make_value<map_value>());
-    facts.add(fact::ec2_userdata, make_value<string_value>("user data"));
+    facts.add(make_shared<ec2_resolver>());
     // TODO: refactor the GCE resolver to use the "collect_data" pattern
     facts.add(fact::gce, make_value<map_value>());
     facts.add(make_shared<identity_resolver>());
@@ -475,7 +483,8 @@ void validate_attributes(YAML::Node const& node)
             Catch::Equals("resolution")).add(
             Catch::Equals("caveats")).add(
             Catch::Equals("elements")).add(
-            Catch::Equals("validate"))
+            Catch::Equals("validate")).add(
+            Catch::Equals("blockgroup"))
         );
     }
 
@@ -558,6 +567,13 @@ void validate_attributes(YAML::Node const& node)
         REQUIRE(caveats_attribute.IsScalar());
         auto caveats = caveats_attribute.as<string>();
         REQUIRE_FALSE(caveats.empty());
+    }
+
+    auto blockgroup_attribute = node["blockgroup"];
+    if (blockgroup_attribute) {
+        REQUIRE(blockgroup_attribute.IsScalar());
+        auto blockgroup = blockgroup_attribute.as<string>();
+        REQUIRE_FALSE(blockgroup.empty());
     }
 
     // Recurse on elements
@@ -710,6 +726,25 @@ SCENARIO("validating schema") {
                 validate_fact(fact, fact_value, false);
                 return true;
             });
+        }
+        THEN("blocked facts are not resolved") {
+            set<string> blocked_facts;
+            set<string> blockgroups;
+            for (auto const& fact : schema) {
+                auto fact_name = fact.first.as<string>();
+                auto blockgroup = fact.second["blockgroup"];
+                if (blockgroup) {
+                    blockgroups.insert(blockgroup.as<string>());
+                    blocked_facts.insert(fact_name);
+                }
+            }
+            collection_fixture with_blocked(blockgroups);
+            add_all_facts(with_blocked);
+            with_blocked.resolve_facts();
+            for (auto const& fact : blocked_facts) {
+                CAPTURE(fact);
+                REQUIRE_FALSE(with_blocked.get<map_value>(fact));
+            }
         }
     }
 }

--- a/man/man8/facter.8
+++ b/man/man8/facter.8
@@ -26,10 +26,14 @@ Collect and display facts about the current system\. The library behind Facter i
 .P
 If no queries are given, then all facts will be returned\.
 .
+.P
+Many of the command line options can also be set via the HOCON config file. This file can also be used to block the collection of certain fact groups\.
+.
 .SH "OPTIONS"
 .
 .nf
       \fB\-\-color\fR                      Enables color output\.
+      \fB\-\-config\fR                     A custom location for the chnfig file\.
       \fB\-\-custom-dir\fR arg             A directory to use for custom facts\.
 \fB\-d, [ \-\-debug ]\fR                    Enable debug output\.
       \fB\-\-external-dir\fR arg           A directory to use for external facts\.
@@ -49,6 +53,13 @@ If no queries are given, then all facts will be returned\.
 \fB\-y, [ \-\-yaml ]\fR                     Output facts in YAML format\.
 .
 .fi
+.
+.SH "FILES"
+.
+.nf
+\fI/etc/puppetlabs/facter/facter.conf\fR
+.RS
+A HOCON config file that can be used to specify directories for custom and external facts, set various command line options, and specify facts to block. See example below for details, or visit the GitHub README.
 .
 .SH "EXAMPLE"
 Display all facts:
@@ -146,6 +157,40 @@ $ facter \-\-json os.name os.release.major processors.isa
 .
 .IP "" 0
 .
+.P
+An example config file.
+.
+.IP "" 4
+.
+.nf
+
+# always loaded (CLI and as Ruby module)
+global : {
+    external-dir : "~/external/facts",
+    custom-dir   :  [
+       "~/custom/facts",
+       "~/custom/facts/more-facts"
+    ],
+    no-external-facts : false,
+    no-custom-facts   : false,
+    no-ruby           : false
+}
+# loaded when running from the command line
+cli : {
+    debug     : false,
+    trace     : true,
+    verbose   : false,
+    log-level : "info"
+}
+# always loaded, fact-sepcific configuration
+facts : {
+    # for valid blocklist entries, see fact schema
+    blocklist : [ "file system", "EC2" ],
+}
+.
+.fi
+.
+.IP "" 0
 .SH "AUTHOR"
 Luke Kanies
 .


### PR DESCRIPTION
New approach: resolvers are blockable by name, and this mapping is documented in the schema with a `blockgroup` tag. Blocking a fact with this tag will also result in all other facts in that group (associated with that resolver) being blocked. Resolvers implement a method describing whether they are blockable or not. If the schema does not list a block group for a given fact, that fact (or rather its associated resolver) cannot be blocked. Usually this is due to some dependency, i.e. other facts rely on the output of that resolver for their own resolution. 

"Blockability" is currently opt-in: to make a resolver blockable, override the is_blockable method to return true, and add the appropriate blockgroup tag to its associated facts in the schema.

If this approach looks sane, I will more thoroughly investigate which resolvers it makes sense to block, and add the appropriate code.