### PR TITLE
(FACT-1492) Correctly report version numbers for Windows 10 and Server 2016

### DIFF
--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -22,7 +22,10 @@ agents.each do |agent|
     os_version  = '2012 R2'
     kernel_version = '6.3'
   elsif agent['platform'] =~ /-10/
-    os_version  = /^10\./
+    os_version  = '10'
+    kernel_version = /^10\./
+  elsif agent['platform'] =~ /2016/
+    os_version = '2016'
     kernel_version = /^10\./
   else
     raise "Unknown agent platform of #{agent['platform']}"

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -100,8 +100,8 @@ namespace facter { namespace facts { namespace windows {
         // Override default release with Windows release names
         auto version = result.release.substr(0, lastDot);
         bool consumerrel = (wmi::get(vals, wmi::producttype) == "1");
-        if (version == "6.4") {
-            result.release = consumerrel ? "10" : result.release;
+        if (version == "10.0") {
+            result.release = consumerrel ? "10" : "2016";
         } else if (version == "6.3") {
             result.release = consumerrel ? "8.1" : "2012 R2";
         } else if (version == "6.2") {


### PR DESCRIPTION
This adds consistent reporting of the Windows version fact for Windows
10 and Windows Server 2016. Before this, we were returning the raw
kernel version string.