### PR TITLE
Distinguish FreeBSD kernelrelease and os.release

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -208,6 +208,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/freebsd/zpool_resolver.cc"
         "src/facts/freebsd/virtualization_resolver.cc"
         "src/facts/freebsd/memory_resolver.cc"
+        "src/facts/freebsd/operating_system_resolver.cc"
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
     set(LIBFACTER_PLATFORM_SOURCES

--- a/lib/inc/internal/facts/freebsd/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/operating_system_resolver.hpp
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * Declares the FreeBSD operating system fact resolver.
+ */
+#pragma once
+
+#include "../posix/operating_system_resolver.hpp"
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving operating system facts.
+     */
+    struct operating_system_resolver : posix::operating_system_resolver
+    {
+    protected:
+        /**
+         * Collects the resolver's release data.
+         * @param facts The fact collection that is resolving facts.
+         * @param result The current resolver data.
+         */
+        virtual void collect_release_data(collection& facts, data& result) override;
+    };
+}}}  // namespace facter::facts::freebsd

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -216,6 +216,20 @@ namespace facter { namespace facts { namespace resolvers {
          * @return Returns the resolver data.
          */
         virtual data collect_data(collection& facts);
+
+        /**
+         * Collects the resolver's kernel data.
+         * @param facts The fact collection that is resolving facts.
+         * @param result The current resolver data.
+         */
+        virtual void collect_kernel_data(collection& facts, data &result);
+
+        /**
+         * Collects the resolver's release data.
+         * @param facts The fact collection that is resolving facts.
+         * @param result The current resolver data.
+         */
+        virtual void collect_release_data(collection& facts, data &result);
     };
 
 }}}  // namespace facter::facts::resolvers

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -8,7 +8,7 @@
 #include <internal/facts/posix/kernel_resolver.hpp>
 #include <internal/facts/posix/ssh_resolver.hpp>
 #include <internal/facts/posix/timezone_resolver.hpp>
-#include <internal/facts/posix/operating_system_resolver.hpp>
+#include <internal/facts/freebsd/operating_system_resolver.hpp>
 #include <internal/facts/freebsd/networking_resolver.hpp>
 #include <internal/facts/freebsd/zfs_resolver.hpp>
 #include <internal/facts/freebsd/zpool_resolver.hpp>
@@ -22,7 +22,7 @@ namespace facter { namespace facts {
     void collection::add_platform_facts()
     {
         add(make_shared<posix::kernel_resolver>());
-        add(make_shared<posix::operating_system_resolver>());
+        add(make_shared<freebsd::operating_system_resolver>());
         add(make_shared<freebsd::networking_resolver>());
         add(make_shared<bsd::uptime_resolver>());
         add(make_shared<bsd::filesystem_resolver>());

--- a/lib/src/facts/freebsd/operating_system_resolver.cc
+++ b/lib/src/facts/freebsd/operating_system_resolver.cc
@@ -1,0 +1,17 @@
+#include <leatherman/execution/execution.hpp>
+
+#include <internal/facts/freebsd/operating_system_resolver.hpp>
+
+using namespace std;
+using namespace leatherman::execution;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    void operating_system_resolver::collect_release_data(collection& facts, data& result)
+    {
+        auto exec = execute("freebsd-version");
+        if (exec.success) {
+            result.release = exec.output;
+        }
+    }
+} } }  // namespace facter::facts::freebsd

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -231,18 +231,27 @@ namespace facter { namespace facts { namespace resolvers {
     {
         data result;
 
+        collect_kernel_data(facts, result);
+        collect_release_data(facts, result);
+
+        return result;
+    }
+
+    void operating_system_resolver::collect_kernel_data(collection& facts, data& result)
+    {
         auto kernel = facts.get<string_value>(fact::kernel);
         if (kernel) {
             result.name = kernel->value();
             result.family = kernel->value();
         }
+    }
 
+    void operating_system_resolver::collect_release_data(collection& facts, data& result)
+    {
         auto release = facts.get<string_value>(fact::kernel_release);
         if (release) {
             result.release = release->value();
         }
-
-        return result;
     }
 
     tuple<string, string> operating_system_resolver::parse_distro(string const& name, string const& release)


### PR DESCRIPTION
FreeBSD release (userland) version (returned by `freebsd-version(1)`) might be different from the kernel version (returned by `uname(1)`).  This happens for example after a vulnerability is fixed in a userland program, the kernel is unaffected by the fix.  Fox example, we can have:

```
g4% uname -r
11.0-RELEASE-p9
g4% freebsd-version
11.0-RELEASE-p11
```

Currently, the same information is returned twice. It would be better to return the appropriate information in order to detect e.g. machines with pending security updates:

```
g4% facter os kernelrelease
kernelrelease => 11.0-RELEASE-p9
os => {
  architecture => "amd64",
  family => "FreeBSD",
  hardware => "amd64",
  name => "FreeBSD",
  release => {
    full => "11.0-RELEASE-p9",         <--- should be "11.0-RELEASE-p11"
    major => "11",
    minor => "0-RELEASE-p9"            <--- should be "0-RELEASE-p11"
  }
}
```

This PR makes it possible to override the kernel and release facts resolution, and introduce a FreeBSD resolver that rely on `freebsd-version(1)` to return the right release information.