### PR TITLE
(FACT-1583) Fix compiler issues

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -299,17 +299,30 @@ if(AIX)
     set_target_properties(libfacter PROPERTIES LINK_FLAGS "-Wl,-G -eInit_libfacter")
 endif()
 
-# Link in additional libraries
-target_link_libraries(libfacter PRIVATE
-    ${CPPHOCON_LIBRARIES}
-    ${LIBFACTER_PLATFORM_LIBRARIES}
-    ${LEATHERMAN_LIBRARIES}
-    ${Boost_LIBRARIES}
+set(LIBS ${CPPHOCON_LIBRARIES})
+
+# Static libraries should come before shared libraries, or you can end up
+# with some really annoying link errors. However, we can configure whether
+# Boost and Leatherman are linked statically or dynamically.
+if (LEATHERMAN_SHARED)
+    # If Leatherman is shared, Boost should come first because
+    # it's static, or the order doesn't matter.
+    list(APPEND LIBS ${Boost_LIBRARIES} ${LEATHERMAN_LIBRARIES})
+else()
+    # If Leatherman is static, it should come first as it depends
+    # on Boost.
+    list(APPEND LIBS ${LEATHERMAN_LIBRARIES} ${Boost_LIBRARIES})
+endif()
+
+list(APPEND LIBS
     ${OPENSSL_LIBRARIES}
     ${YAMLCPP_LIBRARIES}
     ${CURL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
+
+# Link in additional libraries
+target_link_libraries(libfacter PRIVATE ${LIBS} ${LIBFACTER_PLATFORM_LIBRARIES})
 
 symbol_exports(libfacter "${CMAKE_CURRENT_LIST_DIR}/inc/facter/export.h")
 target_compile_definitions(libfactersrc PRIVATE "-Dlibfacter_EXPORTS")

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -128,25 +128,31 @@ include_directories(
 # the error undefined reference to symbol '__tls_get_addr@@GLIBC_2.3'.
 # Build mock_server as a separate shared library to avoid this error.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-add_library(mock-server mock_server.cc)
-target_link_libraries(mock-server PRIVATE ${Boost_LIBRARIES})
+add_library(mock-server SHARED mock_server.cc)
+target_link_libraries(mock-server PRIVATE
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
 
 add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc>
     ${LIBFACTER_TESTS_COMMON_SOURCES}
     ${LIBFACTER_TESTS_PLATFORM_SOURCES}
     ${LIBFACTER_TESTS_CATEGORY_SOURCES})
-target_link_libraries(libfacter_test
-    mock-server
-    ${CPPHOCON_LIBRARIES}
-    ${POSIX_TESTS_LIBRARIES}
-    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
-    ${YAMLCPP_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
-    ${LEATHERMAN_LIBRARIES}
-    ${CURL_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
-)
+# On Windows, mock-server comes after Boost libraries to avoid double
+# definition of boost::system::system_category() on Windows. On Linux, it
+# comes before to avoid picking up incomplete Boost.Asio symbols included
+# by Boost.Log in Leatherman logging.
+if (WIN32)
+    target_link_libraries(libfacter_test
+        ${LIBS}
+        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
+        mock-server)
+else()
+    target_link_libraries(libfacter_test
+        mock-server
+        ${LIBS}
+        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
+endif()
 
 target_compile_definitions(libfacter_test PRIVATE "-Dlibfacter_EXPORTS")
 

--- a/lib/tests/mock_server.hpp
+++ b/lib/tests/mock_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>


### PR DESCRIPTION
Overlooked two issues when sourcing from cpp-pcp-client tests:
- BUILD_SHARED_LIBS in the top-level CMakeLists
- ignoring unused variable warnings from asio

Fix those issues.