### PR TITLE
(FACT-1428) Various fixes for FreeBSD facts

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -201,6 +201,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/bsd/uptime_resolver.cc"
         "src/facts/freebsd/processor_resolver.cc"
         "src/facts/freebsd/dmi_resolver.cc"
+        "src/facts/freebsd/networking_resolver.cc"
         "src/util/bsd/scoped_ifaddrs.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")

--- a/lib/inc/internal/facts/freebsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/networking_resolver.hpp
@@ -1,0 +1,42 @@
+/**
+ * @file
+ * Declares the FreeBSD networking fact resolver.
+ */
+#pragma once
+
+#include "../bsd/networking_resolver.hpp"
+#include <map>
+#include <ifaddrs.h>
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving networking facts.
+     */
+    struct networking_resolver : bsd::networking_resolver
+    {
+     protected:
+        /**
+         * Gets the MTU of the link layer data.
+         * @param interface The name of the link layer interface.
+         * @param data The data pointer from the link layer interface.
+         * @return Returns The MTU of the interface.
+         */
+        virtual boost::optional<uint64_t> get_link_mtu(std::string const& interface, void* data) const override;
+
+        /**
+         * Determines if the given sock address is a link layer address.
+         * @param addr The socket address to check.
+         * @returns Returns true if the socket address is a link layer address or false if it is not.
+         */
+        virtual bool is_link_address(sockaddr const* addr) const override;
+
+        /**
+         * Gets the bytes of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns a pointer to the address bytes or nullptr if not a link address.
+         */
+        virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
+    };
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -9,6 +9,7 @@
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
 #include <internal/facts/resolvers/operating_system_resolver.hpp>
+#include <internal/facts/freebsd/networking_resolver.hpp>
 
 using namespace std;
 
@@ -18,6 +19,7 @@ namespace facter { namespace facts {
     {
         add(make_shared<posix::kernel_resolver>());
         add(make_shared<resolvers::operating_system_resolver>());
+        add(make_shared<freebsd::networking_resolver>());
         add(make_shared<bsd::uptime_resolver>());
         add(make_shared<bsd::filesystem_resolver>());
         add(make_shared<posix::ssh_resolver>());

--- a/lib/src/facts/freebsd/dmi_resolver.cc
+++ b/lib/src/facts/freebsd/dmi_resolver.cc
@@ -14,7 +14,7 @@ namespace facter { namespace facts { namespace freebsd {
         result.bios_version = kenv_lookup("smbios.bios.version");
         result.bios_release_date = kenv_lookup("smbios.bios.reldate");
         result.uuid = kenv_lookup("smbios.system.uuid");
-        result.serial_number = kenv_lookup("smbios.planar.serial");
+        result.serial_number = kenv_lookup("smbios.system.serial");
         result.product_name = kenv_lookup("smbios.system.product");
         result.manufacturer = kenv_lookup("smbios.system.maker");
 

--- a/lib/src/facts/freebsd/networking_resolver.cc
+++ b/lib/src/facts/freebsd/networking_resolver.cc
@@ -1,0 +1,55 @@
+#include <internal/facts/freebsd/networking_resolver.hpp>
+#include <internal/util/bsd/scoped_ifaddrs.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <boost/algorithm/string.hpp>
+#include <sys/sockio.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+
+using namespace std;
+using namespace facter::util;
+using namespace facter::util::bsd;
+using namespace leatherman::execution;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    bool networking_resolver::is_link_address(sockaddr const* addr) const
+    {
+        return addr && addr->sa_family == AF_LINK;
+    }
+
+    uint8_t const* networking_resolver::get_link_address_bytes(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return nullptr;
+        }
+        sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
+        if (link_addr->sdl_alen != 6) {
+            return nullptr;
+        }
+        return reinterpret_cast<uint8_t const*>(LLADDR(link_addr));
+     }
+
+    boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
+    {
+        ifreq ifr;
+        memset(&ifr, 0, sizeof(ifr));
+        strncpy(ifr.ifr_name, interface.c_str(), sizeof(ifr.ifr_name));
+        int s = socket(AF_INET, SOCK_DGRAM, 0);
+        if (s < 0) {
+            LOG_WARNING("socket failed: {1} ({2}): interface MTU fact is unavailable for interface {3}.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        if (ioctl(s, SIOCGIFMTU, &ifr) == -1) {
+            LOG_WARNING("ioctl failed: {1} ({2}): interface MTU fact is unavailable for interface {3}.", strerror(errno), errno, interface);
+            return boost::none;
+        }
+
+        return ifr.ifr_mtu;
+    }
+
+}}}  // namespace facter::facts::freebsd

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -581,6 +581,23 @@ msgstr ""
 msgid "kenv lookup for {1} failed: {2} ({3})"
 msgstr ""
 
+#. warning
+#: lib/src/facts/freebsd/networking_resolver.cc
+#: lib/src/facts/linux/networking_resolver.cc
+#: lib/src/facts/openbsd/networking_resolver.cc
+msgid ""
+"socket failed: {1} ({2}): interface MTU fact is unavailable for interface "
+"{3}."
+msgstr ""
+
+#. warning
+#: lib/src/facts/freebsd/networking_resolver.cc
+#: lib/src/facts/linux/networking_resolver.cc
+#: lib/src/facts/openbsd/networking_resolver.cc
+msgid ""
+"ioctl failed: {1} ({2}): interface MTU fact is unavailable for interface {3}."
+msgstr ""
+
 #. debug
 #: lib/src/facts/freebsd/processor_resolver.cc
 #: lib/src/facts/openbsd/processor_resolver.cc
@@ -662,21 +679,6 @@ msgstr ""
 #: lib/src/facts/linux/filesystem_resolver.cc
 msgid ""
 "cannot determine size of partition '{1}': '{2}' is not an integral value."
-msgstr ""
-
-#. warning
-#: lib/src/facts/linux/networking_resolver.cc
-#: lib/src/facts/openbsd/networking_resolver.cc
-msgid ""
-"socket failed: {1} ({2}): interface MTU fact is unavailable for interface "
-"{3}."
-msgstr ""
-
-#. warning
-#: lib/src/facts/linux/networking_resolver.cc
-#: lib/src/facts/openbsd/networking_resolver.cc
-msgid ""
-"ioctl failed: {1} ({2}): interface MTU fact is unavailable for interface {3}."
 msgstr ""
 
 #. debug


### PR DESCRIPTION
This adds a copy of the OpenBSD networking facts, which work unchanged on FreeBSD.  Most likely there is a better way to handle this because DRY, but the bsd upstream is used in other places too.

It also fixes the issue with Facter using the wrong kenv serial number