### PR TITLE
(FACT-1740) Update the filesystem resolver to skip AHAFS

### DIFF
--- a/lib/src/facts/aix/filesystem_resolver.cc
+++ b/lib/src/facts/aix/filesystem_resolver.cc
@@ -49,7 +49,7 @@ namespace facter { namespace facts { namespace aix {
     {
         for (const auto& mount : mountctl()) {
             mountpoint m;
-            if (mount.vmt_gfstype == MNT_PROCFS) {
+            if (mount.vmt_gfstype == MNT_PROCFS || mount.vmt_gfstype == MNT_AHAFS) {
                 continue;
             }
             m.filesystem = _filesystems[mount.vmt_gfstype];


### PR DESCRIPTION
The /aha filesystem is a for the AIX event infrastructure, and the filesystem
reports 0 size, but several blocks in use. This commit filters out AHAFS in
the same way we filter out PROCFS.