### PR TITLE
(FACT-1551) Initialize WSA before loading custom facts

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ if (RUBY_FOUND)
     set(LIBFACTER_TESTS_COMMON_SOURCES
         ${LIBFACTER_TESTS_COMMON_SOURCES}
         "ruby/ruby.cc"
+        "ruby/ruby_dirfacts.cc"
         "ruby/ruby_helper.cc")
 
     if (WIN32)

--- a/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
+++ b/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
@@ -1,0 +1,11 @@
+require 'net/http'
+Facter.add('sometest') do
+  setcode do
+    uri = URI("http://www.puppet.com")
+    if (Net::HTTP.get_response(uri))
+      'Yay'
+    else
+      'Nay'
+    end
+  end
+end

--- a/lib/tests/ruby/ruby_dirfacts.cc
+++ b/lib/tests/ruby/ruby_dirfacts.cc
@@ -1,0 +1,32 @@
+#include <catch.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/ruby/ruby.hpp>
+#include <internal/ruby/ruby_value.hpp>
+#include <leatherman/ruby/api.hpp>
+#include "../fixtures.hpp"
+#include "../collection_fixture.hpp"
+#include "./ruby_helper.hpp"
+
+using namespace std;
+using namespace facter::ruby;
+using namespace facter::testing;
+using namespace leatherman::ruby;
+
+SCENARIO("directories of custom facts written in Ruby") {
+    collection_fixture facts;
+    REQUIRE(facts.size() == 0u);
+
+    // Setup ruby
+    auto& ruby = api::instance();
+    REQUIRE(ruby.initialized());
+    ruby.include_stack_trace(true);
+
+    string fixtures = LIBFACTER_TESTS_DIRECTORY "/fixtures/ruby/";
+
+    GIVEN("a fact that performs network activity") {
+        load_custom_facts(facts, vector<string>{fixtures+"custom_dir"});
+        THEN("the network location should resolve") {
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("sometest")) == "\"Yay\"");
+        }
+    }
+}


### PR DESCRIPTION
On Windows, Ruby initializes WSA via WSAStartup during its init. However,
that's only performed for the Ruby process, not when hosted as an embedded
runtime. Ensure we initialize WSA while loading custom facts so that facts
using network calls succeed.