### PR TITLE
(FACT-1268) Changed the EC2_CONNECTION_TIMEOUT to 600

### DIFF
--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -33,7 +33,7 @@ namespace facter { namespace facts { namespace resolvers {
 #ifdef USE_CURL
     static const char* EC2_METADATA_ROOT_URL = "http://169.254.169.254/latest/meta-data/";
     static const char* EC2_USERDATA_ROOT_URL = "http://169.254.169.254/latest/user-data/";
-    static const unsigned int EC2_CONNECTION_TIMEOUT = 200;
+    static const unsigned int EC2_CONNECTION_TIMEOUT = 600;
     static const unsigned int EC2_SESSION_TIMEOUT = 5000;
 
     static void query_metadata_value(lth_curl::client& cli, map_value& value, string const& url, string const& name, string const& http_langs)


### PR DESCRIPTION
(FACT-1268) Changed the EC2_CONNECTION_TIMEOUT to 600

The default EC2_CONNECTION_TIMEOUT, 200 ms, results in a time-out on a regular basis. The solution for this would be to change this from 200 ms to 600 ms.