### PR TITLE
(packaging) Update version to 3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(FACTER VERSION 4.0.0)
+project(FACTER VERSION 3.7.0)
 
 # Set this early, so it's available. AIX gets weird, man.
 if("${CMAKE_SYSTEM_NAME}" MATCHES "AIX")

--- a/lib/Doxyfile
+++ b/lib/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = facter
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 4.0.0
+PROJECT_NUMBER         = 3.7.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
This commit updates Facter's version to 3.7.0 in preparation for the
Puppet Agent 5.0.0 release.

We ended up not having any breaking changes to ship, so we are not
shipping at Facter 4 at this time.