### PR TITLE
(FACT-1810) Fix open timeout for fetching ec2 metadata

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -25,7 +25,7 @@ module Facter
         attempts = 0
 
         begin
-          open(@baseurl, :proxy => nil, :read_timeout => timeout).read
+          open(@baseurl, :proxy => nil, :read_timeout => timeout, :open_timeout => timeout).read
           able_to_connect = true
         rescue OpenURI::HTTPError => e
           if e.message.match /404 Not Found/i


### PR DESCRIPTION
The open_timeout wasn't specified, which means that it spent 60s
for each call to open (9 times in total). With this extra argument,
the run duration for facter goes down from over 9 minutes to
several seconds.

A regular 'curl 169.254.169.254' also hangs for a long time on
those machines, unless the --connect-timeout switch is specified.