### PR TITLE
(packaging) Stop building all the things

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,24 +1,9 @@
 ---
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
-default_cow: 'base-squeeze-i386.cow'
-cows: 'base-precise-i386.cow base-precise-amd64.cow base-squeeze-i386.cow base-squeeze-amd64.cow base-trusty-i386.cow base-trusty-amd64.cow base-wheezy-i386.cow base-wheezy-amd64.cow'
-pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
-gpg_name: 'info@puppetlabs.com'
+gpg_name: 'release@puppet.com'
 gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
-# a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-5-x86_64 pl-el-6-i386 pl-el-6-x86_64 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-20-x86_64'
-yum_host: 'yum.puppetlabs.com'
-yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE
-build_dmg: TRUE
-build_ips: TRUE
-apt_host: 'apt.puppetlabs.com'
-apt_repo_url: 'http://apt.puppetlabs.com'
-apt_repo_path: '/opt/repository/incoming'
-ips_repo: '/var/pkgrepo'
-ips_store: '/opt/repository'
-ips_host: 'solaris-11-ips-repo.acctest.dc1.puppetlabs.net'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
We are only making gem and tar archives of facter 2 available, but with
these settings, we were building rpms, dmgs, debs, etc. That wasn't
great, because that automation required old systems that had either been
abandoned or decommissioned. This PR removes that to allow us all to
move on with our lives.