### PR TITLE
(FACT-1729) Refactor FFI declarations

### DIFF
--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -8,11 +8,8 @@ module Facter::Util::Windows::ApiTypes
     ERROR_SUCCESS = 0
   end
 
-  class ::FFI::Pointer
-    NULL_HANDLE = 0
-  end
-
   class ::Facter::Util::Windows::FFI
+    NULL_HANDLE = 0
 
     def self.read_win32_bool(ffi_pointer)
       # BOOL is always a 32-bit integer in Win32
@@ -62,7 +59,7 @@ module Facter::Util::Windows::ApiTypes
         yield ptr
       ensure
         if ptr && ! ptr.null?
-          if FFI::WIN32::LocalFree(ptr.address) != FFI::Pointer::NULL_HANDLE
+          if FFI::WIN32::LocalFree(ptr.address) != NULL_HANDLE
             Puppet.debug "LocalFree memory leak"
           end
         end

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -10,15 +10,16 @@ module Facter::Util::Windows::ApiTypes
 
   class ::FFI::Pointer
     NULL_HANDLE = 0
-
-    def read_win32_bool
-      # BOOL is always a 32-bit integer in Win32
-      # some Win32 APIs return 1 for true, while others are non-0
-      read_int32 != FFI::WIN32_FALSE
-    end
   end
 
   class ::Facter::Util::Windows::FFI
+
+    def self.read_win32_bool(ffi_pointer)
+      # BOOL is always a 32-bit integer in Win32
+      # some Win32 APIs return 1 for true, while others are non-0
+      ffi_pointer.read_int32 != FFI::WIN32_FALSE
+    end
+
     def self.read_dword(ffi_pointer)
       ffi_pointer.read_uint32
     end

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -16,11 +16,12 @@ module Facter::Util::Windows::ApiTypes
       # some Win32 APIs return 1 for true, while others are non-0
       read_int32 != FFI::WIN32_FALSE
     end
-    #
-    alias_method :read_dword, :read_uint32
   end
 
   class ::Facter::Util::Windows::FFI
+    def self.read_dword(ffi_pointer)
+      ffi_pointer.read_uint32
+    end
 
     def self.read_handle(ffi_pointer)
       ffi_pointer.type_size == 4 ? ffi_pointer.read_uint32 : ffi_pointer.read_uint64

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -49,11 +49,13 @@ module Facter::Util::Windows::ApiTypes
       # String is longer than the max; read just to the max
       read_wide_string(max_char_length)
     end
+  end
 
-    def read_win32_local_pointer(&block)
+  class ::Facter::Util::Windows::FFI
+    def self.read_win32_local_pointer(ffi_pointer, &block)
       ptr = nil
       begin
-        ptr = read_pointer
+        ptr = ffi_pointer.read_pointer
         yield ptr
       ensure
         if ptr && ! ptr.null?

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -8,14 +8,6 @@ module Facter::Util::Windows::ApiTypes
     ERROR_SUCCESS = 0
   end
 
-  module ::FFI::Library
-    # Wrapper method for attach_function + private
-    def attach_function_private(*args)
-      attach_function(*args)
-      private args[0]
-    end
-  end
-
   class ::FFI::Pointer
     NULL_HANDLE = 0
 
@@ -126,6 +118,7 @@ module Facter::Util::Windows::ApiTypes
 
     ffi_convention :stdcall
 
+    private
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa366730(v=vs.85).aspx
     # HLOCAL WINAPI LocalFree(
     #   _In_  HLOCAL hMem
@@ -138,6 +131,6 @@ module Facter::Util::Windows::ApiTypes
     #   _In_  HANDLE hObject
     # );
     ffi_lib :kernel32
-    attach_function_private :CloseHandle, [:handle], :win32_bool
+    attach_function :CloseHandle, [:handle], :win32_bool
   end
 end

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -56,7 +56,7 @@ module Facter::Util::Windows::ApiTypes
         yield ptr
       ensure
         if ptr && ! ptr.null?
-          if FFI::WIN32::LocalFree(ptr.address) != NULL_HANDLE
+          if WIN32.LocalFree(ptr.address) != NULL_HANDLE
             Puppet.debug "LocalFree memory leak"
           end
         end
@@ -112,7 +112,7 @@ module Facter::Util::Windows::ApiTypes
   FFI.typedef :uchar, :byte
   FFI.typedef :uint16, :wchar
 
-  module ::FFI::WIN32
+  module ::Facter::Util::Windows::FFI::WIN32
     extend ::FFI::Library
 
     ffi_convention :stdcall

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -1,12 +1,9 @@
 require 'ffi'
 
 module Facter::Util::Windows::ApiTypes
-  module ::FFI
-    WIN32_FALSE = 0
-  end
-
   class ::Facter::Util::Windows::FFI
     # standard Win32 error codes
+    WIN32_FALSE = 0
     ERROR_SUCCESS = 0
 
     NULL_HANDLE = 0
@@ -14,7 +11,7 @@ module Facter::Util::Windows::ApiTypes
     def self.read_win32_bool(ffi_pointer)
       # BOOL is always a 32-bit integer in Win32
       # some Win32 APIs return 1 for true, while others are non-0
-      ffi_pointer.read_int32 != FFI::WIN32_FALSE
+      ffi_pointer.read_int32 != WIN32_FALSE
     end
 
     def self.read_dword(ffi_pointer)

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -18,13 +18,13 @@ module Facter::Util::Windows::ApiTypes
     end
     #
     alias_method :read_dword, :read_uint32
-
-    def read_handle
-      type_size == 4 ? read_uint32 : read_uint64
-    end
   end
 
   class ::Facter::Util::Windows::FFI
+
+    def self.read_handle(ffi_pointer)
+      ffi_pointer.type_size == 4 ? ffi_pointer.read_uint32 : ffi_pointer.read_uint64
+    end
 
     def self.read_wide_string(ffi_pointer, char_length, dst_encoding = Encoding::UTF_8)
       # char_length is number of wide chars (typically excluding NULLs), *not* bytes

--- a/lib/facter/util/windows/api_types.rb
+++ b/lib/facter/util/windows/api_types.rb
@@ -3,12 +3,12 @@ require 'ffi'
 module Facter::Util::Windows::ApiTypes
   module ::FFI
     WIN32_FALSE = 0
-
-    # standard Win32 error codes
-    ERROR_SUCCESS = 0
   end
 
   class ::Facter::Util::Windows::FFI
+    # standard Win32 error codes
+    ERROR_SUCCESS = 0
+
     NULL_HANDLE = 0
 
     def self.read_win32_bool(ffi_pointer)

--- a/lib/facter/util/windows/dir.rb
+++ b/lib/facter/util/windows/dir.rb
@@ -18,7 +18,7 @@ module Facter::Util::Windows::Dir
         raise Facter::Util::Windows::Error.new("Could not find COMMON_APPDATA path")
       end
 
-      common_appdata = buffer_ptr.read_arbitrary_wide_string_up_to(MAX_PATH + 1)
+      common_appdata = Facter::Util::Windows::FFI.read_arbitrary_wide_string_up_to(buffer_ptr, MAX_PATH + 1)
     end
 
     common_appdata

--- a/lib/facter/util/windows/dir.rb
+++ b/lib/facter/util/windows/dir.rb
@@ -25,6 +25,8 @@ module Facter::Util::Windows::Dir
   end
   module_function :get_common_appdata
 
+  private
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/bb762181(v=vs.85).aspx
@@ -36,6 +38,6 @@ module Facter::Util::Windows::Dir
   #   _Out_ LPTSTR pszPath
   # );
   ffi_lib :shell32
-  attach_function_private :SHGetFolderPathW,
+  attach_function :SHGetFolderPathW,
     [:handle, :int32, :handle, :dword, :lpwstr], :hresult
 end

--- a/lib/facter/util/windows/error.rb
+++ b/lib/facter/util/windows/error.rb
@@ -45,7 +45,7 @@ class Facter::Util::Windows::Error < RuntimeError
       end
 
       # returns an FFI::Pointer with autorelease set to false, which is what we want
-      buffer_ptr.read_win32_local_pointer do |wide_string_ptr|
+      Facter::Util::Windows::FFI.read_win32_local_pointer(buffer_ptr) do |wide_string_ptr|
         if wide_string_ptr.null?
           raise Facter::Error.new("FormatMessageW failed to allocate buffer for code #{code}")
         end

--- a/lib/facter/util/windows/error.rb
+++ b/lib/facter/util/windows/error.rb
@@ -50,7 +50,7 @@ class Facter::Util::Windows::Error < RuntimeError
           raise Facter::Error.new("FormatMessageW failed to allocate buffer for code #{code}")
         end
 
-        error_string = wide_string_ptr.read_wide_string(length)
+        error_string = Facter::Util::Windows::FFI.read_wide_string(wide_string_ptr, length)
       end
     end
 

--- a/lib/facter/util/windows/error.rb
+++ b/lib/facter/util/windows/error.rb
@@ -66,6 +66,8 @@ class Facter::Util::Windows::Error < RuntimeError
   FORMAT_MESSAGE_ARGUMENT_ARRAY    = 0x00002000
   FORMAT_MESSAGE_MAX_WIDTH_MASK    = 0x000000FF
 
+  private
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351(v=vs.85).aspx
@@ -80,6 +82,6 @@ class Facter::Util::Windows::Error < RuntimeError
   # );
   # NOTE: since we're not preallocating the buffer, use a :pointer for lpBuffer
   ffi_lib :kernel32
-  attach_function_private :FormatMessageW,
-                          [:dword, :lpcvoid, :dword, :dword, :pointer, :dword, :pointer], :dword
+  attach_function :FormatMessageW,
+                  [:dword, :lpcvoid, :dword, :dword, :pointer, :dword, :pointer], :dword
 end

--- a/lib/facter/util/windows/error.rb
+++ b/lib/facter/util/windows/error.rb
@@ -39,7 +39,7 @@ class Facter::Util::Windows::Error < RuntimeError
       length = FormatMessageW(flags, FFI::Pointer::NULL, code, dwLanguageId,
                               buffer_ptr, 0, FFI::Pointer::NULL)
 
-      if length == FFI::WIN32_FALSE
+      if length == Facter::Util::Windows::FFI::WIN32_FALSE
         # can't raise same error type here or potentially recurse infinitely
         raise Facter::Error.new("FormatMessageW could not format code #{code}")
       end

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -15,7 +15,7 @@ module Facter::Util::Windows::Process
     begin
       FFI::MemoryPointer.new(:handle, 1) do |token_handle_ptr|
         result = OpenProcessToken(handle, desired_access, token_handle_ptr)
-        if result == FFI::WIN32_FALSE
+        if result == Facter::Util::Windows::FFI::WIN32_FALSE
           raise Facter::Util::Windows::Error.new(
               "OpenProcessToken(#{handle}, #{desired_access.to_s(8)}, #{token_handle_ptr})")
         end
@@ -49,7 +49,7 @@ module Facter::Util::Windows::Process
         result = GetTokenInformation(token_handle, token_information,
                                      token_information_buf, return_length, return_length_ptr)
 
-        if result == FFI::WIN32_FALSE
+        if result == Facter::Util::Windows::FFI::WIN32_FALSE
           raise Facter::Util::Windows::Error.new(
               "GetTokenInformation(#{token_handle}, #{token_information}, #{token_information_buf}, " +
                   "#{return_length}, #{return_length_ptr})")

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -156,12 +156,14 @@ module Facter::Util::Windows::Process
   end
   module_function :supports_elevated_security?
 
+  private
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/ms683179(v=vs.85).aspx
   # HANDLE WINAPI GetCurrentProcess(void);
   ffi_lib :kernel32
-  attach_function_private :GetCurrentProcess, [], :handle
+  attach_function :GetCurrentProcess, [], :handle
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379295(v=vs.85).aspx
   # BOOL WINAPI OpenProcessToken(
@@ -170,9 +172,10 @@ module Facter::Util::Windows::Process
   #   _Out_  PHANDLE TokenHandle
   # );
   ffi_lib :advapi32
-  attach_function_private :OpenProcessToken,
-                          [:handle, :dword, :phandle], :win32_bool
+  attach_function :OpenProcessToken,
+                  [:handle, :dword, :phandle], :win32_bool
 
+  public
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379626(v=vs.85).aspx
   TOKEN_INFORMATION_CLASS = enum(
       :TokenUser, 1,
@@ -226,6 +229,8 @@ module Facter::Util::Windows::Process
     layout :TokenIsElevated, :dword
   end
 
+  private
+
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446671(v=vs.85).aspx
   # BOOL WINAPI GetTokenInformation(
   #   _In_       HANDLE TokenHandle,
@@ -235,8 +240,10 @@ module Facter::Util::Windows::Process
   #   _Out_      PDWORD ReturnLength
   # );
   ffi_lib :advapi32
-  attach_function_private :GetTokenInformation,
-                          [:handle, TOKEN_INFORMATION_CLASS, :lpvoid, :dword, :pdword ], :win32_bool
+  attach_function :GetTokenInformation,
+                  [:handle, TOKEN_INFORMATION_CLASS, :lpvoid, :dword, :pdword ], :win32_bool
+
+  public
 
   # https://msdn.microsoft.com/en-us/library/windows/hardware/ff563620(v=vs.85).aspx
   # typedef struct _OSVERSIONINFOEXW {
@@ -267,6 +274,8 @@ module Facter::Util::Windows::Process
       :wReserved, :uchar,
     )
   end
+
+  private
 
   # NTSTATUS -> :int32 (defined in winerror.h / ntstatus.h)
   # https://msdn.microsoft.com/en-us/library/windows/hardware/ff561910(v=vs.85).aspx

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -25,7 +25,7 @@ module Facter::Util::Windows::Process
 
       token_handle
     ensure
-      FFI::WIN32.CloseHandle(token_handle) if token_handle
+      Facter::Util::Windows::FFI::WIN32.CloseHandle(token_handle) if token_handle
     end
 
     # token_handle has had CloseHandle called against it, so nothing to return
@@ -94,7 +94,7 @@ module Facter::Util::Windows::Process
     rescue Facter::Util::Windows::Error => e
       raise e if e.code != ERROR_NO_SUCH_PRIVILEGE
     ensure
-      FFI::WIN32.CloseHandle(handle) if handle
+      Facter::Util::Windows::FFI::WIN32.CloseHandle(handle) if handle
     end
   end
   module_function :elevated_security?

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -37,7 +37,7 @@ module Facter::Util::Windows::Process
     # to determine buffer size
     FFI::MemoryPointer.new(:dword, 1) do |return_length_ptr|
       result = GetTokenInformation(token_handle, token_information, nil, 0, return_length_ptr)
-      return_length = return_length_ptr.read_dword
+      return_length = Facter::Util::Windows::FFI.read_dword(return_length_ptr)
 
       if return_length <= 0
         raise Facter::Util::Windows::Error.new(

--- a/lib/facter/util/windows/process.rb
+++ b/lib/facter/util/windows/process.rb
@@ -20,7 +20,7 @@ module Facter::Util::Windows::Process
               "OpenProcessToken(#{handle}, #{desired_access.to_s(8)}, #{token_handle_ptr})")
         end
 
-        yield token_handle = token_handle_ptr.read_handle
+        yield token_handle = Facter::Util::Windows::FFI.read_handle(token_handle_ptr)
       end
 
       token_handle

--- a/lib/facter/util/windows/user.rb
+++ b/lib/facter/util/windows/user.rb
@@ -35,7 +35,7 @@ module Facter::Util::Windows::User
       end
 
       FFI::MemoryPointer.new(:win32_bool, 1) do |ismember_pointer|
-        if CheckTokenMembership(FFI::Pointer::NULL_HANDLE, sid_pointer, ismember_pointer) == FFI::WIN32_FALSE
+        if CheckTokenMembership(Facter::Util::Windows::FFI::NULL_HANDLE, sid_pointer, ismember_pointer) == FFI::WIN32_FALSE
           raise Facter::Util::Windows::Error.new("Failed to check membership")
         end
 

--- a/lib/facter/util/windows/user.rb
+++ b/lib/facter/util/windows/user.rb
@@ -25,17 +25,17 @@ module Facter::Util::Windows::User
       FFI::MemoryPointer.new(:dword, 1) do |size_pointer|
         size_pointer.write_uint32(SECURITY_MAX_SID_SIZE)
 
-        if CreateWellKnownSid(:WinBuiltinAdministratorsSid, FFI::Pointer::NULL, sid_pointer, size_pointer) == FFI::WIN32_FALSE
+        if CreateWellKnownSid(:WinBuiltinAdministratorsSid, FFI::Pointer::NULL, sid_pointer, size_pointer) == Facter::Util::Windows::FFI::WIN32_FALSE
           raise Facter::Util::Windows::Error.new("Failed to create administrators SID")
         end
       end
 
-      if IsValidSid(sid_pointer) == FFI::WIN32_FALSE
+      if IsValidSid(sid_pointer) == Facter::Util::Windows::FFI::WIN32_FALSE
         raise RuntimeError,"Invalid SID"
       end
 
       FFI::MemoryPointer.new(:win32_bool, 1) do |ismember_pointer|
-        if CheckTokenMembership(Facter::Util::Windows::FFI::NULL_HANDLE, sid_pointer, ismember_pointer) == FFI::WIN32_FALSE
+        if CheckTokenMembership(Facter::Util::Windows::FFI::NULL_HANDLE, sid_pointer, ismember_pointer) == Facter::Util::Windows::FFI::WIN32_FALSE
           raise Facter::Util::Windows::Error.new("Failed to check membership")
         end
 

--- a/lib/facter/util/windows/user.rb
+++ b/lib/facter/util/windows/user.rb
@@ -40,7 +40,7 @@ module Facter::Util::Windows::User
         end
 
         # Is administrators SID enabled in calling thread's access token?
-        is_admin = ismember_pointer.read_win32_bool
+        is_admin = Facter::Util::Windows::FFI.read_win32_bool(ismember_pointer)
       end
     end
 

--- a/lib/facter/util/windows/user.rb
+++ b/lib/facter/util/windows/user.rb
@@ -48,6 +48,8 @@ module Facter::Util::Windows::User
   end
   module_function :check_token_membership
 
+  private
+
   ffi_convention :stdcall
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa376389(v=vs.85).aspx
@@ -57,8 +59,10 @@ module Facter::Util::Windows::User
   #   _Out_     PBOOL IsMember
   # );
   ffi_lib :advapi32
-  attach_function_private :CheckTokenMembership,
-                          [:handle, :pointer, :pbool], :win32_bool
+  attach_function :CheckTokenMembership,
+                  [:handle, :pointer, :pbool], :win32_bool
+
+  public
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379650(v=vs.85).aspx
   WELL_KNOWN_SID_TYPE = enum(
@@ -159,6 +163,8 @@ module Facter::Util::Windows::User
       :WinCapabilityRemovableStorageSid             , 94
   )
 
+  private
+
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446585(v=vs.85).aspx
   # BOOL WINAPI CreateWellKnownSid(
   #   _In_       WELL_KNOWN_SID_TYPE WellKnownSidType,
@@ -167,14 +173,14 @@ module Facter::Util::Windows::User
   #   _Inout_    DWORD *cbSid
   # );
   ffi_lib :advapi32
-  attach_function_private :CreateWellKnownSid,
-                          [WELL_KNOWN_SID_TYPE, :pointer, :pointer, :lpdword], :win32_bool
+  attach_function :CreateWellKnownSid,
+                  [WELL_KNOWN_SID_TYPE, :pointer, :pointer, :lpdword], :win32_bool
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa379151(v=vs.85).aspx
   # BOOL WINAPI IsValidSid(
   #   _In_  PSID pSid
   # );
   ffi_lib :advapi32
-  attach_function_private :IsValidSid,
-                          [:pointer], :win32_bool
+  attach_function :IsValidSid,
+                  [:pointer], :win32_bool
 end


### PR DESCRIPTION
Facter redefines FFI constants in the same area as Puppet.  This can cause Ruby warnings, and has the potential to redefine methods that already exist in Puppet with older / errant code.

To insulate Facter from Puppet, move these similar definitions to new namespaces and update callsites accordingly.