### PR TITLE
(FACT-1737) Add "disks" and "partitions" facts support for FreeBSD

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -201,6 +201,7 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/freebsd/collection.cc"
         "src/facts/glib/load_average_resolver.cc"
         "src/facts/bsd/filesystem_resolver.cc"
+        "src/facts/freebsd/filesystem_resolver.cc"
         "src/facts/bsd/networking_resolver.cc"
         "src/facts/bsd/uptime_resolver.cc"
         "src/facts/freebsd/processor_resolver.cc"
@@ -212,6 +213,11 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
         "src/facts/freebsd/virtualization_resolver.cc"
         "src/facts/freebsd/memory_resolver.cc"
         "src/facts/freebsd/operating_system_resolver.cc"
+        "src/util/freebsd/geom.cc"
+        "src/facts/freebsd/disk_resolver.cc"
+    )
+    set(LIBFACTER_PLATFORM_LIBRARIES
+        geom
     )
 elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
     set(LIBFACTER_PLATFORM_SOURCES

--- a/lib/inc/internal/facts/freebsd/disk_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/disk_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the FreeBSD disk fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/disk_resolver.hpp"
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving disk facts.
+     */
+    struct disk_resolver : resolvers::disk_resolver
+    {
+     protected:
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/inc/internal/facts/freebsd/filesystem_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/filesystem_resolver.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Declares the FreeBSD file system fact resolver.
+ */
+#pragma once
+
+#include "../bsd/filesystem_resolver.hpp"
+
+namespace facter { namespace facts { namespace freebsd {
+
+    /**
+     * Responsible for resolving FreeBSD file system facts.
+     */
+    struct filesystem_resolver : bsd::filesystem_resolver
+    {
+     protected:
+        /**
+         * Collects the file system data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the file system data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/inc/internal/util/freebsd/geom.hpp
+++ b/lib/inc/internal/util/freebsd/geom.hpp
@@ -1,0 +1,149 @@
+/**
+ * @file
+ * Declares geom.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <libgeom.h>
+
+namespace facter { namespace util { namespace freebsd {
+
+    /**
+     * geom exceptions
+     */
+    struct geom_exception : std::runtime_error
+    {
+        /**
+         * Constructs a geom_exception.
+         * @param message the exception message.
+         */
+        explicit geom_exception(std::string const& message);
+    };
+
+    /**
+     * GEOM configuration.
+     * This is a wrapper for struct gconfig.
+     */
+    class geom_config {
+    private:
+        std::string _name;
+        std::string _value;
+    public:
+        /**
+         * Constructs a GEOM configuration item.
+         * @param name the name of the item.
+         * @param value the valure of the item.
+         */
+        geom_config(std::string name, std::string value);
+        /**
+         * Returns the name of the item.
+	 * @return the name of the item.
+         */
+        std::string name();
+        /**
+         * Returns the value of the item.
+         * @return the value of the item.
+         */
+        std::string value();
+    };
+
+    /**
+     * Base GEOM class capable of storing configuration.
+     */
+    class geom_object_with_config {
+    private:
+        std::vector<geom_config> _configs;
+    protected:
+        /**
+         * Loads GEOM configuration.
+         * @param conf the first configuration item.
+         */
+        geom_object_with_config(struct gconf *conf);
+    public:
+        /**
+         * Fetches a configuration value from the object.
+         * @param name the name of the configuration to get.
+         * @return the value of the configuration.
+         */
+        std::string config(std::string name);
+    };
+
+    /**
+     * GEOM providers.
+     * This is a wrapper for struct gprovider.
+     */
+    class geom_provider : public geom_object_with_config {
+    private:
+        std::string _name;
+        std::string _mode;
+        off_t _mediasize;
+        u_int _sectorsize;
+        off_t _stripeoffset;
+        off_t _stripesize;
+    public:
+        /**
+         * Loads a GEOM provider.
+         * @param provider the provider to load.
+         */
+        geom_provider(struct gprovider* provider);
+        /**
+         * Returns the provider name.
+         * @return the name of the provider.
+         */
+        std::string name();
+        /**
+         * Returns the provider media size.
+         * @return the media size in bytes.
+         */
+        off_t mediasize();
+    };
+
+    /**
+     * GEOM geoms (sic).
+     * This is a wrapper for struct ggeom.
+     */
+    class geom_geom : public geom_object_with_config {
+    private:
+        std::string _name;
+    public:
+        /**
+         * Loads a GEOM Geom.
+         * @param geom the Geom to load.
+         */
+        geom_geom(struct ggeom *geom);
+        /**
+         * Providers attached to this Geom.
+         */
+        std::vector<geom_provider> providers;
+        /**
+         * Returns the name of the Geom.
+         * @return the name of the Geom.
+         */
+        std::string name();
+    };
+
+    /**
+     * GEOM classes.
+     * This is a wrapper for struct gclass.
+     */
+    class geom_class {
+    private:
+        struct gmesh _mesh;
+        struct gclass *_class;
+    public:
+        /**
+         * Loads a GEOM class. Throws a geom_exception on failure.
+         * @param type the GEOM class to load.
+         */
+        geom_class(std::string type);
+        ~geom_class();
+        /**
+         * Geoms attached to this class.
+         */
+        std::vector<geom_geom> geoms;
+    };
+
+}}}  // namespace facter::util::freebsd

--- a/lib/src/facts/freebsd/collection.cc
+++ b/lib/src/facts/freebsd/collection.cc
@@ -1,5 +1,5 @@
 #include <facter/facts/collection.hpp>
-#include <internal/facts/bsd/filesystem_resolver.hpp>
+#include <internal/facts/freebsd/filesystem_resolver.hpp>
 #include <internal/facts/bsd/uptime_resolver.hpp>
 #include <internal/facts/glib/load_average_resolver.hpp>
 #include <internal/facts/freebsd/processor_resolver.hpp>
@@ -14,6 +14,7 @@
 #include <internal/facts/freebsd/zpool_resolver.hpp>
 #include <internal/facts/freebsd/virtualization_resolver.hpp>
 #include <internal/facts/freebsd/memory_resolver.hpp>
+#include <internal/facts/freebsd/disk_resolver.hpp>
 
 using namespace std;
 
@@ -25,7 +26,7 @@ namespace facter { namespace facts {
         add(make_shared<freebsd::operating_system_resolver>());
         add(make_shared<freebsd::networking_resolver>());
         add(make_shared<bsd::uptime_resolver>());
-        add(make_shared<bsd::filesystem_resolver>());
+        add(make_shared<freebsd::filesystem_resolver>());
         add(make_shared<posix::ssh_resolver>());
         add(make_shared<posix::identity_resolver>());
         add(make_shared<posix::timezone_resolver>());
@@ -36,6 +37,7 @@ namespace facter { namespace facts {
         add(make_shared<freebsd::zpool_resolver>());
         add(make_shared<freebsd::virtualization_resolver>());
         add(make_shared<freebsd::memory_resolver>());
+        add(make_shared<freebsd::disk_resolver>());
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/freebsd/disk_resolver.cc
+++ b/lib/src/facts/freebsd/disk_resolver.cc
@@ -1,0 +1,34 @@
+#include <internal/facts/freebsd/disk_resolver.hpp>
+#include <internal/util/freebsd/geom.hpp>
+#include <leatherman/logging/logging.hpp>
+
+#include <libgeom.h>
+
+using namespace std;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    disk_resolver::data disk_resolver::collect_data(collection& facts)
+    {
+        data result;
+
+        try {
+            facter::util::freebsd::geom_class disks("DISK");
+
+            for (auto& geom : disks.geoms) {
+                for (auto& provider : geom.providers) {
+                    disk d;
+                    d.name = provider.name();
+                    d.size = provider.mediasize();
+                    d.model = provider.config("descr");
+                    result.disks.push_back(move(d));
+                }
+            }
+        } catch (util::freebsd::geom_exception const &e) {
+            LOG_ERROR(e.what());
+        }
+
+        return result;
+    }
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/src/facts/freebsd/filesystem_resolver.cc
+++ b/lib/src/facts/freebsd/filesystem_resolver.cc
@@ -1,0 +1,37 @@
+#include <internal/facts/freebsd/filesystem_resolver.hpp>
+#include <internal/util/freebsd/geom.hpp>
+#include <leatherman/logging/logging.hpp>
+
+#include <libgeom.h>
+
+using namespace std;
+
+namespace facter { namespace facts { namespace freebsd {
+
+    filesystem_resolver::data filesystem_resolver::collect_data(collection& facts)
+    {
+        data result = bsd::filesystem_resolver::collect_data(facts);
+
+        try {
+            facter::util::freebsd::geom_class disks("PART");
+
+            for (auto& geom : disks.geoms) {
+                for (auto& provider : geom.providers) {
+                    partition p;
+                    p.name = provider.name();
+                    p.size = provider.mediasize();
+                    if (geom.config("scheme") == "GPT") {
+                        p.partition_label = provider.config("label");
+                        p.partition_uuid = provider.config("rawuuid");
+                    }
+                    result.partitions.push_back(move(p));
+                }
+            }
+        } catch (util::freebsd::geom_exception const& e) {
+            LOG_ERROR(e.what());
+        }
+
+        return result;
+    }
+
+}}}  // namespace facter::facts::freebsd

--- a/lib/src/util/freebsd/geom.cc
+++ b/lib/src/util/freebsd/geom.cc
@@ -1,0 +1,130 @@
+#include <internal/util/freebsd/geom.hpp>
+#include <leatherman/locale/locale.hpp>
+#include <leatherman/logging/logging.hpp>
+
+using leatherman::locale::_;
+
+using namespace std;
+
+namespace facter { namespace util { namespace freebsd {
+
+    geom_exception::geom_exception(std::string const& message) :
+        runtime_error(message)
+    {
+    }
+
+
+
+    geom_config::geom_config(string name, string value)
+    {
+        _name = name;
+        _value = value;
+    }
+
+    string
+    geom_config::name()
+    {
+        return _name;
+    }
+
+    string
+    geom_config::value()
+    {
+        return _value;
+    }
+
+
+
+    geom_object_with_config::geom_object_with_config(struct gconf *conf)
+    {
+        struct gconfig *config;
+        LIST_FOREACH(config, conf, lg_config) {
+            if (!config->lg_val) {
+                LOG_DEBUG(_("Skipping config {1} because it has a null value", config->lg_name));
+                continue;
+            }
+            _configs.push_back(geom_config(config->lg_name, config->lg_val));
+        }
+    }
+
+    string
+    geom_object_with_config::config(string name) {
+        for (auto config : _configs) {
+            if (config.name() == name)
+                return config.value();
+        }
+        return "";
+    }
+
+
+
+    geom_provider::geom_provider(struct gprovider* provider) :
+        geom_object_with_config(&provider->lg_config)
+    {
+        _name         = provider->lg_name;
+        _mode         = provider->lg_mode;
+        _mediasize    = provider->lg_mediasize;
+        _sectorsize   = provider->lg_sectorsize;
+        _stripeoffset = provider->lg_stripeoffset;
+        _stripesize   = provider->lg_stripesize;
+    }
+
+    string
+    geom_provider::name()
+    {
+        return _name;
+    }
+
+    off_t
+    geom_provider::mediasize()
+    {
+        return _mediasize;
+    }
+
+
+
+    geom_geom::geom_geom(struct ggeom *geom) :
+        geom_object_with_config(&geom->lg_config)
+    {
+        _name = geom->lg_name;
+        struct gprovider *provider;
+        LIST_FOREACH(provider, &geom->lg_provider, lg_provider) {
+            providers.push_back(geom_provider(provider));
+        }
+    }
+
+    string
+    geom_geom::name()
+    {
+        return _name;
+    }
+
+
+
+    geom_class::geom_class(string type)
+    {
+        if (geom_gettree(&_mesh) < 0) {
+            throw geom_exception(_("Unable to get GEOM tree"));
+        }
+
+        LIST_FOREACH(_class, &(_mesh.lg_class), lg_class) {
+            if (type == string(_class->lg_name))
+                break;
+        }
+
+        if (!_class) {
+            throw geom_exception(_("The GEOM class \"{1}\" was not found", type));
+        }
+
+        struct ggeom *geom;
+        LIST_FOREACH(geom, &(_class->lg_geom), lg_geom) {
+            geoms.push_back(geom_geom(geom));
+        }
+    }
+
+    geom_class::~geom_class()
+    {
+        geom_deletetree(&_mesh);
+    }
+
+}}}  // namespace facter::util::freebsd


### PR DESCRIPTION
Managing FreeBSD storage devices is usually done through a modular disk transformation framework, [GEOM].  The system ships with [libgeom], a library allowing userland interaction with this system.

The commit adds a bunch of `facter::util::freebsd::geom_*` classes, wrapping the API exposed by FreeBSD for an easy use from Facter's code, and use them to build two missing facts on FreeBSD: `disks` and `partitions`.

[GEOM]: https://www.freebsd.org/doc/handbook/geom.html
[libgeom]: https://www.freebsd.org/cgi/man.cgi?query=libgeom