### PR TITLE
(maint) Fix for Amazon7 platform os facter facts

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -187,6 +187,9 @@ module Facter
         end
         release_string = on(agent, 'cat /etc/*-release').stdout.downcase
         case release_string
+          when /amazon_linux/
+            os_name = 'Amazon'
+            os_version = '2'
           when /amazon/
             os_name = 'Amazon'
             os_version = '2017'


### PR DESCRIPTION
The amazon7 platform uses a different os version then the amazon6
platform.  I have added an additional match on the release string
to separate out both platforms.

amazon 7 os facts:
os => {
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2.0",
    major => "2",
    minor => "0"
  },
  selinux => {
    enabled => false
  }
}

amazon6 os facts:
os => {
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2017.03",
    major => "2017",
    minor => "03"
  },
  selinux => {
    enabled => false
  }
}