### PR TITLE
(packaging) Do not use versioned executable

### DIFF
--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -24,7 +24,6 @@ link_directories(
 )
 
 add_executable(facter ${FACTER_SOURCES})
-set_target_properties(facter PROPERTIES VERSION ${PROJECT_VERSION})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(facter rt)


### PR DESCRIPTION
Versioning the executable files clutters the filesystem and,
more importantly, totally breaks service management on SLES.
Since we don't have any use for symlinks to versioned binaries,
we should just get rid of them.