### PR TITLE
Revert "(FACT-1541) javah command runs late in parallel build"

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -265,17 +265,9 @@ if (JRUBY_SUPPORT)
     )
 
     include(UseJava)
-    add_jar(facter-jruby-jar "${CMAKE_BINARY_DIR}/lib/com/puppetlabs/Facter.java" OUTPUT_NAME facter OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib" ENTRY_POINT com/puppetlabs/Facter)
+    add_jar(facter-jruby "${CMAKE_BINARY_DIR}/lib/com/puppetlabs/Facter.java" OUTPUT_NAME facter OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib" ENTRY_POINT com/puppetlabs/Facter)
 
-    # javah does not atomically write the header file, so parallel builds can
-    # read it before it finishes writing if not careful.
-    add_custom_command(OUTPUT "${CMAKE_CURRENT_LIST_DIR}/src/java/com_puppetlabs_Facter.h"
-                       COMMAND javah ARGS -classpath facter.jar -d "${CMAKE_CURRENT_LIST_DIR}/src/java" com.puppetlabs.Facter
-                       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-                       DEPENDS facter-jruby-jar)
-    # Anything that depends on facter-jruby wants both the jar AND the completely written header.
-    add_custom_target(facter-jruby DEPENDS facter-jruby-jar "${CMAKE_CURRENT_LIST_DIR}/src/java/com_puppetlabs_Facter.h")
-    set(LIBFACTER_COMMON_SOURCES ${LIBFACTER_COMMON_SOURCES} src/java/com_puppetlabs_Facter.h)
+    add_custom_command(TARGET facter-jruby POST_BUILD COMMAND javah ARGS -d "${CMAKE_CURRENT_LIST_DIR}/src/java" com.puppetlabs.Facter WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 endif()
 
 # Set include directories


### PR DESCRIPTION
Reverts puppetlabs/facter#1476.

In order to validate puppet-agent for the 1.9.2 release, we need some acceptance changes that landed after the commit this reverts. In order to feel safe pinning back to the 3.6.1 tag in that release, we are reverting all non-acceptance changes from this branch. The work in this commit has already been merged up to the master branch, so it will go out in the next major or minor release. This commit can be itself reverted after the release of 1.9.2 if so desired.