### PR TITLE
(FACT-1595) split the blocklist and ttls tests into multiple files

### DIFF
--- a/acceptance/tests/options/config_file/blocklist.rb
+++ b/acceptance/tests/options/config_file/blocklist.rb
@@ -1,64 +1,33 @@
 # This test verifies that when a fact group is blocked in the config file
 # the corresponding facts do not resolve.
-test_name "facts can be blocked via a list in the config file" do
+test_name "C99972: facts can be blocked via a blocklist in the config file" do
+  tag 'risk:high'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    step "facts should be blocked when Facter is run from the command line" do
-      step "Agent #{agent}: create config file" do
-        custom_conf_dir = agent.tmpdir("config_dir")
-        config_file = File.join(custom_conf_dir, "facter.conf")
-        create_remote_file(agent, config_file, <<-FILE)
+    step "Agent #{agent}: create config file" do
+      custom_conf_dir = agent.tmpdir("config_dir")
+      config_file = File.join(custom_conf_dir, "facter.conf")
+      create_remote_file(agent, config_file, <<-FILE)
         cli : { debug : true }
         facts : { blocklist : [ "file system", "EC2" ] }
-        FILE
-
-        teardown do
-          on(agent, "rm -rf '#{custom_conf_dir}'", :acceptable_exit_codes => [0, 1])
-        end
-
-        step "blocked facts should not be resolved" do
-          on(agent, facter("--config '#{config_file}'")) do
-            # every platform attempts to resolve at least EC2 facts
-            assert_match(/blocking collection of .+ facts/, stderr, "Expected stderr to contain statement about blocking fact collection")
-
-            # on some platforms, file system facts are never resolved, so this will also be true in those cases
-            assert_no_match(/filesystems/, stdout, "filesystems fact should have been blocked")
-            assert_no_match(/mountpoints/, stdout, "mountpoints fact should have been blocked")
-            assert_no_match(/partitions/, stdout, "partitions fact should have been blocked")
-          end
-        end
-      end
-    end
-
-    step "facts should be blocked when Facter is run from Puppet" do
-      # default facter.conf
-      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-      facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+      FILE
 
       teardown do
-        on(agent, "rm -rf '#{facter_conf_default_dir}'",
-            :acceptable_exit_codes => [0,1])
-      end
-
-      step "Agent #{agent}: create default config file" do
-        # create the directories
-        on(agent, "mkdir -p '#{facter_conf_default_dir}'")
-        create_remote_file(agent, facter_conf_default_path, <<-FILE)
-        facts : { blocklist : [ "file system", "EC2" ] }
-        FILE
+        on(agent, "rm -rf '#{custom_conf_dir}'", :acceptable_exit_codes => [0, 1])
       end
 
       step "blocked facts should not be resolved" do
-        on(agent, puppet("facts --debug")) do
+        on(agent, facter("--config '#{config_file}'")) do |facter_output|
           # every platform attempts to resolve at least EC2 facts
-          assert_match(/blocking collection of .+ facts/, stdout, "Expected stderr to contain statement about blocking fact collection")
+          assert_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected stderr to contain statement about blocking fact collection")
 
           # on some platforms, file system facts are never resolved, so this will also be true in those cases
-          assert_no_match(/filesystems/, stdout, "filesystems fact should have been blocked")
-          assert_no_match(/mountpoints/, stdout, "mountpoints fact should have been blocked")
-          assert_no_match(/partitions/, stdout, "partitions fact should have been blocked")
+          assert_no_match(/filesystems/, facter_output.stdout, "filesystems fact should have been blocked")
+          assert_no_match(/mountpoints/, facter_output.stdout, "mountpoints fact should have been blocked")
+          assert_no_match(/partitions/, facter_output.stdout, "partitions fact should have been blocked")
         end
       end
     end

--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -1,0 +1,40 @@
+# This test verifies that when a fact group is blocked in the config file the
+# corresponding facts do not resolve when being run from the puppet facts command.
+test_name "C100036: when run from puppet facts, facts can be blocked via a list in the config file" do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    step "facts should be blocked when Facter is run from Puppet with a configured blocklist" do
+      # default facter.conf
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+
+      teardown do
+        on(agent, "rm -rf '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+      end
+
+      step "Agent #{agent}: create default config file" do
+        # create the directories
+        on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+        create_remote_file(agent, facter_conf_default_path, <<-FILE)
+        facts : { blocklist : [ "file system", "EC2" ] }
+        FILE
+      end
+
+      step "blocked facts should not be resolved" do
+        on(agent, puppet("facts --debug")) do |puppet_facts_output|
+          # every platform attempts to resolve at least EC2 facts
+          assert_match(/blocking collection of .+ facts/, puppet_facts_output.stdout, "Expected stderr to contain statement about blocking fact collection")
+
+          # on some platforms, file system facts are never resolved, so this will also be true in those cases
+          assert_no_match(/filesystems/, puppet_facts_output.stdout, "filesystems fact should have been blocked")
+          assert_no_match(/mountpoints/, puppet_facts_output.stdout, "mountpoints fact should have been blocked")
+          assert_no_match(/partitions/, puppet_facts_output.stdout, "partitions fact should have been blocked")
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refesh_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refesh_the_cached_value.rb
@@ -1,17 +1,26 @@
-# This test verifies that a ttls configured cached facts when initially called
-# create a json cache file
-test_name "C99973: ttls configured cached facts create json cache files" do
+# This test verifies that cached facts that are expired are refreshed
+test_name "C100040: ttls configured facts that are expired are refreshed" do
+  tag 'risk:high'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
   cached_factname = 'uptime'
+
   config = <<EOM
 facts : {
     ttls : [
         { "#{cached_factname}" : 30 days }
     ]
+}
+EOM
+
+  cached_fact_value = "EXPIRED_CACHED_FACT_VALUE"
+  cached_fact_content = <<EOM
+{
+  "#{cached_factname}": "#{cached_fact_value}"
 }
 EOM
 
@@ -32,13 +41,19 @@ EOM
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
       end
 
-      step "should create a JSON file for a fact that is to be cached" do
+      step "should refresh an expired cached fact" do
+        # Setup a known cached fact
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, facter("--debug")) do |facter_output|
-          assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
-        end
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, cached_fact_content)
+        # Change the modified date to sometime in the far distant past
+        on(agent, "touch -mt 198001010000 '#{cached_fact_file}'")
+        # Force facter to recache
+        on(agent, facter("#{cached_factname}"))
+
+        # Read cached fact file content
         on(agent, "cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do |cat_output|
-          assert_match(/#{cached_factname}/, cat_output.stdout, "Expected cached fact file to contain fact information")
+          assert_no_match(/#{cached_fact_value}/, cat_output.stdout, "Expected cached fact file to be refreshed")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
@@ -1,17 +1,26 @@
-# This test verifies that a ttls configured cached facts when initially called
-# create a json cache file
-test_name "C99973: ttls configured cached facts create json cache files" do
+# This test verifies that cached facts are used while still valid
+test_name "C100041: ttls configured cached facts are used while still valid" do
+  tag 'risk:high'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
   cached_factname = 'uptime'
+
   config = <<EOM
 facts : {
     ttls : [
         { "#{cached_factname}" : 30 days }
     ]
+}
+EOM
+
+  cached_fact_value = "CACHED_FACT_VALUE"
+  cached_fact_content = <<EOM
+{
+  "#{cached_factname}": "#{cached_fact_value}"
 }
 EOM
 
@@ -32,13 +41,15 @@ EOM
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
       end
 
-      step "should create a JSON file for a fact that is to be cached" do
+      step "should read from a cached JSON file for a fact that has been cached" do
+        # Setup a known cached fact
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, facter("--debug")) do |facter_output|
-          assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
-        end
-        on(agent, "cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do |cat_output|
-          assert_match(/#{cached_factname}/, cat_output.stdout, "Expected cached fact file to contain fact information")
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, cached_fact_content)
+
+        on(agent, facter("#{cached_factname} --debug")) do
+          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
@@ -1,18 +1,24 @@
-# This test verifies that a ttls configured cached facts when initially called
-# create a json cache file
-test_name "C99973: ttls configured cached facts create json cache files" do
+# This test verifies that cached facts that are empty return an empty string
+test_name "C100043: ttls configured cached facts that are empty, return an empty string" do
+  tag 'risk:high'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
   cached_factname = 'uptime'
+
   config = <<EOM
 facts : {
     ttls : [
         { "#{cached_factname}" : 30 days }
     ]
 }
+EOM
+
+  empty_cached_fact_content = <<EOM
+{ }
 EOM
 
   agents.each do |agent|
@@ -32,13 +38,14 @@ EOM
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
       end
 
-      step "should create a JSON file for a fact that is to be cached" do
+      step "should return an empty string for an empty JSON document" do
+        # Setup a known cached fact
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, facter("--debug")) do |facter_output|
-          assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
-        end
-        on(agent, "cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do |cat_output|
-          assert_match(/#{cached_factname}/, cat_output.stdout, "Expected cached fact file to contain fact information")
+        on(agent, facter(""))
+        create_remote_file(agent, cached_fact_file, empty_cached_fact_content)
+
+        on(agent, facter("#{cached_factname}")) do |facter_output|
+          assert_empty(facter_output.stdout.chomp, "Expected fact to be empty")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
@@ -1,6 +1,8 @@
-# This test verifies that a ttls configured cached facts when initially called
-# create a json cache file
-test_name "C99973: ttls configured cached facts create json cache files" do
+# Verify that setting a ttls, creates a json file for the cached fact when run
+# from puppet facts
+test_name "C100038: with ttls configured create cached facts when run from puppet facts" do
+  tag 'risk:medium'
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
@@ -17,25 +19,22 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-      config_file = File.join(config_dir, "facter.conf")
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
       cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
-      # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
-      create_remote_file(agent, config_file, config)
+      on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+      create_remote_file(agent, facter_conf_default_path, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        on(agent, "rm -rf '#{cached_facts_dir}' '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
       end
 
       step "should create a JSON file for a fact that is to be cached" do
         on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, facter("--debug")) do |facter_output|
-          assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
+        on(agent, puppet("facts --debug")) do |pupppet_fact_output|
+          assert_match(/caching values for .+ facts/, pupppet_fact_output.stdout, "Expected debug message to state that values will be cached")
         end
         on(agent, "cat #{cached_fact_file}", :acceptable_exit_codes => [0]) do |cat_output|
           assert_match(/#{cached_factname}/, cat_output.stdout, "Expected cached fact file to contain fact information")

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -1,0 +1,54 @@
+# Verify that setting a ttls, puppet facts returns the cached value of the fact
+test_name "C100039: ttls configured cached facts run from puppet facts return cached facts" do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  # This fact must be resolvable on ALL platforms
+  # Do NOT use the 'kernel' fact as it is used to configure the tests
+  cached_factname = 'uptime'
+  config = <<EOM
+facts : {
+    ttls : [
+        { "#{cached_factname}" : 30 days }
+    ]
+}
+EOM
+
+  cached_value = "CACHED_FACT_VALUE"
+  cached_fact_content = <<EOM
+{
+  "#{cached_factname}": "#{cached_value}"
+}
+EOM
+
+  agents.each do |agent|
+    step "Agent #{agent}: create config file" do
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_fact_file = File.join(cached_facts_dir, cached_factname)
+
+      on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+      create_remote_file(agent, facter_conf_default_path, config)
+
+      teardown do
+        on(agent, "rm -rf '#{cached_facts_dir}' '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+      end
+
+      step "should read from a cached JSON file for a fact that has been cached" do
+        step "call puppet facts to setup the cached fact" do
+          on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+          on(agent, puppet("facts"))
+          create_remote_file(agent, cached_fact_file, cached_fact_content)
+        end
+
+        on(agent, puppet("facts --debug")) do |puppet_facts_output|
+          assert_match(/loading cached values for .+ facts/, puppet_facts_output.stdout, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_value}/, puppet_facts_output.stdout, "Expected fact to match the cached fact file")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The existing blocklist and ttls tests where all in the same 2 files. I copied the existing tests into separate files, and updated comment and step descriptions to match each of the tests. Then applied code style updates, formatting by RubyMine, TestRail numbers, and risk tags.