### PR TITLE
(FACT-1550) Get os.architecture from processors.models[0] on AIX

### DIFF
--- a/lib/inc/internal/util/aix/odm.hpp
+++ b/lib/inc/internal/util/aix/odm.hpp
@@ -117,7 +117,18 @@ namespace facter { namespace util { namespace aix {
               * @return true if the iterators are not equal
               */
              bool operator != (const iterator& rhs) {
-                 return _data != rhs._data && _owner != rhs._owner;
+                 return _owner != rhs._owner || _data != rhs._data;
+             }
+
+             /**
+              * equality comparison.
+              * @param rhs the other iterator to compare to
+              * @return true if the iterators are equal
+              */
+             bool operator == (const iterator& rhs) {
+                 // We could do !(*this != rhs) here, but it's better to inline
+                 // the expression for performance reasons. It's simple enough.
+                 return _owner == rhs._owner && _data == rhs._data;
              }
 
              /**
@@ -148,6 +159,14 @@ namespace facter { namespace util { namespace aix {
               */
              const T& operator*() const{
                  return *_data;
+             }
+
+             /**
+              * arrow operator
+              * @return a pointer to the held ODM data structure
+              */
+             const T* operator->() const{
+                 return _data;
              }
 
              /**

--- a/lib/src/facts/aix/operating_system_resolver.cc
+++ b/lib/src/facts/aix/operating_system_resolver.cc
@@ -1,43 +1,72 @@
 #include <internal/facts/aix/operating_system_resolver.hpp>
+#include <internal/util/aix/odm.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
 #include <facter/facts/os.hpp>
-#include <leatherman/execution/execution.hpp>
-#include <leatherman/file_util/file.hpp>
+#include <facter/facts/array_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include <facter/facts/scalar_value.hpp>
 #include <leatherman/logging/logging.hpp>
-#include <leatherman/util/regex.hpp>
 
 #include <boost/algorithm/string.hpp>
+#include <odmi.h>
+#include <sys/cfgodm.h>
 
 using namespace std;
-using namespace leatherman::util;
-using namespace leatherman::file_util;
-using namespace boost;
-namespace execution = leatherman::execution;
+using namespace facter::util::aix;
 
+// This routine's meant to be a general utility function that replicates the behavior of
+// lsattr -El <object> -a <field>. Although it's only used to get the modelname of the
+// sys0 device, we still would like to have it here in case we ever need to separate it
+// out to an AIX utils file to query other attributes. Part of what lsattr does is check
+// PdAt if we don't have an entry for the object's attribute in CuAt, even though it is very
+// unlikely that sys0.modelname will not have a CuAt entry. That is why we have the extra code
+// in here.
 static string getattr(string object, string field)
 {
-    string result;
+    // High-level logic here is:
+    //   * Check if there's an entry for our object's field attribute in CuAt (the device-specific
+    //   attribute entry).
+    //
+    //   * Else, check for the field attribute's default value in PdAt. We do this by first
+    //   figuring out the PdDv type from the CuDv entry for the object, then use our PdDv type
+    //   to query the field's default value in PdAt.
+    string query = (boost::format("name = %1% AND attribute = %2%") % object % field).str();
+    auto cuat_query = odm_class<CuAt>::open("CuAt").query(query);
 
-    execution::each_line(
-        "/usr/sbin/lsattr", {"-El", object, "-a", field},
-        [&](string& line) {
-            if (!line.empty()) {
-                vector<string> tokens;
-                boost::split(tokens, line, boost::is_space(), boost::token_compress_on);
-                if (tokens.size() < 2) {
-                    return true;
-                }
-                result = tokens[1];
-                return false;
-            }
-            return true;
-        },
-        nullptr,
-        0);
-
-    if (result == "") {
-        LOG_WARNING("Could not get a value from lsattr -El {1} -a {2}", object, field);
+    // This is a more verbose way of saying that we only expect our query to have one element
+    auto cuat_ref = cuat_query.begin();
+    if (cuat_ref != cuat_query.end()) {
+      auto value = string(cuat_ref->value);
+      if (value.empty()) {
+        LOG_DEBUG("Could not get a value from the ODM for {1}'s '{2}' attribute.", object, field);
+      }
+      return value;
     }
-    return result;
+
+    // Get the PdDv type from the CuDv entry
+    query = (boost::format("name = %1%") % object).str();
+    auto cudv_query = odm_class<CuDv>::open("CuDv").query(query);
+    auto cudv_ref = cudv_query.begin();
+    if (cudv_ref == cudv_query.end()) {
+      LOG_DEBUG("Could not get a value from the ODM for {1}'s '{2}' attribute: There is no CuDv entry for {1}.", object, field);
+      return "";
+    }
+    auto pddv_type = cudv_ref->PdDvLn_Lvalue;
+
+    query = (boost::format("uniquetype = %1% AND attribute = %2%") % pddv_type % field).str();
+    auto pdat_query = odm_class<PdAt>::open("PdAt").query(query);
+    auto pdat_ref = pdat_query.begin();
+    if (pdat_ref != pdat_query.end()) {
+      auto value = string(pdat_ref->deflt);
+      if (value.empty()) {
+        LOG_DEBUG("Could not get a value from the ODM for {1}'s '{2}' attribute.", object, field);
+      }
+      return value;
+    }
+
+    LOG_DEBUG("Could not get a value from the ODM for {1}'s '{2}' attribute: There is no PdAt entry for {1} with {2}.", object, field);
+    return "";
 }
 
 namespace facter { namespace facts { namespace aix {
@@ -53,8 +82,17 @@ namespace facter { namespace facts { namespace aix {
         boost::split(tokens, result.release, boost::is_any_of("-"));
         result.major = tokens[0];
 
-        result.architecture = getattr("proc0", "type");
+        // Get the hardware
         result.hardware = getattr("sys0", "modelname");
+
+        // Now get the architecture. We use processor.models[0] for this information.
+        auto processors = facts.get<map_value>(fact::processors);
+        auto models = processors ? processors->get<array_value>("models") : nullptr;
+        if (! models || models->empty()) {
+          LOG_DEBUG("Could not get a value for the OS architecture. Your machine does not have any processors!");
+        } else {
+          result.architecture = models->get<string_value>(0)->value();
+        }
 
         return result;
     }


### PR DESCRIPTION
On AIX, we can dynamically add and remove resources from the LPAR.
This includes removing proc0, which is what we originally checked
to obtain the OS architecture. In this case, we will report an
empty value for the OS architecture, which is incorrect.

This commit uses the processors.model[0] fact to obtain the
architecture instead, where the processors fact directly queries the
ODM for all of the available processors on the system and thus is not
affected by any LPAR configuration.

We also clean up the code here a bit by using our internal ODM APIs
instead of shelling out to lsattr and parsing its output to get the
hardware info. It is better to use our internal ODM APIs instead to
keep things consistent with our other AIX fact resolvers and to
avoid shelling out when we don't need to. The resulting code's
also a lot cleaner.