### PR TITLE
(FACT-1505) Update URL for new release naming

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development, :test do
   gem 'rspec', "~> 2.11.0"
   gem 'mocha', "~> 0.10.5"
   gem 'json', "~> 1.7", :platforms => :ruby
-  gem 'json-schema', :platforms => :ruby
+  gem 'json-schema', "~> 2.6.2", :platforms => :ruby
   gem 'puppetlabs_spec_helper'
 end
 

--- a/tasks/cfpropertylist.rake
+++ b/tasks/cfpropertylist.rake
@@ -2,7 +2,7 @@ task 'cfpropertylist' do
   if defined? Pkg::Config and Pkg::Config.project_root
     cfp_version = "2.3.3"
     libdir = File.join(Pkg::Config.project_root, "lib")
-    source = "https://github.com/ckruse/CFPropertyList/archive/cfpropertylist-#{cfp_version}.tar.gz"
+    source = "https://github.com/ckruse/CFPropertyList/archive/cfpropertyList-#{cfp_version}.tar.gz"
     target_dir = Pkg::Util::File.mktemp
     target = File.join(target_dir, "cfpropertylist")
     Pkg::Util::Net.fetch_uri(source, target)


### PR DESCRIPTION
In 2.3.0 cfpropertylist changed to an uppercase L, as in cfpropertyList
for its release package names. Update packaging to use the correct URL.