### PR TITLE
Revert "(maint) Update Gemfile to use beaker 3.1 in acceptance tests"

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"


### PR DESCRIPTION
This reverts commit deb7dff1f4888adf0bc7ac698ad1b1369b76cc6e.

Before we can update the beaker Gem version, we will need to update pipelines
to use ruby 2.2.5 at least to run beaker.