### PR TITLE
(FACT-1766) install man page independently from rdoc gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ bundler_args: --without development
 script: "bundle exec rake spec SPEC_OPTS='--color --format documentation'"
 notifications:
   email: false
+# This intended to fix bundler bug in Ruby 1.9.3 (see https://github.com/travis-ci/travis-ci/issues/5239)
+before_install:
+- gem install bundler
 rvm:
   - 1.9.3
   - 1.8.7-p374

--- a/install.rb
+++ b/install.rb
@@ -138,14 +138,11 @@ def prepare_installation
     InstallOptions.ri  = false
   end
 
-
-  if $haveman
-    InstallOptions.man = true
-    if is_windows?
-      InstallOptions.man  = false
-    end
-  else
+  # defaut man page creattion to false on windows, true otherwise
+  if is_windows?
     InstallOptions.man = false
+  else
+    InstallOptions.man = true
   end
 
   ARGV.options do |opts|
@@ -157,7 +154,7 @@ def prepare_installation
     opts.on('--[no-]ri', 'Prevents the creation of RI output.', 'Default off on mswin32.') do |onri|
       InstallOptions.ri = onri
     end
-    opts.on('--[no-]man', 'Presents the creation of man pages.', 'Default on.') do |onman|
+    opts.on('--[no-]man', 'Prevents the creation of man pages.', 'Default on, off for mswin32.') do |onman|
     InstallOptions.man = onman
     end
     opts.on('--destdir[=OPTIONAL]', 'Installation prefix for all targets', 'Default essentially /') do |destdir|


### PR DESCRIPTION
This PR makes minimal changes to install static man page independently form rdoc gem. But install.rb contains some more unused code related to rdoc generation. If it would me appreciated, I can clean up everything related to man/rdoc generation.