### PR TITLE
(PA-2055) Quiet boost 1.67 warnings on windows

### DIFF
--- a/lib/tests/fixtures.cc
+++ b/lib/tests/fixtures.cc
@@ -6,6 +6,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <boost/thread/thread.hpp>
 #include <boost/chrono/duration.hpp>
 #pragma GCC diagnostic pop


### PR DESCRIPTION
In preparing puppet-agent for boost 1.67 (puppetlabs/puppet-agent#1482), we found that a 1.67 thread header defines an an unused variable on Windows under mingw; This ignores the warning so that it doesn't fail the build while using -Werror.