### PR TITLE
(FACT-1593) Disable proxy when fetching metadata.

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -123,7 +123,7 @@ module Facter
       end
 
       def fetch
-        open(@baseurl).read
+        open(@baseurl, :proxy => nil).read
       rescue OpenURI::HTTPError => e
         if e.message.match /404 Not Found/i
           return nil

--- a/lib/facter/gce/metadata.rb
+++ b/lib/facter/gce/metadata.rb
@@ -45,7 +45,7 @@ module Facter
 
         begin
           Timeout.timeout(timeout) do
-            body = open(@url).read
+            body = open(@url, :proxy => nil).read
           end
         rescue *CONNECTION_ERRORS => e
           attempts = attempts + 1

--- a/lib/facter/util/ec2.rb
+++ b/lib/facter/util/ec2.rb
@@ -13,7 +13,7 @@ module Facter::Util::EC2
     def can_connect?(wait_sec=2)
       Facter.warnonce("#{self}.#{__method__} is deprecated; see the Facter::EC2 classes instead")
       url = "http://169.254.169.254:80/"
-      Timeout::timeout(wait_sec) {open(url)}
+      Timeout::timeout(wait_sec) {open(url, :proxy => nil)}
       return true
     rescue Timeout::Error
       return false
@@ -100,7 +100,7 @@ module Facter::Util::EC2
   #
   # @return [String] containing the body of the response
   def self.read_uri(uri)
-    open(uri).read
+    open(uri, :proxy => nil).read
   end
   private_class_method :read_uri
 end

--- a/spec/unit/ec2/rest_spec.rb
+++ b/spec/unit/ec2/rest_spec.rb
@@ -148,18 +148,18 @@ describe Facter::EC2::Userdata do
 
   describe "reaching the userdata" do
     it "queries the userdata URI" do
-      subject.expects(:open).with('http://0.0.0.0/latest/user-data/').returns(response)
+      subject.expects(:open).with('http://0.0.0.0/latest/user-data/', {:proxy => nil}).returns(response)
       subject.fetch
     end
 
     it "returns the result of the query without modification" do
       response.string = "clooouuuuud"
-      subject.expects(:open).with('http://0.0.0.0/latest/user-data/').returns(response)
+      subject.expects(:open).with('http://0.0.0.0/latest/user-data/', {:proxy => nil}).returns(response)
       expect(subject.fetch).to eq  "clooouuuuud"
     end
 
     it "is nil if the URI returned a 404" do
-      subject.expects(:open).with('http://0.0.0.0/latest/user-data/').once.raises(OpenURI::HTTPError.new("404 Not Found", StringIO.new("woo")))
+      subject.expects(:open).with('http://0.0.0.0/latest/user-data/', {:proxy => nil}).once.raises(OpenURI::HTTPError.new("404 Not Found", StringIO.new("woo")))
       expect(subject.fetch).to be_nil
     end
   end

--- a/spec/unit/util/ec2_spec.rb
+++ b/spec/unit/util/ec2_spec.rb
@@ -129,7 +129,7 @@ describe Facter::Util::EC2 do
   describe "can_connect? method" do
     it "returns true if api responds" do
       # Return something upon connecting to the root
-      Module.any_instance.expects(:open).with("#{api_prefix}:80/").
+      Module.any_instance.expects(:open).with("#{api_prefix}:80/", {:proxy => nil}).
         at_least_once.returns("2008-02-01\nlatest")
 
       Facter::Util::EC2.can_connect?.should be_true
@@ -138,7 +138,7 @@ describe Facter::Util::EC2 do
     describe "when connection times out" do
       it "should return false" do
         # Emulate a timeout when connecting by throwing an exception
-        Module.any_instance.expects(:open).with("#{api_prefix}:80/").
+        Module.any_instance.expects(:open).with("#{api_prefix}:80/", {:proxy => nil}).
           at_least_once.raises(RuntimeError)
 
         Facter::Util::EC2.can_connect?.should be_false
@@ -148,7 +148,7 @@ describe Facter::Util::EC2 do
     describe "when connection is refused" do
       it "should return false" do
         # Emulate a connection refused
-        Module.any_instance.expects(:open).with("#{api_prefix}:80/").
+        Module.any_instance.expects(:open).with("#{api_prefix}:80/", {:proxy => nil}).
           at_least_once.raises(Errno::ECONNREFUSED)
 
         Facter::Util::EC2.can_connect?.should be_false


### PR DESCRIPTION
From [FACT-1593](https://tickets.puppetlabs.com/browse/FACT-1593):

> Facter version 2.4.6 uses the openuri mixin, which is affected by the `ENV['http_proxy']` setting.
> 
> It retrieves EC2 metadata by contacting the metadata server at 169.254.169.254.  If `ENV['http_proxy']` is set, facter will wind up retrieving the metadata of the proxy server rather than its own metadata.
> 
> To avoid this, calls to open must include the `:proxy => nil` modifier.  In fact, some of the metadata calls have this modifier, but not all.
> 