### PR TITLE
(FACT-1583) Output exception message when test fails

### DIFF
--- a/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
+++ b/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
@@ -1,11 +1,15 @@
 require 'net/http'
 Facter.add('sometest') do
   setcode do
-    uri = URI("http://www.puppet.com")
-    if (Net::HTTP.get_response(uri))
-      'Yay'
-    else
-      'Nay'
+    begin
+      uri = URI("http://www.puppet.com")
+      if (Net::HTTP.get_response(uri))
+        'Yay'
+      else
+        'Nay'
+      end
+    rescue => e
+      e.message
     end
   end
 end


### PR DESCRIPTION
For reasons unknown, the custom fact that relies on networking sometimes
fails on Fedora 24, but the test output only says that "" doesn't equal
"Yay".

If an exception occurs, output the message as the fact resolution, which
won't equal "Yay". That way we can debug the issue if/when it occurs
again.