### PR TITLE
(FACT-1585) Change metadata host to long hostname

### DIFF
--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -240,7 +240,7 @@ namespace facter { namespace facts { namespace resolvers {
 
         try
         {
-            lth_curl::request req("http://metadata/computeMetadata/v1beta1/?recursive=true&alt=json");
+            lth_curl::request req("http://metadata.google.internal/computeMetadata/v1beta1/?recursive=true&alt=json");
             req.connection_timeout(GCE_CONNECTION_TIMEOUT);
             req.timeout(GCE_SESSION_TIMEOUT);
             if (!http_langs().empty())


### PR DESCRIPTION
In some situations when non google DNS is used, facter can not resolve metadata hostname.

Long hostname is automatically added by google
`/etc/host`
```
169.254.169.254 metadata.google.internal  # Added by Google
```
Moreover google docs are using long hostname in examples. (https://cloud.google.com/compute/docs/storing-retrieving-metadata)