### PR TITLE
(FACT-1588) Fix for OpenSSL 1.1.0

### DIFF
--- a/lib/inc/internal/util/posix/scoped_bio.hpp
+++ b/lib/inc/internal/util/posix/scoped_bio.hpp
@@ -19,7 +19,7 @@ namespace facter { namespace util { namespace posix {
          * Constructs a scoped_bio.
          * @param method The BIO_METHOD to use.
          */
-        explicit scoped_bio(BIO_METHOD* method);
+        explicit scoped_bio(const BIO_METHOD* method);
 
         /**
          * Constructs a scoped_bio.

--- a/lib/src/util/posix/scoped_bio.cc
+++ b/lib/src/util/posix/scoped_bio.cc
@@ -6,8 +6,11 @@ using namespace leatherman::util;
 
 namespace facter { namespace util { namespace posix {
 
-    scoped_bio::scoped_bio(BIO_METHOD* method) :
-        scoped_resource(BIO_new(method), free)
+    // Remove const-ness before calling BIO_new. This is "unsafe",
+    // but in isolation here will not cause issues. Allows the code to work
+    // with both OpenSSL 1.0 and 1.1.
+    scoped_bio::scoped_bio(const BIO_METHOD* method) :
+        scoped_resource(BIO_new(const_cast<BIO_METHOD*>(method)), free)
     {
     }
 

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -303,18 +303,6 @@ msgstr ""
 msgid "querylv returned success but we got a null LV. WTF?"
 msgstr ""
 
-#. warning
-#: lib/src/facts/aix/kernel_resolver.cc
-msgid "oslevel failed: {1}: kernel facts are unavailable"
-msgstr ""
-
-#. warning
-#: lib/src/facts/aix/kernel_resolver.cc
-msgid ""
-"Could not parse rml cache even after regenerating with oslevel: kernel facts "
-"are unavailable. Try running 'oslevel -s' to debug."
-msgstr ""
-
 #: lib/src/facts/aix/networking_resolver.cc
 msgid "getkerninfo call was unsuccessful"
 msgstr ""


### PR DESCRIPTION
Building with OpenSSL 1.1.0 failed due to a change in const-ness of the
`BIO_f_base64` return value. Update functions to accept a const value
when appropriate. Should be backwards compatible with non-const version.