### PR TITLE
(FACT-1367) Add VirtuozzoLinux support 

### DIFF
--- a/lib/inc/facter/facts/os.hpp
+++ b/lib/inc/facter/facts/os.hpp
@@ -42,6 +42,10 @@ namespace facter { namespace facts {
          */
         constexpr static char const* cloud_linux = "CloudLinux";
         /**
+         * The Virtuozzo Linux operating system.
+         */
+        constexpr static char const* virtuozzo_linux = "VirtuozzoLinux";
+        /**
          * The Parallels Server Bare Metal operating system.
          */
         constexpr static char const* psbm = "PSBM";

--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -84,6 +84,7 @@ namespace facter { namespace facts { namespace linux {
                 make_tuple(boost::regex("(?i)scientific linux CERN"),         string(os::scientific_cern)),
                 make_tuple(boost::regex("(?i)scientific linux release"),      string(os::scientific)),
                 make_tuple(boost::regex("(?im)^cloudlinux"),                  string(os::cloud_linux)),
+                make_tuple(boost::regex("(?im)^virtuozzo linux"),             string(os::virtuozzo_linux)),
                 make_tuple(boost::regex("(?i)Ascendos"),                      string(os::ascendos)),
                 make_tuple(boost::regex("(?im)^XenServer"),                   string(os::xen_server)),
                 make_tuple(boost::regex("XCP"),                               string(os::zen_cloud_platform)),


### PR DESCRIPTION
This commit adds support for VirtuozzoLinux to the os.name fact. This
fixes a regression probably introduced by cfacter. It was already fixed
two years ago by #1288/#1325 and fb54206

Warning: I have no idea if this works or even builds. I just spend 3-4 hours trying to setup a proper build environment for facter on CentOS 6 and failed horribly. If someone can help me getting this to work, i'd love to test this change. Sorry about that.