### PR TITLE
(FACT-1772) Use CMAKE_INSTALL_LIBDIR for multilib install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,11 @@ include(FeatureSummary)
 feature_summary(WHAT ALL)
 
 # Set RPATH if not installing to a system library directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" INSTALL_IS_SYSTEM_DIR)
+# TODO: Once a new version of Leatherman is released, update this
+# to use the set_cmake_install_rpath macro
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" INSTALL_IS_SYSTEM_DIR)
 if ("${INSTALL_IS_SYSTEM_DIR}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 # Pull in common cflags setting from leatherman

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -251,8 +251,7 @@ endif()
 if (WIN32)
     set(LIBFACTER_INSTALL_DESTINATION bin)
 else()
-    # TODO: lib64 for certain operating systems?
-    set(LIBFACTER_INSTALL_DESTINATION lib)
+    set(LIBFACTER_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 if (JRUBY_SUPPORT)

--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -37,7 +37,8 @@ module Facter
       if '${WIN32}' == '1'
         ENV['PATH'] = "#{File.join(facter_dir, 'bin')}#{File::PATH_SEPARATOR}#{File.join(facter_dir, '../puppet/bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
       end
-      require "#{facter_dir}/${LIBFACTER_INSTALL_DESTINATION}/libfacter.so"
+      libfacter_dir = ENV['LIBFACTER_DIR'] || '${LIBFACTER_INSTALL_DESTINATION}'
+      require "#{facter_dir}/#{libfacter_dir}/libfacter.so"
     rescue LoadError
       raise LoadError.new('libfacter was not found. Please make sure it was installed to the expected location.')
     end

--- a/lib/spec_helper.rb.in
+++ b/lib/spec_helper.rb.in
@@ -1,5 +1,9 @@
-# Set FACTERDIR so that facter.rb can find libfacter.so
+# Set FACTERDIR and LIBFACTER_DIR so that facter.rb can find libfacter.so.
+# Note for non-Windows platforms libfacter.so will always be in the 'lib'
+# directory, which will not always match up with LIBFACTER_INSTALL_DESTINATION
+# (e.g. on Fedora 26, LIBFACTER_INSTALL_DESTINATION is 'lib64')
 ENV['FACTERDIR'] = '${CMAKE_BINARY_DIR}'
+ENV['LIBFACTER_DIR'] = 'lib' unless '${WIN32}' == '1'
 
 # Add the location of libfacter.so to the path for Windows
 ENV['PATH'] = '${CMAKE_BINARY_DIR}/${LIBFACTER_INSTALL_DESTINATION}' + File::PATH_SEPARATOR + ENV['PATH']


### PR DESCRIPTION
This allows the libfacter library to be installed in e.g.
/usr/lib, /usr/lib64, etc. depending on the platform that it is
being built on.