### PR TITLE
(FACT-1746) Fix virtual and is_virtual facts for Proxmox VMs

### DIFF
--- a/lib/src/facts/freebsd/dmi_resolver.cc
+++ b/lib/src/facts/freebsd/dmi_resolver.cc
@@ -20,6 +20,10 @@ namespace facter { namespace facts { namespace freebsd {
             result.product_name = result.bios_vendor;
         }
         result.manufacturer = kenv_lookup("smbios.system.maker");
+        // Fix for Proxmox VMs
+        if (result.manufacturer == "QEMU") {
+            result.product_name = "KVM";
+        }
 
         return result;
     }


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/FACT-1746

A FreeBSD VM running under a Proxmox host will get:
result.product_name = kenv lookup for smbios.system.product = "Standard PC (i440FX + PIIX, 1996)".
This results in the incorrect facts virtual=physical and is_virtual=false.
 
By simply overriding result.product_name to "KVM", the facts are set correctly to virtual=kvm and is_virtual=true.

Patch was tested on a FreeBSD 10.3 VM.