### PR TITLE
(FACT-1536) List names of facts that belong to each fact group

### DIFF
--- a/acceptance/tests/options/list_block_groups.rb
+++ b/acceptance/tests/options/list_block_groups.rb
@@ -7,6 +7,7 @@ test_name "the `--list-block-groups` command line flag prints available block gr
     step "the EC2 blockgroup should be listed" do
       on(agent, facter("--list-block-groups")) do
         assert_match(/EC2/, stdout, "Expected the EC2 group to be listed")
+        assert_match(/ec2_metadata/, stdout, "Expected the EC2 group's facts to be listed")
         assert_no_match(/kernel/, stdout, "kernel facts should not be listed as blockable")
       end
     end

--- a/acceptance/tests/options/list_cache_groups.rb
+++ b/acceptance/tests/options/list_cache_groups.rb
@@ -5,8 +5,10 @@ test_name "the `--list-cache-groups` command line flag prints available cache gr
   agents.each do |agent|
     step "the various cache groups should be listed" do
       on(agent, facter("--list-cache-groups")) do
-         assert_match(/EC2/, stdout, "EC2 facts should be listed as cacheable")
-         assert_match(/kernel/, stdout, "kernel facts should be listed as cacheable")
+         assert_match(/EC2/, stdout, "EC2 group should be listed as cacheable")
+         assert_match(/ec2_metadata/, stdout, "EC2 group's facts should be listed")
+         assert_match(/kernel/, stdout, "kernel group should be listed as cacheable")
+         assert_match(/kernelversion/, stdout, "kernel group's facts should be listed as cacheable")
       end
     end
   end

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -117,9 +117,9 @@ void log_queries(set<string> const& queries)
 }
 
 void print_fact_groups(map<string, vector<string>> const& fact_groups) {
-    for (auto group : fact_groups) {
+    for (auto& group : fact_groups) {
         boost::nowide::cout << group.first << endl;
-        for (auto fact : group.second) {
+        for (auto& fact : group.second) {
             boost::nowide::cout << "  - " << fact << endl;
         }
     }

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -249,6 +249,9 @@ int main(int argc, char **argv)
             vector<string> fact_groups = facts.get_fact_groups();
             for (auto group : fact_groups) {
                 boost::nowide::cout << group << endl;
+                for (auto fact : facts.get_facts_in_group(group)) {
+                    boost::nowide::cout << "  - " << fact << endl;
+                }
             }
             return EXIT_SUCCESS;
         }
@@ -262,9 +265,12 @@ int main(int argc, char **argv)
         if (vm.count("list-block-groups")) {
             collection facts;
             facts.add_default_facts(!vm.count("no-ruby"));
-            vector<string> blockable_facts = facts.get_blockable_fact_groups();
-            for (auto fact_group : blockable_facts) {
-                boost::nowide::cout << fact_group << endl;
+            vector<string> fact_groups = facts.get_blockable_fact_groups();
+            for (auto group : fact_groups) {
+                boost::nowide::cout << group << endl;
+                for (auto fact : facts.get_facts_in_group(group)) {
+                    boost::nowide::cout << "  - " << fact << endl;
+                }
             }
             return EXIT_SUCCESS;
         }

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -116,6 +116,15 @@ void log_queries(set<string> const& queries)
     log(level::info, "requested queries: %1%.", output.str());
 }
 
+void print_fact_groups(map<string, vector<string>> const& fact_groups) {
+    for (auto group : fact_groups) {
+        boost::nowide::cout << group.first << endl;
+        for (auto fact : group.second) {
+            boost::nowide::cout << "  - " << fact << endl;
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     try
@@ -246,13 +255,7 @@ int main(int argc, char **argv)
         if (vm.count("list-cache-groups")) {
             collection facts;
             facts.add_default_facts(!vm.count("no-ruby"));
-            vector<string> fact_groups = facts.get_fact_groups();
-            for (auto group : fact_groups) {
-                boost::nowide::cout << group << endl;
-                for (auto fact : facts.get_facts_in_group(group)) {
-                    boost::nowide::cout << "  - " << fact << endl;
-                }
-            }
+            print_fact_groups(facts.get_fact_groups());
             return EXIT_SUCCESS;
         }
 
@@ -265,13 +268,7 @@ int main(int argc, char **argv)
         if (vm.count("list-block-groups")) {
             collection facts;
             facts.add_default_facts(!vm.count("no-ruby"));
-            vector<string> fact_groups = facts.get_blockable_fact_groups();
-            for (auto group : fact_groups) {
-                boost::nowide::cout << group << endl;
-                for (auto fact : facts.get_facts_in_group(group)) {
-                    boost::nowide::cout << "  - " << fact << endl;
-                }
-            }
+            print_fact_groups(facts.get_blockable_fact_groups());
             return EXIT_SUCCESS;
         }
 

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -300,6 +300,13 @@ namespace facter { namespace facts {
          */
         std::vector<std::string> get_blockable_fact_groups();
 
+        /**
+         * Returns the names of all the facts associated with a given resolver.
+         * @param fact_group the name of the resolver
+         * @return the names of facts collected by the resolver
+         */
+        std::vector<std::string> get_facts_in_group(std::string const& fact_group);
+
      protected:
         /**
          *  Gets external fact directories for the current platform.

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -286,26 +286,20 @@ namespace facter { namespace facts {
         void resolve_facts();
 
         /**
-         * Returns the names of all the resolvers currently in the collection.
-         * These names correspond to groups of facts, and are used to allow
+         * Returns the names of all the resolvers currently in the collection,
+         * along with their associated facts. The group names are used to allow
          * caching of those facts.
-         * @return a list of fact group names
+         * @return a map of group names to their associated fact names
          */
-        std::vector<std::string> get_fact_groups();
+        std::map<std::string, std::vector<std::string>> get_fact_groups();
 
         /**
-         * Returns the names of all blockable resolvers currently in the collection.
-         * These names correspond to groups of blockable facts.
-         * @return a list of blockable fact groups
+         * Returns the names of all blockable resolvers currently in the collection,
+         * along with their associated facts. The group names are used to allow
+         * blocking of those facts.
+         * @return a map of blockable group names to their associated fact names
          */
-        std::vector<std::string> get_blockable_fact_groups();
-
-        /**
-         * Returns the names of all the facts associated with a given resolver.
-         * @param fact_group the name of the resolver
-         * @return the names of facts collected by the resolver
-         */
-        std::vector<std::string> get_facts_in_group(std::string const& fact_group);
+        std::map<std::string, std::vector<std::string>> get_blockable_fact_groups();
 
      protected:
         /**

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -277,6 +277,15 @@ namespace facter { namespace facts {
         return blockgroups;
     }
 
+    vector<string> collection::get_facts_in_group(string const& fact_group) {
+        for (auto res : _resolvers) {
+            if (res->name() == fact_group) {
+                return res->names();
+            }
+        }
+        return {};
+    }
+
     size_t collection::size()
     {
         resolve_facts();

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -267,37 +267,28 @@ namespace facter { namespace facts {
         return _facts.empty() && _resolvers.empty();
     }
 
-    vector<string> collection::get_blockable_fact_groups() {
-        vector<string> blockgroups;
+    map<string, vector<string>> collection::get_fact_groups() {
+        map<string, vector<string>> fact_groups;
+        for (auto res : _resolvers) {
+            fact_groups.emplace(res->name(), res->names());
+        }
+        return fact_groups;
+    }
+
+    map<string, vector<string>> collection::get_blockable_fact_groups() {
+        map<string, vector<string>> blockgroups;
         for (auto res : _resolvers) {
             if (res->is_blockable()) {
-                blockgroups.push_back(res->name());
+                blockgroups.emplace(res->name(), res->names());
             }
         }
         return blockgroups;
-    }
-
-    vector<string> collection::get_facts_in_group(string const& fact_group) {
-        for (auto res : _resolvers) {
-            if (res->name() == fact_group) {
-                return res->names();
-            }
-        }
-        return {};
     }
 
     size_t collection::size()
     {
         resolve_facts();
         return _facts.size();
-    }
-
-    vector<string> collection::get_fact_groups() {
-        vector<string> fact_groups;
-        for (auto res : _resolvers) {
-            fact_groups.push_back(res->name());
-        }
-        return fact_groups;
     }
 
     value const* collection::operator[](string const& name)


### PR DESCRIPTION
The first commit updates the commands using the existing API. 

The second commit refactors the collection's methods to return structured data. The code is much cleaner after the refactor, but it technically breaks Facter's public API (as released in 3.5.0). Is this a problem?