### PR TITLE
(FACT-1851) Gather DHCP lease data under systemd-networkd

### DIFF
--- a/lib/inc/internal/facts/bsd/networking_resolver.hpp
+++ b/lib/inc/internal/facts/bsd/networking_resolver.hpp
@@ -52,6 +52,8 @@ namespace facter { namespace facts { namespace bsd {
         virtual std::string find_dhcp_server(std::string const& interface) const;
 
      private:
+        void find_dhclient_dhcp_servers(std::map<std::string, std::string>& servers) const;
+        void find_networkd_dhcp_servers(std::map<std::string, std::string>& servers) const;
         void populate_binding(interface& iface, ifaddrs const* addr) const;
         void populate_mtu(interface& iface, ifaddrs const* addr) const;
     };


### PR DESCRIPTION
Previously, the BSD/Linux networking resolver expected to find DHCP lease
information only in files created by dhclient. This change checks the
systemd-networkd DHCP lease files as well.

Running applicable acceptance tests for this change in PR testing is blocked on updates to beaker-puppet for Ubuntu 18.04, which we expect to be merged later today. 