### PR TITLE
(maint) Add a MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
+  "issues": "https://tickets.puppet.com/browse/FACT",
+  "people": [
+    {
+      "github": "kylog",
+      "email": "kylo@puppet.com",
+      "name": "Kylo Ginsberg"
+    },
+    {
+      "github": "magisus",
+      "email": "maggie@puppet.com",
+      "name": "Maggie Dreyer"
+    },
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "branan",
+      "email": "branan@puppet.com",
+      "name": "Branan Riley"
+    },
+    {
+      "github": "whopper",
+      "email": "whopper@puppet.com",
+      "name": "Will Hopper"
+    },
+    {
+      "github": "peterhuene",
+      "email": "peter.huene@puppet.com",
+      "name": "Peter Huene"
+    }
+  ]
+}


### PR DESCRIPTION
Hi @magisus @MikaelSmith @branan @peterhuene @whopper:

Anticipating some possible questions:

* This PR add a MAINTAINERS file to document who is maintaining this repo. The list of people started with the top 10 PR mergers in the last year, plus a little conversation from Michael and me here https://github.com/puppetlabs/kylo_scratchpad/pull/1/files#r76349647
* If the list seems wrong, let's feel free to edit it.
* I pushed the PR branch to the puppetlabs space (rather than mine) so that all parties can edit collaboratively as needed
* Note that this is a public repo. The email and name fields are optional here. As a starting point, I pre-populated them with the publicly available names/emails available for all of us on github (but took bogus or non-puppet emails as an indication that you may not want to share your puppet.com email). Please feel free to edit your email and name fields for any reason.

Thanks!