### PR TITLE
(packaging) Bump version to 3.4.2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.2)
 
 set(LIBFACTER_VERSION_MAJOR 3)
 set(LIBFACTER_VERSION_MINOR 4)
-set(LIBFACTER_VERSION_PATCH 1)
+set(LIBFACTER_VERSION_PATCH 2)
 
 # Get the HEAD SHA1 commit message
 get_commit_string(LIBFACTER_COMMIT)


### PR DESCRIPTION
This updates the Facter version to 3.4.2 in anticipation of the
puppet-agent 1.7.2 release.