### PR TITLE
(FACT-1559) fix os facts on latest CoreOS

### DIFF
--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -29,11 +29,12 @@ namespace facter { namespace facts { namespace linux {
 
     static unique_ptr<os_linux> get_os()
     {
-        auto release_info = os_linux::key_value_file(release_file::os, {"NAME", "CISCO_RELEASE_INFO"});
+        auto release_info = os_linux::key_value_file(release_file::os, {"NAME", "CISCO_RELEASE_INFO", "ID"});
         auto const& name = release_info["NAME"];
+        auto const& id = release_info["ID"];
         if (name == "Cumulus Linux") {
             return unique_ptr<os_linux>(new os_cumulus());
-        } else if (name == "CoreOS") {
+        } else if (name == "CoreOS" || id == "coreos") {
             return unique_ptr<os_linux>(new os_coreos());
         } else {
             auto const& cisco = release_info["CISCO_RELEASE_INFO"];


### PR DESCRIPTION
The latest CoreOS stable release 1235.6.0 introduces a renaming of
the CoreOS project to Container Linux CoreOS.
Unfortunately this affects the `/etc/os-release` NAME entry which
is used to discover the os facts in facter.
This patch now also uses the ID entry of `/etc/os-release` which presumably
will be more stable (see https://www.freedesktop.org/software/systemd/man/os-release.html
for more information).
