### PR TITLE
(MAINT) Fix virtualization resolver for FreeBSD

### DIFF
--- a/lib/src/facts/freebsd/virtualization_resolver.cc
+++ b/lib/src/facts/freebsd/virtualization_resolver.cc
@@ -20,10 +20,7 @@ namespace facter { namespace facts { namespace freebsd {
         string value = get_jail_vm();
 
         if (value.empty()) {
-            auto product_name = facts.get<string_value>(fact::product_name);
-            if (product_name) {
-                value = get_product_name_vm(product_name->value());
-            }
+            value = get_fact_vm(facts);
         }
 
         return value;


### PR DESCRIPTION
`get_product_name_vm()` was renamed to `get_fact_vm()` in 0e9685460f91cc2240babd3c8c1975ab7120c984, but the FreeBSD virtualization resolver was not updated accordingly.

A similar problem existed for Solaris and OpenBSD and was fixed similarly in 97f681863cdced0e6f93c4acf4351eb60434c2d8.