### PR TITLE
(FACT-1518) Add quotes to ttl keys so hocon lookup works correctly

### DIFF
--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -70,8 +70,10 @@ namespace facter { namespace util { namespace config {
         if (hocon_config && hocon_config->has_path("facts.ttls")) {
             auto ttl_objs = hocon_config->get_object_list("facts.ttls");
             for (auto entry : ttl_objs) {
-                string fact = entry->key_set().front();
                 shared_config entry_conf = entry->to_config();
+                // triple-quote this string so that cpp-hocon will correctly parse it as a single path element
+                // and ignore otherwise reserved characters
+                string fact = "\"\"\"" + entry->key_set().front() + "\"\"\"";
                 int64_t duration = entry_conf->get_duration(fact, time_unit::SECONDS);
                 ttls.insert({ fact, duration });
             }


### PR DESCRIPTION
When the key string for each ttl object is passed directly to
config::get_duration, cpp-hocon will parse it as an unquoted string and
choke on special symbols. This adds triple quotes, to treat the string as a
single element with all special symbols ignored.

Note: this disables escape sequences and path splitting on '.'

Note 2: This is in response to [HC-88](https://tickets.puppetlabs.com/browse/HC-88), but I can't use that in the commit message within Facter or Travis will get angry.