### PR TITLE
(maint) Use older FFI version under Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,13 @@ mingw = [:mingw]
 mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 
 platform(*mingw) do
-  gem 'ffi', '~> 1.9.5', :require => false
+  # FFI dropped 1.9.3 support in 1.9.16, and 1.9.15 was an incomplete release.
+  # 1.9.18 is required to support Ruby 2.4
+  if RUBY_VERSION < '2.0.0'
+    gem 'ffi', '<= 1.9.14', :require => false
+  else
+    gem 'ffi', '~> 1.9.18', :require => false
+  end
 end
 
 gem 'facter', ">= 1.0.0", :path => File.expand_path("..", __FILE__)


### PR DESCRIPTION
FFI dropped support for Ruby 1.9.3 in version 1.9.16. However, 1.9.18 is
needed to support Ruby 2.4. Since we need to support both of these
versions, this commit adds a check in the Gemfile for the Ruby version
when installing FFI, choosing an old version for 1.9.3 and the latest
for anything 2.0.0 and above.