### PR TITLE
(FACT-1731) virtual and is_virtual are reported incorrectly on freebsd bhyve vms

### DIFF
--- a/lib/inc/facter/facts/vm.hpp
+++ b/lib/inc/facter/facts/vm.hpp
@@ -147,6 +147,11 @@ namespace facter { namespace facts {
          * The name for OpenBSD vmm
          */
         constexpr static char const* vmm = "vmm";
+
+        /**
+         * The name for FreeBSD bhyve
+         */
+        constexpr static char const* bhyve = "bhyve";
     };
 
 }}  // namespace facter::facts

--- a/lib/src/facts/freebsd/dmi_resolver.cc
+++ b/lib/src/facts/freebsd/dmi_resolver.cc
@@ -16,6 +16,9 @@ namespace facter { namespace facts { namespace freebsd {
         result.uuid = kenv_lookup("smbios.system.uuid");
         result.serial_number = kenv_lookup("smbios.system.serial");
         result.product_name = kenv_lookup("smbios.system.product");
+        if (result.product_name.length() == 0) {
+            result.product_name = result.bios_vendor;
+        }
         result.manufacturer = kenv_lookup("smbios.system.maker");
 
         return result;

--- a/lib/src/facts/resolvers/virtualization_resolver.cc
+++ b/lib/src/facts/resolvers/virtualization_resolver.cc
@@ -84,6 +84,7 @@ namespace facter { namespace facts { namespace resolvers {
             make_tuple("HVM domU",          string(vm::xen_hardware)),
             make_tuple("Bochs",             string(vm::bochs)),
             make_tuple("OpenBSD",           string(vm::vmm)),
+            make_tuple("BHYVE",             string(vm::bhyve)),
         };
 
         for (auto const& vm : vms) {


### PR DESCRIPTION
Bhyve VMs report virtual and is_virtual incorrectly (physical and false). This patch fixes that and will report them as bhyve and true respectively.

Basically the same as buzzdeees commit 881847c74cef4270532e348014e80b3dcaf83e5f but for bhyve instead of vmm.