### PR TITLE
(FACT-1763) Fix acceptance tests on power linux machines

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -117,6 +117,13 @@ EOM
   end
         EOM
       end
+
+      # Returns a boolean indicating whether or not the host
+      # is a power linux machine
+      def power_linux?(host)
+        variant, _, arch, __ = host['platform'].to_array
+        variant =~ /el|sles|ubuntu/ && arch =~ /ppc64/
+      end
     end
   end
 end

--- a/acceptance/tests/no_errors_on_stderr.rb
+++ b/acceptance/tests/no_errors_on_stderr.rb
@@ -1,10 +1,19 @@
 test_name 'C14514: Running facter should not output anything to stderr' do
   tag 'risk:high'
 
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
   agents.each do |agent|
     on(agent, facter) do |facter_output|
       assert_match(/hostname\s*=>\s*\S*/, facter_output.stdout, 'Hostname fact is missing')
-      assert_empty(facter_output.stderr, 'Facter should not have written to stderr')
+      # NOTE: stderr should be empty here. The other case for power linux machines is
+      # necessary until FACT-1765 is resolved.
+      if power_linux?(agent)
+        assert_match(/dmidecode not found at configured location/, facter_output.stderr, 'Facter should have written a warning regarding a missing dmidecode component')
+      else
+        assert_empty(facter_output.stderr, 'Facter should not have written to stderr')
+      end
     end
   end
 end


### PR DESCRIPTION
With the changes introduced in PA-1466, the acceptance tests fail
on power linux because stderr will report the missing dmidecode
component when it is supposed to be empty on normal linux
platforms. This commit fixes that.