### PR TITLE
(FACT-1377) Include key type in ssh fact

### DIFF
--- a/lib/inc/internal/facts/resolvers/ssh_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/ssh_resolver.hpp
@@ -57,6 +57,12 @@ namespace facter { namespace facts { namespace resolvers {
              * Stores the SSH key's fingerprint.
              */
             fingerprint digest;
+
+            /**
+             * Stores the SSH key type. One of ssh-dss, ssh-rsa, ssh-ed25519,
+             * ecdsa-sha2-nistp256, ecdsa-sha2-nistp384, or ecdsa-sha2-nistp512
+             */
+            std::string type;
         };
 
         /**

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1497,6 +1497,9 @@ ssh:
                 key:
                     type: string
                     description: The DSA public key.
+                type:
+                    type: string
+                    description: The exact type of the key, i.e. "ssh-dss".
         ecdsa:
             type: map
             description: Represents the public key and fingerprints for the ECDSA algorithm.
@@ -1514,6 +1517,9 @@ ssh:
                 key:
                     type: string
                     description: The ECDSA public key.
+                type:
+                    type: string
+                    description: The exact type of the key, e.g. "ecdsa-sha2-nistp256".
         ed25519:
             type: map
             description: Represents the public key and fingerprints for the Ed25519 algorithm.
@@ -1531,6 +1537,9 @@ ssh:
                 key:
                     type: string
                     description: The Ed25519 public key.
+                type:
+                    type: string
+                    description: The exact type of the key, i.e. "ssh-ed25519".
         rsa:
             type: map
             description: Represents the public key and fingerprints for the RSA algorithm.
@@ -1548,6 +1557,9 @@ ssh:
                 key:
                     type: string
                     description: The RSA public key.
+                type:
+                    type: string
+                    description: The exact type of the key, i.e. "ssh-rsa".
 
 ssh<algorithm>key:
     pattern: ^ssh\w*key$

--- a/lib/src/facts/posix/ssh_resolver.cc
+++ b/lib/src/facts/posix/ssh_resolver.cc
@@ -72,7 +72,7 @@ namespace facter { namespace facts { namespace posix {
             return;
         }
 
-        // The SSH file format should be <algo> <key> <hostname>
+        // The SSH public key file format is <algo> <key> <comment>
         vector<boost::iterator_range<string::iterator>> parts;
         boost::split(parts, contents, boost::is_any_of(" "), boost::token_compress_on);
         if (parts.size() < 2) {
@@ -80,7 +80,8 @@ namespace facter { namespace facts { namespace posix {
             return;
         }
 
-        // Assign the key
+        // Assign the key and its type
+        key.type.assign(parts[0].begin(), parts[0].end());
         key.key.assign(parts[1].begin(), parts[1].end());
 
         // Only fingerprint if we are using OpenSSL

--- a/lib/src/facts/resolvers/ssh_resolver.cc
+++ b/lib/src/facts/resolvers/ssh_resolver.cc
@@ -50,6 +50,7 @@ namespace facter { namespace facts { namespace resolvers {
 
         facts.add(string(key_fact_name), make_value<string_value>(key.key, true));
         key_value->add("key", make_value<string_value>(move(key.key)));
+        key_value->add("type", make_value<string_value>(move(key.type)));
 
         string fingerprint;
         if (!key.digest.sha1.empty()) {

--- a/lib/tests/facts/resolvers/ssh_resolver.cc
+++ b/lib/tests/facts/resolvers/ssh_resolver.cc
@@ -27,15 +27,19 @@ struct test_ssh_resolver : ssh_resolver
     {
         data result;
         result.dsa.key = "dsa:key";
+        result.dsa.type = "dsa:type";
         result.dsa.digest.sha1 = "dsa:sha1";
         result.dsa.digest.sha256 = "dsa:sha256";
         result.ecdsa.key = "ecdsa:key";
+        result.ecdsa.type = "ecdsa:type";
         result.ecdsa.digest.sha1 = "ecdsa:sha1";
         result.ecdsa.digest.sha256 = "ecdsa:sha256";
         result.ed25519.key = "ed25519:key";
+        result.ed25519.type = "ed25519:type";
         result.ed25519.digest.sha1 = "ed25519:sha1";
         result.ed25519.digest.sha256 = "ed25519:sha256";
         result.rsa.key = "rsa:key";
+        result.rsa.type = "rsa:type";
         result.rsa.digest.sha1 = "rsa:sha1";
         result.rsa.digest.sha256 = "rsa:sha256";
         return result;
@@ -66,10 +70,13 @@ SCENARIO("using the ssh resolver") {
             for (auto const& algorithm : algorithms) {
                 auto entry = ssh->get<map_value>(algorithm);
                 REQUIRE(entry);
-                REQUIRE(entry->size() == 2u);
+                REQUIRE(entry->size() == 3u);
                 auto key = entry->get<string_value>("key");
                 REQUIRE(key);
                 REQUIRE(key->value() == algorithm + ":key");
+                auto type = entry->get<string_value>("type");
+                REQUIRE(type);
+                REQUIRE(type->value() == algorithm + ":type");
                 auto fingerprints = entry->get<map_value>("fingerprints");
                 REQUIRE(fingerprints);
                 REQUIRE(fingerprints->size() == 2u);

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -310,15 +310,19 @@ protected:
     {
         data result;
         result.dsa.key = "dsa:key";
+        result.dsa.type = "dsa:type";
         result.dsa.digest.sha1 = "dsa:sha1";
         result.dsa.digest.sha256 = "dsa:sha256";
         result.ecdsa.key = "ecdsa:key";
+        result.ecdsa.type = "ecdsa:type";
         result.ecdsa.digest.sha1 = "ecdsa:sha1";
         result.ecdsa.digest.sha256 = "ecdsa:sha256";
         result.ed25519.key = "ed25519:key";
+        result.ed25519.type = "ed25519:type";
         result.ed25519.digest.sha1 = "ed25519:sha1";
         result.ed25519.digest.sha256 = "ed25519:sha256";
         result.rsa.key = "rsa:key";
+        result.rsa.type = "rsa:type";
         result.rsa.digest.sha1 = "rsa:sha1";
         result.rsa.digest.sha256 = "rsa:sha256";
         return result;


### PR DESCRIPTION
Previously the ssh fact returned host keys by their general type, e.g. `ecdsa`, but did not include information about their real type, e.g. `ecdsa-sha2-nistp256`.

This adds a `type` attribute for each host key containing the real type.