### PR TITLE
(FACT-1788) More acceptance test fixups for el-7-aarch64

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -208,6 +208,10 @@ module Facter
           os_arch                 = 's390x'
           os_hardware             = 's390x'
           processor_model_pattern = // # s390x does not populate a model value in /proc/cpuinfo
+        elsif agent['platform'] =~ /aarch64/
+          os_arch                 = 'aarch64'
+          os_hardware             = 'aarch64'
+          processor_model_pattern = // # aarch64 does not populate a model value in /proc/cpuinfo
         else
           os_arch                 = 'i386'
           os_hardware             = 'i686'

--- a/acceptance/tests/facts/dmi.rb
+++ b/acceptance/tests/facts/dmi.rb
@@ -24,13 +24,13 @@ test_name "C96148: verify dmi facts" do
                              'dmi.product.uuid'      => /[-0-9A-Fa-f]+/,
                             })
     end
-    unless agent['platform'] =~ /windows|cisco/
+    unless agent['platform'] =~ /windows|cisco|aarch64/
       expected_facts.merge!({'dmi.chassis.asset_tag' => /\w+/})
     end
-    unless agent['platform'] =~ /cisco/
+    unless agent['platform'] =~ /cisco|aarch64/
       expected_facts.merge!({'dmi.product.serial_number' => /\w+/})
     end
-    unless agent['platform'] =~ /windows|cisco|solaris/
+    unless agent['platform'] =~ /windows|cisco|solaris|aarch64/
       expected_facts.merge!({'dmi.board.asset_tag'     => /\w+|/,
                              'dmi.board.manufacturer'  => /\w+/,
                              'dmi.board.product'       => /\w+/,


### PR DESCRIPTION
These changes weren't addressed in the 3.6.x merge-up to 3.9.x as the code had been significantly re-factored, so I made the necessary changes separately here.