### PR TITLE
(FACT-1735) Fix virtual fact on GCE Windows instances

### DIFF
--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -217,6 +217,8 @@ Facter.add("virtual") do
           result = "bochs"
         when /OpenStack/
           result = "openstack"
+        when /Google Compute Engine/
+          result = "gce"
         end
 
         if result.nil? and computersystem.manufacturer =~ /Xen/


### PR DESCRIPTION
Facter 2.x recognizes the GCE Windows instance as physical.
