### PR TITLE
(FACT-1607) split the default external fact directory into 2 test

### DIFF
--- a/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
+++ b/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
@@ -1,0 +1,34 @@
+test_name "C100154: --external-dir fact overrides fact in default facts.d directory" do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    ext = get_external_fact_script_extension(agent['platform'])
+    factsd = get_factsd_dir(agent['platform'], os_version)
+    external_dir = agent.tmpdir('facts.d')
+    fact_file = File.join(factsd, "external_fact#{ext}")
+    content = external_fact_content(agent['platform'], 'external_fact', 'value')
+    override_fact_file = File.join(external_dir, "external_fact#{ext}")
+    override_content = external_fact_content(agent['platform'], 'external_fact', 'OVERRIDE_value')
+
+    teardown do
+      on(agent, "rm -f '#{fact_file}' '#{override_fact_file}'")
+    end
+
+    step "Agent #{agent}: setup default external facts directories and the test facts" do
+      on(agent, "mkdir -p '#{factsd}'")
+      create_remote_file(agent, fact_file, content)
+      create_remote_file(agent, override_fact_file, override_content)
+      on(agent, "chmod +x '#{fact_file}' '#{override_fact_file}'")
+    end
+
+    step "Agent #{agent}: the fact value from the custom external dir should override that of facts.d" do
+      on(agent, facter("--external-dir '#{external_dir}' external_fact")) do |facter_output|
+        assert_equal('OVERRIDE_value', facter_output.stdout.chomp, 'Expected to resolve override version of the external_fact')
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -1,95 +1,34 @@
-test_name "Root default external facts directory (facts.d) is searched for facts"
+# facter resolves facts from the default facts.d directory
+# on Unix this can be 3 directories (See fact_directory_precedence.rb)
+# Unix - /opt/puppetlabs/facter/facts.d/
+# Windows - C:\ProgramData\PuppetLabs\facter\facts.d\
+test_name "C87571: facter resolves facts in the default facts.d directory" do
+  tag 'risk:high'
 
-require 'facter/acceptance/user_fact_utils'
-extend Facter::Acceptance::UserFactUtils
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
 
-#
-# The first of these tests is intended to ensure that executable external facts placed into the
-# default facts.d directory are properly found and resolved by Facter when run as root.
-# The second ensures that when Facter is given a user specified external fact directory, facts
-# from both it and the default facts.d directory are resolved. Finally, we test that given
-# conflicting external facts in a user specified directory and the default facts.d directory,
-# the user specified fact wins.
-#
+  agents.each do |agent|
+    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    ext = get_external_fact_script_extension(agent['platform'])
+    factsd = get_factsd_dir(agent['platform'], os_version)
+    fact_file = File.join(factsd, "external_fact_1#{ext}")
+    content = external_fact_content(agent['platform'], 'external_fact', 'external_value')
 
-unix_fact_1_content = <<EOM
-#!/bin/sh
-echo "external_fact_1=foo"
-EOM
+    teardown do
+      on(agent, "rm -f '#{fact_file}'")
+    end
 
-unix_override_content = <<EOM
-#!/bin/sh
-echo "external_fact_1=baz"
-EOM
+    step "Agent #{agent}: setup default external facts directory and fact" do
+      on(agent, "mkdir -p '#{factsd}'")
+      create_remote_file(agent, fact_file, content)
+      on(agent, "chmod +x '#{fact_file}'")
+    end
 
-unix_fact_2_content = <<EOM
-#!/bin/sh
-echo "external_fact_2=bar"
-EOM
-
-win_fact_1_content = <<EOM
-@echo off
-echo external_fact_1=foo
-EOM
-
-win_override_content = <<EOM
-@echo off
-echo external_fact_1=baz
-EOM
-
-win_fact_2_content = <<EOM
-@echo off
-echo external_fact_2=bar
-EOM
-
-agents.each do |agent|
-  os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
-  factsd = get_factsd_dir(agent['platform'], os_version)
-  custom_external_dir = get_user_fact_dir(agent['platform'], os_version)
-  ext = get_external_fact_script_extension(agent['platform'])
-
-  if agent['platform'] =~ /windows/
-    content_1 = win_fact_1_content
-    content_2 = win_fact_2_content
-    override_content = win_override_content
-  else
-    content_1 = unix_fact_1_content
-    content_2 = unix_fact_2_content
-    override_content = unix_override_content
-  end
-
-  step "Agent #{agent}: setup default external facts directory (facts.d)"
-  on(agent, "mkdir -p '#{factsd}'")
-
-  step "Agent #{agent}: create an executable external fact in default facts.d"
-  ext_fact_1 = File.join(factsd, "external_fact_1#{ext}")
-  create_remote_file(agent, ext_fact_1, content_1)
-  on(agent, "chmod +x '#{ext_fact_1}'")
-
-  step "Agent #{agent}: the external fact should resolve"
-  assert_equal("foo", fact_on(agent, "external_fact_1"))
-
-  step "Ensure that Facter honors default facts.d dir in addition to user specified directories"
-  on(agent, "mkdir -p '#{custom_external_dir}'")
-  ext_fact_2 = File.join(custom_external_dir, "external_fact_2#{ext}")
-  create_remote_file(agent, ext_fact_2, content_2)
-  on(agent, "chmod +x '#{ext_fact_2}'")
-
-  step "Agent #{agent}: both external facts should resolve"
-  on(agent, facter("--external-dir '#{custom_external_dir}' external_fact_1 external_fact_2"))
-  assert_match(/external_fact_1 => foo/, stdout)
-  assert_match(/external_fact_2 => bar/, stdout)
-
-  step "Ensure that facts in the default external fact dir are overridden by facts in specified dirs"
-  ext_fact_3 = File.join(custom_external_dir, "external_fact_3#{ext}")
-  create_remote_file(agent, ext_fact_3, override_content)
-  on(agent, "chmod +x '#{ext_fact_3}'")
-
-  step "Agent #{agent}: the fact value from the custom external dir should override that of facts.d"
-  on(agent, facter("--external-dir '#{custom_external_dir}' external_fact_1"))
-  assert_match(/baz/, stdout)
-
-  teardown do
-    on(agent, "rm -f '#{ext_fact_1}' '#{ext_fact_2}' '#{ext_fact_3}'")
+    step "agent #{agent}: resolve the external fact" do
+      on(agent, facter('external_fact')) do |facter_output|
+        assert_equal('external_value', facter_output.stdout.chomp, 'Expected to resolve the external_fact')
+      end
+    end
   end
 end


### PR DESCRIPTION
I split the 2 tests for the default external fact directory into 2 tests
Updated code style, added risk tags, and TestRail numbers