### PR TITLE
(FACT-1518) Only triple quote keys when passing to cpp-hocon

### DIFF
--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -73,8 +73,8 @@ namespace facter { namespace util { namespace config {
                 shared_config entry_conf = entry->to_config();
                 // triple-quote this string so that cpp-hocon will correctly parse it as a single path element
                 // and ignore otherwise reserved characters
-                string fact = "\"\"\"" + entry->key_set().front() + "\"\"\"";
-                int64_t duration = entry_conf->get_duration(fact, time_unit::SECONDS);
+                string fact = entry->key_set().front();
+                int64_t duration = entry_conf->get_duration("\"\"\"" + fact + "\"\"\"", time_unit::SECONDS);
                 ttls.insert({ fact, duration });
             }
         }


### PR DESCRIPTION
The previous commit which attempted to resolve this ticket triple quoted
the keys too early, resulting in the extra quoted string being compared
against resolver names and always failing to match. This commit only
quotes the strings being passed directly to cpp-hocon.