### PR TITLE
(FACT-1561) Use top namespace when extending TestCase

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -7,7 +7,7 @@ require 'beaker-hostgenerator'
 
 $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
 require 'puppet/acceptance/git_utils'
-extend Puppet::Acceptance::GitUtils
+extend ::Puppet::Acceptance::GitUtils
 
 ONE_DAY_IN_SECS = 24 * 60 * 60
 REPO_CONFIGS_DIR = "repo-configs"

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -1,6 +1,6 @@
 require 'puppet/acceptance/common_utils'
 require 'beaker/dsl/install_utils'
-extend Beaker::DSL::InstallUtils
+extend ::Beaker::DSL::InstallUtils
 
 test_name "Install Packages"
 

--- a/acceptance/setup/common/00_EnvSetup.rb
+++ b/acceptance/setup/common/00_EnvSetup.rb
@@ -3,11 +3,11 @@ test_name "Setup environment"
 step "Ensure Git and Ruby"
 
 require 'puppet/acceptance/install_utils'
-extend Puppet::Acceptance::InstallUtils
+extend ::Puppet::Acceptance::InstallUtils
 require 'puppet/acceptance/git_utils'
-extend Puppet::Acceptance::GitUtils
+extend ::Puppet::Acceptance::GitUtils
 require 'beaker/dsl/install_utils'
-extend Beaker::DSL::InstallUtils
+extend ::Beaker::DSL::InstallUtils
 
 PACKAGES = {
   :redhat => [

--- a/acceptance/setup/git/pre-suite/01_TestSetup.rb
+++ b/acceptance/setup/git/pre-suite/01_TestSetup.rb
@@ -1,5 +1,5 @@
 test_name "Install packages and repositories on target machines..." do
-  extend Beaker::DSL::InstallUtils
+  extend ::Beaker::DSL::InstallUtils
 
   SourcePath  = Beaker::DSL::InstallUtils::SourcePath
   GitURI      = Beaker::DSL::InstallUtils::GitURI

--- a/acceptance/tests/external_facts/fact_precedence.rb
+++ b/acceptance/tests/external_facts/fact_precedence.rb
@@ -1,7 +1,7 @@
 test_name "Fact precedence and resolution order (external & custom facts)"
 
 require 'facter/acceptance/user_fact_utils'
-extend Facter::Acceptance::UserFactUtils
+extend ::Facter::Acceptance::UserFactUtils
 
 # Use a static external fact
 ext_fact = "test: 'EXTERNAL'"

--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -1,7 +1,7 @@
 test_name "Root default external facts directory (facts.d) is searched for facts"
 
 require 'facter/acceptance/user_fact_utils'
-extend Facter::Acceptance::UserFactUtils
+extend ::Facter::Acceptance::UserFactUtils
 
 #
 # The first of these tests is intended to ensure that executable external facts placed into the

--- a/acceptance/tests/external_facts/structured_executable_facts.rb
+++ b/acceptance/tests/external_facts/structured_executable_facts.rb
@@ -5,7 +5,7 @@
 test_name "executable external facts can return structured data" do
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   unix_fact_yaml = <<EOM
 #!/bin/sh

--- a/acceptance/tests/options/config_file/blocklist.rb
+++ b/acceptance/tests/options/config_file/blocklist.rb
@@ -2,7 +2,7 @@
 # the corresponding facts do not resolve.
 test_name "facts can be blocked via a list in the config file" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
     step "facts should be blocked when Facter is run from the command line" do

--- a/acceptance/tests/options/config_file/command_line_override.rb
+++ b/acceptance/tests/options/config_file/command_line_override.rb
@@ -5,7 +5,7 @@
 # line.
 test_name "flags set on the command line override config file settings" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 global : {

--- a/acceptance/tests/options/config_file/custom_facts.rb
+++ b/acceptance/tests/options/config_file/custom_facts.rb
@@ -3,7 +3,7 @@
 # by setting the global.no-custom-facts field to true.
 test_name "custom-dir and no-custom-facts config fields allow control of custom fact lookup" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   custom_fact_content = <<EOM
 Facter.add('custom_fact') do

--- a/acceptance/tests/options/config_file/debug.rb
+++ b/acceptance/tests/options/config_file/debug.rb
@@ -2,7 +2,7 @@
 # causes DEBUG information to be printed to stderr.
 test_name "setting the debug config field to true prints debug info to stderr" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 cli : {

--- a/acceptance/tests/options/config_file/external_facts.rb
+++ b/acceptance/tests/options/config_file/external_facts.rb
@@ -3,7 +3,7 @@
 # setting disables external fact lookup.
 test_name "external-dir and no-external-facts config fields allow control of external fact lookup" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   unix_content = <<EOM
 #!/bin/sh

--- a/acceptance/tests/options/config_file/load_from_ruby.rb
+++ b/acceptance/tests/options/config_file/load_from_ruby.rb
@@ -7,7 +7,7 @@
 # in the directory paths defined with external-dir and custome-dir in the facter.conf file
 test_name "config file is loaded when Facter is run from Puppet" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
     # create paths for default facter.conf, external-dir, and custom-dir

--- a/acceptance/tests/options/config_file/log_level.rb
+++ b/acceptance/tests/options/config_file/log_level.rb
@@ -3,7 +3,7 @@
 # logging level.
 test_name "log-level setting can be used to specific logging level" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 cli : {

--- a/acceptance/tests/options/config_file/no_ruby.rb
+++ b/acceptance/tests/options/config_file/no_ruby.rb
@@ -3,7 +3,7 @@
 test_name "no-ruby config field flag disables requiring Ruby" do
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 global : {

--- a/acceptance/tests/options/config_file/trace.rb
+++ b/acceptance/tests/options/config_file/trace.rb
@@ -2,7 +2,7 @@
 # enables backtrace reporting for errors in custom facts.
 test_name "trace config field enables backtraces for custom facts" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   erroring_custom_fact = <<EOM
 Facter.add('custom_fact') do

--- a/acceptance/tests/options/config_file/ttls.rb
+++ b/acceptance/tests/options/config_file/ttls.rb
@@ -3,7 +3,7 @@
 # covers various failures in the caching mechanism
 test_name "ttls config field stores and retreives cached facts" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/verbose.rb
+++ b/acceptance/tests/options/config_file/verbose.rb
@@ -2,7 +2,7 @@
 # config file causes INFO level logging to output to stderr.
 test_name "verbose config field prints verbose information to stderr" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   config = <<EOM
 cli : {

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -10,10 +10,10 @@ test_name "custom fact commandline options (--no-custom-facts and --custom-dir)"
   confine :except, :platform => 'cisco_nexus' # see BKR-749
 
   require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
+  extend ::Puppet::Acceptance::CommandUtils
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   content = <<EOM
 Facter.add('custom_fact') do

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -6,7 +6,7 @@
 test_name "external fact commandline options (--no-external-facts and --external-dir)" do
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   unix_content = <<EOM
 #!/bin/sh

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -6,7 +6,7 @@ test_name "--json command-line option results in valid JSON output" do
 
   require 'json'
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   content = <<EOM
 Facter.add('structured_fact') do

--- a/acceptance/tests/options/no_block.rb
+++ b/acceptance/tests/options/no_block.rb
@@ -2,7 +2,7 @@
 # fact blocking, desptie a blocklist being specified in the config file.
 test_name "the `--no-block` command line flag prevents facts from being blocked" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
     # default facter.conf

--- a/acceptance/tests/options/no_cache.rb
+++ b/acceptance/tests/options/no_cache.rb
@@ -3,7 +3,7 @@
 # be queried nor refreshed.
 test_name "--no-cache command-line option causes the fact cache to be ignored" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   # the uptime fact should be resolvable on ALL systems
   # Note: do NOT use the kernel fact, as it is used to configure the tests

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -6,7 +6,7 @@
 test_name "--no-ruby commandline option" do
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   content = <<EOM
 Facter.add('custom_fact') do

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -4,7 +4,7 @@
 test_name "--trace command-line option enables backtraces for custom facts" do
 
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   content = <<EOM
 Facter.add('custom_fact') do

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -6,7 +6,7 @@ test_name "--yaml command-line option results in valid YAML output" do
 
   require 'yaml'
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   content = <<EOM
 Facter.add('structured_fact') do

--- a/acceptance/tests/runs_external_facts_once.rb
+++ b/acceptance/tests/runs_external_facts_once.rb
@@ -1,7 +1,7 @@
 test_name "#22944: Facter executes external executable facts many times"
 
 require 'facter/acceptance/user_fact_utils'
-extend Facter::Acceptance::UserFactUtils
+extend ::Facter::Acceptance::UserFactUtils
 
 agents.each do |agent|
   step "Agent #{agent}: create external executable fact"

--- a/acceptance/tests/verify_mountpoints.rb
+++ b/acceptance/tests/verify_mountpoints.rb
@@ -3,7 +3,7 @@
 
 test_name "FACT-1502 - C98163 mountpoints fact should show mounts on tmpfs" do
   require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
+  extend ::Facter::Acceptance::UserFactUtils
 
   confine :except, :platform => 'windows'
   confine :except, :platform => /osx/ # See PUP-4823


### PR DESCRIPTION
A recent change in Beaker renamed one of the module names from
"FacterHelpers" to simply "Facter". This exposed a flaw in the way tests
in this repo were extending the TestCase object. When not specifying the
top namespace, the `extend` method introspects the current module first
before looking out to the `$LOAD_PATH`. Now that `Facter` is a module
included in the DSL, attempting to execute `extend Facter::Lib` will
result in ruby looking into `Beaker::DSL::Facter::Lib`.

This change prepends a `::` to all appropriate module names in testing,
so that ruby knows to look for these helper libraries at the top level
namespace. Fixing the tests here will make them more resilient to future
beaker changes.