### PR TITLE
(packaging) Add beaker-abs dependency for CI

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,6 +12,7 @@ end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 


### PR DESCRIPTION
This adds a dependency on our beaker-abs hypervisor when running beaker
acceptance tests. This will cause the gem to be installed in production
CI pipelines (the gem has already been mirrored internally), but the gem
will not be used until we switch to CI.next.