### PR TITLE
(FACT-1587) update the config file tests for custom and external facts

### DIFF
--- a/acceptance/tests/options/config_file/custom_facts_list.rb
+++ b/acceptance/tests/options/config_file/custom_facts_list.rb
@@ -1,0 +1,56 @@
+# This test verifies that facter can load facts from multiple custom-dir's specified
+# in the configuration file
+test_name "C99996: config custom-dir allows multiple custom fact directories" do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content_1 = <<EOM
+Facter.add('config_fact_1') do
+  setcode do
+    "config_value_1"
+  end
+end
+EOM
+
+  content_2 = <<EOM
+Facter.add('config_fact_2') do
+  setcode do
+    "config_value_2"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create custom fact directories and a custom fact in each and a config file" do
+      custom_dir_1 = agent.tmpdir('custom_dir_1')
+      custom_dir_2 = agent.tmpdir('custom_dir_2')
+      custom_fact_1 = File.join(custom_dir_1, 'custom_fact.rb')
+      custom_fact_2 = File.join(custom_dir_2, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact_1, content_1)
+      create_remote_file(agent, custom_fact_2, content_2)
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    custom-dir : [ "#{custom_dir_1}", "#{custom_dir_2}" ],
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_dir_1}' '#{custom_dir_2}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from each configured custom-dir path" do
+        on(agent, facter("--config '#{config_file}' --json")) do |facter_output|
+          results = JSON.parse(facter_output.stdout)
+          assert_equal("config_value_1", results['config_fact_1'], "Incorrect custom fact value for config_fact_1")
+          assert_equal("config_value_2", results['config_fact_2'], "Incorrect custom fact value for config_fact_2")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/external_facts.rb
+++ b/acceptance/tests/options/config_file/external_facts.rb
@@ -1,97 +1,37 @@
-# This test is intended to demonstrate that the global.external-dir config file setting allows
-# a directory to be specified for external fact lookup. It also shows that the global.no-external-facts 
-# setting disables external fact lookup.
-test_name "external-dir and no-external-facts config fields allow control of external fact lookup" do
+# This test verifies that facter can load facts from a single external-dir specified
+# in the configuration file
+test_name "C98142: config external-dir allows single external fact directory" do
+  tag 'risk:low'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
-  unix_content = <<EOM
-#!/bin/sh
-echo "external_fact=testvalue"
-EOM
-
-  windows_content = <<EOM
-@echo off
-echo external_fact=testvalue
-EOM
-
   agents.each do |agent|
-    os_version = on(agent, facter('kernalmajversion')).stdout.chomp.to_f
-    factsd = get_factsd_dir(agent['platform'], os_version)
-    custom_external_dir = get_user_fact_dir(agent['platform'], os_version)
-    ext = get_external_fact_script_extension(agent['platform'])
-
-    if agent['platform'] =~ /windows/
-      content = windows_content
-    else
-      content = unix_content
-    end
-
-    step "Agent #{agent}: set up facts.d, custom external fact directories, and config file" do
-      on(agent, "mkdir -p '#{factsd}'")
-      on(agent, "mkdir -p '#{custom_external_dir}'")
-      ext_fact_factsd     = File.join(factsd, "external_fact#{ext}")
-      ext_fact_custom_dir = File.join(custom_external_dir, "external_fact#{ext}")
-      create_remote_file(agent, ext_fact_factsd, content)
-      create_remote_file(agent, ext_fact_custom_dir, content)
-      on(agent, "chmod +x '#{ext_fact_factsd}' '#{ext_fact_custom_dir}'")
-
-      config_no_ext = <<EOM
-global : {
-    no-external-facts : true
-}
-cli : {
-    debug : true
-}
-EOM
+    step "Agent #{agent}: create an external fact directory with an external fact and a config file" do
+      external_dir = agent.tmpdir('external_dir')
+      ext = get_external_fact_script_extension(agent['platform'])
+      external_fact = File.join(external_dir, "external_fact#{ext}")
+      create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'single_fact', 'external_value'))
+      on(agent, "chmod +x '#{external_fact}'")
 
       config_dir = agent.tmpdir("config_dir")
-      config_no_ext_file = File.join(config_dir, "no_ext.conf")
-      create_remote_file(agent, config_no_ext_file, config_no_ext)
-
-      config_ext = <<EOM
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
 global : {
-    external-dir : "#{ext_fact_custom_dir}"
-}
-cli : {
-    debug : true
+    external-dir : "#{external_dir}",
 }
 EOM
-
-      config_ext_file = File.join(config_dir, "ext.conf")
-      create_remote_file(agent, config_ext_file, config_ext)
-
-      config_ext_list = <<EOM
-global : {
-    external-dir : [ "#{ext_fact_custom_dir}", "fake/external/dir" ]
-}
-EOM
-      config_ext_list_file = File.join(config_dir, "ext_list.conf")
-      create_remote_file(agent, config_ext_list_file, config_ext_list)
+      create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{ext_fact_factsd}' '#{ext_fact_custom_dir}' '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
       end
 
-      step "setting no-external-facts to true should disable external facts" do
-        on(agent, facter("--config '#{config_no_ext_file}' external_fact")) do
-          assert_equal("", stdout.chomp, "Expected external fact to be disabled, but it resolved as #{stdout.chomp}")
-        end
-      end
-
-      step "setting external-dir should specify location of external facts" do
-        on(agent, facter("--config '#{config_ext_file}' external_fact")) do
-          assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
-        end
-      end
-
-      step "external-dir should support a list of directories" do
-        on(agent, facter("--config '#{config_ext_list_file}' external_fact")) do
-          assert_equal("testvalue", stdout.chomp, "External fact output does not match expected output")
-          assert_match(/skipping external facts for "fake\/external\/dir"/, stderr, "Did not attempt to search second external fact directory")
+      step "Agent #{agent}: resolve a fact in the external-dir in the configuration file" do
+        on(agent, facter("--config '#{config_file}' single_fact")) do |facter_output|
+          assert_equal("external_value", facter_output.stdout.chomp, "Incorrect external fact value")
         end
       end
     end
   end
 end
-

--- a/acceptance/tests/options/config_file/external_facts_list.rb
+++ b/acceptance/tests/options/config_file/external_facts_list.rb
@@ -1,0 +1,43 @@
+# facter should be able to load facts from multiple external-dir's specified
+# in the configuration file
+test_name "C99995: config file supports external-dir for multiple fact directories" do
+  tag 'risk:medium'
+
+  require 'json'
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create external fact directories and a external fact in each and a config file" do
+      external_dir_1 = agent.tmpdir('external_dir_1')
+      external_dir_2 = agent.tmpdir('external_dir_2')
+      ext = get_external_fact_script_extension(agent['platform'])
+      external_fact_1 = File.join(external_dir_1, "external_fact#{ext}")
+      external_fact_2 = File.join(external_dir_2, "external_fact#{ext}")
+      create_remote_file(agent, external_fact_1, external_fact_content(agent['platform'], 'external_fact_1', 'external_value_1'))
+      create_remote_file(agent, external_fact_2, external_fact_content(agent['platform'], 'external_fact_2', 'external_value_2'))
+      on(agent, "chmod +x '#{external_fact_1}' '#{external_fact_2}'")
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    external-dir : [ "#{external_dir_1}", "#{external_dir_2}" ],
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{external_dir_1}' '#{external_dir_2}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from each configured external-dir path" do
+        on(agent, facter("--config '#{config_file}' --json")) do |facter_output|
+          results = JSON.parse(facter_output.stdout)
+          assert_equal("external_value_1", results['external_fact_1'], "Incorrect external fact value for external_fact_1")
+          assert_equal("external_value_2", results['external_fact_2'], "Incorrect external fact value for external_fact_2")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
@@ -1,0 +1,43 @@
+# This test verifies that setting both custom-dir and no-custom-facts results in an error
+test_name "C99994: config option no-custom-facts conflicts with custom-dir" do
+  tag 'risk:low'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create a custom fact directory and fact and a config file" do
+      custom_dir = agent.tmpdir('custom_dir')
+      custom_fact = File.join(custom_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    custom-dir : "#{custom_dir}"
+    no-custom-facts : true,
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_fact}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: config option no-custom-facts : true and custom-dir should result in an options conflict error" do
+        on(agent, facter("--config '#{config_file}'"), :acceptable_exit_codes => 1) do |facter_output|
+          assert_match(/options conflict/, facter_output.stderr, "Output does not contain error string")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
@@ -1,0 +1,43 @@
+# This test verifies that setting no-custom-facts in the config file disables
+# finding facts under the environment variable FACTERLIB
+test_name "C99997: config option no-custom-facts : true does not load facts from FACTERLIB" do
+  tag 'risk:low'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create a custom fact directory and fact and a config file" do
+      facterlib_dir = agent.tmpdir('facterlib')
+      custom_fact = File.join(facterlib_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    no-custom-facts : true,
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{facterlib_dir}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: no-custom-facts should ignore the FACTERLIB environment variable" do
+        on(agent, facter("--config '#{config_file}' custom_fact", :environment => {'FACTERLIB' => facterlib_dir})) do |facter_output|
+          assert_equal("", facter_output.stdout.chomp, "Custom fact in FACTERLIB should not have resolved")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
@@ -1,0 +1,49 @@
+# This test verifies that setting no-custom-facts in the config file disables the
+# the loading of custom facts in facter directories under the $LOAD_PATH
+test_name "C100004: config file option no-custom-facts : true does not load $LOAD_PATH facter directories" do
+  confine :except, :platform => 'cisco_nexus' # see BKR-749
+  tag 'risk:low'
+
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::CommandUtils
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  content = <<EOM
+Facter.add('custom_fact') do
+  setcode do
+    "testvalue"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step("Agent #{agent}: determine the load path and create a custom facter directory on it and a config file") do
+      ruby_path = on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'").stdout.chomp
+      load_path_facter_dir = File.join(ruby_path, 'facter')
+      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_fact, content)
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    no-custom-facts : true,
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{load_path_facter_dir}' '#{config_dir}'")
+      end
+
+      step("Agent #{agent}: using config no-custom-facts : true should not resolve facts in facter directories on the $LOAD_PATH") do
+        on(agent, facter("--config '#{config_file}' custom_fact")) do |facter_output|
+          assert_equal("", facter_output.stdout.chomp, "Custom fact in $LOAD_PATH/facter should not have resolved")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/no_external_facts.rb
+++ b/acceptance/tests/options/config_file/no_external_facts.rb
@@ -1,0 +1,38 @@
+# This test verifies that no-external-facts : true set in the configuration file
+# does not load external facts
+test_name "C99962: config no-external-facts : true does not load external facts" do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create external fact directory and external fact and a config file" do
+      external_dir = agent.tmpdir('external_dir')
+      ext = get_external_fact_script_extension(agent['platform'])
+      external_fact = File.join(external_dir, "external_fact#{ext}")
+      create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'external_fact', 'external_value'))
+      on(agent, "chmod +x '#{external_fact}'")
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    no-external-facts : true,
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+
+      teardown do
+        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: --no-external-facts option should not load external facts" do
+        on(agent, facter("--no-external-facts external_fact")) do |facter_output|
+          assert_equal("", facter_output.stdout.chomp, "External fact should not have resolved")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
@@ -1,0 +1,34 @@
+# This test verifies that setting external-dir and no-external-facts in the config file
+# results in an error
+test_name "C99993: config option no-external-facts conflicts with external-dir" do
+  tag 'risk:low'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create the exernal-dir and a config file" do
+      external_dir = agent.tmpdir('external_dir')
+
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    external-dir : "#{external_dir}"
+    no-external-facts : true,
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: config option no-external-facts : true and external-dir should result in an options conflict error" do
+        on(agent, facter("--config '#{config_file}'"), :acceptable_exit_codes => 1) do |facter_output|
+          assert_match(/options conflict/, facter_output.stderr, "Output does not contain error string")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Split out the 2 existing tests into separate files and added tests for other missing custom and external facts tests for setting custom-dir, no-custom-facts, external-dir, and no-external-facts in the configuration file

Included TestRail numbers, and risk tags

Tested on:
arista4-32a
ciscoxr-64a%7Bhypervisor=vmpooler%7D
cumulus25-64a
debian8-64a
fedora25-64a
osx1012-64a
redhat7-64a
sles12-64a
solaris11-64a
ubuntu1604-64a
windows10ent-64a
windows2016-64a