### PR TITLE
(FACT-1765) Do not check for dmidecode on power linux machines

### DIFF
--- a/acceptance/lib/facter/acceptance/user_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/user_fact_utils.rb
@@ -117,13 +117,6 @@ EOM
   end
         EOM
       end
-
-      # Returns a boolean indicating whether or not the host
-      # is a power linux machine
-      def power_linux?(host)
-        variant, _, arch, __ = host['platform'].to_array
-        variant =~ /el|sles|ubuntu/ && arch =~ /ppc64/
-      end
     end
   end
 end

--- a/acceptance/tests/no_errors_on_stderr.rb
+++ b/acceptance/tests/no_errors_on_stderr.rb
@@ -1,19 +1,10 @@
 test_name 'C14514: Running facter should not output anything to stderr' do
   tag 'risk:high'
 
-  require 'facter/acceptance/user_fact_utils'
-  extend Facter::Acceptance::UserFactUtils
-
   agents.each do |agent|
     on(agent, facter) do |facter_output|
       assert_match(/hostname\s*=>\s*\S*/, facter_output.stdout, 'Hostname fact is missing')
-      # NOTE: stderr should be empty here. The other case for power linux machines is
-      # necessary until FACT-1765 is resolved.
-      if power_linux?(agent)
-        assert_match(/dmidecode not found at configured location/, facter_output.stderr, 'Facter should have written a warning regarding a missing dmidecode component')
-      else
-        assert_empty(facter_output.stderr, 'Facter should not have written to stderr')
-      end
+      assert_empty(facter_output.stderr, 'Facter should not have written to stderr')
     end
   end
 end


### PR DESCRIPTION
It looks like the changes from FACT-1763 caused the 1.10.x pipeline to fail at the Puppet acceptance tests. This suggests that FACT-1765 should be completed to avoid having to fix a bunch of acceptance tests in different repos. Looking into the codebase, there are instances where the hardware "isa" fact is computed in a different resolver before proceeding any further (e.g. here: https://github.com/puppetlabs/facter/blob/master/lib/src/facts/solaris/dmi_resolver.cc#L20). So it is probably best to just go ahead and do the same thing, as it is the simplest solution.

This PR reverts the FACT-1763 changes and incorporates the FACT-1765 changes. I ran the acceptance tests for a power linux machine and they passed.