### PR TITLE
(FACT-1477) Also check for config. file when resolving selinux.enabled

### DIFF
--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -61,11 +61,13 @@ namespace facter { namespace facts { namespace linux {
 
     operating_system_resolver::selinux_data operating_system_resolver::collect_selinux_data()
     {
+        static string SELINUX_CONFIG_FILE("/etc/selinux/config");
+
         selinux_data result;
         result.supported = true;
 
         string mountpoint = get_selinux_mountpoint();
-        result.enabled = !mountpoint.empty();
+        result.enabled = !mountpoint.empty() && exists(SELINUX_CONFIG_FILE);
         if (!result.enabled) {
             return result;
         }
@@ -87,7 +89,7 @@ namespace facter { namespace facts { namespace linux {
         // Parse the SELinux config for mode and policy
         static boost::regex mode_regex("(?m)^SELINUX=(\\w+)$");
         static boost::regex policy_regex("(?m)^SELINUXTYPE=(\\w+)$");
-        lth_file::each_line("/etc/selinux/config", [&](string& line) {
+        lth_file::each_line(SELINUX_CONFIG_FILE, [&](string& line) {
             if (re_search(line, mode_regex, &result.config_mode)) {
                 return true;
             }


### PR DESCRIPTION
Previously, we'd determine if selinux was enabled on a given system by
checking if the selinux filesystem is mounted. This is incorrect. Based
on https://github.com/SELinuxProject/selinux/blob/e93899c8f3c01dfb47e81d3da4b67283fb459f20/libselinux/src/enabled.c#L20, we also need to check if the selinux config. file
/etc/selinux/config also exists. We can have a scenario where the selinux
filesystem is mounted, but the /etc/selinux/config file does not exist. This
is what was happening to the customer, presumably because their kickstart file
was installing some selinux stuff under yum-utils (while our machines weren't).
Here, Facter would erroneously report that selinux is enabled.

This commit fixes our selinux enablement check by also checking for the
existence of the selinux config. file.