### PR TITLE
(FACT-1781) Don't try to print boost::optionals in tests

### DIFF
--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -480,16 +480,16 @@ void validate_attributes(YAML::Node const& node)
     for (auto const& attribute : node) {
         auto attribute_name = attribute.first.as<string>();
         CAPTURE(attribute_name);
-        REQUIRE_THAT(attribute_name, AnyOf(
-            Catch::Equals("pattern"),
-            Catch::Equals("type")).add(
-            Catch::Equals("hidden")).add(
-            Catch::Equals("description")).add(
-            Catch::Equals("resolution")).add(
-            Catch::Equals("caveats")).add(
-            Catch::Equals("elements")).add(
-            Catch::Equals("validate")).add(
-            Catch::Equals("blockgroup"))
+        REQUIRE_THAT(attribute_name,
+            Catch::Equals("pattern") ||
+            Catch::Equals("type") ||
+            Catch::Equals("hidden") ||
+            Catch::Equals("description") ||
+            Catch::Equals("resolution") ||
+            Catch::Equals("caveats") ||
+            Catch::Equals("elements") ||
+            Catch::Equals("validate") ||
+            Catch::Equals("blockgroup")
         );
     }
 
@@ -506,16 +506,16 @@ void validate_attributes(YAML::Node const& node)
     REQUIRE(type_attribute);
     REQUIRE(type_attribute.IsScalar());
     auto type = type_attribute.as<string>();
-    REQUIRE_THAT(type, AnyOf(
-        Catch::Equals("integer"),
-        Catch::Equals("double")).add(
-        Catch::Equals("string")).add(
-        Catch::Equals("boolean")).add(
-        Catch::Equals("array")).add(
-        Catch::Equals("map")).add(
-        Catch::Equals("ip")).add(
-        Catch::Equals("ip6")).add(
-        Catch::Equals("mac"))
+    REQUIRE_THAT(type,
+        Catch::Equals("integer") ||
+        Catch::Equals("double") ||
+        Catch::Equals("string") ||
+        Catch::Equals("boolean") ||
+        Catch::Equals("array") ||
+        Catch::Equals("map") ||
+        Catch::Equals("ip") ||
+        Catch::Equals("ip6") ||
+        Catch::Equals("mac")
     );
 
     // Check map types

--- a/lib/tests/util/string.cc
+++ b/lib/tests/util/string.cc
@@ -279,13 +279,13 @@ SCENARIO("converting strings to integers") {
     GIVEN("a string that is a valid integer") {
         THEN("it should be converted to its integer representation") {
             auto oint = maybe_stoi("12");
-            REQUIRE(oint);
-            REQUIRE(oint.get() == 12);
+            REQUIRE(oint.is_initialized());
+            REQUIRE(oint.get_value_or(0) == 12);
         }
     }
     GIVEN("a string that is not a valid integer") {
         THEN("nothing should be returned") {
-            REQUIRE_FALSE(maybe_stoi("foo"));
+            REQUIRE_FALSE(maybe_stoi("foo").is_initialized());
         }
     }
 }

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -622,7 +622,7 @@ msgstr ""
 msgid "kenv lookup for {1}"
 msgstr ""
 
-#. warning
+#. info
 #: lib/src/facts/freebsd/dmi_resolver.cc
 msgid "kenv lookup for {1} failed: {2} ({3})"
 msgstr ""


### PR DESCRIPTION
Trying to print a `boost::optional` without its IO header was failing in tests on Solaris and AIX - this commit changes the tests so they don't attempt to print the value. It also backports a Catch 1.10 compatibility fix from master, which reappeared here when I built the agent with this branch.