### PR TITLE
(FACT-1591) add TestRail numbers and missing teardown code

### DIFF
--- a/acceptance/tests/options/config_file/debug.rb
+++ b/acceptance/tests/options/config_file/debug.rb
@@ -1,6 +1,7 @@
 # This test is intended to demonstrate that setting the cli.debug field to true
 # causes DEBUG information to be printed to stderr.
-test_name "setting the debug config field to true prints debug info to stderr" do
+test_name "C99965: setting the debug config field to true prints debug info to stderr" do
+
   config = <<EOM
 cli : {
     debug : true
@@ -12,6 +13,10 @@ EOM
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
       create_remote_file(agent, config_file, config)
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'")
+      end
 
       step "debug output should print when config file is loaded" do
         on(agent, facter("--config '#{config_file}'")) do

--- a/acceptance/tests/options/config_file/default_file_location.rb
+++ b/acceptance/tests/options/config_file/default_file_location.rb
@@ -2,7 +2,8 @@
 # saved at the default location without any special command line flags.
 # On Unix, this location is /etc/puppetlabs/facter/facter.conf.
 # On Windows, it is C:\ProgramData\PuppetLabs\facter\etc\facter.conf
-test_name "config file is loaded from default location" do
+test_name "C99991: config file is loaded from default location" do
+
   config = <<EOM
 cli : {
     debug : true

--- a/acceptance/tests/options/config_file/log_level.rb
+++ b/acceptance/tests/options/config_file/log_level.rb
@@ -1,7 +1,8 @@
 # This test ensures that the cli.log-level config file setting works
 # properly. The value of the setting should be a string indicating the
 # logging level.
-test_name "log-level setting can be used to specific logging level" do
+test_name "C99990: log-level setting can be used to specific logging level" do
+
   config = <<EOM
 cli : {
     log-level : debug
@@ -13,6 +14,10 @@ EOM
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
       create_remote_file(agent, config_file, config)
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'")
+      end
 
       step "log-level set to debug should print DEBUG output to stderr" do
         on(agent, facter("--config '#{config_file}'")) do

--- a/acceptance/tests/options/config_file/no_ruby.rb
+++ b/acceptance/tests/options/config_file/no_ruby.rb
@@ -1,6 +1,6 @@
 # This test is intended to demonstrate that the global.no-ruby config file field
 # disables requiring Ruby and prevents custom fact lookup.
-test_name "no-ruby config field flag disables requiring Ruby" do
+test_name "C99964: no-ruby config field flag disables requiring Ruby" do
 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
@@ -25,6 +25,10 @@ EOM
       config_file = File.join(config_dir, "facter.conf")
       create_remote_file(agent, config_file, config)
 
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'")
+      end
+
       step "no-ruby option should disable Ruby and facts requiring Ruby" do
         on(agent, facter("--config '#{config_file}' ruby")) do
           assert_equal("", stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{stdout.chomp}")
@@ -38,6 +42,10 @@ EOM
           on(agent, "mkdir -p '#{custom_dir}'")
           custom_fact = File.join(custom_dir, 'custom_fact.rb')
           create_remote_file(agent, custom_fact, custom_fact_content)
+
+          teardown do
+            on(agent, "rm -f '#{custom_fact}'")
+          end
 
           on(agent, facter("--config '#{config_file}' custom_fact", :environment => { 'FACTERLIB' => custom_dir })) do
             assert_equal("", stdout.chomp, "Expected custom fact to be disabled when no-ruby is true, but it resolved as #{stdout.chomp}")

--- a/acceptance/tests/options/config_file/trace.rb
+++ b/acceptance/tests/options/config_file/trace.rb
@@ -1,6 +1,7 @@
 # This test is intended to demonstrate that setting the cli.trace field to true
 # enables backtrace reporting for errors in custom facts.
-test_name "trace config field enables backtraces for custom facts" do
+test_name "C99988: trace config field enables backtraces for custom facts" do
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
@@ -33,6 +34,10 @@ EOM
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
       create_remote_file(agent, config_file, config)
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'")
+      end
 
       step "trace setting should provide a backtrace for a custom fact with errors" do
         on(agent, facter("--custom-dir '#{custom_dir}' --config '#{config_file}' custom_fact"), :acceptable_exit_codes => [1])

--- a/acceptance/tests/options/config_file/verbose.rb
+++ b/acceptance/tests/options/config_file/verbose.rb
@@ -1,6 +1,7 @@
 # This test is intended to demonstrate that setting cli.verbose to true in the 
 # config file causes INFO level logging to output to stderr.
-test_name "verbose config field prints verbose information to stderr" do
+test_name "C99989: verbose config field prints verbose information to stderr" do
+
   config = <<EOM
 cli : {
     verbose : true
@@ -12,6 +13,10 @@ EOM
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
       create_remote_file(agent, config_file, config)
+
+      teardown do
+        on(agent, "rm -rf '#{config_dir}'")
+      end
 
       step "debug output should print when config file is loaded" do
         on(agent, facter("--config '#{config_file}'")) do

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -1,6 +1,6 @@
 # This test is intended to ensure that the --debug command-line option works
 # properly. This option prints debugging information to stderr.
-test_name "--debug command-line option prints debugging information to stderr" do
+test_name "C63191: --debug command-line option prints debugging information to stderr" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using --debug option" do

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -1,7 +1,7 @@
 # This test is intended to ensure that the --help command-line option works
 # properly. This option prints usage information and available command-line
 # options.
-test_name "--help command-line option prints usage information to stdout" do
+test_name "C99984: --help command-line option prints usage information to stdout" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve usage info from stdout using --help option" do

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -2,7 +2,7 @@
 # properly. This option causes Facter to output facts in JSON format.
 # A custom fact is used to test for parity between Facter's output and
 # the expected JSON output.
-test_name "--json command-line option results in valid JSON output" do
+test_name "C99966, C98083: --json command-line option results in valid JSON output" do
 
   require 'json'
   require 'facter/acceptance/user_fact_utils'

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -1,7 +1,7 @@
 # This test is intended to ensure that the --log-level command-line option works
 # properly. This option can be used with an argument to specify the level of logging
 # which will present in Facter's output.
-test_name "--log-level command-line option can be used to specify logging level" do
+test_name "C99985: --log-level command-line option can be used to specify logging level" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option" do

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -3,7 +3,7 @@
 # when using the --no-ruby fact, and also checks that the 'No Ruby' warning does
 # not appear in stderr. The second test ensures that custom facts are not resolved
 # when the --no-ruby option is present.
-test_name "--no-ruby commandline option" do
+test_name "C99987: --no-ruby commandline option" do
 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
@@ -30,6 +30,10 @@ EOM
         on(agent, "mkdir -p '#{custom_dir}'")
         custom_fact = File.join(custom_dir, 'custom_fact.rb')
         create_remote_file(agent, custom_fact, content)
+
+        teardown do
+          on(agent, "rm -f '#{custom_fact}'")
+        end
 
         on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do
           assert_equal("", stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{stdout.chomp}")

--- a/acceptance/tests/options/show_legacy.rb
+++ b/acceptance/tests/options/show_legacy.rb
@@ -1,6 +1,6 @@
 # This test is intended to demonstrate that the `--show-legacy` command line option
 # causes hidden old facts to appear in the fact list.
-test_name "--show-legacy command-line option results in output with legacy (hidden) facts" do
+test_name "C87580: --show-legacy command-line option results in output with legacy (hidden) facts" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve legacy output using a hash" do

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -1,7 +1,7 @@
 # This test is intended to ensure that the --trace command-line option works
 # properly. This option provides backtraces for erroring custom Ruby facts.
 # To test, we try to resolve an erroneous custom fact and catch the backtrace.
-test_name "--trace command-line option enables backtraces for custom facts" do
+test_name "C99982: --trace command-line option enables backtraces for custom facts" do
 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -1,6 +1,6 @@
 # This test is intended to ensure that the --verbose command-line option
 # works properly. This option provides verbose (INFO) output to stderr.
-test_name "--verbose command-line option prints verbose information to stderr" do
+test_name "C99986: --verbose command-line option prints verbose information to stderr" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve verbose info from stderr using --verbose option" do

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -1,6 +1,6 @@
 # This test is intended to ensure that the --version command-line option works
 # properly. This option outputs the current Facter version.
-test_name "--version command-line option returns the version string" do
+test_name "C99983: --version command-line option returns the version string" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve version info using the --version option" do

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -2,7 +2,7 @@
 # properly. This option causes Facter to output facts in YAML format.
 # A custom fact is used to test for parity between Facter's output and
 # the expected YAML output.
-test_name "--yaml command-line option results in valid YAML output" do
+test_name "C99967: --yaml command-line option results in valid YAML output" do
 
   require 'yaml'
   require 'facter/acceptance/user_fact_utils'


### PR DESCRIPTION
Add TestRail number to the associated test_name strings
While I was there I added teardown code for a couple missing items
tested on Linux and windows