### PR TITLE
(PA-655) Add Windows Server 2016 to the LTS agent

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 2.32")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1.0")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.1")
 gem 'rake', "~> 10.1.0"

--- a/acceptance/tests/facts/macosx.rb
+++ b/acceptance/tests/facts/macosx.rb
@@ -23,6 +23,8 @@ agents.each do |agent|
     kernel_major = '14'
   when '10.11'
     kernel_major = '15'
+  when '10.12'
+    kernel_major = '16'
   else
     fail_test("Unknown os_version #{os_version}")
   end

--- a/acceptance/tests/facts/windows.rb
+++ b/acceptance/tests/facts/windows.rb
@@ -24,7 +24,10 @@ agents.each do |agent|
     os_version  = '2012 R2'
     kernel_version = '6.3'
   elsif agent['platform'] =~ /-10/
-    os_version  = /^10\./
+    os_version  = '10'
+    kernel_version = /^10\./
+  elsif agent['platform'] =~ /2016/
+    os_version = '2016'
     kernel_version = /^10\./
   else
     raise "Unknown agent platform of #{agent['platform']}"

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -100,8 +100,8 @@ namespace facter { namespace facts { namespace windows {
         // Override default release with Windows release names
         auto version = result.release.substr(0, lastDot);
         bool consumerrel = (wmi::get(vals, wmi::producttype) == "1");
-        if (version == "6.4") {
-            result.release = consumerrel ? "10" : result.release;
+        if (version == "10.0") {
+            result.release = consumerrel ? "10" : "2016";
         } else if (version == "6.3") {
             result.release = consumerrel ? "8.1" : "2012 R2";
         } else if (version == "6.2") {


### PR DESCRIPTION
This is a cherry-pick of several commits from master to LTS-1.7, in support of [PA-655](https://tickets.puppetlabs.com/browse/PA-655).

Because the LTS pipeline also includes macOS Sierra as a test target, this PR also includes one test fix for Sierra.