### PR TITLE
make system fact paths available to all. implement FACT-42

### DIFF
--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -157,7 +157,7 @@ namespace facter { namespace facts {
             } else {
                 LOG_DEBUG("skipping external facts for \"{1}\": {2}", dir, msg);
             }
-            return found;
+            return false;
         }
 
         LOG_DEBUG("searching {1} for external facts.", search_dir);
@@ -166,15 +166,15 @@ namespace facter { namespace facts {
             for (auto const& res : resolvers) {
                 if (res->can_resolve(path)) {
                     try {
-                        found = true;
                         res->resolve(path, *this);
+                        found = true;
                     }
                     catch (external::external_fact_exception& ex) {
                         LOG_ERROR("error while processing \"{1}\" for external facts: {2}", path, ex.what());
                     }
                     break;
                 }
-            }
+            } # always
             return true;
         });
         return found;

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -174,7 +174,7 @@ namespace facter { namespace facts {
                     }
                     break;
                 }
-            } # always
+            }
             return true;
         });
         return found;

--- a/lib/src/facts/posix/collection.cc
+++ b/lib/src/facts/posix/collection.cc
@@ -25,11 +25,10 @@ namespace facter { namespace facts {
                 directories.emplace_back(home + "/.puppetlabs/opt/facter/facts.d");
                 directories.emplace_back(home + "/.facter/facts.d");
             }
-        } else {
-            directories.emplace_back("/opt/puppetlabs/facter/facts.d");
-            directories.emplace_back("/etc/facter/facts.d");
-            directories.emplace_back("/etc/puppetlabs/facter/facts.d");
         }
+        directories.emplace_back("/opt/puppetlabs/facter/facts.d");
+        directories.emplace_back("/etc/facter/facts.d");
+        directories.emplace_back("/etc/puppetlabs/facter/facts.d");
         return directories;
     }
 


### PR DESCRIPTION
FACT-42 was 100% valid and should have been honored. There is never cause to prohibit non-root users from being able to utilize facts that the sysadmin deliberately put in the system-wide directory(s). If some of the external facts can't return valid values without elevated privileges, it's up to the external fact writer to handle it properly (eg. use sudo or return a blank value). Puppet has no business interfering in perfectly reasonable and expected system behavior. Even if Puppet-agent is run as root most (all?) of the time, Facter is extremely useful in non-Puppet contexts and deserves to work correctly.