### PR TITLE
(maint) Report zpool_version=5000 for feature flags

### DIFF
--- a/lib/src/facts/resolvers/zpool_resolver.cc
+++ b/lib/src/facts/resolvers/zpool_resolver.cc
@@ -62,7 +62,7 @@ namespace facter { namespace facts { namespace resolvers {
             case UNKNOWN:
                 if (re_search(line, zpool_version, &result.version)) {
                 } else if (re_search(line, zpool_feature_flags)) {
-                    result.version = "1000";
+                    result.version = "5000";
                 } else if (re_search(line, zpool_supported_feature_header)) {
                     state = FEATURES;
                 } else if (re_search(line, zpool_supported_versions_header)) {


### PR DESCRIPTION
This is a follow-up to #1597.

The OpenZFS folks on IRC confirmed that reporting *5000* instead of *1000*
would be better: « on-disk the fields show version number 5000 »; « some
material is old, 5000 is what's used now. 1000 may have been a sort of
plan that changed early in openzfs creation ».