### PR TITLE
(maint) Do not rely on external networking for WSASetup validation

### DIFF
--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -4,9 +4,6 @@
 #include <internal/ruby/ruby_value.hpp>
 #include <leatherman/ruby/api.hpp>
 #include <leatherman/logging/logging.hpp>
-#ifdef _WIN32
-#include <internal/util/windows/wsa.hpp>
-#endif
 
 #include <numeric>
 
@@ -50,13 +47,6 @@ namespace facter { namespace ruby {
 
     void load_custom_facts(collection& facts, bool initialize_puppet, vector<string> const& paths)
     {
-#ifdef _WIN32
-        // Initialize WSA before resolving custom facts. The Ruby runtime does this only when running
-        // in a Ruby process, it leaves it up to us when embedding it. See
-        // https://github.com/ruby/ruby/blob/v2_1_9/ruby.c#L2011-L2022 for comments.
-        // The only piece we seem to need out of rb_w32_sysinit is WSAStartup.
-        util::windows::wsa winsocket;
-#endif
         api& ruby = api::instance();
         module mod(facts, {}, !initialize_puppet);
         if (initialize_puppet) {

--- a/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
+++ b/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
@@ -1,11 +1,15 @@
 require 'net/http'
 Facter.add('sometest') do
   setcode do
-    uri = URI("http://www.puppet.com")
-    if (Net::HTTP.get_response(uri))
-      'Yay'
-    else
-      'Nay'
+    begin
+      s = Socket::new(:INET, :STREAM);
+      sockaddr = Socket.pack_sockaddr_in(5555, '127.0.0.1')
+      s.bind(sockaddr)
+      s.listen(1)
+      s.close
+      "Yay"
+    rescue
+      "Nay"
     end
   end
 end


### PR DESCRIPTION
For FACT-1551, we added a test to ensure we had called WSASetup before
trying to resolve Ruby facts. As originally implemented, this test
required public network access and a functional external resource.

Most of this is not necessary to validate that WSA has been setup, and
makes the test more fragile. Instead, we can simply ensure that
creating and closing a socket proceeds without error.