### PR TITLE
(FACT-1744) Use LOG_INFO instead of LOG_WARNING on failed lookup

### DIFF
--- a/lib/src/facts/freebsd/dmi_resolver.cc
+++ b/lib/src/facts/freebsd/dmi_resolver.cc
@@ -30,7 +30,7 @@ namespace facter { namespace facts { namespace freebsd {
 
         LOG_DEBUG("kenv lookup for {1}", file);
         if (kenv(KENV_GET, file, buffer, sizeof(buffer) - 1) == -1) {
-            LOG_WARNING("kenv lookup for {1} failed: {2} ({3})", file, strerror(errno), errno);
+            LOG_INFO("kenv lookup for {1} failed: {2} ({3})", file, strerror(errno), errno);
             return "";
         }
         return buffer;


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/FACT-1744

If the kenv() lookup fails, only give an INFOrmational error message, not a WARNing.

When I run puppet I don't want to see an error in each run!

When I run 'puppet agent -t -d' or 'facter -p -d' in debug mode, I see that all other errors of the same significance all use INFO, not WARN, so I think we should simply use WARN here as well, and the problem is solved. :-)