### PR TITLE
(FACT-1637) Remove win32-security gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,6 @@ mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 platform(*mingw) do
   gem 'ffi', '~> 1.9.5', :require => false
   gem 'win32-dir', '~> 0.4.8', :require => false
-  # Use of the win32-security gem is deprecated
-  gem 'win32-security', '~> 0.2.5', :require => false
 end
 
 gem 'facter', ">= 1.0.0", :path => File.expand_path("..", __FILE__)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -21,13 +21,11 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.8'
-      win32-security: '~> 0.2.5'
       win32console: '~> 1.3.2'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
       win32-dir: '~> 0.4.8'
-      win32-security: '~> 0.2.5'
 bundle_platforms:
   universal-darwin: ruby
   x86-mingw32: mingw


### PR DESCRIPTION
 - 2b9a6ff41ce77f2d60606015b2f4410d01955fa6 moved relevant security
   code into Facter, and removed any usage of win32/security gem code

 - Note that the usage was removed on 2/24/2016 but was never released
   as Facter 2.4.7 never saw the light of day.

   The next Puppet version 5 will remove all of these win32-*** gems
   which are considered internal implementation details (but which
   may could plausibly be externally consumed).  Facter will be
   released as 2.5.0 with some of these removals.

   The only impacted workflows for Facter should be strictly gem
   based - i.e. local development.  Packages will generally not be
   impacted as their dependencies are expressed differently (and
   Puppet itself carries a superset of what Facter carries).