### PR TITLE
(FACT-1720) Resolve environmnt facts after all other sources

### DIFF
--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -329,9 +329,6 @@ int main(int argc, char **argv)
         collection facts(blocklist, ttls);
         facts.add_default_facts(ruby);
 
-        // Add the environment facts
-        facts.add_environment_facts();
-
         if (ruby && !vm["no-custom-facts"].as<bool>()) {
             if (vm.count("custom-dir")) {
                 custom_directories = vm["custom-dir"].as<vector<string>>();
@@ -354,6 +351,9 @@ int main(int argc, char **argv)
             facts.add_external_facts(external_directories);
           }
         }
+
+        // Add the environment facts
+        facts.add_environment_facts();
 
         // Output the facts
         facter::facts::format fmt = facter::facts::format::hash;


### PR DESCRIPTION
Previous versions of facter would resolve environment facts last,
allowing users to override both built-in and external facts from
the command line. CFacter resolved in a different order, which
would cause external facts to take precedence over those set in
the environment.

This brings Facter 3 in line with earlier facter releases by
resolving environment facts last.