### PR TITLE
Task/lts 1.7/fact 1587/update custom and external facts command line tests

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -62,6 +62,24 @@ module Facter
           '.sh'
         end
       end
+
+      def external_fact_content(platform, key='external_fact', value='test_value')
+        unix_content = <<EOM
+#!/bin/sh
+echo "#{key}=#{value}"
+EOM
+
+        win_content = <<EOM
+@echo off
+echo #{key}=#{value}
+EOM
+
+        if platform =~ /windows/
+          win_content
+        else
+          unix_content
+        end
+      end
     end
   end
 end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -1,16 +1,7 @@
-# These tests are intended to ensure both custom fact related command-line options
-# work properly. The first step tests that an existing custom fact in Facter's
-# custom fact load path will not execute when the `--no-custom-facts` option is passed.
-# The second step checks that a custom fact in a directory specified by the `--custom-dir`
-# option is found by Facter and resolved.
-#
-# The second set of tests are intended to ensure that custom facts located in FACTERLIB
-# or $LOAD_PATH directories are resolved.
-test_name "custom fact commandline options (--no-custom-facts and --custom-dir)" do
-  confine :except, :platform => 'cisco_nexus' # see BKR-749
-
-  require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
+# This test checks that we can call facter with a --custom-dir and get a custom fact
+# from that directory
+test_name "C14905: custom fact command line option --custom-dir loads custom fact" do
+  tag 'risk:low'
 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
@@ -18,57 +9,27 @@ test_name "custom fact commandline options (--no-custom-facts and --custom-dir)"
   content = <<EOM
 Facter.add('custom_fact') do
   setcode do
-    "testvalue"
+    "single_fact"
   end
 end
 EOM
 
   agents.each do |agent|
-    step "Agent #{agent}: create custom fact directory and custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    step "Agent #{agent}: create custom fact directory and a custom fact" do
+      custom_dir = agent.tmpdir('custom_dir')
       on(agent, "mkdir -p '#{custom_dir}'")
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
 
-      step "--no-custom-facts option should disable custom facts" do
-        on(agent, facter("--no-custom-facts custom_fact")) do
-          assert_equal("", stdout.chomp, "Expected custom fact to be disabled, but it resolved as #{stdout.chomp}")
-        end
+      teardown do
+        on(agent, "rm -rf '#{custom_dir}'")
       end
 
-      step "--custom-dir option should allow custom facts to be resolved from a specific directory" do
+      step "Agent #{agent}: --custom-dir option should resoolve custom facts from the specific directory" do
         on(agent, facter("--custom-dir '#{custom_dir}' custom_fact")) do
-          assert_equal("testvalue", stdout.chomp, "Custom fact output does not match expected output")
+          assert_equal("single_fact", stdout.chomp, "Custom fact output does not match expected output #{stdout.chomp}")
         end
       end
-
-      on(agent, "rm -f '#{custom_fact}'")
-    end
-
-    step "Agent #{agent}: ensure custom facts in $FACTERLIB resolve" do
-      facterlib_dir = agent.tmpdir('arbitrary_dir')
-      custom_fact = File.join(facterlib_dir, 'custom_fact.rb')
-      create_remote_file(agent, custom_fact, content)
-
-      on(agent, facter('custom_fact', :environment => { 'FACTERLIB' => facterlib_dir })) do
-        assert_equal("testvalue", stdout.chomp, "Output from custom fact in FACTERLIB does not match expected outout")
-      end
-
-      on(agent, "rm -rf '#{facterlib_dir}'")
-    end
-
-    step "Agent #{agent}: ensure custom facts in $LOAD_PATH resolve" do
-      on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'")
-      load_path_facter_dir = File.join(stdout.chomp, 'facter')
-      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
-      custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
-      create_remote_file(agent, custom_fact, content)
-
-      on(agent, facter("custom_fact")) do
-        assert_equal("testvalue", stdout.chomp, "Output from custom fact in $LOAD_PATH does not match expected output")
-      end
-
-      on(agent, "rm -rf '#{load_path_facter_dir}'")
     end
   end
 end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -25,7 +25,7 @@ EOM
         on(agent, "rm -rf '#{custom_dir}'")
       end
 
-      step "Agent #{agent}: --custom-dir option should resoolve custom facts from the specific directory" do
+      step "Agent #{agent}: --custom-dir option should resolve custom facts from the specific directory" do
         on(agent, facter("--custom-dir '#{custom_dir}' custom_fact")) do
           assert_equal("single_fact", stdout.chomp, "Custom fact output does not match expected output #{stdout.chomp}")
         end

--- a/acceptance/tests/options/custom_facts_facterlib.rb
+++ b/acceptance/tests/options/custom_facts_facterlib.rb
@@ -1,0 +1,33 @@
+# This test verifies that we can load a custom fact using the environment variable FACTERLIB
+test_name "C14779: custom facts are loaded from the environment variable FACTERLIB path" do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "facterlib"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create custom directory and fact" do
+      custom_dir = agent.tmpdir('facter_lib_dir')
+      custom_fact = File.join(custom_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_dir}'")
+      end
+
+      step "Agent #{agent}: facter should resolve a fact from the directory specified by the environment variable FACTERLIB" do
+        on(agent, facter('custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do
+          assert_equal("facterlib", stdout.chomp, "Output of the custom fact in FACTERLIB does not match expected output #{stdout.chomp}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/custom_facts_list.rb
+++ b/acceptance/tests/options/custom_facts_list.rb
@@ -1,0 +1,49 @@
+# facter should be able to be called with multiple --custom-dir's and find a fact in each
+# directory specified
+test_name "C99999: custom fact commandline option --custom-dir can be specified multiple times" do
+  tag 'risk:high'
+
+  require 'json'
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content_1 = <<EOM
+Facter.add('custom_fact_1') do
+  setcode do
+    "testvalue_1"
+  end
+end
+EOM
+
+  content_2 = <<EOM
+Facter.add('custom_fact_2') do
+  setcode do
+    "testvalue_2"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create custom fact directory and a custom fact in each" do
+      custom_dir_1 = agent.tmpdir('custom_dir_1')
+      custom_dir_2 = agent.tmpdir('custom_dir_2')
+      on(agent, "mkdir -p '#{custom_dir_1}' '#{custom_dir_2}'")
+      custom_fact_1 = File.join(custom_dir_1, 'custom_fact.rb')
+      custom_fact_2 = File.join(custom_dir_2, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact_1, content_1)
+      create_remote_file(agent, custom_fact_2, content_2)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_dir_1}' '#{custom_dir_2}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from each specified --custom-dir option" do
+        on(agent, facter("--custom-dir #{custom_dir_1} --custom-dir #{custom_dir_2} --json")) do
+          results = JSON.parse(stdout)
+          assert_equal("testvalue_1", results['custom_fact_1'], "Expected custom fact for custom_fact_1, but it resolved as #{results['custom_fact_1']}")
+          assert_equal("testvalue_2", results['custom_fact_2'], "Expected custom fact for custom_fact_2, but it resolved as #{results['custom_fact_2']}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/custom_facts_load_path.rb
+++ b/acceptance/tests/options/custom_facts_load_path.rb
@@ -1,0 +1,42 @@
+# This test verifies that we can load a custom fact using the ruby $LOAD_PATH variable
+#
+# Facter searches all directories in the Ruby $LOAD_PATH variable for subdirectories
+# named ‘facter’, and loads all Ruby files in those directories.
+test_name "C14777: custom facts loaded from facter subdirectory found in $LOAD_PATH directory" do
+  confine :except, :platform => 'cisco_nexus' # see BKR-749
+
+  tag 'risk:medium'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::CommandUtils
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "load_path"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: determine $LOAD_PATH and create custom fact" do
+      on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'")
+      load_path_facter_dir = File.join(stdout.chomp, 'facter')
+      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      teardown do
+        on(agent, "rm -rf '#{load_path_facter_dir}'")
+      end
+
+      step("Agent #{agent}: resolve the custom fact that is in a facter directory on the $LOAD_PATH")
+      on(agent, facter("custom_fact")) do
+        assert_equal("load_path", stdout.chomp, "Output from custom fact in $LOAD_PATH/facter does not match expected output #{stdout.chomp}")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/external_facts_list.rb
+++ b/acceptance/tests/options/external_facts_list.rb
@@ -1,0 +1,36 @@
+# facter should be able to be called with multiple --external-dir's and find a fact in each
+# directory specified
+
+test_name "C99998: external fact commandline option --external-dir can be specified multiple times" do
+  tag 'risk:high'
+
+  require 'json'
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create external fact directories and a external fact in each" do
+      external_dir_1 = agent.tmpdir('external_dir_1')
+      external_dir_2 = agent.tmpdir('external_dir_2')
+      on(agent, "mkdir -p '#{external_dir_1}' '#{external_dir_2}'")
+      ext = get_external_fact_script_extension(agent['platform'])
+      external_fact_1 = File.join(external_dir_1, "external_fact#{ext}")
+      external_fact_2 = File.join(external_dir_2, "external_fact#{ext}")
+      create_remote_file(agent, external_fact_1, external_fact_content(agent['platform'], 'external_fact_1', 'external_value_1'))
+      create_remote_file(agent, external_fact_2, external_fact_content(agent['platform'], 'external_fact_2', 'external_value_2'))
+      on(agent, "chmod +x '#{external_fact_1}' '#{external_fact_2}'")
+
+      teardown do
+        on(agent, "rm -rf '#{external_dir_1}' '#{external_dir_2}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from each specified --external_dir option" do
+        on(agent, facter("--external-dir #{external_dir_1} --external-dir #{external_dir_2} --json")) do
+          results = JSON.parse(stdout)
+          assert_equal("external_value_1", results['external_fact_1'], "Expected external fact for external_fact_1, but it resolved as #{results['external_fact_1']}")
+          assert_equal("external_value_2", results['external_fact_2'], "Expected external fact for external_fact_2, but it resolved as #{results['external_fact_2']}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_custom_facts.rb
+++ b/acceptance/tests/options/no_custom_facts.rb
@@ -1,0 +1,34 @@
+# This test verifies that --no-custom-facts does not load custom facts
+test_name "C64171: custom fact command line option --no-custom-facts does not load custom facts" do
+  tag 'risk:med'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create custom fact directory and custom fact" do
+      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      on(agent, "mkdir -p '#{custom_dir}'")
+      custom_fact = File.join(custom_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      teardown do
+        on(agent, "rm -f '#{custom_fact}'")
+      end
+
+      step "Agent #{agent}: --no-custom-facts option should not load custom facts" do
+        on(agent, facter("--no-custom-facts custom_fact")) do
+          assert_equal("", stdout.chomp, "Expected custom fact to be empty, but it resolved as #{stdout.chomp}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
@@ -1,0 +1,19 @@
+# This test verifies that calling facter with both --no-custom-facts and --custom-dir results
+# in an options conflict error
+test_name "C100001: custom fact commandline options --no-custom-facts together with --custom-dir should produce an error" do
+  tag 'risk:low'
+
+  agents.each do |agent|
+    custom_dir = agent.tmpdir('custom_dir')
+
+    teardown do
+      on(agent, "rm -rf '#{custom_dir}'")
+    end
+
+    step "Agent #{agent}: --no-custom-facts and --custom-dir options should result in a error" do
+      on(agent, facter("--no-custom-facts --custom-dir '#{custom_dir}'"), :acceptable_exit_codes => 1) do
+        assert_match(/options conflict/, stderr.chomp, "Expected error options conflict, but it returned error as #{stderr.chomp}")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/no_custom_facts_and_facterlib.rb
@@ -1,0 +1,34 @@
+# This test verifies that --no-custom-facts keeps facter from loading facts from the environment
+# variable FACTERLIB
+test_name "C100000: custom fact commandline options --no-custom-facts does not load from FACTERLIB" do
+  tag 'risk:low'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create a custom fact directory and fact" do
+      facterlib_dir = agent.tmpdir('facterlib')
+      custom_fact = File.join(facterlib_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      teardown do
+        on(agent, "rm -rf '#{facterlib_dir}'")
+      end
+
+      step "Agent #{agent}: --no-custom-facts should ignore the FACTERLIB environment variable" do
+        on(agent, facter('--no-custom-facts custom_fact', :environment => { 'FACTERLIB' => facterlib_dir })) do
+          assert_equal("", stdout.chomp, "Expected custom fact in FACTERLIB to not be resolved, but resolved as #{stdout.chomp}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/no_custom_facts_and_load_path.rb
@@ -1,0 +1,43 @@
+# This tests verifies that when --no-custom-facts is used we do not look for
+# 'facter' subdirectories in the $LOAD_PATH
+#
+# Facter searches all directories in the Ruby $LOAD_PATH variable for subdirectories
+# named ‘facter’, and loads all Ruby files in those directories.
+test_name "C100003: custom fact commandline options --no-custom-facts does not load $LOAD_PATH facter directories" do
+  confine :except, :platform => 'cisco_nexus' # see BKR-749
+  tag 'risk:low'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::CommandUtils
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step("Agent #{agent}: determine the load path and create a custom facter directory on it") do
+      on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'")
+      load_path_facter_dir = File.join(stdout.chomp, 'facter')
+      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      teardown do
+        on(agent, "rm -rf '#{load_path_facter_dir}'")
+      end
+
+      step("Agent #{agent}: using --no-custom-facts should not resolve facts on the $LOAD_PATH") do
+        on(agent, facter("--no-custom-facts custom_fact")) do
+          assert_equal("", stdout.chomp, "Output of the custom fact in a $LOAD_PATH/facter directory should not be resolved, but resolved as #{stdout.chomp}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_external_facts.rb
+++ b/acceptance/tests/options/no_external_facts.rb
@@ -1,0 +1,30 @@
+# This test verifies that --no-external-facts does not load external facts
+
+test_name "C99961: external fact command line option --no-external-facts does not load external facts" do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create external fact directory and external fact" do
+
+      external_dir = agent.tmpdir('external_dir')
+      on(agent, "mkdir -p '#{external_dir}'")
+      ext = get_external_fact_script_extension(agent['platform'])
+      external_fact     = File.join(external_dir, "external_fact#{ext}")
+      create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'external_fact', 'external_value'))
+      on(agent, "chmod +x '#{external_fact}'")
+
+      teardown do
+        on(agent, "rm -rf '#{external_dir}'")
+      end
+
+      step "Agent #{agent}: --no-external-facts option should not load external facts" do
+        on(agent, facter("--no-external-facts external_fact")) do
+          assert_equal("", stdout.chomp, "Expected external fact to be empty, but it resolved as #{stdout.chomp}")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/no_external_facts_and_external_dir.rb
@@ -1,0 +1,19 @@
+# This test verifies that calling facter with both --no-external-facts and --external-dir results
+# in an options conflict error
+test_name "C100002: external fact commandline options --no-external-facts together with --external-dir should produce an error" do
+  tag 'risk:low'
+
+  agents.each do |agent|
+    external_dir = agent.tmpdir('external_dir')
+
+    teardown do
+      on(agent, "rm -rf '#{external_dir}'")
+    end
+
+    step "Agent #{agent}: --no-external-facts and --external-dir options should result in a error" do
+      on(agent, facter("--no-external-facts --external-dir '#{external_dir}'"), :acceptable_exit_codes => 1) do
+        assert_match(/options conflict/, stderr.chomp, "Expected error options conflict, but it returned error as #{stderr.chomp}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Split the existing tests for testing --custom-dir --no-custom-facts --external-dir and --no-external-facts into multiple test files, and add missing tests on the --no-custom-facts cases and options conflict errors.

I also added TestRail numbers to the test names and added risk level tags

All tests pass on VMpooler boxes, and I've only excluded the cisco_nexus on the 2 tests where it has to be excluded. So we have better coverage now that the tests are split into different files.