### PR TITLE
(FACT-1742) Add hypervisors fact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,11 @@ endif()
 
 find_package(CPPHOCON REQUIRED)
 
+find_package(WHEREAMI)
+if (WHEREAMI_FOUND)
+    add_definitions(-DUSE_WHEREAMI)
+endif()
+
 if (NOT WITHOUT_JRUBY AND NOT WIN32)
     find_package(JNI)
     set_package_properties(JNI PROPERTIES DESCRIPTION "Java Native Interface (JNI) is a programming framework that enables Java code running in a Java Virtual Machine (JVM) to call and be called by native applications.")

--- a/cmake/FindWHEREAMI.cmake
+++ b/cmake/FindWHEREAMI.cmake
@@ -1,0 +1,6 @@
+include(FindDependency)
+find_dependency(WHEREAMI DISPLAY "whereami" HEADERS "whereami/whereami.hpp" LIBRARIES "libwhereami.a")
+
+include(FeatureSummary)
+set_package_properties(WHEREAMI PROPERTIES DESCRIPTION "A hypervisor detection library" URL "https://github.com/puppetlabs/libwhereami")
+set_package_properties(WHEREAMI PROPERTIES PURPOSE "Reports hypervisors in use.")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/facts/resolvers/ec2_resolver.cc"
     "src/facts/resolvers/filesystem_resolver.cc"
     "src/facts/resolvers/gce_resolver.cc"
+    "src/facts/resolvers/hypervisors_resolver.cc"
     "src/facts/resolvers/identity_resolver.cc"
     "src/facts/resolvers/kernel_resolver.cc"
     "src/facts/resolvers/ldom_resolver.cc"
@@ -301,6 +302,7 @@ link_directories(
     ${YAMLCPP_LIBRARY_DIRS}
     ${CURL_LIBRARY_DIRS}
     ${CPPHOCON_LIBRARY_DIRS}
+    ${WHEREAMI_LIBRARY_DIRS}
 )
 
 # Add the library target without a prefix (name already has the 'lib') and use '.so' for all platforms (Ruby extension file extension)
@@ -338,6 +340,7 @@ list(APPEND LIBS
     ${YAMLCPP_LIBRARIES}
     ${CURL_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${WHEREAMI_LIBRARIES}
 )
 
 # Link in additional libraries

--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -440,10 +440,13 @@ namespace facter { namespace facts {
          */
         constexpr static char const* is_virtual = "is_virtual";
         /**
+         * The fact for all detected hypervisors
+         */
+        constexpr static char const* hypervisors = "hypervisors";
+        /**
          * The fact for the cloud info, including provider, for a node.
          */
         constexpr static char const* cloud = "cloud";
-
         /**
          * The structured fact for identity information.
          */

--- a/lib/inc/internal/facts/resolvers/hypervisors_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/hypervisors_resolver.hpp
@@ -1,0 +1,68 @@
+/**
+ * @file
+ * Declares the hypervisors fact resolver
+ */
+#pragma once
+
+#include <facter/facts/map_value.hpp>
+#include <facter/facts/array_value.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/resolver.hpp>
+#include <facter/facts/fact.hpp>
+#include <boost/variant.hpp>
+#include <string>
+#include <unordered_map>
+
+namespace facter { namespace facts { namespace resolvers {
+
+    /**
+     * Represents hypervisor data collected from libwhereami
+     */
+    using hypervisor_data = std::unordered_map<std::string, std::unordered_map<std::string, boost::variant<std::string, bool, int>>>;
+
+    /**
+     * This base resolver exists to allow libfacter schema tests to pass when libwhereami is not included in the build.
+     */
+    struct hypervisors_resolver_base : resolver
+    {
+        /**
+         * Default constructor
+         */
+        hypervisors_resolver_base() :
+            resolver(
+                "hypervisors",
+                {
+                    fact::hypervisors
+                })
+        {
+        }
+
+        /**
+         * Called to resolve all facts the resolver is responsible for
+         * @param facts The fact collection that is resolving the facts
+         */
+        virtual void resolve(collection& facts) override;
+
+     protected:
+        /**
+         * Collects hypervisor data
+         * @param facts
+         * @return Returns the hypervisor data.
+         */
+        virtual hypervisor_data collect_data(collection& facts) = 0;
+    };
+
+    /**
+     * Hypervisors resolver for use when libwhereami is included
+     */
+    struct hypervisors_resolver : hypervisors_resolver_base
+    {
+        /**
+         * Collects hypervisor data
+         * @param facts
+         * @return Returns the hypervisor data.
+         */
+        virtual hypervisor_data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::resolvers

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -419,6 +419,14 @@ hostname:
         POSIX platforms: use the `gethostname` function to retrieve the host name
         Windows: use the `GetComputerNameExW` function to retrieve the host name.
 
+hypervisors:
+    type: map
+    description: |
+        Experimental fact: Return the names of any detected hypervisors and any collected metadata about them.
+    resolution: |
+        All platforms: Use the external `whereami` library to gather hypervisor data, if available.
+    validate: false
+
 id:
     type: string
     hidden: true

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -7,6 +7,7 @@
 #include <facter/ruby/ruby.hpp>
 #include <facter/util/string.hpp>
 #include <facter/version.h>
+#include <internal/facts/resolvers/hypervisors_resolver.hpp>
 #include <internal/facts/resolvers/ruby_resolver.hpp>
 #include <internal/facts/resolvers/path_resolver.hpp>
 #include <internal/facts/resolvers/ec2_resolver.hpp>
@@ -637,6 +638,9 @@ namespace facter { namespace facts {
         add(make_shared<resolvers::ec2_resolver>());
         add(make_shared<resolvers::gce_resolver>());
         add(make_shared<resolvers::augeas_resolver>());
+#ifdef USE_WHEREAMI
+        add(make_shared<resolvers::hypervisors_resolver>());
+#endif
     }
 
 }}  // namespace facter::facts

--- a/lib/src/facts/resolvers/hypervisors_resolver.cc
+++ b/lib/src/facts/resolvers/hypervisors_resolver.cc
@@ -1,0 +1,72 @@
+#include <internal/facts/resolvers/hypervisors_resolver.hpp>
+#include <facter/facts/collection.hpp>
+#ifdef USE_WHEREAMI
+#include <whereami/whereami.hpp>
+#endif
+
+using namespace std;
+using namespace facter::facts;
+
+namespace facter { namespace facts { namespace resolvers {
+
+    using value_ptr = std::unique_ptr<value>;
+
+    /**
+     * Raw pointers must be extracted here because old versions of boost don't allow visitors to return move-only types.
+     */
+    struct metadata_value_visitor : public boost::static_visitor<value*>
+    {
+        value* operator()(int value) const
+        {
+            return make_value<integer_value>(value).release();
+        }
+
+        value* operator()(const std::string& value) const
+        {
+            return make_value<string_value>(value).release();
+        }
+
+        value* operator()(bool value) const
+        {
+            return make_value<boolean_value>(value).release();
+        }
+    };
+
+    void hypervisors_resolver_base::resolve(collection& facts)
+    {
+        auto data = collect_data(facts);
+        auto hypervisors = make_value<map_value>();
+
+        for (auto const& hypervisor_pair : data) {
+            auto hypervisor_metadata = make_value<map_value>();
+
+            for (auto const& metadata_pair : hypervisor_pair.second) {
+                value* the_value = boost::apply_visitor(metadata_value_visitor(), metadata_pair.second);
+                hypervisor_metadata->add(
+                    metadata_pair.first,
+                    unique_ptr<value>(the_value));
+            }
+
+            hypervisors->add(hypervisor_pair.first, move(hypervisor_metadata));
+        }
+
+        if (!hypervisors->empty()) {
+            facts.add(fact::hypervisors, move(hypervisors));
+        }
+    }
+
+#ifdef USE_WHEREAMI
+    hypervisor_data hypervisors_resolver::collect_data(collection& facts)
+    {
+        hypervisor_data data;
+        auto results = whereami::hypervisors();
+
+        for (auto const& res : results) {
+            data.insert({res.name(), res.metadata()});
+        }
+
+        return data;
+    }
+#endif
+
+}}}  // namespace facter::facts::resolvers

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -18,6 +18,7 @@
 #include <internal/facts/resolvers/ec2_resolver.hpp>
 #include <internal/facts/resolvers/filesystem_resolver.hpp>
 #include <internal/facts/resolvers/gce_resolver.hpp>
+#include <internal/facts/resolvers/hypervisors_resolver.hpp>
 #include <internal/facts/resolvers/identity_resolver.hpp>
 #include <internal/facts/resolvers/kernel_resolver.hpp>
 #include <internal/facts/resolvers/ldom_resolver.hpp>
@@ -135,6 +136,26 @@ struct filesystem_resolver : resolvers::filesystem_resolver
         p.backing_file = "/foo/bar";
         result.partitions.emplace_back(move(p));
         return result;
+    }
+};
+
+using hypervisor_data = std::unordered_map<std::string, std::unordered_map<std::string, boost::variant<std::string, bool, int>>>;
+
+struct hypervisors_resolver_test : resolvers::hypervisors_resolver_base
+{
+    virtual hypervisor_data collect_data(collection& facts)
+    {
+        hypervisor_data results;
+
+        unordered_map<std::string, boost::variant<std::string, bool, int>> metadata {
+            {"string_value", string{"string"}}, // boost assumes const char* values are bools when bool is among the variants
+            {"integer_value", 42},
+            {"boolean_value", true},
+        };
+
+        results.insert({"hypervisor_name", metadata});
+
+        return results;
     }
 };
 
@@ -451,6 +472,7 @@ void add_all_facts(collection& facts)
     // TODO: refactor the EC2 resolver to use the "collect_data" pattern
     facts.add(make_shared<ec2_resolver>());
     // TODO: refactor the GCE resolver to use the "collect_data" pattern
+    facts.add(make_shared<hypervisors_resolver_test>());
     facts.add(fact::gce, make_value<map_value>());
     facts.add(make_shared<identity_resolver>());
     facts.add(make_shared<kernel_resolver>());


### PR DESCRIPTION
This commit introduces a new fact, `hypervisors`, which contains a list
of hypervisors detected by libwhereami, plus any collected metadata for
these hypervisors. The libwhereami dependency is optional, so this
change will have no effect unless it is installed.