### PR TITLE
(FACT-1418) Nano fix - deprecate WMI COM monikers

### DIFF
--- a/lib/facter/util/wmi.rb
+++ b/lib/facter/util/wmi.rb
@@ -1,10 +1,28 @@
 module Facter::Util::WMI
   class << self
-    def connect(uri = wmi_resource_uri)
+
+    # Impersonation Level Constants
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms693790%28v=vs.85%29.aspx
+    RPC_C_IMP_LEVEL_DEFAULT       = 0
+    RPC_C_IMP_LEVEL_ANONYMOUS     = 1
+    RPC_C_IMP_LEVEL_IDENTIFY      = 2
+    RPC_C_IMP_LEVEL_IMPERSONATE   = 3
+    RPC_C_IMP_LEVEL_DELEGATE      = 4
+
+    # returns a COM class implementing ISWbemServicesEx
+    # prior to Facter 2.5.0, this defaulted to using a moniker
+    # but now defaults to using COM classes directly to support Nano
+    # backward compatibility is maintained in case custom facts specified a moniker
+    # but note that passing in the uri parameter can never work on Nano
+    def connect(uri = nil)
       require 'win32ole'
-      WIN32OLE.connect(uri)
+      uri.nil? ?
+        connect2() :
+        # NOTE: in the future it would be better to parse a given moniker uri / call connect2
+        WIN32OLE.connect(uri)
     end
 
+    # @deprecated
     def wmi_resource_uri( host = '.' )
       "winmgmts:{impersonationLevel=impersonate}!//#{host}/root/cimv2"
     end
@@ -12,5 +30,20 @@ module Facter::Util::WMI
     def execquery(query)
       connect().execquery(query)
     end
+
+    private
+
+    # this mimics the previous behavior of using the COM moniker
+    # winmgmts:{impersonationLevel=impersonate}!//./root/cimv2
+    # which is not supported on Nano Server
+    def connect2( server = '.', namespace = 'root\\cimv2', impersonation_level = RPC_C_IMP_LEVEL_IMPERSONATE )
+      locator = WIN32OLE.new("WbemScripting.SWbemLocator")
+      # https://msdn.microsoft.com/en-us/library/aa393720%28v=vs.85%29.aspx
+      # ConnectServer returns an ISWbemServicesEx
+      conn = locator.ConnectServer(server, namespace)
+      conn.Security_.ImpersonationLevel = impersonation_level
+      conn
+    end
+
   end
 end


### PR DESCRIPTION
 - To support Nano server, COM monikers cannot be used when
   establishing the connection to WMI.

   Create a new private method that behaves, by default, identically
   to the previous connect() behavior called connect2()

   Change the connect() signature slightly to provide no default
   value to uri so that the behavior can be transparently swapped by
   default to use actual COM classes instead of monikers.

   To cleanly support the prior behavior in a backwards-compatible way
   allow for passing a non-nil uri directly as a moniker - there
   should not be any such cases, but there's a possibility that
   custom facts may be using this interface.

   Note that such calls with not work on Nano.

 - This change only impacts running Puppet spec tests in a gem based
   workflow until native Facter 3+ is bundled into a gem.  This has
   the possibility to impact AppVeyor or other module workflows that
   consume gems.  This will not impact currently shipping puppet-agent
   packages.