### PR TITLE
[FACT-1822] Add support for EC2 instances based on the Nitro Hypervisor

### DIFF
--- a/lib/facter/ec2.rb
+++ b/lib/facter/ec2.rb
@@ -20,7 +20,7 @@ require 'facter/ec2/rest' unless defined?(Facter::EC2)
 Facter.define_fact(:ec2_metadata) do
   define_resolution(:rest) do
     confine do
-      Facter.value(:virtual).match /^(xen|kvm)/
+      Facter.value(:virtual).match /^(xen|kvm|nitro)/
     end
 
     @querier = Facter::EC2::Metadata.new
@@ -37,7 +37,7 @@ end
 Facter.define_fact(:ec2_userdata) do
   define_resolution(:rest) do
     confine do
-      Facter.value(:virtual).match /^(xen|kvm)/
+      Facter.value(:virtual).match /^(xen|kvm|nitro)/
     end
 
     @querier = Facter::EC2::Userdata.new

--- a/lib/facter/util/virtual.rb
+++ b/lib/facter/util/virtual.rb
@@ -142,6 +142,10 @@ module Facter::Util::Virtual
     File.read("/sys/devices/virtual/dmi/id/product_name") =~ /Google/ rescue false
   end
 
+  def self.nitro?
+    File.read("/sys/devices/virtual/dmi/id/bios_vendor") =~ /Amazon/ rescue false
+  end
+
   def self.jail?
     path = case Facter.value(:kernel)
       when "FreeBSD" then "/sbin"

--- a/lib/facter/virtual.rb
+++ b/lib/facter/virtual.rb
@@ -149,6 +149,7 @@ Facter.add("virtual") do
     next Facter::Util::Virtual.kvm_type if Facter::Util::Virtual.kvm?
     next "rhev" if Facter::Util::Virtual.rhev?
     next "ovirt" if Facter::Util::Virtual.ovirt?
+    next "nitro" if Facter::Util::Virtual.nitro?
 
     # Parse lspci
     output = Facter::Util::Virtual.lspci
@@ -223,6 +224,10 @@ Facter.add("virtual") do
 
         if result.nil? and computersystem.manufacturer =~ /Xen/
           result = "xen"
+        end
+
+        if result.nil? and computersystem.manufacturer =~ /Amazon/
+          result = "nitro"
         end
 
         break


### PR DESCRIPTION
The new Amazon C5 instances are based on the Nitro Hypervisor: https://aws.amazon.com/about-aws/whats-new/2018/01/amazon-ec2-c5-instances-are-now-available-in-us-west--n--california--and-europe--london/

So here is the patch to add support of that instances to the Facter 2.x.

There is another pull-request for this issue (#1700) but it does not cover the Windows instances.