### PR TITLE
(maint) Force Travis to use precise images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 compiler:
   - gcc
+dist: precise
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Travis has updated their default to Trusty images. These are
causing us problems, so for now we need to pin. This is only
temporary until we resolve the issues with Trusty.