### PR TITLE
(FACT-1641) Remove win32console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,10 +33,6 @@ data['gem_platform_dependencies'].each_pair do |gem_platform, info|
   end
 end
 
-platform(:mingw_19) do
-  gem 'win32console', '~> 1.3.2', :require => false
-end
-
 mingw = [:mingw]
 mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -20,7 +20,6 @@ gem_platform_dependencies:
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'
-      win32console: '~> 1.3.2'
   x64-mingw32:
     gem_runtime_dependencies:
       ffi: '~> 1.9.5'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,13 +38,6 @@ LogSpecOrder.log_spec_order
 RSpec.configure do |config|
   config.mock_with :mocha
 
-  if Facter::Util::Config.is_windows? && RUBY_VERSION =~ /^1\./
-    require 'win32console'
-    config.output_stream = $stdout
-    config.error_stream = $stderr
-    config.formatters.each { |f| f.instance_variable_set(:@output, $stdout) }
-  end
-
   config.before :each do
     # Ensure that we don't accidentally cache facts and environment
     # between test cases.


### PR DESCRIPTION
 - win32console gem was only needed for Ruby 1.9.3 running on 32-bit
   Windows, which is no longer a supported platform combination.

 - Remove the reference from ext/project_data.yaml, which changes what
   a shipped Facter 2.5.0 gem will reference from the x86 Windows
   gem.

 - Update the Gemfile so that source based workflows will no longer
   include win32console if testing Ruby 1.9.3 on 32-bit windows
   locally from source.

 - Remove the win32console related hacks that modify streams when
   running specs introduced 4 years ago in
   6ebe9d1d244749b5875be21f7e4705065aeef612