### PR TITLE
(FACT-1544) Removed unused cache files

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -204,9 +204,7 @@ int main(int argc, char **argv)
                 load_global_settings(hocon_conf, vm);
                 load_cli_settings(hocon_conf, vm);
                 load_fact_settings(hocon_conf, vm);
-                if (!vm.count("no-cache")) {
-                    ttls = load_ttls(hocon_conf);
-                }
+                ttls = load_ttls(hocon_conf);
             }
 
             // Check for a help option first before notifying
@@ -326,7 +324,8 @@ int main(int argc, char **argv)
             auto facts_to_block = vm["blocklist"].as<vector<string>>();
             blocklist.insert(facts_to_block.begin(), facts_to_block.end());
         }
-        collection facts(blocklist, ttls);
+        bool ignore_cache = vm.count("no-cache");
+        collection facts(blocklist, ttls, ignore_cache);
         facts.add_default_facts(ruby);
 
         // Add the environment facts

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -92,9 +92,11 @@ namespace facter { namespace facts {
          * @param blocklist the names of resolvers that should not be resolved
          * @param ttls a map of resolver names to cache intervals (times-to-live)
          *        for the facts they resolve
+         * @param ignore_cache true if the cache should not be consulted when resolving facts
          */
         collection(std::set<std::string> const& blocklist = std::set<std::string>(),
-                   std::unordered_map<std::string, int64_t> const& ttls = std::unordered_map<std::string, int64_t>{});
+                   std::unordered_map<std::string, int64_t> const& ttls = std::unordered_map<std::string, int64_t>{},
+                   bool ignore_cache = false);
 
         /**
          * Destructor for fact collection.
@@ -331,6 +333,7 @@ namespace facter { namespace facts {
         std::list<std::shared_ptr<resolver>> _pattern_resolvers;
         std::set<std::string> _blocklist;
         std::unordered_map<std::string, int64_t> _ttls;
+        bool _ignore_cache;
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/internal/facts/cache.hpp
+++ b/lib/inc/internal/facts/cache.hpp
@@ -59,4 +59,13 @@ namespace facter { namespace facts { namespace cache {
      * @return the timespan in seconds since last modification
      */
     int64_t get_file_lifetime(boost::filesystem::path file_path);
+
+    /**
+     * Removes the cache file for any resolver that does not appear in the
+     * supplied list of fact groups.
+     * @param facts_to_cache the list of fact groups that should be cached
+     * @param cache_location the absolute path to the fact cache directory
+     */
+    void clean_cache(std::unordered_map<std::string, int64_t> const& facts_to_cache,
+            std::string cache_location = fact_cache_location());
 }}}  // namespace facter::facts::cache

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -247,6 +247,62 @@ msgstr ""
 msgid "Cannot iterate over the same ODM class concurrently"
 msgstr ""
 
+#. debug
+#: lib/inc/internal/util/aix/vmount.hpp
+msgid "Required space for mountpoints is {1}"
+msgstr ""
+
+#. debug
+#: lib/inc/internal/util/aix/vmount.hpp
+msgid "Got {1} mountpoints"
+msgstr ""
+
+#. debug
+#: lib/src/facts/aix/disk_resolver.cc
+msgid "got a disk type: {1}"
+msgstr ""
+
+#: lib/src/facts/aix/disk_resolver.cc
+#: lib/src/facts/aix/processor_resolver.cc
+msgid "PdDvLn=%1%"
+msgstr ""
+
+#. debug
+#: lib/src/facts/aix/disk_resolver.cc
+msgid "got a disk: {1}"
+msgstr ""
+
+#: lib/src/facts/aix/disk_resolver.cc
+msgid "/dev/%1%"
+msgstr ""
+
+#. warning
+#: lib/src/facts/aix/disk_resolver.cc
+msgid ""
+"Expected a Disk or SCSI disk device, got device code '{1}'. This is probably "
+"a Facter bug. Please report it, and include this error message."
+msgstr ""
+
+#. warning
+#: lib/src/facts/aix/filesystem_resolver.cc
+msgid "Could not get fs data for {1}: {2}"
+msgstr ""
+
+#: lib/src/facts/aix/filesystem_resolver.cc
+#: lib/src/facts/aix/processor_resolver.cc
+msgid "name=%1%"
+msgstr ""
+
+#. warning
+#: lib/src/facts/aix/filesystem_resolver.cc
+msgid "Could not get info for partition '{1}' from the LVM subsystem"
+msgstr ""
+
+#. warning
+#: lib/src/facts/aix/filesystem_resolver.cc
+msgid "querylv returned success but we got a null LV. WTF?"
+msgstr ""
+
 #. warning
 #: lib/src/facts/aix/kernel_resolver.cc
 msgid "oslevel failed: {1}: kernel facts are unavailable"
@@ -305,17 +361,9 @@ msgstr ""
 msgid "got a processor type: {1}"
 msgstr ""
 
-#: lib/src/facts/aix/processor_resolver.cc
-msgid "PdDvLn=%1%"
-msgstr ""
-
 #. debug
 #: lib/src/facts/aix/processor_resolver.cc
 msgid "got a processor: {1}"
-msgstr ""
-
-#: lib/src/facts/aix/processor_resolver.cc
-msgid "name=%1%"
 msgstr ""
 
 #. debug
@@ -364,6 +412,11 @@ msgstr ""
 #. debug
 #: lib/src/facts/bsd/networking_resolver.cc
 msgid "reading \"{1}\" for dhclient lease information."
+msgstr ""
+
+#. debug
+#: lib/src/facts/cache.cc
+msgid "Deleting unused cache file {1}"
 msgstr ""
 
 #. debug
@@ -1350,11 +1403,6 @@ msgstr ""
 
 #: lib/src/ruby/module.cc
 msgid "execution of command \"{1}\" failed."
-msgstr ""
-
-#. debug
-#: lib/src/ruby/module.cc
-msgid "path \"{1}\" will not be searched for custom facts: {2}."
 msgstr ""
 
 #. debug


### PR DESCRIPTION
Previously, when a fact that used to be cached was removed from the
config file, the corresponding cache file continued to exist on disk,
even though Facter ignored it. This commit ensures that such superfluous
files get removed whenever facts are resolved.