### PR TITLE
	(FACT-1356) Allow executable facts to output Yaml/Json 

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/util/scoped_file.cc"
     "src/util/string.cc"
     "src/util/config/config.cc"
+    "src/util/yaml.cc"
 )
 
 # Set the POSIX sources if on a POSIX platform

--- a/lib/inc/internal/util/yaml.hpp
+++ b/lib/inc/internal/util/yaml.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares helper methods for dealing with YAML
+ */
+#pragma once
+
+#include <string>
+
+namespace YAML {
+    class Node;
+}
+
+namespace facter { namespace facts {
+    class collection;
+    struct array_value;
+    struct map_value;
+}}
+
+namespace facter { namespace util { namespace yaml {
+    /**
+     * Adds a YAML value into a Facter collection.
+     */
+    void add_value(std::string const& name, YAML::Node const& node, facts::collection& facts,
+                   facts::array_value* array_parent = nullptr, facts::map_value* map_parent = nullptr);
+}}}

--- a/lib/src/facts/external/execution_resolver.cc
+++ b/lib/src/facts/external/execution_resolver.cc
@@ -37,7 +37,8 @@ namespace facter { namespace facts { namespace external {
                 {
                     execution_options::trim_output,
                     execution_options::merge_environment,
-                    execution_options::throw_on_failure
+                    execution_options::throw_on_failure,
+                    execution_options::convert_newlines
                 });
 
             try {

--- a/lib/src/facts/external/execution_resolver.cc
+++ b/lib/src/facts/external/execution_resolver.cc
@@ -3,15 +3,18 @@
 #include <facter/facts/array_value.hpp>
 #include <facter/facts/map_value.hpp>
 #include <facter/facts/scalar_value.hpp>
+#include <internal/util/yaml.hpp>
 
 #include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/algorithm/string.hpp>
+#include <yaml-cpp/yaml.h>
 
 using namespace std;
 using namespace leatherman::execution;
 using namespace facter::facts;
 using namespace facter::facts::external;
+using namespace facter::util::yaml;
 
 namespace facter { namespace facts { namespace external {
 
@@ -29,38 +32,50 @@ namespace facter { namespace facts { namespace external {
 
         try
         {
-            string error;
-            each_line(
-                path,
-                [&](string const& line) {
-                    auto pos = line.find('=');
-                    if (pos == string::npos) {
-                        LOG_DEBUG("ignoring line in output: {1}", line);
-                        return true;
-                    }
-                    // Add as a string fact
-                    string fact = line.substr(0, pos);
-                    boost::to_lower(fact);
-                    facts.add_external(move(fact), make_value<string_value>(line.substr(pos+1)));
-                    return true;
-                },
-                [&](string const& line) {
-                    if (!error.empty()) {
-                        error += "\n";
-                    }
-                    error += line;
-                    return true;
-                },
-                0,
+            bool resolved = false;
+            auto result = execute(path, 0,
                 {
                     execution_options::trim_output,
                     execution_options::merge_environment,
                     execution_options::throw_on_failure
                 });
 
+            try {
+                auto node = YAML::Load(result.output);
+                for (auto const& kvp : node) {
+                    add_value(kvp.first.as<string>(), kvp.second, facts);
+
+                    // If YAML doesn't correctly parse, it will
+                    // sometimes just return an empty node instead of
+                    // erroring. Only claiming we've resolved if we
+                    // add at least one child value from the YAML
+                    // allows us to still pass on to the keyval
+                    // interpretation in those cases.
+                    resolved = true;
+                }
+            }  catch (YAML::Exception& ex) {
+                LOG_DEBUG("Could not parse executable fact output as YAML ({1})", ex.msg);
+            }
+
+            if (!resolved) {
+                std::vector<string> lines;
+                boost::split(lines, result.output, boost::is_any_of("\n"));
+                for (const auto& line : lines) {
+                    auto pos = line.find('=');
+                    if (pos == string::npos) {
+                        LOG_DEBUG("ignoring line in output: {1}", line);
+                        continue;
+                    }
+                    // Add as a string fact
+                    string fact = line.substr(0, pos);
+                    boost::to_lower(fact);
+                    facts.add_external(move(fact), make_value<string_value>(line.substr(pos+1)));
+                }
+            }
+
             // Log a warning if there is error output from the command
-            if (!error.empty()) {
-                LOG_WARNING("external fact file \"{1}\" had output on stderr: {2}", path, error);
+            if (!result.error.empty()) {
+                LOG_WARNING("external fact file \"{1}\" had output on stderr: {2}", path, result.error);
             }
         }
         catch (execution_exception& ex) {

--- a/lib/src/facts/external/yaml_resolver.cc
+++ b/lib/src/facts/external/yaml_resolver.cc
@@ -1,8 +1,5 @@
 #include <internal/facts/external/yaml_resolver.hpp>
-#include <facter/facts/collection.hpp>
-#include <facter/facts/array_value.hpp>
-#include <facter/facts/map_value.hpp>
-#include <facter/facts/scalar_value.hpp>
+#include <internal/util/yaml.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <leatherman/locale/locale.hpp>
 #include <boost/algorithm/string.hpp>
@@ -15,63 +12,9 @@ using leatherman::locale::_;
 
 using namespace std;
 using namespace YAML;
+using namespace facter::util::yaml;
 
 namespace facter { namespace facts { namespace external {
-
-    static void add_value(
-        string const& name,
-        Node const& node,
-        collection& facts,
-        array_value* array_parent = nullptr,
-        map_value* map_parent = nullptr)
-    {
-        unique_ptr<value> val;
-        // For scalars, code the value into a specific value type
-        if (node.IsScalar()) {
-            bool bool_val;
-            int64_t int_val;
-            double double_val;
-            // If the node tag is "!", it was a quoted scalar and should be treated as a string
-            if (node.Tag() != "!") {
-                if (convert<bool>::decode(node, bool_val)) {
-                    val = make_value<boolean_value>(bool_val);
-                } else if (convert<int64_t>::decode(node, int_val)) {
-                    val = make_value<integer_value>(int_val);
-                } else if (convert<double>::decode(node, double_val)) {
-                    val = make_value<double_value>(double_val);
-                }
-            }
-            if (!val) {
-                val = make_value<string_value>(node.as<string>());
-            }
-        } else if (node.IsSequence()) {
-            // For arrays, convert to a array value
-            auto array = make_value<array_value>();
-            for (auto const& child : node) {
-                add_value({}, child, facts, array.get());
-            }
-            val = move(array);
-        } else if (node.IsMap()) {
-            // For maps, convert to a map value
-            auto map = make_value<map_value>();
-            for (auto const& child : node) {
-                add_value(child.first.as<string>(), child.second, facts, nullptr, map.get());
-            }
-            val = move(map);
-        } else if (!node.IsNull()) {
-            // Ignore nodes we don't understand
-            return;
-        }
-
-        // Put the value in the array, map, or directly as a top-level fact
-        if (array_parent) {
-            array_parent->add(move(val));
-        } else if (map_parent) {
-            map_parent->add(string(name), move(val));
-        } else {
-            facts.add_external(boost::to_lower_copy(name), move(val));
-        }
-    }
 
     bool yaml_resolver::can_resolve(string const& path) const
     {

--- a/lib/src/util/yaml.cc
+++ b/lib/src/util/yaml.cc
@@ -1,0 +1,72 @@
+#include <internal/util/yaml.hpp>
+
+#include <facter/facts/collection.hpp>
+#include <facter/facts/array_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+using namespace std;
+using namespace YAML;
+using namespace facter::facts;
+
+namespace facter { namespace util { namespace yaml {
+
+    void add_value(
+        string const& name,
+        Node const& node,
+        collection& facts,
+        array_value* array_parent,
+        map_value* map_parent)
+    {
+        unique_ptr<value> val;
+        // For scalars, code the value into a specific value type
+        if (node.IsScalar()) {
+            bool bool_val;
+            int64_t int_val;
+            double double_val;
+            // If the node tag is "!", it was a quoted scalar and should be treated as a string
+            if (node.Tag() != "!") {
+                if (convert<bool>::decode(node, bool_val)) {
+                    val = make_value<boolean_value>(bool_val);
+                } else if (convert<int64_t>::decode(node, int_val)) {
+                    val = make_value<integer_value>(int_val);
+                } else if (convert<double>::decode(node, double_val)) {
+                    val = make_value<double_value>(double_val);
+                }
+            }
+            if (!val) {
+                val = make_value<string_value>(node.as<string>());
+            }
+        } else if (node.IsSequence()) {
+            // For arrays, convert to a array value
+            auto array = make_value<array_value>();
+            for (auto const& child : node) {
+                add_value({}, child, facts, array.get());
+            }
+            val = move(array);
+        } else if (node.IsMap()) {
+            // For maps, convert to a map value
+            auto map = make_value<map_value>();
+            for (auto const& child : node) {
+                add_value(child.first.as<string>(), child.second, facts, nullptr, map.get());
+            }
+            val = move(map);
+        } else if (!node.IsNull()) {
+            // Ignore nodes we don't understand
+            return;
+        }
+
+        // Put the value in the array, map, or directly as a top-level fact
+        if (array_parent) {
+            array_parent->add(move(val));
+        } else if (map_parent) {
+            map_parent->add(string(name), move(val));
+        } else {
+            facts.add_external(boost::to_lower_copy(name), move(val));
+        }
+    }
+}}}
+

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -445,6 +445,11 @@ msgstr ""
 
 #. debug
 #: lib/src/facts/external/execution_resolver.cc
+msgid "Could not parse executable fact output as YAML ({1})"
+msgstr ""
+
+#. debug
+#: lib/src/facts/external/execution_resolver.cc
 #: lib/src/facts/external/text_resolver.cc
 #: lib/src/facts/external/windows/powershell_resolver.cc
 msgid "ignoring line in output: {1}"
@@ -1282,12 +1287,21 @@ msgstr ""
 
 #. debug
 #: lib/src/ruby/module.cc
+msgid "loading custom fact directories from config file"
+msgstr ""
+
+#. debug
+#: lib/src/ruby/module.cc
 msgid "searching for custom facts in {1}."
 msgstr ""
 
 #. error
 #: lib/src/ruby/module.cc
 msgid "{1} uncaught exception: {2}"
+msgstr ""
+
+#: lib/src/ruby/module.cc
+msgid "loading external fact directories from config file"
 msgstr ""
 
 #: lib/src/ruby/module.cc


### PR DESCRIPTION
Previously, executable facts could only return simple key/value pairs. This code now attempts to parse executable output as Yaml, and only falls back to the key/value parsing if we do not get a useful result. Because Yaml is a superset of Json, we do not have to separately try to parse Json output.

This also moves the helper code for converting a Yaml object into facts into a new shared location where both the flat-file yaml resolver and the executable resolver can share it.