### PR TITLE
(PA-652) Bump Facter version to 3.5.1

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.2)
 
 set(LIBFACTER_VERSION_MAJOR 3)
 set(LIBFACTER_VERSION_MINOR 5)
-set(LIBFACTER_VERSION_PATCH 0)
+set(LIBFACTER_VERSION_PATCH 1)
 
 # Get the HEAD SHA1 commit message
 get_commit_string(LIBFACTER_COMMIT)

--- a/lib/Doxyfile
+++ b/lib/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = facter
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.5.0
+PROJECT_NUMBER         = 3.5.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
This bumps the Facter version to 3.5.1 following the release of 3.5.0 as
part of the puppet-agent 1.8.0 release.