### PR TITLE
(maint) cwrapper returns failure if malloc fails

### DIFF
--- a/lib/src/cwrapper.cc
+++ b/lib/src/cwrapper.cc
@@ -30,7 +30,12 @@ uint8_t get_default_facts(char **result) {
 
         auto json_facts = stream.str();
         auto l = json_facts.length()+1;
+
         *result = static_cast<char*>(malloc(sizeof(char)*l));
+        if (*result == nullptr) {
+            return EXIT_FAILURE;
+        }
+
         strncpy(*result, json_facts.c_str(), l);
     } catch (const std::exception&) {
         return EXIT_FAILURE;


### PR DESCRIPTION
Update the C wrapper get_default_facts to return EXIT_FAILURE if malloc
fails to allocate memory.