### PR TITLE
(packaging) Preapre for 3.6.6 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2.2)
-project(FACTER VERSION 3.6.5)
+project(FACTER VERSION 3.6.6)
 
 # Set this early, so it's available. AIX gets weird, man.
 if("${CMAKE_SYSTEM_NAME}" MATCHES "AIX")

--- a/lib/Doxyfile
+++ b/lib/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = facter
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.6.5
+PROJECT_NUMBER         = 3.6.6
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: FACTER 3.6.4\n"
+"Project-Id-Version: FACTER 3.6.6\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -301,18 +301,6 @@ msgstr ""
 #. warning
 #: lib/src/facts/aix/filesystem_resolver.cc
 msgid "querylv returned success but we got a null LV. WTF?"
-msgstr ""
-
-#. warning
-#: lib/src/facts/aix/kernel_resolver.cc
-msgid "oslevel failed: {1}: kernel facts are unavailable"
-msgstr ""
-
-#. warning
-#: lib/src/facts/aix/kernel_resolver.cc
-msgid ""
-"Could not parse rml cache even after regenerating with oslevel: kernel facts "
-"are unavailable. Try running 'oslevel -s' to debug."
 msgstr ""
 
 #: lib/src/facts/aix/networking_resolver.cc


### PR DESCRIPTION
This commit updates Facter's version to 3.6.6 and updates the POT file
in preparation for the puppet-agent 1.10.5 release.