### PR TITLE
(FACT-1712) Improve zpool_version fact resolution

### DIFF
--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -528,9 +528,9 @@ namespace facter { namespace facts {
         constexpr static char const* zfs_version = "zfs_version";
 
         /**
-         * The ZFS supported feature numbers.
+         * The ZFS supported version numbers.
          */
-        constexpr static char const* zfs_featurenumbers = "zfs_featurenumbers";
+        constexpr static char const* zfs_versionnumbers = "zfs_featurenumbers";
 
         /**
          * The ZFS storage pool (zpool) version fact.
@@ -538,9 +538,9 @@ namespace facter { namespace facts {
         constexpr static char const* zpool_version = "zpool_version";
 
         /**
-         * The ZFS storage pool supported feature numbers.
+         * The ZFS storage pool supported version numbers.
          */
-        constexpr static char const* zpool_featurenumbers = "zpool_featurenumbers";
+        constexpr static char const* zpool_versionnumbers = "zpool_featurenumbers";
 
         /**
          * The fact for number of Solaris zones.

--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -538,6 +538,11 @@ namespace facter { namespace facts {
         constexpr static char const* zpool_version = "zpool_version";
 
         /**
+         * The ZFS storage pool supported feature flags.
+         */
+        constexpr static char const* zpool_featureflags = "zpool_featureflags";
+
+        /**
          * The ZFS storage pool supported version numbers.
          */
         constexpr static char const* zpool_versionnumbers = "zpool_featurenumbers";

--- a/lib/inc/internal/facts/resolvers/zfs_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zfs_resolver.hpp
@@ -43,9 +43,9 @@ namespace facter { namespace facts { namespace resolvers {
              */
             std::string version;
             /**
-             * Stores the ZFS feature numbers.
+             * Stores the ZFS version numbers.
              */
-            std::vector<std::string> features;
+            std::vector<std::string> versions;
         };
 
         /**

--- a/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
@@ -43,6 +43,10 @@ namespace facter { namespace facts { namespace resolvers {
              */
             std::string version;
             /**
+             * Stores the zpool feature flags.
+             */
+            std::vector<std::string> feature_flags;
+            /**
              * Stores the zpool version numbers.
              */
             std::vector<std::string> versions;

--- a/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/zpool_resolver.hpp
@@ -43,9 +43,9 @@ namespace facter { namespace facts { namespace resolvers {
              */
             std::string version;
             /**
-             * Stores the zpool feature numbers.
+             * Stores the zpool version numbers.
              */
-            std::vector<std::string> features;
+            std::vector<std::string> versions;
         };
 
         /**

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1894,6 +1894,14 @@ zones:
     caveats: |
         Solaris: the `zoneadm` utility must be present.
 
+zpool_featureflags:
+    type: string
+    description: Return the comma-delimited feature flags for ZFS storage pools.
+    resolution: |
+        Solaris: use the `zpool` utility to retrieve the feature numbers for ZFS storage pools
+    caveats: |
+        Solaris: the `zpool` utility must be present.
+
 zpool_featurenumbers:
     type: string
     description: Return the comma-delimited feature numbers for ZFS storage pools.

--- a/lib/src/facts/resolvers/zfs_resolver.cc
+++ b/lib/src/facts/resolvers/zfs_resolver.cc
@@ -18,7 +18,7 @@ namespace facter { namespace facts { namespace resolvers {
             "ZFS",
             {
                 fact::zfs_version,
-                fact::zfs_featurenumbers
+                fact::zfs_versionnumbers
             })
     {
     }
@@ -30,8 +30,8 @@ namespace facter { namespace facts { namespace resolvers {
         if (!data.version.empty()) {
             facts.add(fact::zfs_version, make_value<string_value>(move(data.version)));
         }
-        if (!data.features.empty()) {
-            facts.add(fact::zfs_featurenumbers, make_value<string_value>(boost::join(data.features, ",")));
+        if (!data.versions.empty()) {
+            facts.add(fact::zfs_versionnumbers, make_value<string_value>(boost::join(data.versions, ",")));
         }
     }
 
@@ -48,12 +48,12 @@ namespace facter { namespace facts { namespace resolvers {
             return true;
         });
 
-        // Get the ZFS features
-        static boost::regex zfs_feature("^\\s*(\\d+)[ ]");
+        // Get the ZFS versions
+        static boost::regex zfs_supported_version("^\\s*(\\d+)[ ]");
         each_line(zfs_command(), {"upgrade", "-v"}, [&] (string& line) {
-            string feature;
-            if (re_search(line, zfs_feature, &feature)) {
-                result.features.emplace_back(move(feature));
+            string version;
+            if (re_search(line, zfs_supported_version, &version)) {
+                result.versions.emplace_back(move(version));
             }
             return true;
         });

--- a/lib/src/facts/resolvers/zpool_resolver.cc
+++ b/lib/src/facts/resolvers/zpool_resolver.cc
@@ -18,7 +18,7 @@ namespace facter { namespace facts { namespace resolvers {
             "ZFS storage pool",
             {
                 fact::zpool_version,
-                fact::zpool_featurenumbers,
+                fact::zpool_versionnumbers,
             })
     {
     }
@@ -30,8 +30,8 @@ namespace facter { namespace facts { namespace resolvers {
         if (!data.version.empty()) {
             facts.add(fact::zpool_version, make_value<string_value>(move(data.version)));
         }
-        if (!data.features.empty()) {
-            facts.add(fact::zpool_featurenumbers, make_value<string_value>(boost::join(data.features, ",")));
+        if (!data.versions.empty()) {
+            facts.add(fact::zpool_versionnumbers, make_value<string_value>(boost::join(data.versions, ",")));
         }
     }
 
@@ -39,16 +39,16 @@ namespace facter { namespace facts { namespace resolvers {
     {
         data result;
 
-        // Get the zpool version and features
+        // Get the zpool version
         static boost::regex zpool_version("ZFS pool version (\\d+)[.]");
-        static boost::regex zpool_feature("^\\s*(\\d+)[ ]");
+        static boost::regex zpool_supported_version("^\\s*(\\d+)[ ]");
         each_line(zpool_command(), {"upgrade", "-v"}, [&] (string& line) {
             if (re_search(line, zpool_version, &result.version)) {
                 return true;
             }
-            string feature;
-            if (re_search(line, zpool_feature, &feature)) {
-                result.features.emplace_back(move(feature));
+            string version;
+            if (re_search(line, zpool_supported_version, &version)) {
+                result.versions.emplace_back(move(version));
             }
             return true;
         });

--- a/lib/src/facts/resolvers/zpool_resolver.cc
+++ b/lib/src/facts/resolvers/zpool_resolver.cc
@@ -18,6 +18,7 @@ namespace facter { namespace facts { namespace resolvers {
             "ZFS storage pool",
             {
                 fact::zpool_version,
+                fact::zpool_featureflags,
                 fact::zpool_versionnumbers,
             })
     {
@@ -30,6 +31,9 @@ namespace facter { namespace facts { namespace resolvers {
         if (!data.version.empty()) {
             facts.add(fact::zpool_version, make_value<string_value>(move(data.version)));
         }
+        if (!data.feature_flags.empty()) {
+            facts.add(fact::zpool_featureflags, make_value<string_value>(boost::join(data.feature_flags, ",")));
+        }
         if (!data.versions.empty()) {
             facts.add(fact::zpool_versionnumbers, make_value<string_value>(boost::join(data.versions, ",")));
         }
@@ -39,16 +43,47 @@ namespace facter { namespace facts { namespace resolvers {
     {
         data result;
 
-        // Get the zpool version
-        static boost::regex zpool_version("ZFS pool version (\\d+)[.]");
+        enum { UNKNOWN, FEATURES, VERSIONS } state = UNKNOWN;
+
+        // Get the zpool version and features
+        static boost::regex zpool_version("^This system is currently running ZFS pool version (\\d+)\\.$");
+        static boost::regex zpool_feature_flags("^This system supports ZFS pool feature flags\\.$");
+
+        static boost::regex zpool_supported_feature_header("^The following features are supported:$");
+        static boost::regex zpool_supported_versions_header("^The following versions are supported:$");
+        static boost::regex zpool_supported_legacy_versions_header("^The following legacy versions are also supported:$");
+
+        static boost::regex zpool_supported_feature("^([[:alnum:]_]+)(\\s+\\(read-only compatible\\))?$");
         static boost::regex zpool_supported_version("^\\s*(\\d+)[ ]");
+
+        string feature;
         each_line(zpool_command(), {"upgrade", "-v"}, [&] (string& line) {
-            if (re_search(line, zpool_version, &result.version)) {
-                return true;
-            }
-            string version;
-            if (re_search(line, zpool_supported_version, &version)) {
-                result.versions.emplace_back(move(version));
+            switch (state) {
+            case UNKNOWN:
+                if (re_search(line, zpool_version, &result.version)) {
+                } else if (re_search(line, zpool_feature_flags)) {
+                    result.version = "1000";
+                } else if (re_search(line, zpool_supported_feature_header)) {
+                    state = FEATURES;
+                } else if (re_search(line, zpool_supported_versions_header)) {
+                    state = VERSIONS;
+                }
+                break;
+
+            case FEATURES:
+                if (re_search(line, zpool_supported_feature, &feature)) {
+                    result.feature_flags.emplace_back(move(feature));
+                } else if (re_search(line, zpool_supported_legacy_versions_header)) {
+                    state = VERSIONS;
+                }
+                break;
+
+            case VERSIONS:
+                string feature;
+                if (re_search(line, zpool_supported_version, &feature)) {
+                    result.versions.emplace_back(move(feature));
+                }
+                break;
             }
             return true;
         });

--- a/lib/tests/facts/resolvers/zfs_resolver.cc
+++ b/lib/tests/facts/resolvers/zfs_resolver.cc
@@ -37,7 +37,7 @@ struct test_zfs_resolver : zfs_resolver
     {
         data result;
         result.version = "1";
-        result.features = { "1", "2", "3" };
+        result.versions = { "1", "2", "3" };
         return result;
     }
 };
@@ -57,7 +57,7 @@ SCENARIO("using the ZFS resolver") {
             auto value = facts.get<string_value>(fact::zfs_version);
             REQUIRE(value);
             REQUIRE(value->value() == "1");
-            value = facts.get<string_value>(fact::zfs_featurenumbers);
+            value = facts.get<string_value>(fact::zfs_versionnumbers);
             REQUIRE(value);
             REQUIRE(value->value() == "1,2,3");
         }

--- a/lib/tests/facts/resolvers/zpool_resolver.cc
+++ b/lib/tests/facts/resolvers/zpool_resolver.cc
@@ -37,7 +37,7 @@ struct test_zpool_resolver : zpool_resolver
     {
         data result;
         result.version = "1";
-        result.features = { "1", "2", "3" };
+        result.versions = { "1", "2", "3" };
         return result;
     }
 };
@@ -57,7 +57,7 @@ SCENARIO("using the zpool resolver") {
             auto value = facts.get<string_value>(fact::zpool_version);
             REQUIRE(value);
             REQUIRE(value->value() == "1");
-            value = facts.get<string_value>(fact::zpool_featurenumbers);
+            value = facts.get<string_value>(fact::zpool_versionnumbers);
             REQUIRE(value);
             REQUIRE(value->value() == "1,2,3");
         }

--- a/lib/tests/facts/resolvers/zpool_resolver.cc
+++ b/lib/tests/facts/resolvers/zpool_resolver.cc
@@ -38,6 +38,7 @@ struct test_zpool_resolver : zpool_resolver
         data result;
         result.version = "1";
         result.versions = { "1", "2", "3" };
+        result.feature_flags = { "async_destroy", "lz4_compress", "enabled_txg" };
         return result;
     }
 };
@@ -53,13 +54,16 @@ SCENARIO("using the zpool resolver") {
     WHEN("data is present") {
         facts.add(make_shared<test_zpool_resolver>());
         THEN("flat facts are added") {
-            REQUIRE(facts.size() == 2u);
+            REQUIRE(facts.size() == 3u);
             auto value = facts.get<string_value>(fact::zpool_version);
             REQUIRE(value);
             REQUIRE(value->value() == "1");
             value = facts.get<string_value>(fact::zpool_versionnumbers);
             REQUIRE(value);
             REQUIRE(value->value() == "1,2,3");
+            value = facts.get<string_value>(fact::zpool_featureflags);
+            REQUIRE(value);
+            REQUIRE(value->value() == "async_destroy,lz4_compress,enabled_txg");
         }
     }
 }

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -396,7 +396,7 @@ protected:
     {
         data result;
         result.version = 1;
-        result.features = { "1", "2", "3" };
+        result.versions = { "1", "2", "3" };
         return result;
     }
 };
@@ -433,7 +433,7 @@ protected:
     {
         data result;
         result.version = 1;
-        result.features = { "1", "2", "3" };
+        result.versions = { "1", "2", "3" };
         return result;
     }
 };

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -434,6 +434,7 @@ protected:
         data result;
         result.version = 1;
         result.versions = { "1", "2", "3" };
+        result.feature_flags = { "async_destroy", "lz4_compress", "enabled_txg" };
         return result;
     }
 };


### PR DESCRIPTION
When `zpool upgrade -v` does not output 'ZFS pool version XXX.',
fall-back to the last version reported.

This mimics the behavior of the Ruby version of Facter and makes the
fact reported when feature flags are enabled.