### PR TITLE
(maint) Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/docs/generate.rb
+++ b/lib/docs/generate.rb
@@ -16,7 +16,12 @@ def format_facts(fact_hash)
     :facts => fact_hash
   })
 
-  ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-').result(scope.instance_eval {binding})
+  erb = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+          ERB.new(File.read(PATH_TO_TEMPLATE), trim_mode: '-')
+        else
+          ERB.new(File.read(PATH_TO_TEMPLATE), nil, '-')
+        end
+  erb.result(scope.instance_eval {binding})
 end
 
 print "## Modern Facts\n\n"


### PR DESCRIPTION
The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only