### PR TITLE
FACT-1822 - Fix get ec2_metadata on AWS EC2 5 generation for facter 2.x

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -20,7 +20,7 @@ require 'facter/ec2/rest' unless defined?(Facter::EC2)
 Facter.define_fact(:ec2_metadata) do
   define_resolution(:rest) do
     confine do
-      Facter.value(:virtual).match /^(xen|kvm)/
+      Facter.value(:virtual).match /^(xen|kvm|ec2)/
     end
 
     @querier = Facter::EC2::Metadata.new
@@ -37,7 +37,7 @@ end
 Facter.define_fact(:ec2_userdata) do
   define_resolution(:rest) do
     confine do
-      Facter.value(:virtual).match /^(xen|kvm)/
+      Facter.value(:virtual).match /^(xen|kvm|ec2)/
     end
 
     @querier = Facter::EC2::Userdata.new

--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -106,6 +106,10 @@ module Facter::Util::Virtual
     end
   end
 
+  def self.ec2?
+    File.read("/sys/devices/virtual/dmi/id/bios_vendor") =~ /Amazon EC2/ rescue false
+  end
+
   def self.kvm?
      txt = if FileTest.exists?("/proc/cpuinfo")
        File.read("/proc/cpuinfo")

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -145,6 +145,10 @@ Facter.add("virtual") do
       next "xenu" if FileTest.exists?("/proc/xen") || FileTest.exists?("/dev/xvda1")
     end
 
+    if Facter::Util::Virtual.ec2?
+      next "ec2" if FileTest.exists?("/dev/nvme0")
+    end
+
     next "virtualbox" if Facter::Util::Virtual.virtualbox?
     next Facter::Util::Virtual.kvm_type if Facter::Util::Virtual.kvm?
     next "rhev" if Facter::Util::Virtual.rhev?


### PR DESCRIPTION
Facter currently checks for virtualization type **xen** or **kvm** to execute ec2_metadata, but this has changed since AWS 5 generation.

To define *xen* it looks for "/proc/sys/xen", "/sys/bus/xen" or "/proc/xen", what is true for "/sys/bus/xen" in AWS 5 generation, but it checks for "/dev/xvda1" to assume that's a **xen** VM.

I created a new ec2 check in "util/virtual.rb" and it looks the file "/sys/devices/virtual/dmi/id/bios_vendor" and looking for "Amazon EC2", I also check if "/dev/nvme0" exists to set "ec2" as virtual variable.
Finally I included a check for "ec2" and  included in "ec2.rb"

Test details:

Instance Type: C5
```

$ uname -a
Linux ip-xx-xx-xx-xx 4.9.76-3.78.amzn1.x86_64 #1 SMP Fri Jan 12 19:51:35 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```

```
$ lsb_release -a
LSB Version:    :base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch
Distributor ID: AmazonAMI
Description:    Amazon Linux AMI release 2017.09
Release:    2017.09
Codename:   n/a
```