### PR TITLE
(FACT-1797) Fix virtualization resolvers for solaris, openbsd

### DIFF
--- a/lib/src/facts/openbsd/virtualization_resolver.cc
+++ b/lib/src/facts/openbsd/virtualization_resolver.cc
@@ -14,12 +14,7 @@ namespace facter { namespace facts { namespace openbsd {
 
     string virtualization_resolver::get_hypervisor(collection& facts)
     {
-        auto product_name = facts.get<string_value>(fact::product_name);
-        if (product_name) {
-            return get_product_name_vm(product_name->value());
-        }
-
-        return {};
+        return get_fact_vm(facts);
     }
 
 } } }  // namespace facter::facts::openbsd

--- a/lib/src/facts/solaris/virtualization_resolver.cc
+++ b/lib/src/facts/solaris/virtualization_resolver.cc
@@ -32,23 +32,7 @@ namespace facter { namespace facts { namespace solaris {
             return vm::zone;
         }
 
-        string guest_of;
-
-        // Use the same timeout as in Facter 2.x
-        const uint32_t timeout = 20;
-        try {
-            each_line(
-                "/usr/sbin/prtdiag",
-                [&](string& line) {
-                    guest_of = get_product_name_vm(line);
-                    return guest_of.empty();
-                },
-                nullptr,
-                timeout);
-        } catch (timeout_exception const&) {
-            LOG_WARNING("execution of prtdiag has timed out after {1} seconds.", timeout);
-        }
-
-        return guest_of;
+        // Look for hypervisor matches based on other facts
+        return get_fact_vm(facts);
     }
 }}}  // namespace facter::facts::solaris


### PR DESCRIPTION
I broke the solaris and openbsd virtualization resolvers when I reorganized the base resolver to detect amazon ec2 c5 instances. This updates them so that they use the updated detection function.