### PR TITLE
(FACT-1865) Determine OS release on Amazon Linux 2

### DIFF
--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -285,8 +285,10 @@ namespace facter { namespace facts { namespace linux {
             })) {
                 if (boost::ends_with(contents, "(Rawhide)")) {
                     value = "Rawhide";
-                } else {
+                } else if (contents.find("release") != string::npos) {
                     re_search(contents, boost::regex("release (\\d[\\d.]*)"), &value);
+                } else {
+                    re_search(contents, boost::regex("Amazon Linux (\\d+)"), &value);
                 }
             }
         }


### PR DESCRIPTION
The format of /etc/system-release changed in Amazon Linux 2; This adds a
special case to check for the new format before allowing the os release
value to fall back to the kernel version.

I've built this on an Amazon Linux 2 container and gotten the following:
```
bash-4.2# ./bin/facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2",
    major => "2"
  },
  selinux => {
    enabled => false
  }
}
```

The 2018.03 image still reports its previous values, too:
```
bash-4.2# ./bin/facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2018.03",
    major => "2018",
    minor => "03"
  },
  selinux => {
    enabled => false
  }
}
```

I'll install and test the built agent packages on some actual ec2 instances once PR tests finish.