### PR TITLE
(maint) Update docs to include fact caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,18 @@ cli : {
 }
 facts : {
     blocklist : [ "file system", "EC2" ]
+    ttls : [
+        { "timezone" : 30 days },
+    ]
 }
 ```
 All options are respected when running Facter standalone, while calling Facter from Ruby will only load `external-dir`, `custom-dir`, and the fact-specific configuration.
 
 The file will be loaded by default from `/etc/puppetlabs/facter/facter.conf` on Unix and `C:\ProgramData\PuppetLabs\facter\etc\facter.conf` on Windows. A different location can be specified using the `--config` command line option.
 
-Elements in the blocklist are fact groupings which will not be resolved when Facter runs. Valid elements correspond to the `blockgroup` field in the fact schema. If a fact does not have a blockgroup, it cannot be blocked.
+Elements in the blocklist are fact groupings which will not be resolved when Facter runs. Use the `--list-block-group` command line option to see valid blockable groups.
+
+Elements in the ttls section are key-value pairs of fact groupings that will be cached with the duration for which to cache them. Cached facts are stored as JSON in `/opt/puppetlabs/facter/cache/cached_facts` on Unix and `C:\ProgramData\PuppetLabs\facter\cache\cached_facts` on Windows. Use the `--list-cache-groups` command line option to see valid cacheable groups.
 
 Uninstall
 ---------

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -71,7 +71,7 @@ void help(po::options_description& desc)
           "===========\n"
           "\n"
           "Contains settings for configuring external and custom fact directories,\n"
-          "setting command line options, and blocking facts.\n"
+          "setting command line options, and blocking and caching facts.\n"
           "Loaded by default from %2%.\n"
           "See man page, README, or docs for more details.",
           desc, default_config_location()) << endl;
@@ -140,29 +140,29 @@ int main(int argc, char **argv)
         // boolean must be specified explicitly).
         po::options_description visible_options("");
         visible_options.add_options()
-            ("color", _("Enables color output.").c_str())
+            ("color", _("Enable color output.").c_str())
             ("config,c", po::value<string>(), _("The location of the config file.").c_str())
             ("custom-dir", po::value<vector<string>>(), _("A directory to use for custom facts.").c_str())
             ("debug,d", po::bool_switch()->default_value(false), _("Enable debug output.").c_str())
             ("external-dir", po::value<vector<string>>(), _("A directory to use for external facts.").c_str())
             ("help,h", _("Print this help message.").c_str())
             ("json,j", _("Output in JSON format.").c_str())
-            ("show-legacy", _("Show legacy facts when querying all facts.").c_str())
-            ("list-block-groups", _("Lists the names of all blockable fact groups.").c_str())
-            ("list-cache-groups", _("List the name of each cacheable group of facts").c_str())
+            ("list-block-groups", _("List the names of all blockable fact groups.").c_str())
+            ("list-cache-groups", _("List the names of all cacheable fact groups.").c_str())
             ("log-level,l", po::value<level>()->default_value(level::warning, "warn"), _("Set logging level.\nSupported levels are: none, trace, debug, info, warn, error, and fatal.").c_str())
-            ("no-block", _("Disables fact blocking.").c_str())
+            ("no-block", _("Disable fact blocking.").c_str())
             ("no-cache", _("Disable loading and refreshing facts from the cache").c_str())
-            ("no-color", _("Disables color output.").c_str())
-            ("no-custom-facts", po::bool_switch()->default_value(false), _("Disables custom facts.").c_str())
-            ("no-external-facts", po::bool_switch()->default_value(false), _("Disables external facts.").c_str())
-            ("no-ruby", po::bool_switch()->default_value(false), _("Disables loading Ruby, facts requiring Ruby, and custom facts.").c_str())
+            ("no-color", _("Disable color output.").c_str())
+            ("no-custom-facts", po::bool_switch()->default_value(false), _("Disable custom facts.").c_str())
+            ("no-external-facts", po::bool_switch()->default_value(false), _("Disable external facts.").c_str())
+            ("no-ruby", po::bool_switch()->default_value(false), _("Disable loading Ruby, facts requiring Ruby, and custom facts.").c_str())
             ("puppet,p", _("(Deprecated: use `puppet facts` instead) Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.").c_str())
+            ("show-legacy", _("Show legacy facts when querying all facts.").c_str())
             ("trace", po::bool_switch()->default_value(false), _("Enable backtraces for custom facts.").c_str())
             ("verbose", po::bool_switch()->default_value(false), _("Enable verbose (info) output.").c_str())
             ("version,v", _("Print the version and exit.").c_str())
             ("yaml,y", _("Output in YAML format.").c_str())
-            ("strict", _("Enables more aggressive error reporting.").c_str());
+            ("strict", _("Enable more aggressive error reporting.").c_str());
 
         // Build a list of "hidden" options that are not visible on the command line
         po::options_description hidden_options("");

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -53,7 +53,7 @@ msgid ""
 "===========\n"
 "\n"
 "Contains settings for configuring external and custom fact directories,\n"
-"setting command line options, and blocking facts.\n"
+"setting command line options, and blocking and caching facts.\n"
 "Loaded by default from %2%.\n"
 "See man page, README, or docs for more details."
 msgstr ""
@@ -74,7 +74,7 @@ msgid "requested queries: %1%."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Enables color output."
+msgid "Enable color output."
 msgstr ""
 
 #: exe/facter.cc
@@ -102,15 +102,11 @@ msgid "Output in JSON format."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Show legacy facts when querying all facts."
+msgid "List the names of all blockable fact groups."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Lists the names of all blockable fact groups."
-msgstr ""
-
-#: exe/facter.cc
-msgid "List the name of each cacheable group of facts"
+msgid "List the names of all cacheable fact groups."
 msgstr ""
 
 #: exe/facter.cc
@@ -120,7 +116,7 @@ msgid ""
 msgstr ""
 
 #: exe/facter.cc
-msgid "Disables fact blocking."
+msgid "Disable fact blocking."
 msgstr ""
 
 #: exe/facter.cc
@@ -128,25 +124,29 @@ msgid "Disable loading and refreshing facts from the cache"
 msgstr ""
 
 #: exe/facter.cc
-msgid "Disables color output."
+msgid "Disable color output."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Disables custom facts."
+msgid "Disable custom facts."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Disables external facts."
+msgid "Disable external facts."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Disables loading Ruby, facts requiring Ruby, and custom facts."
+msgid "Disable loading Ruby, facts requiring Ruby, and custom facts."
 msgstr ""
 
 #: exe/facter.cc
 msgid ""
 "(Deprecated: use `puppet facts` instead) Load the Puppet libraries, thus "
 "allowing Facter to load Puppet-specific facts."
+msgstr ""
+
+#: exe/facter.cc
+msgid "Show legacy facts when querying all facts."
 msgstr ""
 
 #: exe/facter.cc
@@ -166,7 +166,7 @@ msgid "Output in YAML format."
 msgstr ""
 
 #: exe/facter.cc
-msgid "Enables more aggressive error reporting."
+msgid "Enable more aggressive error reporting."
 msgstr ""
 
 #: exe/facter.cc

--- a/man/man8/facter.8
+++ b/man/man8/facter.8
@@ -13,10 +13,10 @@ Collect and display facts about the system\.
 .
 .nf
 
-facter [\-\-color] [\-\-custom\-dir DIR] [\-d|\-\-debug] [\-\-external\-dir DIR] [\-\-help]
-  [\-j|\-\-json] [\-l|\-\-log\-level LEVEL (=warn)] [\-\-no\-color] [\-\-no\-custom\-facts]
-  [\-\-no\-external\-facts] [\-\-trace] [\-\-verbose] [\-v|\-\-version] [\-y|\-\-yaml]
-  [fact] [fact] [\.\.\.]
+facter [\-\-color] [\-\-config] [\-\-custom\-dir DIR] [\-d|\-\-debug] [\-\-external\-dir DIR] [\-\-help]
+  [\-j|\-\-json] [\-\-list\-block\-groups] [\-\-list\-cache\-groups] [\-l|\-\-log\-level LEVEL (=warn)]
+  [\-\-no\-block] [\-\-no\-cache] [\-\-no\-color] [\-\-no\-custom\-facts] [\-\-no\-external\-facts]
+  [\-\-trace] [\-\-verbose] [\-v|\-\-version] [\-y|\-\-yaml] [\-\-strict] [fact] [fact] [\.\.\.]
 .
 .fi
 .
@@ -27,28 +27,32 @@ Collect and display facts about the current system\. The library behind Facter i
 If no queries are given, then all facts will be returned\.
 .
 .P
-Many of the command line options can also be set via the HOCON config file. This file can also be used to block the collection of certain fact groups\.
+Many of the command line options can also be set via the HOCON config file. This file can also be used to block or cache certain fact groups\.
 .
 .SH "OPTIONS"
 .
 .nf
-      \fB\-\-color\fR                      Enables color output\.
-      \fB\-\-config\fR                     A custom location for the chnfig file\.
+      \fB\-\-color\fR                      Enable color output\.
+      \fB\-\-config\fR                     A custom location for the config file\.
       \fB\-\-custom-dir\fR arg             A directory to use for custom facts\.
 \fB\-d, [ \-\-debug ]\fR                    Enable debug output\.
       \fB\-\-external-dir\fR arg           A directory to use for external facts\.
       \fB\-\-help\fR                       Print help and usage information\.
 \fB\-j, [ \-\-json ]\fR                     Output facts in JSON format\.
+      \fB\-\-list\-block\-groups\fR          List the names of all blockable fact groups\.
+      \fB\-\-list\-cache\-groups\fR          List the names of all cacheable fact groups\.
       \fB\-\-show-legacy\fR                Show legacy facts when querying all facts\.
 \fB\-l, [ \-\-log-level ]\fR arg (=warn)    Set logging level\.
                                    Supported levels are: none, trace, debug,
                                    info, warn, error, and fatal\.
-      \fB\-\-no-color\fR                   Disables color output\.
-      \fB\-\-no-custom-fact\fR             Disables custom facts\.
-      \fB\-\-no-external-facts\fR          Disables external facts\.
-      \fB\-\-no-ruby\fR                    Disables loading Ruby, facts requiring Ruby, and custom facts\.
-      \fB\-\-trace\fR                      Enables backtraces for custom facts\.
-      \fB\-\-verbose\fR                    Enables verbose (info) output\.
+      \fB\-\-no\-block\fR                   Disable fact blocking\.
+      \fB\-\-no\-cache\fR                   Disable fact caching\.
+      \fB\-\-no-color\fR                   Disable color output\.
+      \fB\-\-no-custom-fact\fR             Disable custom facts\.
+      \fB\-\-no-external-facts\fR          Disable external facts\.
+      \fB\-\-no-ruby\fR                    Disable loading Ruby, facts requiring Ruby, and custom facts\.
+      \fB\-\-trace\fR                      Enable backtraces for custom facts\.
+      \fB\-\-verbose\fR                    Enable verbose (info) output\.
 \fB\-v, [ \-\-version ]\fR                  Print the version and exit\.
 \fB\-y, [ \-\-yaml ]\fR                     Output facts in YAML format\.
 .
@@ -184,8 +188,10 @@ cli : {
 }
 # always loaded, fact-sepcific configuration
 facts : {
-    # for valid blocklist entries, see fact schema
+    # for valid blocklist entries, use --list-block-groups
     blocklist : [ "file system", "EC2" ],
+    # for valid time-to-live entries, use --list-cache-groups
+    ttls : [ { "timezone" : 30 days } ]
 }
 .
 .fi


### PR DESCRIPTION
This updates the readme and the man page to include information about
fact caching. Also updates the POT file to include all recently added
strings.
