### PR TITLE
(FACT-1504) Use GetTickCount64 as an uptime metric for windows platof…

### DIFF
--- a/lib/inc/internal/facts/windows/uptime_resolver.hpp
+++ b/lib/inc/internal/facts/windows/uptime_resolver.hpp
@@ -18,9 +18,8 @@ namespace facter { namespace facts { namespace windows {
     {
         /**
          * Constructs the uptime_resolver.
-         * @param wmi_conn The WMI connection to use when resolving facts.
          */
-        uptime_resolver(std::shared_ptr<leatherman::windows::wmi> wmi_conn = std::make_shared<leatherman::windows::wmi>());
+        uptime_resolver();
 
      protected:
         /**
@@ -28,9 +27,6 @@ namespace facter { namespace facts { namespace windows {
          * @return Returns the system uptime in seconds.
          */
         virtual int64_t get_uptime() override;
-
-     private:
-        std::shared_ptr<leatherman::windows::wmi> _wmi;
     };
 
 }}}  // namespace facter::facts::windows

--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -75,6 +75,7 @@ namespace facter { namespace facts {
         add(make_shared<windows::memory_resolver>());
         add(make_shared<windows::networking_resolver>());
         add(make_shared<windows::timezone_resolver>());
+        add(make_shared<windows::uptime_resolver>());
 
         try {
             shared_ptr<wmi> shared_wmi = make_shared<wmi>();
@@ -82,7 +83,6 @@ namespace facter { namespace facts {
             add(make_shared<windows::operating_system_resolver>(shared_wmi));
             add(make_shared<windows::processor_resolver>(shared_wmi));
             add(make_shared<windows::virtualization_resolver>(shared_wmi));
-            add(make_shared<windows::uptime_resolver>(shared_wmi));
         } catch (wmi_exception &e) {
             LOG_ERROR("failed adding platform facts that require WMI: {1}", e.what());
         }

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: FACTER 3.6.8\n"
+"Project-Id-Version: FACTER 3.6.10\n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -262,8 +262,7 @@ msgstr ""
 msgid "got a disk type: {1}"
 msgstr ""
 
-#: lib/src/facts/aix/disk_resolver.cc
-#: lib/src/facts/aix/processor_resolver.cc
+#: lib/src/facts/aix/disk_resolver.cc lib/src/facts/aix/processor_resolver.cc
 msgid "PdDvLn=%1%"
 msgstr ""
 
@@ -501,28 +500,24 @@ msgid "cannot lookup a hash element with \"{1}\": element does not exist."
 msgstr ""
 
 #. debug
-#: lib/src/facts/collection.cc
-#: lib/src/ruby/ruby.cc
+#: lib/src/facts/collection.cc lib/src/ruby/ruby.cc
 msgid ""
 "cannot lookup an array element with \"{1}\": expected an integral value."
 msgstr ""
 
 #. debug
-#: lib/src/facts/collection.cc
-#: lib/src/ruby/ruby.cc
+#: lib/src/facts/collection.cc lib/src/ruby/ruby.cc
 msgid ""
 "cannot lookup an array element with \"{1}\": expected a non-negative value."
 msgstr ""
 
 #. debug
-#: lib/src/facts/collection.cc
-#: lib/src/ruby/ruby.cc
+#: lib/src/facts/collection.cc lib/src/ruby/ruby.cc
 msgid "cannot lookup an array element with \"{1}\": the array is empty."
 msgstr ""
 
 #. debug
-#: lib/src/facts/collection.cc
-#: lib/src/ruby/ruby.cc
+#: lib/src/facts/collection.cc lib/src/ruby/ruby.cc
 msgid ""
 "cannot lookup an array element with \"{1}\": expected an integral value "
 "between 0 and {2} (inclusive)."
@@ -540,6 +535,7 @@ msgstr ""
 
 #. debug
 #: lib/src/facts/external/execution_resolver.cc
+#: lib/src/facts/external/windows/powershell_resolver.cc
 msgid "Could not parse executable fact output as YAML or JSON ({1})"
 msgstr ""
 
@@ -622,7 +618,7 @@ msgstr ""
 msgid "kenv lookup for {1}"
 msgstr ""
 
-#. info
+#. warning
 #: lib/src/facts/freebsd/dmi_resolver.cc
 msgid "kenv lookup for {1} failed: {2} ({3})"
 msgstr ""
@@ -1114,11 +1110,6 @@ msgid "failed to read processor data from kstat api: {1}."
 msgstr ""
 
 #. warning
-#: lib/src/facts/solaris/virtualization_resolver.cc
-msgid "execution of prtdiag has timed out after {1} seconds."
-msgstr ""
-
-#. warning
 #: lib/src/facts/windows/collection.cc
 msgid "external facts unavailable, %1%"
 msgstr ""
@@ -1244,14 +1235,12 @@ msgstr ""
 msgid "expected chunk name to be a Symbol"
 msgstr ""
 
-#: lib/src/ruby/aggregate_resolution.cc
-#: lib/src/ruby/resolution.cc
+#: lib/src/ruby/aggregate_resolution.cc lib/src/ruby/resolution.cc
 #: lib/src/ruby/simple_resolution.cc
 msgid "a block must be provided"
 msgstr ""
 
-#: lib/src/ruby/aggregate_resolution.cc
-#: lib/src/ruby/fact.cc
+#: lib/src/ruby/aggregate_resolution.cc lib/src/ruby/fact.cc
 msgid "expected a Symbol for options key"
 msgstr ""
 
@@ -1259,13 +1248,11 @@ msgstr ""
 msgid "expected a Symbol or Array of Symbol for require option"
 msgstr ""
 
-#: lib/src/ruby/aggregate_resolution.cc
-#: lib/src/ruby/fact.cc
+#: lib/src/ruby/aggregate_resolution.cc lib/src/ruby/fact.cc
 msgid "unexpected option {1}"
 msgstr ""
 
-#: lib/src/ruby/aggregate_resolution.cc
-#: lib/src/ruby/fact.cc
+#: lib/src/ruby/aggregate_resolution.cc lib/src/ruby/fact.cc
 #: lib/src/ruby/module.cc
 msgid "wrong number of arguments ({1} for 2)"
 msgstr ""
@@ -1333,14 +1320,12 @@ msgid ""
 "with the same name already exists"
 msgstr ""
 
-#: lib/src/ruby/fact.cc
-#: lib/src/ruby/module.cc
+#: lib/src/ruby/fact.cc lib/src/ruby/module.cc
 msgid "expected a String or Symbol for fact name"
 msgstr ""
 
 #. warning
-#: lib/src/ruby/module.cc
-#: lib/src/ruby/ruby.cc
+#: lib/src/ruby/module.cc lib/src/ruby/ruby.cc
 msgid "{1}: facts requiring Ruby will not be resolved."
 msgstr ""
 
@@ -1434,8 +1419,7 @@ msgstr ""
 msgid "expected argument to be a String, Symbol, or Hash"
 msgstr ""
 
-#: lib/src/ruby/resolution.cc
-#: lib/src/ruby/simple_resolution.cc
+#: lib/src/ruby/resolution.cc lib/src/ruby/simple_resolution.cc
 msgid "wrong number of arguments ({1} for 1)"
 msgstr ""
 


### PR DESCRIPTION
…orms

The earlier metric was unreliable and also stopped working altogether
(uptime fact on windows comes as empty) causing CI failures.
We now use GetTickCount64 instead which offers better resolution
and is available on all supported windows platforms.