### PR TITLE
(PA-657) Update network fact tests to correctly exclude SPARC

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -33,35 +33,21 @@ test_name 'FACT-1361 - C59029 networking facts should be fully populated' do
         "\"networking.interfaces.#{primary_interface}.bindings6.0.network\"" => /[a-f0-9:]+/
     }
 
-    case agent['platform']
-      when /solaris/, /eos/
-        #remove the invalid networking facts on Solaris or Arista
-        expected_networking.delete("networking.ip6")
-        expected_networking.delete("networking.netmask6")
-        expected_networking.delete("networking.network6")
+    if agent['platform'] =~ /solaris|eos|sparc|aix|cisco/
+      #remove the invalid networking facts on eccentric platforms
+      expected_networking.delete("networking.ip6")
+      expected_networking.delete("networking.netmask6")
+      expected_networking.delete("networking.network6")
 
-        #remove invalid bindings for the primary networking interface on AIX and Solaris
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+      #remove invalid bindings for the primary networking interface eccentric platforms
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
+      expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
+    end
 
-      when /sparc/, /aix/, /cisco/
-        #remove the invalid networking facts on SPARC, AIX, or Cisco
-        #Our SPARC testing platforms don't use DHCP
-        expected_networking.delete("networking.dhcp")
-        expected_networking.delete("networking.ip6")
-        expected_networking.delete("networking.netmask6")
-        expected_networking.delete("networking.network6")
-
-        #remove invalid bindings for the primary networking interface on SPARC or AIX
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.address\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.netmask\"")
-        expected_bindings.delete("\"networking.interfaces.#{primary_interface}.bindings6.0.network\"")
-
-      when /sles/
-        #some sles VMs do not have networking.dhcp
-        expected_networking.delete("networking.dhcp")
-
+    if agent['platform'] =~ /sparc|aix|cisco|sles/
+      # some of our testing platforms do not use DHCP
+      expected_networking.delete("networking.dhcp")
     end
 
     step "Ensure the Networking fact resolves with reasonable values for at least one interface" do


### PR DESCRIPTION
This refactors which networking facts are excluded from eccentric platforms to
correctly handle SPARC and Cisco. Before this commit, some tests were
failing because the case statement didn't correctly constrain certain
platforms.