### PR TITLE
(doc) Replace Latin 'e.g.' abbreviations.

### DIFF
--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -234,7 +234,7 @@ disks:
                     caveats: Only present on Solaris.
                 size:
                     type: string
-                    description: The display size of the disk or block device (e.g. "1 GiB").
+                    description: The display size of the disk or block device, such as "1 GiB".
                 size_bytes:
                     type: integer
                     description: The size of the disk or block device, in bytes.
@@ -730,7 +730,7 @@ memory:
             elements:
                 available:
                     type: string
-                    description: The display size of the available amount of swap memory (e.g. "1 GiB").
+                    description: The display size of the available amount of swap memory, such as "1 GiB".
                 available_bytes:
                     type: integer
                     description: The size of the available amount of swap memory, in bytes.
@@ -742,13 +742,13 @@ memory:
                     description: True if the swap is encrypted or false if not.
                 total:
                     type: string
-                    description: The display size of the total amount of swap memory (e.g. "1 GiB").
+                    description: The display size of the total amount of swap memory, such as "1 GiB".
                 total_bytes:
                     type: integer
                     description: The size of the total amount of swap memory, in bytes.
                 used:
                     type: string
-                    description: The display size of the used amount of swap memory (e.g. "1 GiB").
+                    description: The display size of the used amount of swap memory, such as "1 GiB".
                 used_bytes:
                     type: integer
                     description: The size of the used amount of swap memory, in bytes.
@@ -758,7 +758,7 @@ memory:
             elements:
                 available:
                     type: string
-                    description: The display size of the available amount of system memory (e.g. "1 GiB").
+                    description: The display size of the available amount of system memory, such as "1 GiB".
                 available_bytes:
                     type: integer
                     description: The size of the available amount of system memory, in bytes.
@@ -767,13 +767,13 @@ memory:
                     description: The capacity percentage (0% is empty, 100% is full).
                 total:
                     type: string
-                    description: The display size of the total amount of system memory (e.g. "1 GiB").
+                    description: The display size of the total amount of system memory, such as "1 GiB".
                 total_bytes:
                     type: integer
                     description: The size of the total amount of system memory, in bytes.
                 used:
                     type: string
-                    description: The display size of the used amount of system memory (e.g. "1 GiB").
+                    description: The display size of the used amount of system memory, such as "1 GiB".
                 used_bytes:
                     type: integer
                     description: The size of the used amount of system memory, in bytes.
@@ -781,7 +781,7 @@ memory:
 memoryfree:
     type: string
     hidden: true
-    description: Return the display size of the free system memory (e.g. "1 GiB").
+    description: Return the display size of the free system memory, such as "1 GiB".
     resolution: |
         Linux: parse the contents of `/proc/meminfo` to retrieve the free system memory.
         Mac OSX: use the `sysctl` function to retrieve the free system memory.
@@ -801,7 +801,7 @@ memoryfree_mb:
 memorysize:
     type: string
     hidden: true
-    description: Return the display size of the total system memory (e.g. "1 GiB").
+    description: Return the display size of the total system memory, such as "1 GiB".
     resolution: |
         Linux: parse the contents of `/proc/meminfo` to retrieve the total system memory.
         Mac OSX: use the `sysctl` function to retrieve the total system memory.
@@ -835,7 +835,7 @@ mountpoints:
             elements:
                 available:
                     type: string
-                    description: The display size of the available space (e.g. "1 GiB").
+                    description: The display size of the available space, such as "1 GiB".
                 available_bytes:
                     type: integer
                     description: The size of the available space, in bytes.
@@ -853,13 +853,13 @@ mountpoints:
                     description: The mount options.
                 size:
                     type: string
-                    description: The display size of the total space (e.g. "1 GiB").
+                    description: The display size of the total space, such as "1 GiB".
                 size_bytes:
                     type: integer
                     description: The size of the total space, in bytes.
                 used:
                     type: string
-                    description: The display size of the used space (e.g. "1 GiB").
+                    description: The display size of the used space, such as "1 GiB".
                 used_bytes:
                     type: integer
                     description: The size of the used space, in bytes.
@@ -1074,7 +1074,7 @@ operatingsystemmajrelease:
         Solaris: parse the contents of `/etc/release` to retrieve the OS major release.
         Windows: use WMI to retrieve the OS major release.
     caveats: |
-        Linux: for Ubuntu, the major release is X.Y (e.g. "10.4").
+        Linux: for Ubuntu, the major release is X.Y, such as "10.4".
 
 operatingsystemrelease:
     type: string
@@ -1212,7 +1212,7 @@ osfamily:
     description: Return the family of the operating system.
     resolution: |
         All platforms: default to the kernel name.
-        Linux: map various Linux distributions to their base distribution (e.g. Ubuntu is a "Debian" distro).
+        Linux: map various Linux distributions to their base distribution. For example, Ubuntu is a "Debian" distro.
         Solaris: map various Solaris-based operating systems to the "Solaris" family.
         Windows: use "windows" as the family name.
 
@@ -1248,7 +1248,7 @@ partitions:
                     description: The unique identifier of a GPT partition.
                 size:
                     type: string
-                    description: The display size of the partition (e.g. "1 GiB").
+                    description: The display size of the partition, such as "1 GiB".
                 size_bytes:
                     type: integer
                     description: The size of the partition, in bytes.
@@ -1323,7 +1323,7 @@ processors:
             description: The count of physical processors.
         speed:
             type: string
-            description: The speed of the processors (e.g. "2.0 GHz").
+            description: The speed of the processors, such as "2.0 GHz".
 
 productname:
     type: string
@@ -1599,7 +1599,7 @@ swapencrypted:
 swapfree:
     type: string
     hidden: true
-    description: Return the display size of the free swap memory (e.g. "1 GiB").
+    description: Return the display size of the free swap memory, such as "1 GiB".
     resolution: |
         Linux: parse the contents of `/proc/meminfo` to retrieve the free swap memory.
         Mac OSX: use the `sysctl` function to retrieve the free swap memory.
@@ -1617,7 +1617,7 @@ swapfree_mb:
 swapsize:
     type: string
     hidden: true
-    description: Return the display size of the total swap memory (e.g. "1 GiB").
+    description: Return the display size of the total swap memory, such as "1 GiB".
     resolution: |
         Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
         Mac OSX: use the `sysctl` function to retrieve the total swap memory.


### PR DESCRIPTION
For clarity and to aid in localization, remove Latin abbreviations and replace them with English equivalents.

CC @mindymo; this PR is for the March potholes project with edits to content in code repos used to generate docs content.