### PR TITLE
(FACT-1544) Fix exit code check for ttls test

### DIFF
--- a/acceptance/tests/options/config_file/ttls.rb
+++ b/acceptance/tests/options/config_file/ttls.rb
@@ -123,7 +123,7 @@ EOM
         end
 
         # Expect the fact file to exist
-        on(agent,"cat #{cached_fact_file}", :acceptable_exit_codes => [0])
+        assert(agent.file_exist?("#{cached_fact_file}"), "Expected cache file to exist")
       end
 
       # When calling Facter from Puppet
@@ -178,7 +178,7 @@ EOM
 
           on(agent, facter("--config '#{no_cache_config_file}'"))
           # Expect cache file to not exist
-          on(agent, "cat '#{cached_fact_file}'", :acceptable_exit_codes => [1])
+          refute(agent.file_exist?("#{cached_fact_file}"), "Expected cache file to be absent")
         end
       end
 


### PR DESCRIPTION
On Solaris, `cat` exits 2 when a file doesn't exist, while all other
systems exit 1. This commit switches to using beaker's file_exist?
method instead of `cat` to check for files.