### PR TITLE
(maint) Fix flaky cached fact tests

### DIFF
--- a/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
@@ -8,7 +8,7 @@ test_name "C99973: ttls configured cached facts create json cache files" do
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
   config = <<EOM
 facts : {
     ttls : [

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
@@ -7,7 +7,7 @@ test_name "C100037: ttls configured cached valued that are expired are not retur
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
@@ -7,7 +7,7 @@ test_name "C100040: ttls configured facts that are expired are refreshed" do
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
@@ -7,7 +7,7 @@ test_name "C100041: ttls configured cached facts are used while still valid" do
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
@@ -7,7 +7,7 @@ test_name "C100042: ttls configured cached facts that are corrupt are refreshed 
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
@@ -7,7 +7,7 @@ test_name "C100043: ttls configured cached facts that are empty, return an empty
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
 
   config = <<EOM
 facts : {

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
@@ -8,7 +8,7 @@ test_name "C100038: with ttls configured create cached facts when run from puppe
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
   config = <<EOM
 facts : {
     ttls : [

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -7,7 +7,7 @@ test_name "C100039: ttls configured cached facts run from puppet facts return ca
 
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
-  cached_factname = 'uptime'
+  cached_factname = 'timezone'
   config = <<EOM
 facts : {
     ttls : [


### PR DESCRIPTION
A few cached fact tests relied on the uptime, which can be unreliable on
some windows systems (see FACT-1504) - This changes those tests to use timezone instead,
which doesn't have the same problems.