### PR TITLE
(FACT-1268) Changed the EC2_CONNECTION_TIMEOUT to 600

### DIFF
--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -33,7 +33,7 @@ namespace facter { namespace facts { namespace resolvers {
 #ifdef USE_CURL
     static const char* EC2_METADATA_ROOT_URL = "http://169.254.169.254/latest/meta-data/";
     static const char* EC2_USERDATA_ROOT_URL = "http://169.254.169.254/latest/user-data/";
-    static const unsigned int EC2_CONNECTION_TIMEOUT = 200;
+    static const unsigned int EC2_CONNECTION_TIMEOUT = 600;
     static const unsigned int EC2_SESSION_TIMEOUT = 5000;
 
     static void query_metadata_value(lth_curl::client& cli, map_value& value, string const& url, string const& name, string const& http_langs)


### PR DESCRIPTION
The default EC2_CONNECTION_TIMEOUT of 200 is too short. The connection-timeout occurs regularly when spinning up ec2-servers. The fix for this is changing the EC2_CONNECTION_TIMEOUT to 600. 