### PR TITLE
(FACT-1646) fix label regex to allow for '/' on aix

### DIFF
--- a/acceptance/tests/facts/partitions.rb
+++ b/acceptance/tests/facts/partitions.rb
@@ -13,7 +13,7 @@ test_name "C96148: verify partitions facts" do
       ['uuid', /^[-a-zA-Z0-9]+$/],
       ['partuuid', /^[-a-f0-9]+$/],
       ['mount', /^\/.*/],
-      ['label', /\w+/],
+      ['label', /.*/],
       ['partlabel', /\w+/],
   ]
 


### PR DESCRIPTION
On AIX the label can contain just '/', so allow zero or more words
after the '/'