### PR TITLE
(FACT-1714) Use posix::operating_system_resolver for bsd, freebsd and openbsd

### DIFF
--- a/lib/src/facts/bsd/collection.cc
+++ b/lib/src/facts/bsd/collection.cc
@@ -1,6 +1,6 @@
 #include <facter/facts/collection.hpp>
 #include <internal/facts/posix/kernel_resolver.hpp>
-#include <internal/facts/resolvers/operating_system_resolver.hpp>
+#include <internal/facts/posix/operating_system_resolver.hpp>
 #include <internal/facts/bsd/uptime_resolver.hpp>
 #include <internal/facts/bsd/filesystem_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
@@ -15,7 +15,7 @@ namespace facter { namespace facts {
     void collection::add_platform_facts()
     {
         add(make_shared<posix::kernel_resolver>());
-        add(make_shared<resolvers::operating_system_resolver>());
+        add(make_shared<posix::operating_system_resolver>());
         add(make_shared<bsd::uptime_resolver>());
         add(make_shared<bsd::filesystem_resolver>());
         add(make_shared<posix::ssh_resolver>());

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -8,7 +8,7 @@
 #include <internal/facts/posix/kernel_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
-#include <internal/facts/resolvers/operating_system_resolver.hpp>
+#include <internal/facts/posix/operating_system_resolver.hpp>
 #include <internal/facts/freebsd/networking_resolver.hpp>
 
 using namespace std;
@@ -18,7 +18,7 @@ namespace facter { namespace facts {
     void collection::add_platform_facts()
     {
         add(make_shared<posix::kernel_resolver>());
-        add(make_shared<resolvers::operating_system_resolver>());
+        add(make_shared<posix::operating_system_resolver>());
         add(make_shared<freebsd::networking_resolver>());
         add(make_shared<bsd::uptime_resolver>());
         add(make_shared<bsd::filesystem_resolver>());

--- a/lib/src/facts/openbsd/collection.cc
+++ b/lib/src/facts/openbsd/collection.cc
@@ -11,7 +11,7 @@
 #include <internal/facts/posix/kernel_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
-#include <internal/facts/resolvers/operating_system_resolver.hpp>
+#include <internal/facts/posix/operating_system_resolver.hpp>
 
 using namespace std;
 
@@ -20,7 +20,7 @@ namespace facter { namespace facts {
     void collection::add_platform_facts()
     {
         add(make_shared<posix::kernel_resolver>());
-        add(make_shared<resolvers::operating_system_resolver>());
+        add(make_shared<posix::operating_system_resolver>());
         add(make_shared<bsd::uptime_resolver>());
         add(make_shared<bsd::filesystem_resolver>());
         add(make_shared<posix::ssh_resolver>());


### PR DESCRIPTION
*BSD are basically POSIX compliant systems, so rely on `posix::operating_system_resolver` instead of `resolvers::operating_system_resolver` to resolve Operating System facts.

This makes some facts previously visible in the Ruby version of Facter usable again with the C++ version of Facter.