### PR TITLE
(FACT-1750) Catch exceptions in resolvers and report as warnings

### DIFF
--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -364,7 +364,11 @@ namespace facter { namespace facts {
 
         // Resolve normally
         LOG_DEBUG("resolving {1} facts.", res->name());
-        res->resolve(*this);
+        try {
+            res->resolve(*this);
+        } catch (std::runtime_error &e) {
+            LOG_WARNING("exception resolving {1} facts, some facts will not be available: {2}", res->name(), e.what());
+        }
     }
 
     void collection::resolve_facts()

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -495,6 +495,11 @@ msgstr ""
 msgid "resolving {1} facts."
 msgstr ""
 
+#. warning
+#: lib/src/facts/collection.cc
+msgid "exception resolving {1} facts, some facts will not be available: {2}"
+msgstr ""
+
 #. debug
 #: lib/src/facts/collection.cc
 msgid "cannot lookup an element with \"{1}\" from Ruby fact"


### PR DESCRIPTION
Resolver failures should not prevent Facter continuing to function. If
we find failures that prevent the resolver from working, report them as
warnings rather than stopping Facter.