### PR TITLE
(packaging) Bump version to 3.5.2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.2)
 
 set(LIBFACTER_VERSION_MAJOR 3)
 set(LIBFACTER_VERSION_MINOR 5)
-set(LIBFACTER_VERSION_PATCH 1)
+set(LIBFACTER_VERSION_PATCH 2)
 
 # Get the HEAD SHA1 commit message
 get_commit_string(LIBFACTER_COMMIT)

--- a/lib/Doxyfile
+++ b/lib/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = facter
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.5.1
+PROJECT_NUMBER         = 3.5.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
This commit bumps Facter's version to 3.5.2 following the release of
3.5.1 as part of puppet-agent 1.8.3