### PR TITLE
(maint) Use a different fake command name

### DIFF
--- a/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
+++ b/lib/tests/fixtures/ruby/execute_on_fail_raise.rb
@@ -1,17 +1,17 @@
 # Should raise by default
 begin
-    Facter::Core::Execution.execute('not a command')
+    Facter::Core::Execution.execute('the_most_interesting_command_in_the_world')
     raise 'did not raise'
 rescue Facter::Core::Execution::ExecutionFailure
 end
 
 # Should raise if given an option hash that does not contain :on_fail
 begin
-    Facter::Core::Execution.execute('not a command', {})
+    Facter::Core::Execution.execute('the_most_interesting_command_in_the_world', {})
     raise 'did not raise'
 rescue Facter::Core::Execution::ExecutionFailure
 end
 
 # Should raise if directly given the option
-Facter::Core::Execution.execute('not a command', :on_fail => :raise)
+Facter::Core::Execution.execute('the_most_interesting_command_in_the_world', :on_fail => :raise)
 raise 'did not raise'

--- a/lib/tests/fixtures/ruby/execute_on_fail_value.rb
+++ b/lib/tests/fixtures/ruby/execute_on_fail_value.rb
@@ -1,5 +1,5 @@
 Facter.add(:foo) do
     setcode do
-        Facter::Core::Execution.execute('not a command', :on_fail => 'default')
+        Facter::Core::Execution.execute('the_most_interesting_command_in_the_world', :on_fail => 'default')
     end
 end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -479,7 +479,7 @@ SCENARIO("custom facts written in Ruby") {
         THEN("an error is logged") {
             auto output = capture.result();
             CAPTURE(output);
-            REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - .* execution of command \"not a command\" failed")));
+            REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - .* execution of command \"the_most_interesting_command_in_the_world\" failed")));
         }
     }
     GIVEN("a fact resolution that uses Facter::Core::Execution#execute with a default value") {


### PR DESCRIPTION
Some recent versions of LLVM can ship a binary called `not` into the
system path. This can break our tests that assume "not a command" is
invalid. This commit uses a much more likely to be invalid command
string to try to avoid this in the future.