### PR TITLE
(FACT-1709) Add support for memory fact on FreeBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -206,6 +206,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/freebsd/zfs_resolver.cc"
         "src/facts/freebsd/zpool_resolver.cc"
         "src/facts/freebsd/virtualization_resolver.cc"
+        "src/facts/freebsd/memory_resolver.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
     set(LIBFACTER_PLATFORM_SOURCES

--- a/lib/inc/internal/facts/freebsd/memory_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/memory_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the FreeBSD memory fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/memory_resolver.hpp"
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving memory facts.
+     */
+    struct memory_resolver : resolvers::memory_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::osx

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -13,6 +13,7 @@
 #include <internal/facts/freebsd/zfs_resolver.hpp>
 #include <internal/facts/freebsd/zpool_resolver.hpp>
 #include <internal/facts/freebsd/virtualization_resolver.hpp>
+#include <internal/facts/freebsd/memory_resolver.hpp>
 
 using namespace std;
 
@@ -34,6 +35,7 @@ namespace facter { namespace facts {
         add(make_shared<freebsd::zfs_resolver>());
         add(make_shared<freebsd::zpool_resolver>());
         add(make_shared<freebsd::virtualization_resolver>());
+        add(make_shared<freebsd::memory_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/freebsd/memory_resolver.cc
+++ b/lib/src/facts/freebsd/memory_resolver.cc
@@ -1,0 +1,76 @@
+#include <internal/facts/freebsd/memory_resolver.hpp>
+#include <leatherman/execution/execution.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <vm/vm_param.h>
+#include <unistd.h>
+
+using namespace std;
+using namespace leatherman::execution;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    memory_resolver::data memory_resolver::collect_data(collection& facts)
+    {
+        data result;
+
+        size_t size;
+        int pagesize = getpagesize();
+
+        // Memory usage
+
+        unsigned long physmem;
+        size = sizeof(physmem);
+        if (0 == sysctlbyname("hw.physmem", &physmem, &size, NULL, 0)) {
+            result.mem_total = physmem;
+        }
+
+        unsigned int inactive_count = 0;
+        size = sizeof(inactive_count);
+        sysctlbyname("vm.stats.vm.v_inactive_count", &inactive_count, &size, NULL, 0);
+
+        unsigned int cache_count = 0;
+        size = sizeof(cache_count);
+        sysctlbyname("vm.stats.vm.v_cache_count", &cache_count, &size, NULL, 0);
+
+        unsigned int free_count = 0;
+        size = sizeof(free_count);
+        sysctlbyname("vm.stats.vm.v_free_count", &free_count, &size, NULL, 0);
+
+        long mem_free_page_count = inactive_count + cache_count + free_count;
+        result.mem_free = mem_free_page_count * pagesize;
+
+        // Swap usage
+
+        struct xswdev xsw;
+        size = sizeof(xsw);
+
+        int mib[16];
+        size_t mibsize;
+        mibsize = sizeof mib / sizeof mib[0];
+        if (sysctlnametomib("vm.swap_info", mib, &mibsize) == -1) {
+            LOG_DEBUG("sysctlnametomib() failed");
+        } else {
+            for (int n = 0; ; ++n) {
+                mib[mibsize] = n;
+                if (-1 == sysctl(mib, mibsize + 1, &xsw, &size, NULL, 0))
+                    break;
+
+                if (xsw.xsw_version != XSWDEV_VERSION) {
+                    LOG_DEBUG("xswdev version mismatch");
+                } else {
+                    result.swap_total += xsw.xsw_nblks;
+                    result.swap_free += xsw.xsw_nblks - xsw.xsw_used;
+                }
+            }
+
+            result.swap_free *= pagesize;
+            result.swap_total *= pagesize;
+        }
+
+        return result;
+    }
+
+}}}  // namespace facter::facts::freebsd


### PR DESCRIPTION
The structure was copied from the OpenBSD resolver, adjusted to collect information through FreeBSD's sysctl interface.