### PR TITLE
(doc) Add documentation for running a version from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,17 @@ top of things.
 All new facts should also be included in `lib/schema/facter.yaml`. Without this
 facts won't pass acceptance tests.
 
+## Running repo version
+
+When you want to reproduce a certain problem on the source code from git, you can use this:
+
+````
+# if bundler is not already installed
+gem install bundler
+bundle install --path=.bundle/gems
+bundle exec facter
+````
+
 ## Making Changes
 
 * Create a topic branch from where you want to base your work.


### PR DESCRIPTION
I wanted to reproduce something with the source code as found on
github, but some google searches later I couldn't find anything useful

I got help through the ticket, but I could have made progress 2 days
earlier if I had found this info.

For reference: my ticket:
https://tickets.puppetlabs.com/browse/FACT-1810

Some other ticket that references the same steps:
https://tickets.puppetlabs.com/browse/FACT-567