### PR TITLE
(FACT-1638) Remove win32-dir from Facter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 
 platform(*mingw) do
   gem 'ffi', '~> 1.9.5', :require => false
-  gem 'win32-dir', '~> 0.4.8', :require => false
 end
 
 gem 'facter', ">= 1.0.0", :path => File.expand_path("..", __FILE__)

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -20,12 +20,10 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
-      win32-dir: '~> 0.4.8'
       win32console: '~> 1.3.2'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
-      win32-dir: '~> 0.4.8'
 bundle_platforms:
   universal-darwin: ruby
   x86-mingw32: mingw

--- a/lib/facter/util/config.rb
+++ b/lib/facter/util/config.rb
@@ -22,8 +22,8 @@ module Facter::Util::Config
   end
 
   def self.windows_data_dir
-    if Dir.const_defined? 'COMMON_APPDATA' then
-      Dir::COMMON_APPDATA
+    if Facter::Util::Config.is_windows?
+      Facter::Util::Windows::Dir.get_common_appdata()
     else
       nil
     end
@@ -60,7 +60,7 @@ module Facter::Util::Config
   end
 
   if Facter::Util::Config.is_windows?
-    require 'win32/dir'
+    require 'facter/util/windows/dir'
     require 'facter/util/windows_root'
   else
     require 'facter/util/unix_root'

--- a/lib/facter/util/windows/dir.rb
+++ b/lib/facter/util/windows/dir.rb
@@ -1,0 +1,41 @@
+require 'facter/util/windows'
+require 'ffi'
+
+module Facter::Util::Windows::Dir
+  extend FFI::Library
+
+  COMMON_APPDATA = 0x0023
+  S_OK           = 0x0
+  MAX_PATH       = 260;
+
+  def get_common_appdata
+    common_appdata = ''
+
+    # this pointer actually points to a :lpwstr (pointer) since we're letting Windows allocate for us
+    FFI::MemoryPointer.new(:pointer, ((MAX_PATH + 1) * 2)) do |buffer_ptr|
+      # hwndOwner, nFolder, hToken, dwFlags, pszPath
+      if SHGetFolderPathW(0, COMMON_APPDATA, 0, 0, buffer_ptr) != S_OK
+        raise Facter::Util::Windows::Error.new("Could not find COMMON_APPDATA path")
+      end
+
+      common_appdata = buffer_ptr.read_arbitrary_wide_string_up_to(MAX_PATH + 1)
+    end
+
+    common_appdata
+  end
+  module_function :get_common_appdata
+
+  ffi_convention :stdcall
+
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/bb762181(v=vs.85).aspx
+  # HRESULT SHGetFolderPath(
+  #   _In_  HWND   hwndOwner,
+  #   _In_  int    nFolder,
+  #   _In_  HANDLE hToken,
+  #   _In_  DWORD  dwFlags,
+  #   _Out_ LPTSTR pszPath
+  # );
+  ffi_lib :shell32
+  attach_function_private :SHGetFolderPathW,
+    [:handle, :int32, :handle, :dword, :lpwstr], :hresult
+end


### PR DESCRIPTION
 - Facter was only using Dir::COMMON_APPDATA so replace that with FFI
   calls to the SHGetFolderPathW API which can return this value.

   Note that SHGetFolderPathW has been replaced with a newer API, but
   the newer API is much more complex and requires COM memory
   management, so instead rely on this simpler variant given it should
   not be going away anytime soon.

 - There may be custom fact consumers in the wild relying on the
   existence of various Dir::XXXX constants provided by the win32-dir
   gem. This should not be a problem in practice for a few reasons:

   * Puppet agent packages still include win32-dir and adorn Dir::
     until work is completed to remove the gem - this will likely be
     done in a backward compatible way to avoice breakage
   * Puppet gem still depends on win32-dir, so even without Facter
     explicitly requiring it, it's still present in Rubys global state
   * Only Facter only gem workflows should be impacted, and I don't
     believe there are any