### PR TITLE
(FACT-1441) Add basic "cloud" fact 

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,16 @@ To generate API documentation, install doxygen 1.8.7 or later.
     $ doxygen
 
 To view the documentation, open `lib/html/index.html` in a web browser.
+
+Debugging
+---------
+
+If when running the tests you encounter this error message:
+
+"could not locate a ruby library"
+
+You may need to use a different static ruby library in Leatherman. To do
+this, run this command, where the location below is the default for a
+puppet agent installation:
+
+    $ export LEATHERMAN_RUBY=/opt/puppetlabs/puppet/lib/libruby.dylib

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ If when running the tests you encounter this error message:
 
 "could not locate a ruby library"
 
-You may need to use a different static ruby library in Leatherman. To do
+You may need to use a different shared ruby library in Leatherman. To do
 this, run this command, where the location below is the default for a
 puppet agent installation:
 

--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -439,6 +439,10 @@ namespace facter { namespace facts {
          * The fact for whether or not the machine is virtual or physical.
          */
         constexpr static char const* is_virtual = "is_virtual";
+        /**
+         * The fact for the cloud info, including provider, for a node.
+         */
+        constexpr static char const* cloud = "cloud";
 
         /**
          * The structured fact for identity information.

--- a/lib/inc/internal/facts/linux/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/linux/virtualization_resolver.hpp
@@ -20,7 +20,21 @@ namespace facter { namespace facts { namespace linux {
          * @param facts The fact collection that is resolving facts.
          * @return Returns the name of the hypervisor or empty string if no hypervisor.
          */
-        virtual std::string get_hypervisor(collection& facts) override;
+        std::string get_hypervisor(collection& facts) override;
+        /**
+         * Gets the name of the cloud provider.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the name of the cloud provider or empty string if no hypervisor.
+         */
+        std::string get_cloud_provider(collection& facts) override;
+
+        /**
+         * Gets whether the machine is running in Azure.
+         * @param facts The fact collection that is resolving facts.
+         * @param leases_file The location of where the leases file exists.
+         * @return Returns "azure" if running on azure, otherwise an empty string.
+         */
+        static std::string get_azure(collection& facts, std::string const& leases_file = "/var/lib/dhcp/dhclient.eth0.leases");
 
      private:
         static std::string get_cgroup_vm();

--- a/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
@@ -10,6 +10,36 @@
 namespace facter { namespace facts { namespace resolvers {
 
     /**
+     *  Represents cloud data.
+     */
+    struct cloud_
+    {
+        /**
+         * Stores the cloud provider.
+         */
+        std::string provider;
+    };
+
+    /**
+     *  Represents virtualization data.
+     */
+    struct data
+    {
+        /**
+         * Stores the cloud data.
+         */
+        cloud_ cloud;
+        /**
+         * Stores the hypervisor data.
+         */
+        std::string hypervisor;
+        /**
+         * Stores the is_virtual data.
+         */
+        bool is_virtual;
+    };
+
+    /**
      * Responsible for resolving virtualization facts.
      */
     struct virtualization_resolver : resolver
@@ -34,6 +64,13 @@ namespace facter { namespace facts { namespace resolvers {
         virtual std::string get_hypervisor(collection& facts) = 0;
 
         /**
+         * Gets the name of the cloud provider.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the name of the cloud provider or empty string if no cloud provider.
+         */
+        virtual std::string get_cloud_provider(collection& facts);
+
+        /**
          * Determines if the given hypervisor is considered to be virtual.
          * @param hypervisor The hypervisor to check.
          * @return Returns true if the hypervisor is virtual or false if it is physical.
@@ -47,6 +84,13 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns the hypervisor product name if matched.
          */
         static std::string get_product_name_vm(std::string const& product_name);
+
+        /**
+         * Collects the virtualization data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the virtualization data.
+         */
+        virtual data collect_data(collection& facts);
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -184,6 +184,14 @@ chassistype:
     caveats: |
         Linux: kernel 2.6+ is required due to the reliance on sysfs.
 
+cloud:
+    type: map
+    description: Information about the cloud instance of the node. This is currently only populated on Linux nodes running in Microsoft Azure.
+    elements:
+        provider:
+            type: string
+            description: The cloud provider for the node.
+
 dhcp_servers:
     type: map
     hidden: true

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(LIBFACTER_TESTS_PLATFORM_SOURCES
         "facts/linux/dmi_resolver.cc"
         "facts/linux/filesystem_resolver.cc"
+        "facts/linux/virtualization_resolver.cc"
         "util/bsd/scoped_ifaddrs.cc"
     )
 endif()

--- a/lib/tests/facts/linux/virtualization_resolver.cc
+++ b/lib/tests/facts/linux/virtualization_resolver.cc
@@ -1,0 +1,48 @@
+#include <catch.hpp>
+#include <facter/util/string.hpp>
+#include <internal/facts/linux/virtualization_resolver.hpp>
+#include "../../fixtures.hpp"
+#include <iostream>
+
+using namespace std;
+using namespace facter::util;
+using namespace facter::facts;
+using namespace facter::facts::resolvers;
+using namespace facter::testing;
+
+struct peek_resolver : linux::virtualization_resolver
+{
+    using virtualization_resolver::get_azure;
+};
+
+SCENARIO("azure") {
+    collection_fixture facts;
+
+    WHEN("leases file does not exist") {
+        auto result = peek_resolver::get_azure(facts, "does-not-exist");
+        THEN("azure is empty") {
+            REQUIRE(result == "");
+        }
+    }
+
+    WHEN("leases file contains 'option 245'") {
+        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure");
+        THEN("it reports azure") {
+            REQUIRE(result == "azure");
+        }
+    }
+
+    WHEN("leases file contains 'option unknown-245'") {
+        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure-unknown");
+        THEN("it reports azure") {
+            REQUIRE(result == "azure");
+        }
+    }
+
+    WHEN("leases file does not contain correct option") {
+        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/not-azure");
+        THEN("it does not report azure") {
+            REQUIRE(result == "");
+        }
+    }
+}

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -361,6 +361,11 @@ protected:
         // The xen fact only resolves if virtualization is xen_privileged.
         return vm::xen_privileged;
     }
+
+    virtual string get_cloud_provider(collection& facts) override
+    {
+        return "azure";
+    }
 };
 
 struct xen_resolver : resolvers::xen_resolver

--- a/lib/tests/fixtures/facts/linux/cloud/azure
+++ b/lib/tests/fixtures/facts/linux/cloud/azure
@@ -1,0 +1,3 @@
+first line
+this has option 245 defined
+last line

--- a/lib/tests/fixtures/facts/linux/cloud/azure-unknown
+++ b/lib/tests/fixtures/facts/linux/cloud/azure-unknown
@@ -1,0 +1,3 @@
+first line
+this has option unknown-245 defined
+last line


### PR DESCRIPTION
TODOs for future tickets:
- OpenBSD implementation
- OSX implementation
- Windows - convert or include [existing script](https://gallery.technet.microsoft.com/scriptcenter/Detect-Windows-Azure-aed06d51) in implementation
- Add more detail to the `cloud` fact for non-Azure stuff (may be separate PR)

Since there currently exists no fact that can identify if a machine is running
inside Azure, we need to add a more robust virtualization fact. This fact
will be differentiated from the existing `is_virtual` and `virtual` facts
in that it will be structured to include cloud and metadata info as well.

This step adds the `cloud` fact and checks for azure.