### PR TITLE
(FACT-1633) Relax version constraint of CFPropertyList gem

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -16,7 +16,7 @@ gem_default_executables: 'facter'
 gem_platform_dependencies:
   universal-darwin:
     gem_runtime_dependencies:
-      CFPropertyList: '~> 2.3.3'
+      CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'

--- a/tasks/cfpropertylist.rake
+++ b/tasks/cfpropertylist.rake
@@ -1,6 +1,6 @@
 task 'cfpropertylist' do
   if defined? Pkg::Config and Pkg::Config.project_root
-    cfp_version = "2.3.3"
+    cfp_version = "2.3.5"
     libdir = File.join(Pkg::Config.project_root, "lib")
     source = "https://github.com/ckruse/CFPropertyList/archive/cfpropertyList-#{cfp_version}.tar.gz"
     target_dir = Pkg::Util::File.mktemp


### PR DESCRIPTION
We want to pull in the newest version of CFPropertyList gem, 2.3.5,
which supports Ruby 2.4. This commit relaxes the version constraint to
allow that to be pulled in, while also preventing us from needed to do
further releases of Facter 2 if it updates again.