### PR TITLE
(FACT-1583) Use mock server to test HTTP custom fact

### DIFF
--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -83,6 +83,10 @@ set(LIBFACTER_TESTS_PLATFORM_LIBRARIES
 )
 
 if (WIN32)
+    list(APPEND LIBFACTER_TESTS_PLATFORM_LIBRARIES Mswsock)
+endif()
+
+if (WIN32)
     set(LIBFACTER_TESTS_CATEGORY_SOURCES
         "facts/windows/collection.cc"
         "facts/windows/networking_resolver.cc"
@@ -118,8 +122,21 @@ include_directories(
     ${CPPHOCON_INCLUDE_DIRS}
 )
 
-add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc> ${LIBFACTER_TESTS_COMMON_SOURCES} ${LIBFACTER_TESTS_PLATFORM_SOURCES} ${LIBFACTER_TESTS_CATEGORY_SOURCES})
+# On EL 4, we run into a linking error when trying to create libraries or
+# executables that link in a static library with code using threads. As I
+# described in https://gcc.gnu.org/ml/gcc-help/2015-08/msg00035.html, we get
+# the error undefined reference to symbol '__tls_get_addr@@GLIBC_2.3'.
+# Build mock_server as a separate shared library to avoid this error.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+add_library(mock-server mock_server.cc)
+target_link_libraries(mock-server PRIVATE ${Boost_LIBRARIES})
+
+add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc>
+    ${LIBFACTER_TESTS_COMMON_SOURCES}
+    ${LIBFACTER_TESTS_PLATFORM_SOURCES}
+    ${LIBFACTER_TESTS_CATEGORY_SOURCES})
 target_link_libraries(libfacter_test
+    mock-server
     ${CPPHOCON_LIBRARIES}
     ${POSIX_TESTS_LIBRARIES}
     ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}

--- a/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
+++ b/lib/tests/fixtures/ruby/custom_dir/expect_network_init.rb
@@ -2,7 +2,7 @@ require 'net/http'
 Facter.add('sometest') do
   setcode do
     begin
-      uri = URI("http://www.puppet.com")
+      uri = URI("http://localhost:42000")
       if (Net::HTTP.get_response(uri))
         'Yay'
       else

--- a/lib/tests/mock_server.cc
+++ b/lib/tests/mock_server.cc
@@ -1,0 +1,44 @@
+#include <cstdlib>
+#include <iostream>
+#include <utility>
+#include "mock_server.hpp"
+
+namespace facter {
+
+static void session(tcp::socket sock) {
+  try {
+      for (;;) {
+          char data[1024];
+
+          boost::system::error_code error;
+          sock.read_some(boost::asio::buffer(data), error);
+          if (error == boost::asio::error::eof) {
+              break; // Connection closed cleanly by peer.
+          } else if (error) {
+              throw boost::system::system_error(error); // Some other error.
+          }
+
+          std::string response = "HTTP/1.1 301 Moved Permanently\nContent-length: 0\nLocation: https://puppet.com/\nConnection: close\n\n";
+          boost::asio::write(sock, boost::asio::buffer(response));
+      }
+  } catch (std::exception& e) {
+    std::cerr << "Exception in thread: " << e.what() << "\n";
+  }
+}
+
+mock_server::mock_server(int port) :
+    acceptor_(io_service_, tcp::endpoint(tcp::v4(), port)),
+    socket_(io_service_)
+{
+    acceptor_.async_accept(socket_, [this](boost::system::error_code ec) {
+        if (!ec) session(std::move(socket_));
+    });
+    thread_ = boost::thread([this]() {io_service_.run_one();});
+}
+
+mock_server::~mock_server()
+{
+    thread_.join();
+}
+
+}  // namespace facter

--- a/lib/tests/mock_server.hpp
+++ b/lib/tests/mock_server.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#include <boost/asio.hpp>
+#include <boost/thread.hpp>
+#pragma GCC diagnostic pop
+
+namespace facter {
+
+    using boost::asio::ip::tcp;
+
+    class mock_server {
+    public:
+        mock_server(int port);
+        ~mock_server();
+    private:
+        boost::asio::io_service io_service_;
+        tcp::acceptor acceptor_;
+        tcp::socket socket_;
+        boost::thread thread_;
+    };
+
+}  // namespace facter

--- a/lib/tests/ruby/ruby_dirfacts.cc
+++ b/lib/tests/ruby/ruby_dirfacts.cc
@@ -7,6 +7,8 @@
 #include "../collection_fixture.hpp"
 #include "./ruby_helper.hpp"
 
+#include "../mock_server.hpp"
+
 using namespace std;
 using namespace facter::ruby;
 using namespace facter::testing;
@@ -24,6 +26,7 @@ SCENARIO("directories of custom facts written in Ruby") {
     string fixtures = LIBFACTER_TESTS_DIRECTORY "/fixtures/ruby/";
 
     GIVEN("a fact that performs network activity") {
+        facter::mock_server m(42000);
         load_custom_facts(facts, vector<string>{fixtures+"custom_dir"});
         THEN("the network location should resolve") {
             REQUIRE(ruby_value_to_string(facts.get<ruby_value>("sometest")) == "\"Yay\"");


### PR DESCRIPTION
Uses a mock server to test an HTTP custom fact. This avoids intermittent
failures when dns resolution fails or the network is unavailable.