### PR TITLE
(FACT-1599) add --color and --no-color tests

### DIFF
--- a/acceptance/tests/options/color.rb
+++ b/acceptance/tests/options/color.rb
@@ -1,0 +1,16 @@
+# This test is intended to ensure with --debug and --color, facter sends escape sequences to colorize the output
+test_name "C86545: --debug and --color command-line options should print DEBUG messages with color escape sequences" do
+  tag 'risk:high'
+
+  confine :except, :platform => 'windows' # On windows we don't get an escape sequence to detect to color change
+
+  agents.each do |agent|
+    step "Agent #{agent}: retrieve debug info from stderr using --debug and --color option" do
+      # set the TERM type to be a color xterm to help ensure we emit the escape sequence to change the color
+      on(agent, facter('--debug --color'), :environment => { 'TERM' => 'xterm-256color' }) do |facter_output|
+        assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
+        assert_match(/\e\[0;/, facter_output.stderr, "Expected to see an escape sequence in the output")
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/no_color.rb
+++ b/acceptance/tests/options/no_color.rb
@@ -1,0 +1,16 @@
+# This test is intended to ensure with --debug and --no-color, facter does not send any escape sequences
+# to colorize the output
+test_name "C99975: --debug and --no-color command-line options should print DEBUG messages without color escape sequences" do
+  tag 'risk:low'
+
+  confine :except, :platform => 'windows' # On windows we don't get an escape sequence so we can't detect a color change
+
+  agents.each do |agent|
+    step "Agent #{agent}: retrieve debug info from stderr using --debug anod --no-color options" do
+      on(agent, facter('--debug --no-color')) do |facter_output|
+        assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
+        refute_match(/\e\[0;/, facter_output.stderr, "Expected to output to not contain an escape sequence")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added tests to verify that --debug with --color and --no-color actually
produce escape sequences to change the output color as appropriate