### PR TITLE
(FACT-348) Allow fact caching

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -33,6 +33,20 @@ module Facter
         end
       end
 
+      # Retrieve the path of the standard cached facts directory.
+      #
+      def get_cached_facts_dir(platform, version)
+        if platform =~ /windows/
+          if version < 6.0
+            File.join('C:', 'Documents and Settings', 'All Users', 'Application Data', 'PuppetLabs', 'facter', 'cache', 'cached_facts')
+          else
+            File.join('C:', 'ProgramData', 'PuppetLabs', 'facter', 'cache', 'cached_facts')
+          end
+        else
+          File.join('/', 'opt', 'puppetlabs', 'facter', 'cache', 'cached_facts')
+        end
+      end
+
       # Retrieve the extension to use for an external fact script.
       # Windows uses '.bat' and everything else uses '.sh'
       def get_external_fact_script_extension(platform)

--- a/acceptance/tests/options/config_file/ttls.rb
+++ b/acceptance/tests/options/config_file/ttls.rb
@@ -1,0 +1,164 @@
+# This test is intended to demonstrate that setting a ttl on a resolver set
+# caches the fact information for later facter invocations.  This test also
+# covers various failures in the caching mechanism
+test_name "ttls config field stores and retreives cached facts" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  config = <<EOM
+facts : {
+    ttls : [
+        { "uptime" : 30 days }
+    ]
+}
+EOM
+
+  # This fact must be resolvable on ALL platforms
+  # Do NOT use the 'kernel' fact as it is used to configure the tests
+  cached_factname = 'uptime'
+  cached_fact_content = <<EOM
+{
+  "uptime": "cachedfact"
+}
+EOM
+  empty_cached_fact_content = <<EOM
+{ }
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create config file" do
+      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_file = File.join(config_dir, "facter.conf")
+      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+      cached_fact_file = File.join(cached_facts_dir, cached_factname)
+
+      # Setup facter conf
+      on(agent, "mkdir -p '#{config_dir}'")
+      create_remote_file(agent, config_file, config)
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+      end
+
+      step "should create a JSON file for a fact that is to be cached" do
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter("--debug")) do
+          assert_match(/caching values for .+ facts/, stderr, "Expected debug message to state that values will be cached")
+
+          on(agent,"cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do
+            assert_match(/#{cached_factname}/, stdout, "Expected cached fact file to contain fact information")
+          end
+        end
+      end
+
+      step "should read from a cached JSON file for a fact that has been cached" do
+        # Setup a known cached fact
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, cached_fact_content)
+
+        on(agent, facter("#{cached_factname} --debug")) do
+          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/cachedfact/, stdout, "Expected fact to match the cached fact file")
+        end
+      end
+
+      step "should return an empty string for an empty JSON document" do
+        # Setup a known cached fact
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, empty_cached_fact_content)
+
+        on(agent, facter("#{cached_factname}")) do
+          assert(stdout.chomp == '', "Expected fact to be empty")
+        end
+      end
+
+      step "should not read from a cached JSON file for a fact that has been cached but TTL expired" do
+        # Setup a known cached fact
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, cached_fact_content)
+        # Change the modified date to sometime in the far distant past
+        on(agent, "touch -mt 198001010000 '#{cached_fact_file}'")
+
+        on(agent, facter("#{cached_factname}")) do
+          assert_not_match(/cachedfact/, stdout, "Expected fact to not match the cached fact file")
+        end
+      end
+
+      step "should refresh an expired cached fact" do
+        # Setup a known cached fact
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, cached_fact_content)
+        # Change the modified date to sometime in the far distant past
+        on(agent, "touch -mt 198001010000 '#{cached_fact_file}'")
+        # Force facter to recache
+        on(agent, facter("#{cached_factname}"))
+
+        # Read cached fact file content
+        on(agent,"cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do
+          assert(cached_fact_content != stdout, "Expected cached fact file to be refreshed")
+        end
+      end
+
+      step "should refresh a cached fact if cache file is corrupt" do
+        # Setup a known cached fact
+        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, facter(""))
+        # Corrupt the cached fact file
+        create_remote_file(agent, cached_fact_file, 'ThisIsNotvalidJSON')
+
+        on(agent, facter("#{cached_factname}")) do
+          assert_match(/.+/, stdout, "Expected fact to be resolved")
+        end
+
+        # Expect the fact file to exist
+        on(agent,"cat #{cached_fact_file}", :acceptable_exit_codes => [0])
+      end
+
+      # When calling Facter from Puppet
+      step "when Facter is called from Puppet" do
+        facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+        facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+
+        teardown do
+          on(agent, "rm -rf '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0,1])
+        end
+
+        step "Create default facter.conf file" do
+          # create the directories
+          on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+          create_remote_file(agent, facter_conf_default_path, config)
+        end
+
+        step "should create a JSON file for a fact that is to be cached" do
+          on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+          on(agent, puppet("facts --debug")) do
+            assert_match(/caching values for .+ facts/, stdout, "Expected debug message to state that values will be cached")
+
+            on(agent,"cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do
+              assert_match(/#{cached_factname}/, stdout, "Expected cached fact file to contain fact information")
+            end
+          end
+        end
+
+        step "should read from a cached JSON file for a fact that has been cached" do
+          # Setup a known cached fact
+          on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+          on(agent, puppet("facts"))
+          create_remote_file(agent, cached_fact_file, cached_fact_content)
+
+          on(agent, puppet("facts --debug")) do
+            assert_match(/loading cached values for .+ facts/, stdout, "Expected debug message to state that values are read from cache")
+            assert_match(/cachedfact/, stdout, "Expected fact to match the cached fact file")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/acceptance/tests/options/list_cache_groups.rb
+++ b/acceptance/tests/options/list_cache_groups.rb
@@ -1,0 +1,13 @@
+# This tests is intended to verify that passing the `--list-cache-groups` flag
+# will cause the names of cacheable resolvers to be printed to stdout.
+test_name "the `--list-cache-groups` command line flag prints available cache groups to stdout" do
+
+  agents.each do |agent|
+    step "the various cache groups should be listed" do
+      on(agent, facter("--list-cache-groups")) do
+         assert_match(/EC2/, stdout, "EC2 facts should be listed as cacheable")
+         assert_match(/kernel/, stdout, "kernel facts should be listed as cacheable")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_cache.rb
+++ b/acceptance/tests/options/no_cache.rb
@@ -1,0 +1,79 @@
+# This test is intended to verify that the `--no-cache` command line flag will
+# cause the cache to be ignored. During a run with this flag, the cache will neither
+# be queried nor refreshed.
+test_name "--no-cache command-line option causes the fact cache to be ignored" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  # the uptime fact should be resolvable on ALL systems
+  # Note: do NOT use the kernel fact, as it is used to configure the tests
+  cached_fact_name = "uptime"
+  bad_cached_content = '{ "uptime": "fake uptime" }'
+
+  config = <<-FILE
+  cli : { debug : true }
+  facts : { ttls : [ { "uptime" : 30 minutes } ] }
+  FILE
+
+  agents.each do |agent|
+    kernel_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    config_dir = get_default_fact_dir(agent['platform'], kernel_version)
+    config_file = File.join(config_dir, "facter.conf")
+
+    cached_facts_dir = get_cached_facts_dir(agent['platform'], kernel_version)
+    cached_fact_dir = File.join(cached_facts_dir, cached_fact_name)
+    cached_fact_file = File.join(cached_fact_dir, cached_fact_name)
+
+    teardown do
+      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+    end
+
+    step "Agent #{agent}: create config file in default location" do
+      on(agent, "mkdir -p '#{config_dir}'")
+      create_remote_file(agent, config_file, config)
+    end
+
+    step "facter should not cache facts when --no-cache is specified" do
+      on(agent, facter("--no-cache")) do
+        assert_no_match(/caching/, stderr, "facter should not have tried to cache any facts")
+      end
+    end
+
+    step "facter should not load facts from the cache when --no-cache is specified" do
+      # clear the fact cache
+      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+
+      # run once to cache the uptime fact
+      on(agent, facter(""))
+      # override cached content
+      create_remote_file(agent, cached_fact_file, bad_cached_content)
+
+      on(agent, facter("--no-cache #{cached_fact_name}")) do
+        assert_no_match(/loading cached values for .+ fact/, stderr, "facter should not have tried to load any cached facts")
+        assert_no_match(/#{bad_cached_content}/, stdout, "facter should not have loaded the cached value")
+      end
+    end
+
+    step "facter should not refresh an expired cache when --no-cache is specified" do
+      # clear the fact cache
+      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0,1])
+
+      # run once to cache the uptime fact
+      on(agent, facter(""))
+
+      # override cached content
+      create_remote_file(agent, cached_fact_file, bad_cached_content)
+      # update the modify time on the new cached fact to prompt a refresh
+      on(agent, "touch -mt 0301010000 '#{cached_fact_file}'")
+
+      on(agent, facter("--no-cache")) do
+        assert_no_match(/caching/, stderr, "facter should not have tried to refresh the cache")
+      end
+
+      on(agent, "cat '#{cached_fact_file}'", :acceptable_exit_codes => [0]) do
+        assert_match(/#{bad_cached_content}/, stdout, "facter should not have updated the cached value")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_cache.rb
+++ b/acceptance/tests/options/no_cache.rb
@@ -21,8 +21,7 @@ test_name "--no-cache command-line option causes the fact cache to be ignored" d
     config_file = File.join(config_dir, "facter.conf")
 
     cached_facts_dir = get_cached_facts_dir(agent['platform'], kernel_version)
-    cached_fact_dir = File.join(cached_facts_dir, cached_fact_name)
-    cached_fact_file = File.join(cached_fact_dir, cached_fact_name)
+    cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
     teardown do
       on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -128,6 +128,7 @@ int main(int argc, char **argv)
 
         vector<string> external_directories;
         vector<string> custom_directories;
+        unordered_map<string, int64_t> ttls;
 
         // Build a list of options visible on the command line
         // Keep this list sorted alphabetically
@@ -190,7 +191,9 @@ int main(int argc, char **argv)
                 load_global_settings(hocon_conf, vm);
                 load_cli_settings(hocon_conf, vm);
                 load_fact_settings(hocon_conf, vm);
+                ttls = load_ttls(hocon_conf);
             }
+
 
             // Check for a help option first before notifying
             if (vm.count("help")) {
@@ -294,7 +297,7 @@ int main(int argc, char **argv)
             auto facts_to_block = vm["blocklist"].as<vector<string>>();
             blocklist.insert(facts_to_block.begin(), facts_to_block.end());
         }
-        collection facts(blocklist);
+        collection facts(blocklist, ttls);
         facts.add_default_facts(ruby);
 
         // Add the environment facts

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -148,6 +148,7 @@ int main(int argc, char **argv)
             ("help,h", _("Print this help message.").c_str())
             ("json,j", _("Output in JSON format.").c_str())
             ("show-legacy", _("Show legacy facts when querying all facts.").c_str())
+            ("list-cache-groups", _("List the name of each cacheable group of facts").c_str())
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
             ("no-cache", _("Disable loading and refreshing facts from the cache").c_str())
             ("no-color", _("Disables color output.").c_str())
@@ -237,6 +238,17 @@ int main(int argc, char **argv)
             colorize(boost::nowide::cerr);
             help(visible_options);
             return EXIT_FAILURE;
+        }
+
+        // Check for listing fact groups
+        if (vm.count("list-cache-groups")) {
+            collection facts;
+            facts.add_default_facts(!vm.count("no-ruby"));
+            vector<string> fact_groups = facts.get_fact_groups();
+            for (auto group : fact_groups) {
+                boost::nowide::cout << group << endl;
+            }
+            return EXIT_SUCCESS;
         }
 
         // Check for printing the version

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -149,6 +149,7 @@ int main(int argc, char **argv)
             ("json,j", _("Output in JSON format.").c_str())
             ("show-legacy", _("Show legacy facts when querying all facts.").c_str())
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
+            ("no-cache", _("Disable loading and refreshing facts from the cache").c_str())
             ("no-color", _("Disables color output.").c_str())
             ("no-custom-facts", po::bool_switch()->default_value(false), _("Disables custom facts.").c_str())
             ("no-external-facts", po::bool_switch()->default_value(false), _("Disables external facts.").c_str())
@@ -191,9 +192,10 @@ int main(int argc, char **argv)
                 load_global_settings(hocon_conf, vm);
                 load_cli_settings(hocon_conf, vm);
                 load_fact_settings(hocon_conf, vm);
-                ttls = load_ttls(hocon_conf);
+                if (!vm.count("no-cache")) {
+                    ttls = load_ttls(hocon_conf);
+                }
             }
-
 
             // Check for a help option first before notifying
             if (vm.count("help")) {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,6 +59,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/facts/resolvers/zpool_resolver.cc"
     "src/facts/resolvers/zone_resolver.cc"
     "src/facts/resolvers/zfs_resolver.cc"
+    "src/facts/cache.cc"
     "src/facts/scalar_value.cc"
     "src/logging/logging.cc"
     "src/ruby/aggregate_resolution.cc"
@@ -87,6 +88,7 @@ if (UNIX)
         "src/facts/posix/timezone_resolver.cc"
         "src/facts/posix/uptime_resolver.cc"
         "src/facts/posix/xen_resolver.cc"
+        "src/facts/posix/cache.cc"
         "src/util/posix/scoped_addrinfo.cc"
         "src/util/posix/scoped_descriptor.cc"
         "src/util/config/posix/config.cc"
@@ -227,6 +229,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         "src/facts/windows/timezone_resolver.cc"
         "src/facts/windows/uptime_resolver.cc"
         "src/facts/windows/virtualization_resolver.cc"
+        "src/facts/windows/cache.cc"
         "src/util/config/windows/config.cc"
     )
 

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -41,6 +41,31 @@ namespace facter { namespace facts {
     };
 
     /**
+     * Stream adapter for using with rapidjson
+     */
+    namespace {
+        struct stream_adapter
+        {
+            explicit stream_adapter(std::ostream& stream) : _stream(stream)
+            {
+            }
+
+            void Put(char c)
+            {
+                _stream << c;
+            }
+
+            void Flush()
+            {
+                _stream.flush();
+            }
+
+         private:
+            std::ostream& _stream;
+        };
+    }
+
+    /**
      * Represents the fact collection.
      * The fact collection is responsible for resolving and storing facts.
      */

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -40,21 +40,32 @@ namespace facter { namespace facts {
         yaml
     };
 
-    /**
-     * Stream adapter for using with rapidjson
-     */
     namespace {
+        /**
+         * Stream adapter for using with rapidjson
+         */
         struct stream_adapter
         {
+            /**
+             * Constructs an adapter for use with rapidjson around the given stream.
+             * @param stream an output stream to which JSON will be written
+             */
             explicit stream_adapter(std::ostream& stream) : _stream(stream)
             {
             }
 
+            /**
+             * Adds a character to the stream.
+             * @param c the char to add
+             */
             void Put(char c)
             {
                 _stream << c;
             }
 
+            /**
+             * Flushes the stream.
+             */
             void Flush()
             {
                 _stream.flush();

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -274,6 +274,14 @@ namespace facter { namespace facts {
          */
         void resolve_facts();
 
+        /**
+         * Returns the names of all the resolvers currently in the collection.
+         * These names correspond to groups of facts, and are used to block
+         * collection of those facts or to allow caching them.
+         * @return a list of fact group names
+         */
+        std::vector<std::string> get_fact_groups();
+
      protected:
         /**
          *  Gets external fact directories for the current platform.

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -11,6 +11,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <memory>
@@ -53,8 +54,11 @@ namespace facter { namespace facts {
         /**
          * Constructs a fact collection.
          * @param blocklist the names of resolvers that should not be resolved
+         * @param ttls a map of resolver names to cache intervals (times-to-live)
+         *        for the facts they resolve
          */
-        collection(std::set<std::string> const& blocklist = std::set<std::string>());
+        collection(std::set<std::string> const& blocklist = std::set<std::string>(),
+                   std::unordered_map<std::string, int64_t> const& ttls = {});
 
         /**
          * Destructor for fact collection.
@@ -263,6 +267,7 @@ namespace facter { namespace facts {
         LIBFACTER_NO_EXPORT void add_common_facts(bool include_ruby_facts);
         LIBFACTER_NO_EXPORT bool add_external_facts_dir(std::vector<std::unique_ptr<external::resolver>> const& resolvers, std::string const& directory, bool warn);
         LIBFACTER_NO_EXPORT bool try_block(std::shared_ptr<resolver> const& res);
+        LIBFACTER_NO_EXPORT void resolve(std::shared_ptr<resolver> const& res);
 
         // Platform specific members
         LIBFACTER_NO_EXPORT void add_platform_facts();
@@ -273,6 +278,7 @@ namespace facter { namespace facts {
         std::multimap<std::string, std::shared_ptr<resolver>> _resolver_map;
         std::list<std::shared_ptr<resolver>> _pattern_resolvers;
         std::set<std::string> _blocklist;
+        std::unordered_map<std::string, int64_t> _ttls;
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/facter/util/config.hpp
+++ b/lib/inc/facter/util/config.hpp
@@ -67,4 +67,18 @@ namespace facter { namespace util { namespace config {
      * @return names, values, and descriptions of fact blocking config options
      */
     LIBFACTER_EXPORT boost::program_options::options_description fact_config_options();
+
+    /**
+     * Returns a map of resolver names and durations (in milliseconds). The listed resolvers will
+     * have their output cached, then re-resolved no more frequently than the given interval.
+     * @param hocon_config the config object representing the parsed config file
+     * @return a map of resolvers to time-to-live durations (in milliseconds)
+     */
+    LIBFACTER_EXPORT std::unordered_map<std::string, int64_t> load_ttls(hocon::shared_config hocon_config);
+
+    /**
+     * Returns the directory of the fact cache.
+     * @return the absolute path to the fact cache
+     */
+    LIBFACTER_EXPORT std::string fact_cache_location();
 }}}  // namespace facter::util::config

--- a/lib/inc/internal/facts/cache.hpp
+++ b/lib/inc/internal/facts/cache.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <facter/facts/collection.hpp>
+
+#include <boost/filesystem.hpp>
+
+namespace facter { namespace facts { namespace cache {
+
+    /**
+     * Adds the cached value to the collection if it both exists and
+     * has not expired. Otherwise, resolves the value afresh and caches it.
+     * @param facts the collection of facts to which to add
+     * @param res the resolver that should be cached
+     * @param ttl the duration in seconds for which the cahced value is considered valid
+     */
+    void use_cache(collection& facts, std::shared_ptr<resolver> res, int64_t ttl);
+
+    /**
+     * Checks the given directory for cached facts of the given names.
+     * Each fact found is added to the collection.
+     * @param cache_dir the subdirectory of the cache where the give facts should be found
+     * @param cached_facts the names of the facts to search for
+     * @param facts to collection of facts to which to add
+     */
+    void load_facts_from_cache(boost::filesystem::path const& cache_dir, std::vector<std::string> const& cached_facts, collection& facts);
+
+    /**
+     * Resolve facts from the given resolver and write them out to the cache, one fact per file.
+     * @param res the resolver that should be cached
+     * @param cache_dir the path to the top-level cache directory
+     * @param facts the collection of facts to which to add
+     */
+    void refresh_cache(std::shared_ptr<resolver> res, boost::filesystem::path const& cache_dir, collection& facts);
+
+    /**
+     * Returns the location of the fact cache directory.
+     * @return the absolute path to the cache directory
+     */
+    std::string fact_cache_location();
+
+    /**
+     * Returns true if the cache has not expired, false otherwise.
+     * @param cache_dir the absolute path to the cache directory to be verified
+     * @param ttl a duration in seconds representing the time to live for the cache
+     * @return true if cache is expired, false otherwise
+     */
+    bool cache_is_valid(boost::filesystem::path const& cache_dir, int64_t ttl);
+
+    /**
+     * Creates a cache file for the given fact in json format.
+     * @param file_path the absolute path to the cache file
+     * @param fact_name the name of the fact to cache
+     */
+    void write_json_cache_file(collection& facts, boost::filesystem::path const& file_path, std::string const& fact_name);
+
+    /**
+     * Returns the timespan in seconds since the file was last modified.
+     * @param file_path the absolute path to the file
+     * @return the timespan in seconds since last modification
+     */
+    int64_t get_file_lifetime(boost::filesystem::path file_path);
+}}}  // namespace facter::facts::cache

--- a/lib/inc/internal/facts/cache.hpp
+++ b/lib/inc/internal/facts/cache.hpp
@@ -18,19 +18,19 @@ namespace facter { namespace facts { namespace cache {
     /**
      * Checks the given directory for cached facts of the given names.
      * Each fact found is added to the collection.
-     * @param cache_dir the subdirectory of the cache where the give facts should be found
+     * @param cache_file the JSON cache file associated with this resolver
      * @param cached_facts the names of the facts to search for
      * @param facts to collection of facts to which to add
      */
-    void load_facts_from_cache(boost::filesystem::path const& cache_dir, std::shared_ptr<resolver> res, collection& facts);
+    void load_facts_from_cache(boost::filesystem::path const& cache_file, std::shared_ptr<resolver> res, collection& facts);
 
     /**
-     * Resolve facts from the given resolver and write them out to the cache, one fact per file.
+     * Resolve facts from the given resolver and write them out to the cache, one file per resolver.
      * @param res the resolver that should be cached
-     * @param cache_dir the path to the top-level cache directory
+     * @param cache_file the path to the JSON cache file for this resolver
      * @param facts the collection of facts to which to add
      */
-    void refresh_cache(std::shared_ptr<resolver> res, boost::filesystem::path const& cache_dir, collection& facts);
+    void refresh_cache(std::shared_ptr<resolver> res, boost::filesystem::path const& cache_file, collection& facts);
 
     /**
      * Returns the location of the fact cache directory.
@@ -40,22 +40,22 @@ namespace facter { namespace facts { namespace cache {
 
     /**
      * Returns true if the cache has not expired, false otherwise.
-     * @param cache_dir the absolute path to the cache directory to be verified
+     * @param cache_file the path to the cache file to be verified
      * @param ttl a duration in seconds representing the time to live for the cache
      * @return true if cache is expired, false otherwise
      */
-    bool cache_is_valid(boost::filesystem::path const& cache_dir, int64_t ttl);
+    bool cache_is_valid(boost::filesystem::path const& cache_file, int64_t ttl);
 
     /**
-     * Creates a cache file for the given fact in json format.
-     * @param file_path the absolute path to the cache file
+     * Creates a cache file for the given fact in JSON format.
+     * @param file_path the path to the cache file
      * @param fact_name the name of the fact to cache
      */
-    void write_json_cache_file(collection& facts, boost::filesystem::path const& file_path, std::string const& fact_name);
+    void write_json_cache_file(collection& facts, boost::filesystem::path const& file_path, std::vector<std::string> const& fact_names);
 
     /**
      * Returns the timespan in seconds since the file was last modified.
-     * @param file_path the absolute path to the file
+     * @param file_path the path to the file
      * @return the timespan in seconds since last modification
      */
     int64_t get_file_lifetime(boost::filesystem::path file_path);

--- a/lib/inc/internal/facts/cache.hpp
+++ b/lib/inc/internal/facts/cache.hpp
@@ -22,7 +22,7 @@ namespace facter { namespace facts { namespace cache {
      * @param cached_facts the names of the facts to search for
      * @param facts to collection of facts to which to add
      */
-    void load_facts_from_cache(boost::filesystem::path const& cache_dir, std::vector<std::string> const& cached_facts, collection& facts);
+    void load_facts_from_cache(boost::filesystem::path const& cache_dir, std::shared_ptr<resolver> res, collection& facts);
 
     /**
      * Resolve facts from the given resolver and write them out to the cache, one fact per file.

--- a/lib/src/facts/cache.cc
+++ b/lib/src/facts/cache.cc
@@ -1,0 +1,109 @@
+#include <internal/facts/cache.hpp>
+#include <internal/facts/external/json_resolver.hpp>
+
+#include <rapidjson/document.h>
+#include <rapidjson/prettywriter.h>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/file_util/directory.hpp>
+#include <leatherman/file_util/file.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <time.h>
+
+using namespace std;
+using namespace rapidjson;
+using namespace facter::facts::external;
+namespace boost_file = boost::filesystem;
+
+namespace facter { namespace facts { namespace cache {
+
+    bool cache_is_valid(boost_file::path const& cache_dir, int64_t ttl) {
+        time_t last_mod = boost_file::last_write_time(cache_dir);
+        time_t now;
+        double lifetime_seconds = difftime(time(&now), last_mod);
+        return static_cast<int64_t>(lifetime_seconds) < ttl;
+    }
+
+    void load_facts_from_cache(boost_file::path const& cache_dir, vector<string> const& cached_facts, collection& facts) {
+        for (auto name : cached_facts) {
+            string cached_fact_file = (cache_dir / name).string();
+            if (leatherman::file_util::file_readable(cached_fact_file)) {
+                json_resolver json_res;
+                json_res.resolve(cached_fact_file, facts);
+            } else {
+                LOG_DEBUG("no {1} fact cached", name);
+            }
+        }
+    }
+
+    void refresh_cache(shared_ptr<resolver> res, boost_file::path const& cache_dir, collection& facts) {
+        res->resolve(facts);
+        boost_file::remove_all(cache_dir);
+        boost_file::create_directories(cache_dir);
+        for (auto name : res->names()) {
+            boost_file::path fact_path = cache_dir / name;
+            write_json_cache_file(facts, fact_path.string(), name);
+        }
+    }
+
+    void use_cache(collection& facts, shared_ptr<resolver> res, int64_t ttl) {
+        boost_file::path cache_dir = boost_file::path(fact_cache_location() + res->name());
+        if (boost_file::is_directory(cache_dir) && cache_is_valid(cache_dir, ttl)) {
+            LOG_DEBUG("loading cached values for {1} facts", res->name());
+            load_facts_from_cache(cache_dir, res->names(), facts);
+        } else {
+            LOG_DEBUG("caching values for {1} facts", res->name());
+            refresh_cache(res, cache_dir, facts);
+        }
+    }
+
+    struct stream_adapter
+    {
+        explicit stream_adapter(boost::nowide::ofstream& stream) : _stream(stream)
+        {
+        }
+
+        void Put(char c)
+        {
+            _stream << c;
+        }
+
+        void Flush()
+        {
+            _stream.flush();
+        }
+
+     private:
+        boost::nowide::ofstream& _stream;
+    };
+
+
+    void write_json_cache_file(collection& facts, boost_file::path const& file_path, string const& fact_name)
+    {
+        json_document document;
+        document.SetObject();
+
+        auto builder = ([&](string const& key, value const* val) {
+            json_value value;
+            if (val) {
+                val->to_json(document.GetAllocator(), value);
+            } else {
+                value.SetString("", 0);
+            }
+            document.AddMember(StringRef(key.c_str(), key.size()), value, document.GetAllocator());
+        });
+
+        auto fact_value = facts.get_resolved(fact_name);
+        if (!fact_value) {
+            return;
+        }
+        builder(fact_name, fact_value);
+
+        string file_path_string = file_path.string();
+        boost::nowide::ofstream stream(file_path_string);
+        stream_adapter adapter(stream);
+        PrettyWriter<stream_adapter> writer(adapter);
+        writer.SetIndent(' ', 2);
+        document.Accept(writer);
+    }
+
+}}}  // namespace facter::facts::cache

--- a/lib/src/facts/cache.cc
+++ b/lib/src/facts/cache.cc
@@ -16,51 +16,49 @@ namespace boost_file = boost::filesystem;
 
 namespace facter { namespace facts { namespace cache {
 
-    bool cache_is_valid(boost_file::path const& cache_dir, int64_t ttl) {
-        time_t last_mod = boost_file::last_write_time(cache_dir);
+    bool cache_is_valid(boost_file::path const& cache_file, int64_t ttl) {
+        time_t last_mod = boost_file::last_write_time(cache_file);
         time_t now;
         double lifetime_seconds = difftime(time(&now), last_mod);
         return static_cast<int64_t>(lifetime_seconds) < ttl;
     }
 
-    void load_facts_from_cache(boost_file::path const& cache_dir, shared_ptr<resolver> res, collection& facts) {
-        for (auto name : res->names()) {
-            string cached_fact_file = (cache_dir / name).string();
-            if (leatherman::file_util::file_readable(cached_fact_file)) {
-                try {
-                    json_resolver json_res;
-                    json_res.resolve(cached_fact_file, facts);
-                } catch (external_fact_exception& ex) {
-                    LOG_DEBUG("cache for {1} facts contained invalid JSON files, refreshing", res->name());
-                    refresh_cache(res, cache_dir, facts);
-                    return;
-                }
-            } else {
-                LOG_DEBUG("cache for {1} facts was missing files, refreshing", res->name());
-                refresh_cache(res, cache_dir, facts);
+    void load_facts_from_cache(boost_file::path const& cache_file, shared_ptr<resolver> res, collection& facts) {
+        string cache_file_path = cache_file.string();
+        if (leatherman::file_util::file_readable(cache_file_path)) {
+            try {
+                json_resolver json_res;
+                json_res.resolve(cache_file_path, facts);
+            } catch (external_fact_exception& ex) {
+                LOG_DEBUG("cache file for {1} facts contained invalid JSON, refreshing", res->name());
+                refresh_cache(res, cache_file, facts);
                 return;
             }
+        } else {
+            LOG_DEBUG("cache file for {1} facts was missing, refreshing", res->name());
+            refresh_cache(res, cache_file, facts);
+            return;
         }
     }
 
-    void refresh_cache(shared_ptr<resolver> res, boost_file::path const& cache_dir, collection& facts) {
+    void refresh_cache(shared_ptr<resolver> res, boost_file::path const& cache_file, collection& facts) {
         res->resolve(facts);
-        boost_file::remove_all(cache_dir);
-        boost_file::create_directories(cache_dir);
-        for (auto name : res->names()) {
-            boost_file::path fact_path = cache_dir / name;
-            write_json_cache_file(facts, fact_path.string(), name);
-        }
+        boost_file::remove(cache_file);
+        write_json_cache_file(facts, cache_file.string(), res->names());
     }
 
     void use_cache(collection& facts, shared_ptr<resolver> res, int64_t ttl) {
-        boost_file::path cache_dir = boost_file::path(fact_cache_location() + res->name());
-        if (boost_file::is_directory(cache_dir) && cache_is_valid(cache_dir, ttl)) {
+        boost_file::path cache_dir = boost_file::path(fact_cache_location());
+        if (!boost_file::is_directory(cache_dir)) {
+            boost_file::create_directories(cache_dir);
+        }
+        boost_file::path cache_file = cache_dir / res->name();
+        if (leatherman::file_util::file_readable(cache_file.string()) && cache_is_valid(cache_file, ttl)) {
             LOG_DEBUG("loading cached values for {1} facts", res->name());
-            load_facts_from_cache(cache_dir, res, facts);
+            load_facts_from_cache(cache_file, res, facts);
         } else {
             LOG_DEBUG("caching values for {1} facts", res->name());
-            refresh_cache(res, cache_dir, facts);
+            refresh_cache(res, cache_file, facts);
         }
     }
 
@@ -79,9 +77,11 @@ namespace facter { namespace facts { namespace cache {
             document.AddMember(StringRef(key.c_str(), key.size()), value, document.GetAllocator());
         });
 
-        auto fact_value = facts.get_resolved(fact_name);
-        if (fact_value) {
-            builder(fact_name, fact_value);
+        for (auto const& name : fact_names) {
+            auto fact_value = facts.get_resolved(name);
+            if (fact_value) {
+                builder(name, fact_value);
+            }
         }
 
         string file_path_string = file_path.string();

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -273,6 +273,14 @@ namespace facter { namespace facts {
         return _facts.size();
     }
 
+    vector<string> collection::get_fact_groups() {
+        vector<string> fact_groups;
+        for (auto res : _resolvers) {
+            fact_groups.push_back(res->name());
+        }
+        return fact_groups;
+    }
+
     value const* collection::operator[](string const& name)
     {
         return get_value(name);

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -526,26 +526,6 @@ namespace facter { namespace facts {
         }
     }
 
-    struct stream_adapter
-    {
-        explicit stream_adapter(ostream& stream) : _stream(stream)
-        {
-        }
-
-        void Put(char c)
-        {
-            _stream << c;
-        }
-
-        void Flush()
-        {
-            _stream.flush();
-        }
-
-     private:
-         ostream& _stream;
-    };
-
     void collection::write_json(ostream& stream, set<string> const& queries, bool show_legacy, bool strict_errors)
     {
         json_document document;

--- a/lib/src/facts/posix/cache.cc
+++ b/lib/src/facts/posix/cache.cc
@@ -1,0 +1,9 @@
+#include <internal/facts/cache.hpp>
+
+namespace facter { namespace facts { namespace cache {
+
+    std::string fact_cache_location() {
+        return "/opt/puppetlabs/facter/cache/cached_facts/";
+    }
+
+}}}  // namespace facter::facts::cache

--- a/lib/src/facts/windows/cache.cc
+++ b/lib/src/facts/windows/cache.cc
@@ -1,0 +1,11 @@
+#include <internal/facts/cache.hpp>
+#include <leatherman/windows/file_util.hpp>
+
+namespace facter { namespace facts { namespace cache {
+
+    std::string fact_cache_location() {
+        return leatherman::windows::file_util::get_programdata_dir() +
+            "\\PuppetLabs\\facter\\cache\\cached_facts\\";
+    }
+
+}}}  // namespace facter::facts::cache

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -50,13 +50,15 @@ namespace facter { namespace ruby {
         {
             // Create a collection and a facter module
             boost::program_options::variables_map vm;
-            load_fact_settings(load_default_config_file(), vm);
+            auto hocon_conf = load_default_config_file();
+            load_fact_settings(hocon_conf, vm);
             set<string> blocklist;
             if (vm.count("blocklist")) {
                 auto facts_to_block = vm["blocklist"].as<vector<string>>();
                 blocklist.insert(facts_to_block.begin(), facts_to_block.end());
             }
-            _facts.reset(new collection(blocklist));
+            auto ttls = load_ttls(hocon_conf);
+            _facts.reset(new collection(blocklist, ttls));
             _module.reset(new module(*_facts));
 
             // Ruby doesn't have a proper way of notifying extensions that the VM is shutting down

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -64,4 +64,18 @@ namespace facter { namespace util { namespace config {
             ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
         return fact_settings;
     }
+
+    unordered_map<string, int64_t> load_ttls(shared_config hocon_config) {
+        unordered_map<string, int64_t> ttls;
+        if (hocon_config && hocon_config->has_path("facts.ttls")) {
+            auto ttl_objs = hocon_config->get_object_list("facts.ttls");
+            for (auto entry : ttl_objs) {
+                string fact = entry->key_set().front();
+                shared_config entry_conf = entry->to_config();
+                int64_t duration = entry_conf->get_duration(fact, time_unit::SECONDS);
+                ttls.insert({ fact, duration });
+            }
+        }
+        return ttls;
+    }
 }}}  // namespace facter::util::config;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "facts/resolvers/zone_resolver.cc"
     "facts/resolvers/zpool_resolver.cc"
     "facts/schema.cc"
+    "facts/cache.cc"
     "facts/string_value.cc"
     "logging/logging.cc"
     "log_capture.cc"

--- a/lib/tests/collection_fixture.cc
+++ b/lib/tests/collection_fixture.cc
@@ -4,7 +4,8 @@ namespace facter { namespace testing {
 
     using namespace std;
 
-    collection_fixture::collection_fixture(set<string> const& blocklist) : collection(blocklist) { }
+    collection_fixture::collection_fixture(set<string> const& blocklist,
+            unordered_map<string, int64_t> const& ttls) : collection(blocklist, ttls) { }
 
     vector<string> collection_fixture::get_external_fact_directories() const
     {

--- a/lib/tests/collection_fixture.hpp
+++ b/lib/tests/collection_fixture.hpp
@@ -9,7 +9,8 @@ namespace facter { namespace testing {
     class collection_fixture : public facter::facts::collection
     {
     public:
-        collection_fixture(std::set<std::string> const& blocklist = std::set<std::string>());
+        collection_fixture(std::set<std::string> const& blocklist = std::set<std::string>(),
+                std::unordered_map<std::string, int64_t> const& ttls = {});
 
     protected:
         virtual std::vector<std::string> get_external_fact_directories() const override;

--- a/lib/tests/facts/cache.cc
+++ b/lib/tests/facts/cache.cc
@@ -1,0 +1,71 @@
+#include <catch.hpp>
+#include "../fixtures.hpp"
+
+#include<internal/facts/cache.hpp>
+#include <facter/facts/scalar_value.hpp>
+
+#include <leatherman/file_util/file.hpp>
+
+using namespace std;
+using namespace facter::testing;
+using namespace facter::facts;
+namespace boost_file = boost::filesystem;
+
+struct simple_resolver : facter::facts::resolver
+{
+    simple_resolver() : resolver("test", { "foo" })
+    {
+    }
+
+    virtual void resolve(collection& facts) override
+    {
+        facts.add("foo", make_value<string_value>("bar"));
+    }
+
+    bool is_blockable() const override
+    {
+        return true;
+    }
+};
+
+SCENARIO("refreshing cache") {
+    boost_file::path cache_dir(LIBFACTER_TESTS_DIRECTORY + string("/fixtures/cache"));
+
+    GIVEN("a resolver that needs to be cached") {
+        collection_fixture facts;
+        auto test_res = make_shared<simple_resolver>();
+
+        THEN("new JSON files should be written") {
+            auto cache_file = (cache_dir / "foo").string();
+            REQUIRE_FALSE(leatherman::file_util::file_readable(cache_file));
+
+            cache::refresh_cache(test_res, cache_dir, facts);
+            REQUIRE(leatherman::file_util::file_readable(cache_file));
+            string contents;
+            load_fixture("cache/foo", contents);
+            REQUIRE(contents.find("foo") != string::npos);
+        }
+    }
+
+    // Clean up directory
+    boost_file::remove_all(cache_dir);
+}
+
+SCENARIO("loading facts from cache") {
+    boost_file::path cache_dir(LIBFACTER_TESTS_DIRECTORY + string("/fixtures/cache"));
+
+    GIVEN("an existing cache directory with cached fact") {
+        collection_fixture facts;
+        boost_file::create_directories(cache_dir);
+        auto cache_file = cache_dir / "test_fact";
+        leatherman::file_util::atomic_write_to_file("{ \"test_fact\" : \"test_value\" }", cache_file.string());
+
+        THEN("facts should be loaded from the cache") {
+            cache::load_facts_from_cache(cache_dir, { "test_fact" }, facts);
+            REQUIRE(facts.get_resolved("test_fact"));
+        }
+    }
+
+    // Clean up directory
+    boost_file::remove_all(cache_dir);
+}

--- a/lib/tests/facts/cache.cc
+++ b/lib/tests/facts/cache.cc
@@ -56,13 +56,14 @@ SCENARIO("loading facts from cache") {
 
     GIVEN("an existing cache directory with cached fact") {
         collection_fixture facts;
+        auto test_res = make_shared<simple_resolver>();
         boost_file::create_directories(cache_dir);
-        auto cache_file = cache_dir / "test_fact";
-        leatherman::file_util::atomic_write_to_file("{ \"test_fact\" : \"test_value\" }", cache_file.string());
+        auto cache_file = cache_dir / "foo";
+        leatherman::file_util::atomic_write_to_file("{ \"foo\" : \"bar\" }", cache_file.string());
 
         THEN("facts should be loaded from the cache") {
-            cache::load_facts_from_cache(cache_dir, { "test_fact" }, facts);
-            REQUIRE(facts.get_resolved("test_fact"));
+            cache::load_facts_from_cache(cache_dir, test_res, facts);
+            REQUIRE(facts.get_resolved("foo"));
         }
     }
 

--- a/lib/tests/facts/cache.cc
+++ b/lib/tests/facts/cache.cc
@@ -34,15 +34,16 @@ SCENARIO("refreshing cache") {
     GIVEN("a resolver that needs to be cached") {
         collection_fixture facts;
         auto test_res = make_shared<simple_resolver>();
+        boost_file::create_directories(cache_dir);
 
         THEN("new JSON files should be written") {
-            auto cache_file = (cache_dir / "foo").string();
+            auto cache_file = (cache_dir / "test").string();
             REQUIRE_FALSE(leatherman::file_util::file_readable(cache_file));
 
-            cache::refresh_cache(test_res, cache_dir, facts);
+            cache::refresh_cache(test_res, cache_file, facts);
             REQUIRE(leatherman::file_util::file_readable(cache_file));
             string contents;
-            load_fixture("cache/foo", contents);
+            load_fixture("cache/test", contents);
             REQUIRE(contents.find("foo") != string::npos);
         }
     }
@@ -58,11 +59,11 @@ SCENARIO("loading facts from cache") {
         collection_fixture facts;
         auto test_res = make_shared<simple_resolver>();
         boost_file::create_directories(cache_dir);
-        auto cache_file = cache_dir / "foo";
+        auto cache_file = cache_dir / "test";
         leatherman::file_util::atomic_write_to_file("{ \"foo\" : \"bar\" }", cache_file.string());
 
         THEN("facts should be loaded from the cache") {
-            cache::load_facts_from_cache(cache_dir, test_res, facts);
+            cache::load_facts_from_cache(cache_file, test_res, facts);
             REQUIRE(facts.get_resolved("foo"));
         }
     }


### PR DESCRIPTION
This allows a `ttls` element to be specified in the config file with the following structure:
`facts : { ttls : [ { "block group" : 30 days } ] }`. Facts in the specified block groups will be cached as json files and loaded from those files until the files expire, i.e. the file is older than the specified duration.

This can be used with any fact that has a blockgroup specified in the schema.