### PR TITLE
(packaging) Update beaker and PA install method

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,9 +10,9 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.10")
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.24")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.3")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 

--- a/acceptance/setup/aio/pre-suite/010_Install.rb
+++ b/acceptance/setup/aio/pre-suite/010_Install.rb
@@ -5,12 +5,8 @@ extend Beaker::DSL::InstallUtils
 test_name "Install Packages"
 
 step "Install puppet-agent..." do
-  opts = {
-    :puppet_collection    => 'PC1',
-    :puppet_agent_sha     => ENV['SHA'],
-    :puppet_agent_version => ENV['SUITE_VERSION'] || ENV['SHA']
-  }
-  install_puppet_agent_dev_repo_on(hosts, opts)
+  dev_builds_url  = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+  install_from_build_data_url('puppet-agent', "#{dev_builds_url}/puppet-agent/#{ENV['SHA']}/artifacts/#{ENV['SHA']}.yaml")
 end
 
 # make sure install is sane, beaker has already added puppet and ruby


### PR DESCRIPTION
The latest beaker release includes new install utilities that enable
less reliance on correctly guessing the path to artifacts staged on
builds.delivery.puppetlabs.net. This commit updates the puppet tests to
use these new install utilities.