### PR TITLE
(maint) Use explicit set constructor

### DIFF
--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -54,7 +54,7 @@ namespace facter { namespace facts {
          * Constructs a fact collection.
          * @param blocklist the names of resolvers that should not be resolved
          */
-        collection(std::set<std::string> const& blocklist = {});
+        collection(std::set<std::string> const& blocklist = std::set<std::string>());
 
         /**
          * Destructor for fact collection.


### PR DESCRIPTION
Some compilers do not allow the use of `{}` to initialize an empty std::set. Use the explicit constructor instead.