### PR TITLE
(maint) Minor fixes to get validation working

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -25,7 +25,7 @@ module HarnessOptions
     :timesync => false,
     :repo_proxy => true,
     :add_el_extras => true,
-    :epel_7_pkg => "epel-release-7-9.noarch.rpm",
+    :epel_7_pkg => "epel-release-7-10.noarch.rpm",
     :epel_6_pkg => "epel-release-6-8.noarch.rpm",
     :epel_5_pkg => "epel-release-5-4.noarch.rpm",
     :preserve_hosts => 'onfail',

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -208,7 +208,7 @@ module Puppet
             arch = $3
 
             deb = fetch(
-              "http://apt.puppetlabs.com/",
+              "http://apt.puppetlabs.com",
               "puppetlabs-release-%s.deb" % version,
               platform_configs_dir
             )


### PR DESCRIPTION
We recently moved our apt repos, and the new servers do not accept
extraneous slashes in their URLs. This commit fixes a typo in the URL
formation.

It also updates the EPEL dependency, due to an upstream version bump.