### PR TITLE
(FACT-1578) Cast to long long for correct 32-bit behavior

### DIFF
--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -397,7 +397,7 @@ namespace facter { namespace ruby {
             return ruby.utf8_value(ptr->value());
         }
         if (auto ptr = dynamic_cast<integer_value const*>(val)) {
-            return ruby.rb_ll2inum(static_cast<SIGNED_VALUE>(ptr->value()));
+            return ruby.rb_ll2inum(static_cast<LONG_LONG>(ptr->value()));
         }
         if (auto ptr = dynamic_cast<boolean_value const*>(val)) {
             return ptr->value() ? ruby.true_value() : ruby.false_value();


### PR DESCRIPTION
Handling an integer is expected to treat it as a 64-bit number. On
32-bit systems, this was violated by casting to a SIGNED_VALUE before
converting to a Ruby value. Cast to a LONG_LONG instead to use 64-bit
integers on 32-bit OS.