### PR TITLE
(FACT-1512) Add flags to the command line with options for fact blocking

### DIFF
--- a/acceptance/tests/options/list_block_groups.rb
+++ b/acceptance/tests/options/list_block_groups.rb
@@ -1,0 +1,14 @@
+# This tests is intended to verify that passing the `--list-block-groups` flag
+# will cause the names of blockable resolvers to be printed to stdout. It should not list
+# any resolver name that is not blockable.
+test_name "the `--list-block-groups` command line flag prints available block groups to stdout" do
+
+  agents.each do |agent|
+    step "the EC2 blockgroup should be listed" do
+      on(agent, facter("--list-block-groups")) do
+        assert_match(/EC2/, stdout, "Expected the EC2 group to be listed")
+        assert_no_match(/kernel/, stdout, "kernel facts should not be listed as blockable")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_block.rb
+++ b/acceptance/tests/options/no_block.rb
@@ -1,0 +1,32 @@
+# This tests is inteded to verify that passing the `--no-block` command to facter will prevent
+# fact blocking, desptie a blocklist being specified in the config file.
+test_name "the `--no-block` command line flag prevents facts from being blocked" do
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    # default facter.conf
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+
+    teardown do
+      on(agent, "rm -rf '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+    end
+
+    # create the directories
+    on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+
+    step "Agent #{agent}: create config file" do
+      create_remote_file(agent, facter_conf_default_path, <<-FILE)
+      cli : { debug : true }
+      facts : { blocklist : [ "EC2" ] }
+      FILE
+    end
+
+    step "no facts should be blocked when `--no-block` is specified" do
+      on(agent, facter("--no-block")) do 
+        assert_no_match(/blocking collection of .+ facts/, stderr, "Expected no facts to be blocked")
+      end
+    end
+  end
+end

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
             ("list-block-groups", _("Lists the names of all blockable fact groups.").c_str())
             ("list-cache-groups", _("List the name of each cacheable group of facts").c_str())
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
+            ("no-block", _("Disables fact blocking.").c_str())
             ("no-cache", _("Disable loading and refreshing facts from the cache").c_str())
             ("no-color", _("Disables color output.").c_str())
             ("no-custom-facts", po::bool_switch()->default_value(false), _("Disables custom facts.").c_str())
@@ -318,7 +319,7 @@ int main(int argc, char **argv)
         log_queries(queries);
 
         set<string> blocklist;
-        if (vm.count("blocklist")) {
+        if (vm.count("blocklist") && !vm.count("no-block")) {
             auto facts_to_block = vm["blocklist"].as<vector<string>>();
             blocklist.insert(facts_to_block.begin(), facts_to_block.end());
         }

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -148,6 +148,7 @@ int main(int argc, char **argv)
             ("help,h", _("Print this help message.").c_str())
             ("json,j", _("Output in JSON format.").c_str())
             ("show-legacy", _("Show legacy facts when querying all facts.").c_str())
+            ("list-block-groups", _("Lists the names of all blockable fact groups.").c_str())
             ("list-cache-groups", _("List the name of each cacheable group of facts").c_str())
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
             ("no-cache", _("Disable loading and refreshing facts from the cache").c_str())
@@ -254,6 +255,16 @@ int main(int argc, char **argv)
         // Check for printing the version
         if (vm.count("version")) {
             boost::nowide::cout << LIBFACTER_VERSION_WITH_COMMIT << endl;
+            return EXIT_SUCCESS;
+        }
+
+        if (vm.count("list-block-groups")) {
+            collection facts;
+            facts.add_default_facts(!vm.count("no-ruby"));
+            vector<string> blockable_facts = facts.get_blockable_fact_groups();
+            for (auto fact_group : blockable_facts) {
+                boost::nowide::cout << fact_group << endl;
+            }
             return EXIT_SUCCESS;
         }
 

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -287,11 +287,18 @@ namespace facter { namespace facts {
 
         /**
          * Returns the names of all the resolvers currently in the collection.
-         * These names correspond to groups of facts, and are used to block
-         * collection of those facts or to allow caching them.
+         * These names correspond to groups of facts, and are used to allow
+         * caching of those facts.
          * @return a list of fact group names
          */
         std::vector<std::string> get_fact_groups();
+
+        /**
+         * Returns the names of all blockable resolvers currently in the collection.
+         * These names correspond to groups of blockable facts.
+         * @return a list of blockable fact groups
+         */
+        std::vector<std::string> get_blockable_fact_groups();
 
      protected:
         /**

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -267,6 +267,16 @@ namespace facter { namespace facts {
         return _facts.empty() && _resolvers.empty();
     }
 
+    vector<string> collection::get_blockable_fact_groups() {
+        vector<string> blockgroups;
+        for (auto res : _resolvers) {
+            if (res->is_blockable()) {
+                blockgroups.push_back(res->name());
+            }
+        }
+        return blockgroups;
+    }
+
     size_t collection::size()
     {
         resolve_facts();


### PR DESCRIPTION
This adds two flags:

1) `--no-block` will ignore the blocklist specified in the config file, causing all facts to be resolved

2) `--list-block-groups` will print out the names of all groups of facts which can be blocked on the current system

It also includes acceptance tests for these commands, which have had a green run [here](https://jenkins.puppetlabs.com/view/puppet-agent/view/ad%20hoc/job/platform_puppet-agent_intn-van-sys_suite-manual-facter-ad-hoc/98/).