### PR TITLE
(FACT-1711) Fix zfs/zpool feature reporting

### DIFF
--- a/lib/src/facts/resolvers/zfs_resolver.cc
+++ b/lib/src/facts/resolvers/zfs_resolver.cc
@@ -49,7 +49,7 @@ namespace facter { namespace facts { namespace resolvers {
         });
 
         // Get the ZFS features
-        static boost::regex zfs_feature("\\s*(\\d+)[ ]");
+        static boost::regex zfs_feature("^\\s*(\\d+)[ ]");
         each_line(zfs_command(), {"upgrade", "-v"}, [&] (string& line) {
             string feature;
             if (re_search(line, zfs_feature, &feature)) {

--- a/lib/src/facts/resolvers/zpool_resolver.cc
+++ b/lib/src/facts/resolvers/zpool_resolver.cc
@@ -41,7 +41,7 @@ namespace facter { namespace facts { namespace resolvers {
 
         // Get the zpool version and features
         static boost::regex zpool_version("ZFS pool version (\\d+)[.]");
-        static boost::regex zpool_feature("\\s*(\\d+)[ ]");
+        static boost::regex zpool_feature("^\\s*(\\d+)[ ]");
         each_line(zpool_command(), {"upgrade", "-v"}, [&] (string& line) {
             if (re_search(line, zpool_version, &result.version)) {
                 return true;


### PR DESCRIPTION
This change prevents numbers follwed by spaces to be catched as
supported features, e.g.

```
lz4_compress
     LZ4 compression algorithm support.
       ^^
[...]
sha512
     SHA-512/256 hash algorithm.
             ^^^^
```

which resulted in:

```
zpool_featurenumbers => 4,256,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28
                        ^^^^^
```