### PR TITLE
(FACT-1384) Fix failure to return external fact path when admin

### DIFF
--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -37,6 +37,7 @@ namespace facter { namespace facts {
             // Get the common data path
             try {
                 path p = file_util::get_programdata_dir() / "PuppetLabs" / "facter" / "facts.d";
+                return {p.string()};
             } catch (file_util::unknown_folder_exception &e) {
                 LOG_WARNING("external facts unavailable, %1%", e.what());
             }


### PR DESCRIPTION
The previous commits for FACT-1384 failed to return the path resolved for
external facts when running with elevated privileges on Windows. Return
the value to fix resolving external facts. This was caught by acceptance
tests on Windows.