### PR TITLE
(packaging) Use beaker-abs that supports beaker 3

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,6 +12,7 @@ end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 


### PR DESCRIPTION
Facter now requires beaker 3, so we need to require at least beaker-abs
0.2.0.

This is a cherry-pick of master back to stable. We're requiring at least 0.2 because that version supports both beaker 2 and 3.
