### PR TITLE
(maint) Fix the os_processors_and_kernel.rb test for amazon7

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -187,15 +187,15 @@ module Facter
         end
         release_string = on(agent, 'cat /etc/*-release').stdout.downcase
         case release_string
+          when /amazon/
+            os_name = 'Amazon'
+            os_version = '2017'
           when /centos/
             os_name = 'CentOS'
           when /oracle/
             os_name = 'OracleLinux'
           when /scientific/
             os_name = 'Scientific'
-          when /amazon/
-            os_name = 'Amazon'
-            os_version = '2017'
           else
             os_name = 'RedHat'
         end


### PR DESCRIPTION
The 'cat /etc/*-release' command on amazon7 has the string 'centos'
in it.  This fix moves the match for the 'amazon' string first otherwise
the test tries to match the os_name on 'CentOs' instead of 'Amazon'.