### PR TITLE
(FACT-1587) split out or adde command line override tests

### DIFF
--- a/acceptance/tests/options/config_file/command_line_override.rb
+++ b/acceptance/tests/options/config_file/command_line_override.rb
@@ -30,21 +30,14 @@ EOM
     end
 
     step "--debug flag should override debug=false in config file" do
-       on(agent, facter("--debug")) do
-         assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
-       end
-     end
-
-     step "--external_dir flag should override external_dir in config file" do
-       on(agent, facter("--external-dir 'cmd/line/dir'")) do
-         assert_match(/cmd\/line\/dir/, stderr, "Facter should attempt to find external fact dir 'cmd/line/dir'")
-         assert_no_match(/config\/file\/dir/, stderr, "Facter should not attempt to find external fact dir 'config/file/dir'")
+       on(agent, facter("--debug")) do |facter_output|
+         assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
        end
      end
 
     step "conflict logic applies across settings sources" do
-      on(agent, facter("--no-external-facts"), :acceptable_exit_codes => [1]) do
-       assert_match(/no-external-facts and external-dir options conflict/, stderr, "Facter should have warned about conflicting settings")
+      on(agent, facter("--no-external-facts"), :acceptable_exit_codes => [1]) do |facter_output|
+       assert_match(/no-external-facts and external-dir options conflict/, facter_output.stderr, "Facter should have warned about conflicting settings")
       end
     end
   end

--- a/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
+++ b/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
@@ -1,0 +1,56 @@
+# This test verifies that the custom-dir specified in the configuration file can be overridden by using
+# --custom-dir on the command line
+test_name "C100015: config custom-dir overridden by command line --custom-dir" do
+  tag 'risk:medium'
+
+  require 'json'
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  config_fact_content = <<EOM
+Facter.add('config_fact') do
+  setcode do
+    "config_value"
+  end
+end
+EOM
+
+  cli_fact_content = <<EOM
+Facter.add('cli_fact') do
+  setcode do
+    "cli_value"
+  end
+end
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create 2 custom fact directories with facts and a config file pointing at 1 directory" do
+      custom_config_dir = agent.tmpdir('custom_dir')
+      custom_cli_dir = agent.tmpdir('cli_custom_dir')
+      custom_config_fact = File.join(custom_config_dir, 'custom_fact.rb')
+      custom_cli_fact = File.join(custom_cli_dir, 'custom_fact.rb')
+      create_remote_file(agent, custom_config_fact, config_fact_content)
+      create_remote_file(agent, custom_cli_fact, cli_fact_content)
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    custom-dir : "#{custom_config_dir}",
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{custom_config_dir}' '#{custom_cli_dir}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from the command line custom-dir and not the config file" do
+        on(agent, facter("--config '#{config_file}' --custom-dir '#{custom_cli_dir}' --json")) do |facter_output|
+          results = JSON.parse(facter_output.stdout)
+          assert_equal("cli_value", results['cli_fact'], "Incorrect custom fact value for cli_fact")
+          assert_nil(results['config_fact'], "Config fact should not resolve and be nil")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
+++ b/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
@@ -1,0 +1,40 @@
+# This test verifies that the external-dir specified in the configuration file can be overridden by using
+# --external-dir on the command line
+test_name "C100016: config external-dir overridden by command line --external-dir" do
+  tag 'risk:medium'
+
+  require 'json'
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "Agent #{agent}: create 2 custom fact directories with facts and a config file pointing at 1 directory" do
+      external_config_dir = agent.tmpdir('external_dir')
+      external_cli_dir = agent.tmpdir('cli_external_dir')
+      external_config_fact = File.join(external_config_dir, 'external.txt')
+      external_cli_fact = File.join(external_cli_dir, 'external.txt')
+      create_remote_file(agent, external_config_fact, "config_fact=config_value")
+      create_remote_file(agent, external_cli_fact, "cli_fact=cli_value")
+      config_dir = agent.tmpdir("config_dir")
+      config_file = File.join(config_dir, "facter.conf")
+      config_content = <<EOM
+global : {
+    external-dir : "#{external_config_dir}",
+}
+EOM
+      create_remote_file(agent, config_file, config_content)
+
+      teardown do
+        on(agent, "rm -rf '#{external_config_dir}' '#{external_cli_dir}' '#{config_dir}'")
+      end
+
+      step "Agent #{agent}: resolve a fact from the command line external-dir and not the config file" do
+        on(agent, facter("--config '#{config_file}' --external-dir '#{external_cli_dir}' --json")) do |facter_output|
+          results = JSON.parse(facter_output.stdout)
+          assert_equal("cli_value", results['cli_fact'], "Incorrect custom fact value for cli_fact")
+          assert_nil(results['config_fact'], "Config fact should not resolve and be nil")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I split out one test and created the other to verify command line override of the
configuratino file. I also updated some of the old test since I was there.