### PR TITLE
(FACT-1394) Fix warning for linkdown routes

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -143,6 +143,13 @@ namespace facter { namespace facts { namespace linux {
             vector<boost::iterator_range<string::iterator>> parts;
             boost::split(parts, line, boost::is_space(), boost::token_compress_on);
 
+            // skip links that are linkdown
+            if (std::find_if(parts.cbegin(), parts.cend(), [](const boost::iterator_range<string::iterator>& range) {
+                return std::string(range.begin(), range.end()) == "linkdown";
+            }) != parts.cend()) {
+                return true;
+            }
+
             // remove trailing "onlink" or "pervasive" flags
             while (parts.size() > 0) {
                 std::string last_token(parts.back().begin(), parts.back().end());


### PR DESCRIPTION
Currently, Facter fails to process routes that are marked as linkdown, instead generating warnings for them.

This patch will therefore skip such entries entirely, giving the same outcome but without the warnings that the earlier method generates.

```
$ facter -p networking.interfaces.docker0
2016-10-31 08:54:40.260618 WARN  puppetlabs.facter - Could not process routing table entry: Expected a destination followed by key/value pairs, got '172.17.0.0/16 dev docker0  proto kernel  scope link  src 172.17.0.1 linkdown'
2016-10-31 08:54:40.261368 WARN  puppetlabs.facter - Could not process routing table entry: Expected a destination followed by key/value pairs, got 'fe80::/64 dev docker0  proto kernel  metric 256 linkdown  pref medium'
{
  bindings => [
    {
      address => "172.17.0.1",
      netmask => "255.255.0.0",
      network => "172.17.0.0"
    }
  ],
  bindings6 => [
    {
      address => "fe80::42:d5ff:fe36:1a50",
      netmask => "ffff:ffff:ffff:ffff::",
      network => "fe80::"
    }
  ],
  ip => "172.17.0.1",
  ip6 => "fe80::42:d5ff:fe36:1a50",
  mac => "02:42:d5:36:1a:50",
  mtu => 1500,
  netmask => "255.255.0.0",
  netmask6 => "ffff:ffff:ffff:ffff::",
  network => "172.17.0.0",
  network6 => "fe80::"
}
$ ./facter -p networking.interfaces.docker0
{
  bindings => [
    {
      address => "172.17.0.1",
      netmask => "255.255.0.0",
      network => "172.17.0.0"
    }
  ],
  bindings6 => [
    {
      address => "fe80::42:d5ff:fe36:1a50",
      netmask => "ffff:ffff:ffff:ffff::",
      network => "fe80::"
    }
  ],
  ip => "172.17.0.1",
  ip6 => "fe80::42:d5ff:fe36:1a50",
  mac => "02:42:d5:36:1a:50",
  mtu => 1500,
  netmask => "255.255.0.0",
  netmask6 => "ffff:ffff:ffff:ffff::",
  network => "172.17.0.0",
  network6 => "fe80::"
}
```