### PR TITLE
(maint) Update AppVeyor to use hosted packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,21 @@
 version: 3.1.0.{build}
 clone_depth: 10
 environment:
-  LEATHERMAN_VERSION: 0.99.0
-  CPPHOCON_VERSION: 0.1.4
+  LEATHERMAN_VERSION: 1.4.0
+  CPPHOCON_VERSION: 0.1.6
 
 init:
   - |
-      choco install mingw-w64 -y -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+      choco install -y mingw-w64 -Version 5.2.0 -source https://www.myget.org/F/puppetlabs
+      choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
       choco install -y gettext -Version 0.19.6 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-toolchain-x64 -Version 2015.12.01.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-boost-x64 -Version 1.58.0.2 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-yaml-cpp-x64 -Version 0.5.1.2 -source https://www.myget.org/F/puppetlabs
       cmake --version
   - ps: |
-      $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
-      $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\boost.7z"
-      7z.exe x $env:temp\boost.7z -oC:\tools | FIND /V "ing  "
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\yaml-cpp.7z"
-      7z.exe x $env:temp\yaml-cpp.7z -oC:\tools | FIND /V "ing  "
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
-      7z.exe x "$env:temp\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
-
       wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$env:temp\leatherman.7z"
       7z.exe x $env:temp\leatherman.7z -oC:\tools | FIND /V "ing "
 
@@ -29,12 +23,15 @@ init:
       7z.exe x $env:temp\cpp-hocon.7z -oC:\tools | FIND /V "ing "
 
 install:
-  - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;C:\Program Files\gettext-iconv;%PATH%
+    # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
+    # Include Ruby and Powershell for unit tests.
+  - SET PATH=C:\tools\pl-build-tools\bin;C:\tools\mingw64\bin;C:\ProgramData\chocolatey\bin;C:\Ruby22-x64\bin;C:\Program Files\7-Zip;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Program Files\gettext-iconv
+  - ps: rm -r C:\OpenSSL-Win64
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:
   - ps: |
-      cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools\cpp-hocon" .
+      cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\cpp-hocon" -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DBOOST_STATIC=ON .
       mingw32-make -j2
 
 test_script:

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "logging/logging.cc"
     "log_capture.cc"
     "main.cc"
+    "mock_server.cc"
     "util/string.cc"
     "fixtures.cc"
     "collection_fixture.cc"
@@ -127,37 +128,20 @@ include_directories(
     ${CPPHOCON_INCLUDE_DIRS}
 )
 
-# On EL 4, we run into a linking error when trying to create libraries or
-# executables that link in a static library with code using threads. As I
-# described in https://gcc.gnu.org/ml/gcc-help/2015-08/msg00035.html, we get
-# the error undefined reference to symbol '__tls_get_addr@@GLIBC_2.3'.
-# Build mock_server as a separate shared library to avoid this error.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-add_library(mock-server SHARED mock_server.cc)
-target_link_libraries(mock-server PRIVATE
-    ${Boost_THREAD_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
+if (WIN32)
+    # On Windows with GCC 5.2, Boost.System emits warnings that aren't correctly
+    # suppressed by pragmas. Explicitly skip them.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
+endif()
 
 add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc>
     ${LIBFACTER_TESTS_COMMON_SOURCES}
     ${LIBFACTER_TESTS_PLATFORM_SOURCES}
     ${LIBFACTER_TESTS_CATEGORY_SOURCES})
-# On Windows, mock-server comes after Boost libraries to avoid double
-# definition of boost::system::system_category() on Windows. On Linux, it
-# comes before to avoid picking up incomplete Boost.Asio symbols included
-# by Boost.Log in Leatherman logging.
-if (WIN32)
-    target_link_libraries(libfacter_test
-        ${LIBS}
-        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
-        mock-server)
-else()
-    target_link_libraries(libfacter_test
-        mock-server
-        ${LIBS}
-        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
-endif()
+target_link_libraries(libfacter_test
+    ${LIBS}
+    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND BOOST_STATIC AND LEATHERMAN_USE_LOCALES)
     target_link_libraries(libfacter_test iconv)


### PR DESCRIPTION
Updates AppVeyor to use GCC 5.2 and hosted packages at myget.org.
Required to use latest releases of Leatherman and cpp-hocon.