### PR TITLE
(FACT-1751) Make the hypervisors fact blockable

### DIFF
--- a/lib/inc/internal/facts/resolvers/hypervisors_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/hypervisors_resolver.hpp
@@ -43,6 +43,7 @@ namespace facter { namespace facts { namespace resolvers {
          */
         virtual void resolve(collection& facts) override;
 
+        bool is_blockable() const override;
      protected:
         /**
          * Collects hypervisor data

--- a/lib/src/facts/resolvers/hypervisors_resolver.cc
+++ b/lib/src/facts/resolvers/hypervisors_resolver.cc
@@ -69,4 +69,8 @@ namespace facter { namespace facts { namespace resolvers {
     }
 #endif
 
+    bool hypervisors_resolver_base::is_blockable() const {
+        return true;
+    }
+
 }}}  // namespace facter::facts::resolvers


### PR DESCRIPTION
The hypervisors fact is still new and experimental. As such,
users may want to disable it.