### PR TITLE
(FACT-1569) Add Ubuntu 16.10 to Ubuntu acceptance test

### DIFF
--- a/acceptance/tests/facts/ubuntu.rb
+++ b/acceptance/tests/facts/ubuntu.rb
@@ -38,6 +38,10 @@ agents.each do |agent|
     os_name    = 'xenial'
     os_version = '16.04'
     os_kernel  = /4.\d+/
+  elsif agent['platform'] =~ /ubuntu-16.10/
+    os_name    = 'yakkety'
+    os_version = '16.10'
+    os_kernel  = /4.\d+/
   else
     fail_test("Unknown Ubuntu platform: #{agent['platform']}")
   end


### PR DESCRIPTION
This commit adds Ubuntu 16.10 data to the switch statement in the Ubuntu
facts test, allowing the test to pass on the new platform.