### PR TITLE
(FACT-1819) Keep libfacter load failure backtrace

### DIFF
--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -39,7 +39,7 @@ module Facter
       end
       require "#{facter_dir}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
     rescue LoadError
-      raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
+      raise LoadError, "libfacter was not found. Please make sure it was installed to the expected location.\n" + ($!.message || ''), $!.backtrace
     end
   end
 end


### PR DESCRIPTION
 - When libfacter is not found, append to the message the message from
   the rescued exception.

   Furthermore, preserve the backtrace from the original exception.

   That changes a previous message like:

```
   LoadError: new message
```

   To one that preserves more information like this instead:

```
   LoadError: new message
   cannot load such file -- /invalid/file/path
   from /usr/local/opt/rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```