### PR TITLE
(FACT-1504) Use GetTickCount64 as an uptime metric for windows platof…

### DIFF
--- a/lib/inc/internal/facts/windows/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/windows/uptime_resolver.hpp
@@ -18,9 +18,8 @@ namespace facter { namespace facts { namespace windows {
     {
         /**
          * Constructs the uptime_resolver.
-         * @param wmi_conn The WMI connection to use when resolving facts.
          */
-        uptime_resolver(std::shared_ptr<leatherman::windows::wmi> wmi_conn = std::make_shared<leatherman::windows::wmi>());
+        uptime_resolver();
 
      protected:
         /**
@@ -28,9 +27,6 @@ namespace facter { namespace facts { namespace windows {
          * @return Returns the system uptime in seconds.
          */
         virtual int64_t get_uptime() override;
-
-     private:
-        std::shared_ptr<leatherman::windows::wmi> _wmi;
     };
 
 }}}  // namespace facter::facts::windows

--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -75,6 +75,7 @@ namespace facter { namespace facts {
         add(make_shared<windows::memory_resolver>());
         add(make_shared<windows::networking_resolver>());
         add(make_shared<windows::timezone_resolver>());
+        add(make_shared<windows::uptime_resolver>());
 
         try {
             shared_ptr<wmi> shared_wmi = make_shared<wmi>();
@@ -82,7 +83,6 @@ namespace facter { namespace facts {
             add(make_shared<windows::operating_system_resolver>(shared_wmi));
             add(make_shared<windows::processor_resolver>(shared_wmi));
             add(make_shared<windows::virtualization_resolver>(shared_wmi));
-            add(make_shared<windows::uptime_resolver>(shared_wmi));
         } catch (wmi_exception &e) {
             LOG_ERROR("failed adding platform facts that require WMI: {1}", e.what());
         }


### PR DESCRIPTION
…orms

The earlier metric was unreliable and also stopped working altogether
(uptime fact on windows comes as empty) causing CI failures.
We now use GetTickCount64 instead which offers better resolution
and is available on all supported windows platforms.

Let know if there is any preference for value in seconds or just ticks (msecs). Also if this is not a priority right now this can wait but it appeared to be causing some failures. 