### PR TITLE
(FACT-1728) Correctly report when Puppet cannot be loaded

### DIFF
--- a/lib/src/ruby/ruby.cc
+++ b/lib/src/ruby/ruby.cc
@@ -63,7 +63,7 @@ namespace facter { namespace ruby {
             try {
                 ruby.eval(load_puppet);
             } catch (exception& ex) {
-                log(facter::logging::level::warning, "Could not load puppet; some facts may be unavailable: {1}", ex.what());
+                LOG_WARNING("Could not load puppet; some facts may be unavailable: {1}", ex.what());
             }
         }
         mod.search(paths);


### PR DESCRIPTION
A string formatting change was missed when updating Facter, which
caused it to crash when Puppet could not be loaded for facter -p.
This patch fixes the log line to properly report a warning and
proceed with the rest of the facter operation.