### PR TITLE
Mergeup 3.6.x to 3.9.x

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -374,6 +374,10 @@ module Facter
           os_arch                 = 'x86_64'
           os_hardware             = 'x86_64'
           processor_model_pattern = /(Intel\(R\).*)|(AMD.*)/
+        elsif agent['platform'] =~ /ppc|power|64le/
+          os_arch                 = 'ppc64le'
+          os_hardware             = 'ppc64le'
+          processor_model_pattern = // # facter doesn't figure out the processor type on these machines
         elsif agent['platform'] =~ /s390x/
           os_arch                 = 's390x'
           os_hardware             = 's390x'


### PR DESCRIPTION
Since the acceptance tests were refactored, this also includes a separate commit to update the base_fact_utils test to work with SLES 12 Power8. Tests pass against the agent when run manually.