### PR TITLE
(FACT 1797) Fix Amazon EC2 c5 instance virtualization facts

### DIFF
--- a/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/virtualization_resolver.hpp
@@ -78,12 +78,11 @@ namespace facter { namespace facts { namespace resolvers {
         virtual bool is_virtual(std::string const& hypervisor);
 
         /**
-         * Gets the product name which is matched against a list of known
-         * hypervisors.
-         * @param product_name The product_name fact to match against.
-         * @return Returns the hypervisor product name if matched.
+         * Gets the name of the hypervisor based on other facts and a set of matching strings
+         * @param facts The fact collection that is resolving facts
+         * @return Returns the hypervisor name if matched.
          */
-        static std::string get_product_name_vm(std::string const& product_name);
+        static std::string get_fact_vm(collection& facts);
 
         /**
          * Collects the virtualization data.

--- a/lib/src/facts/linux/virtualization_resolver.cc
+++ b/lib/src/facts/linux/virtualization_resolver.cc
@@ -84,12 +84,9 @@ namespace facter { namespace facts { namespace linux {
             value = get_xen_vm();
         }
 
-        // Next check the DMI product name for the VM
+        // Next check other facts for the VM
         if (value.empty()) {
-            auto product_name = facts.get<string_value>(fact::product_name);
-            if (product_name) {
-                value = get_product_name_vm(product_name->value());
-            }
+            value = get_fact_vm(facts);
         }
 
         // Lastly, resort to lspci to look for hardware related to certain VMs

--- a/lib/src/facts/windows/virtualization_resolver.cc
+++ b/lib/src/facts/windows/virtualization_resolver.cc
@@ -53,6 +53,10 @@ namespace facter { namespace facts { namespace windows {
             return vm::xen;
         }
 
+        if (manufacturer.find("Amazon EC2") != string::npos) {
+            return vm::kvm;
+        }
+
         return {};
     }
 


### PR DESCRIPTION
Amazon's more recent c5 instance types report custom SMBIOS values which weren't being detected as virtual. These commits add WMI and DMI checks for those values and reports KVM as their hypervisor (Amazon's hypervisor for c5 is based on KVM). This allows the `ec2_metadata` fact to be resolved, too.