### PR TITLE
FQDN lookup: fix off-by-one error

### DIFF
--- a/acceptance/tests/ticket_1238_hostname_fqdn.rb
+++ b/acceptance/tests/ticket_1238_hostname_fqdn.rb
@@ -5,6 +5,7 @@ test_name 'C93827: facter fqdn should return the hostname when its a fully quali
   confine :except, :platform => 'windows'
 
   fqdn = 'foo.bar.example.org'
+  fqdn_long = 'a23456789.b23456789.c23456789.d23456789.e23456789.f23456789.wxyz'
 
   agents.each do |agent|
     orig_hostname = on(agent, 'hostname').stdout.chomp
@@ -32,6 +33,25 @@ test_name 'C93827: facter fqdn should return the hostname when its a fully quali
       on(agent, 'facter fqdn') do |facter_output|
         assert_equal(fqdn, facter_output.stdout.chomp, 'facter did not return the hostname set by the test')
       end
+    end
+  end
+
+  step "long hostname as #{fqdn_long}" do
+    on(agent, "hostname #{fqdn_long}")
+    begin
+      Timeout.timeout(20) do
+        until on(agent, 'hostname').stdout =~ /#{fqdn_long}/
+          sleep(0.25) # on Solaris 11 hostname returns before the hostname is updated
+        end
+      end
+    rescue Timeout::Error
+      raise "Failed to reset the hostname of the test machine to #{fqdn_long}"
+    end
+  end
+
+  step 'validate facter uses hostname as the LONG fqdn if its a fully qualified domain name' do
+    on(agent, 'facter fqdn') do |facter_output|
+      assert_equal(fqdn_long, facter_output.stdout.chomp, 'facter did not return the hostname set by the test')
     end
   end
 end

--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -68,7 +68,7 @@ namespace facter { namespace facts { namespace posix {
         }
         // Get the hostname (+1 to ensure a null is returned on platforms where maximum truncation may occur)
         vector<char> name(size + 1);
-        if (gethostname(name.data(), size) != 0) {
+        if (gethostname(name.data(), size + 1) != 0) {
             LOG_WARNING("gethostname failed: {1} ({2}): hostname is unavailable.", strerror(errno), errno);
         } else {
             // Check for fully-qualified hostname


### PR DESCRIPTION
This is my first submission to this project, so I apologize for the refactoring that'll be necessary.

This PR fixes an off-by-one hostname lookup bug probably introduced in https://tickets.puppetlabs.com/browse/FACT-1238 / https://github.com/puppetlabs/facter/pull/1202 . On Linux hosts with hostnames of *exactly* 64 bytes, `facter fqdn` fails with the same error from FACT-1238. Digging into the spec, the [Linux manpage](http://man7.org/linux/man-pages/man2/gethostname.2.html) for `gethostname(2)` says...

> POSIX.1 guarantees that "Host names (not including the terminating null byte)
       are limited to HOST_NAME_MAX bytes".  On Linux, HOST_NAME_MAX is
       defined with the value 64, which has been the limit since Linux 1.0
       (earlier kernels imposed a limit of 8 bytes).

The "you have to count the null byte" behavior is confirmed in the spec ([link](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)), so this should be true everywhere vaguely unix-like.

> {HOST_NAME_MAX}
   Maximum length of a host name (not including the terminating null) as returned from the gethostname() function.

Here's a trivial example:
```
tmaher@lowryder:~/puppet-fqdn-bug$ cat offbyone.c
#include <unistd.h>
#include <limits.h>
#include <netinet/in.h>
#include <arpa/inet.h>
#include <stdlib.h>
#include <stdio.h>
#include <errno.h>
#include <string.h>

int main(void){
  int size = sysconf(_SC_HOST_NAME_MAX);
  char buffer[256];
  printf("HOST_NAME_MAX: %d\n", size);
  errno = 0;

  if (gethostname(buffer, size) != 0){
    printf("FAIL: size %d, error %s (errno %d)\n", size, strerror(errno), errno);
  } else {
    printf("PASS: %s\n", buffer);
  }

  size += 1;
  if (gethostname(buffer, size) != 0){
    printf("FAIL: size %d, error %s (errno %d)\n", size, strerror(errno), errno);
  } else {
    printf("PASS: size %d, %s\n", size, buffer);
  }

  return 0;
}
```

/cc @MikaelSmith 