### PR TITLE
(FACT-1675) fix virtual, and is_virtual facts for OpenBSD VMs

### DIFF
--- a/lib/inc/facter/facts/vm.hpp
+++ b/lib/inc/facter/facts/vm.hpp
@@ -142,6 +142,11 @@ namespace facter { namespace facts {
          * The name of FreeBSD jails
          */
         constexpr static char const* jail = "jail";
+
+        /**
+         * The name for OpenBSD vmm
+         */
+        constexpr static char const* vmm = "vmm";
     };
 
 }}  // namespace facter::facts

--- a/lib/src/facts/openbsd/dmi_resolver.cc
+++ b/lib/src/facts/openbsd/dmi_resolver.cc
@@ -13,7 +13,14 @@ namespace facter { namespace facts { namespace openbsd {
         result.bios_vendor = sysctl_lookup(HW_VENDOR);
         result.uuid = sysctl_lookup(HW_UUID);
         result.serial_number = sysctl_lookup(HW_SERIALNO);
+        // OpenBSD running as virtual machine within
+        // OpenBSD vmm don't return HW_PRODUCT. For that
+        // case use the HW_VENDOR, to please the
+        // virtualization_resolver
         result.product_name = sysctl_lookup(HW_PRODUCT);
+        if (result.product_name.length() == 0) {
+            result.product_name = result.bios_vendor;
+        }
         result.bios_version = sysctl_lookup(HW_VERSION);
 
         return result;

--- a/lib/src/facts/resolvers/virtualization_resolver.cc
+++ b/lib/src/facts/resolvers/virtualization_resolver.cc
@@ -83,6 +83,7 @@ namespace facter { namespace facts { namespace resolvers {
             make_tuple("oVirt Node",        string(vm::ovirt)),
             make_tuple("HVM domU",          string(vm::xen_hardware)),
             make_tuple("Bochs",             string(vm::bochs)),
+            make_tuple("OpenBSD",           string(vm::vmm)),
         };
 
         for (auto const& vm : vms) {


### PR DESCRIPTION
Without the patch, OpenBSD VMs running within OpenBSD's hypervisor
vmm will wrongly report the fact virtual -> physical, and is_virtual -> false
With the patch, the following will be reported: virtual -> vmm, is_virtual -> true

It's unfortunate, but hw.product doesn't return anything in such
cases, therefore in openbsd/dmi_resolver, set the make use of
hw.vendor to set the product name.
The rest is rather mechanic, add a string for the hypervisor to facts/vm
as well as a mapping from the sysctl value to the string to
virtualization_resolver.