### PR TITLE
(FACT-1761) Fix MAC address for Infiniband

### DIFF
--- a/lib/inc/internal/facts/aix/networking_resolver.hpp
+++ b/lib/inc/internal/facts/aix/networking_resolver.hpp
@@ -38,6 +38,13 @@ namespace facter { namespace facts { namespace aix {
         */
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
 
+        /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const override;
+
      private:
         using mtu_map = std::unordered_map<std::string, std::string>;
 

--- a/lib/inc/internal/facts/freebsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/freebsd/networking_resolver.hpp
@@ -37,6 +37,13 @@ namespace facter { namespace facts { namespace freebsd {
          * @return Returns a pointer to the address bytes or nullptr if not a link address.
          */
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
+
+        /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const override;
     };
 
 }}}  // namespace facter::facts::freebsd

--- a/lib/inc/internal/facts/linux/networking_resolver.hpp
+++ b/lib/inc/internal/facts/linux/networking_resolver.hpp
@@ -41,6 +41,13 @@ namespace facter { namespace facts { namespace linux {
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
 
         /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const override;
+
+        /**
          * Gets the MTU of the link layer data.
          * @param interface The name of the link layer interface.
          * @param data The data pointer from the link layer interface.

--- a/lib/inc/internal/facts/openbsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/openbsd/networking_resolver.hpp
@@ -37,6 +37,13 @@ namespace facter { namespace facts { namespace openbsd {
          * @return Returns a pointer to the address bytes or nullptr if not a link address.
          */
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
+
+        /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const override;
     };
 
 }}}  // namespace facter::facts::openbsd

--- a/lib/inc/internal/facts/osx/networking_resolver.hpp
+++ b/lib/inc/internal/facts/osx/networking_resolver.hpp
@@ -29,6 +29,13 @@ namespace facter { namespace facts { namespace osx {
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const override;
 
         /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const override;
+
+        /**
          * Gets the MTU of the link layer data.
          * @param interface The name of the link layer interface.
          * @param data The data pointer from the link layer interface.

--- a/lib/inc/internal/facts/posix/networking_resolver.hpp
+++ b/lib/inc/internal/facts/posix/networking_resolver.hpp
@@ -38,6 +38,13 @@ namespace facter { namespace facts { namespace posix {
         virtual uint8_t const* get_link_address_bytes(sockaddr const* addr) const = 0;
 
         /**
+         * Gets the length of the link address.
+         * @param addr The socket address representing the link address.
+         * @return Returns the length of the address or 0 if not a link address.
+         */
+        virtual uint8_t get_link_address_length(sockaddr const* addr) const = 0;
+
+        /**
          * Collects the resolver data.
          * @param facts The fact collection that is resolving facts.
          * @return Returns the resolver data.

--- a/lib/inc/internal/facts/resolvers/networking_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/networking_resolver.hpp
@@ -24,10 +24,11 @@ namespace facter { namespace facts { namespace resolvers {
 
         /**
          * Utility function to convert the bytes of a MAC address to a string.
-         * @param bytes The bytes of the MAC address; expected to be 6 bytes long.
+         * @param bytes The bytes of the MAC address; accepts 6-byte and 20-byte addresses.
+         * @param byte_count The number of bytes in the MAC address; defaults to be 6 bytes long.
          * @returns Returns the MAC address as a string or an empty string if the address is the "NULL" MAC address.
          */
-        static std::string macaddress_to_string(uint8_t const* bytes);
+        static std::string macaddress_to_string(uint8_t const* bytes, uint8_t byte_count = 6);
 
         /**
         * Returns whether the address is an ignored IPv4 address.

--- a/lib/src/facts/aix/networking_resolver.cc
+++ b/lib/src/facts/aix/networking_resolver.cc
@@ -241,5 +241,10 @@ namespace facter { namespace facts { namespace aix {
         return nullptr;
     }
 
+    uint8_t networking_resolver::get_link_address_length(const sockaddr * addr) const
+    {
+        return 0;
+    }
+
 
 }}}  // namespace facter::facts::aix

--- a/lib/src/facts/freebsd/networking_resolver.cc
+++ b/lib/src/facts/freebsd/networking_resolver.cc
@@ -27,11 +27,20 @@ namespace facter { namespace facts { namespace freebsd {
             return nullptr;
         }
         sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
-        if (link_addr->sdl_alen != 6) {
+        if (link_addr->sdl_alen != 6 && link_addr->sdl_alen != 20) {
             return nullptr;
         }
         return reinterpret_cast<uint8_t const*>(LLADDR(link_addr));
      }
+
+    uint8_t networking_resolver::get_link_address_length(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return 0;
+        }
+        sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
+        return link_addr->sdl_alen;
+    }
 
     boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
     {

--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -67,10 +67,19 @@ namespace facter { namespace facts { namespace linux {
             return nullptr;
         }
         sockaddr_ll const* link_addr = reinterpret_cast<sockaddr_ll const*>(addr);
-        if (link_addr->sll_halen != 6) {
+        if (link_addr->sll_halen != 6 && link_addr->sll_halen != 20) {
             return nullptr;
         }
         return reinterpret_cast<uint8_t const*>(link_addr->sll_addr);
+    }
+
+    uint8_t networking_resolver::get_link_address_length(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return 0;
+        }
+        sockaddr_ll const* link_addr = reinterpret_cast<sockaddr_ll const*>(addr);
+        return link_addr->sll_halen;
     }
 
     boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const

--- a/lib/src/facts/openbsd/networking_resolver.cc
+++ b/lib/src/facts/openbsd/networking_resolver.cc
@@ -27,11 +27,20 @@ namespace facter { namespace facts { namespace openbsd {
             return nullptr;
         }
         sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
-        if (link_addr->sdl_alen != 6) {
+        if (link_addr->sdl_alen != 6 && link_addr->sdl_alen != 20) {
             return nullptr;
         }
         return reinterpret_cast<uint8_t const*>(LLADDR(link_addr));
      }
+
+    uint8_t networking_resolver::get_link_address_length(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return 0;
+        }
+        sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
+        return link_addr->sdl_alen;
+    }
 
     boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const
     {

--- a/lib/src/facts/osx/networking_resolver.cc
+++ b/lib/src/facts/osx/networking_resolver.cc
@@ -23,10 +23,19 @@ namespace facter { namespace facts { namespace osx {
             return nullptr;
         }
         sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
-        if (link_addr->sdl_alen != 6) {
+        if (link_addr->sdl_alen != 6 && link_addr->sdl_alen != 20) {
             return nullptr;
         }
         return reinterpret_cast<uint8_t const*>(LLADDR(link_addr));
+    }
+
+    uint8_t networking_resolver::get_link_address_length(sockaddr const* addr) const
+    {
+        if (!is_link_address(addr)) {
+            return 0;
+        }
+        sockaddr_dl const* link_addr = reinterpret_cast<sockaddr_dl const*>(addr);
+        return link_addr->sdl_alen;
     }
 
     boost::optional<uint64_t> networking_resolver::get_link_mtu(string const& interface, void* data) const

--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -49,8 +49,9 @@ namespace facter { namespace facts { namespace posix {
             return buffer;
         } else if (is_link_address(addr)) {
             auto link_addr = get_link_address_bytes(addr);
+            uint8_t link_addr_len = get_link_address_length(addr);
             if (link_addr) {
-                return macaddress_to_string(reinterpret_cast<uint8_t const*>(link_addr));
+                return macaddress_to_string(reinterpret_cast<uint8_t const*>(link_addr), link_addr_len);
             }
         }
 

--- a/lib/src/facts/resolvers/networking_resolver.cc
+++ b/lib/src/facts/resolvers/networking_resolver.cc
@@ -151,15 +151,15 @@ namespace facter { namespace facts { namespace resolvers {
         }
     }
 
-    string networking_resolver::macaddress_to_string(uint8_t const* bytes)
+    string networking_resolver::macaddress_to_string(uint8_t const* bytes, uint8_t byte_count)
     {
-        if (!bytes) {
+        if (!bytes || (byte_count != 6 && byte_count != 20)) {
             return {};
         }
 
         // Ignore MAC address "0"
         bool nonzero = false;
-        for (size_t i = 0; i < 6; ++i) {
+        for (size_t i = 0; i < byte_count; ++i) {
             if (bytes[i] != 0) {
                 nonzero = true;
                 break;
@@ -169,10 +169,26 @@ namespace facter { namespace facts { namespace resolvers {
             return {};
         }
 
-        return (boost::format("%02x:%02x:%02x:%02x:%02x:%02x") %
-                static_cast<int>(bytes[0]) % static_cast<int>(bytes[1]) %
-                static_cast<int>(bytes[2]) % static_cast<int>(bytes[3]) %
-                static_cast<int>(bytes[4]) % static_cast<int>(bytes[5])).str();
+        if (byte_count == 6) {
+            return (boost::format("%02x:%02x:%02x:%02x:%02x:%02x") %
+                    static_cast<int>(bytes[0]) % static_cast<int>(bytes[1]) %
+                    static_cast<int>(bytes[2]) % static_cast<int>(bytes[3]) %
+                    static_cast<int>(bytes[4]) % static_cast<int>(bytes[5])).str();
+        } else if (byte_count == 20) {
+            return (boost::format("%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x") %
+                    static_cast<int>(bytes[0]) % static_cast<int>(bytes[1]) %
+                    static_cast<int>(bytes[2]) % static_cast<int>(bytes[3]) %
+                    static_cast<int>(bytes[4]) % static_cast<int>(bytes[5]) %
+                    static_cast<int>(bytes[6]) % static_cast<int>(bytes[7]) %
+                    static_cast<int>(bytes[8]) % static_cast<int>(bytes[9]) %
+                    static_cast<int>(bytes[10]) % static_cast<int>(bytes[11]) %
+                    static_cast<int>(bytes[12]) % static_cast<int>(bytes[13]) %
+                    static_cast<int>(bytes[14]) % static_cast<int>(bytes[15]) %
+                    static_cast<int>(bytes[16]) % static_cast<int>(bytes[17]) %
+                    static_cast<int>(bytes[18]) % static_cast<int>(bytes[19])).str();
+        } else {
+            return {};
+        }
     }
 
     bool networking_resolver::ignored_ipv4_address(string const& addr)

--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -171,6 +171,11 @@ namespace facter { namespace facts { namespace solaris {
         return nullptr;
     }
 
+    uint8_t networking_resolver::get_link_address_length(const sockaddr * addr) const
+    {
+        return 0;
+    }
+
     string networking_resolver::find_dhcp_server(string const& interface) const
     {
         auto exec = execute("dhcpinfo", { "-i", interface, "ServerID" });

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -1014,6 +1014,13 @@ msgstr ""
 msgid "%02x:%02x:%02x:%02x:%02x:%02x"
 msgstr ""
 
+#: lib/src/facts/resolvers/networking_resolver.cc
+#, c-format
+msgid ""
+"%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:"
+"%02x:%02x:%02x:%02x:%02x"
+msgstr ""
+
 #. error
 #: lib/src/facts/resolvers/ruby_resolver.cc
 msgid "error while resolving ruby {1} fact: {2}"


### PR DESCRIPTION
This currently hardcodes the 20-byte width for infiniband hardware
addresses by the same hardcoded 6-byte limit for regular ethernet.

(cherry-pick of 84b3baeeacf25cd494fb649decbe68d2ab1f54ad)