### PR TITLE
(FACT-1484) Change failure of getaddrinfo from error to warning

### DIFF
--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -91,7 +91,7 @@ namespace facter { namespace facts { namespace posix {
             // Retrieve the FQDN by resolving the hostname
             scoped_addrinfo info(result.hostname);
             if (info.result() != 0 && info.result() != EAI_NONAME) {
-                LOG_ERROR("getaddrinfo failed: %1% (%2%): hostname may not be externally resolvable.", gai_strerror(info.result()), info.result());
+                LOG_WARNING("getaddrinfo failed: %1% (%2%): hostname may not be externally resolvable.", gai_strerror(info.result()), info.result());
             } else if (!info || info.result() == EAI_NONAME || result.hostname == static_cast<addrinfo*>(info)->ai_canonname) {
                 LOG_DEBUG("hostname \"%1%\" could not be resolved: hostname may not be externally resolvable.", result.hostname);
             } else {


### PR DESCRIPTION
When this is logged as an error, it frequently causes the Facter smoke
tests to fail on Cisco WR Linux when running though CI pipelines.
However, Facter is still able to return good output. Changing this to a
warning allows the test to pass, while still reporting the failure of
the system call. This is more consistent with the way we handle these
failures elsewhere in Facter.