### PR TITLE
(FACT-1825) Update cmake definitions to allow skipping of test dir

### DIFF
--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -132,7 +132,7 @@ extern "C" {
         string logging_init_error_msg;
         try {
             facter::logging::setup_logging(boost::nowide::cerr);
-            set_level(log_level::warning);
+            set_level(log_level::debug);
         } catch(facter::logging::locale_error const& e) {
             logging_init_failed = true;
             logging_init_error_msg = e.what();


### PR DESCRIPTION
The cfacter gem does not need to include the tests directory, nor should it.
If we allow builds to specify NO_FACTER_TESTS and skip the test dir we can
make the gem smaller