### PR TITLE
(FACT-1497) Try calculating the uptime from the utmp file first

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -91,6 +91,7 @@ if (UNIX)
         "src/facts/posix/cache.cc"
         "src/util/posix/scoped_addrinfo.cc"
         "src/util/posix/scoped_descriptor.cc"
+        "src/util/posix/utmpx_file.cc"
         "src/util/config/posix/config.cc"
     )
     if (OPENSSL_FOUND)

--- a/lib/inc/internal/util/posix/utmpx_file.hpp
+++ b/lib/inc/internal/util/posix/utmpx_file.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * Declares an interface for querying the contents of the utmpx file
+ */
+#pragma once
+
+#include <utmpx.h>
+
+namespace facter { namespace util { namespace posix {
+
+    /**
+     * Class representing a utmpx file. We create only one instance at a time since
+     * the utmpx API calls deal with global state. See https://linux.die.net/man/3/getutxid
+     * for the documentation.
+    */
+    class utmpx_file {
+    public:
+         /**
+          * Constructs a utmpx_file instance. We only do this if no other utmpx_file instance exists,
+          * which we can determine by querying the 'instance_exists' static variable. Otherwise,
+          * we throw an std::logic_error.
+          */
+         utmpx_file();
+
+         /// deleted copy constructor
+         utmpx_file(const utmpx_file&) = delete;
+
+         /// deleted assignment operator
+         /// @return nothing
+         utmpx_file& operator=(const utmpx_file&) = delete;
+
+         /**
+          * Destroys our utmpx_file instance. Here, we also set `instance_exists` to false so that another
+          * utmpx_file instance can be created.
+          */
+         ~utmpx_file();
+
+         /**
+          * Returns a pointer to the utmpx entry corresponding to the passed-in query. Make sure
+          * that the calling instance does not go out of scope after invoking this method, otherwise
+          * the data in the returned utmpx entry will be garbage. Note that this will move the
+          * underlying utmpx file pointer forward, so be sure to call reset() if you want subsequent
+          * calls to this routine to always start from the beginning of the utmpx file.
+          * @param query the utmpx query. See https://www.systutorials.com/docs/linux/man/5-utmpx/
+          * @return pointer to the utmpx entry satisfying the query
+          */
+         const utmpx* query(utmpx const& query) const;
+
+         /**
+          * Resets the utmpx file.
+          */
+         void reset() const;
+
+    private:
+         static bool instance_exists;  // set to true if a utmpx_file instance exists, false otherwise
+    };
+}}}  // namespace facter::util::posix

--- a/lib/src/util/posix/utmpx_file.cc
+++ b/lib/src/util/posix/utmpx_file.cc
@@ -1,0 +1,36 @@
+#include <internal/util/posix/utmpx_file.hpp>
+#include <leatherman/locale/locale.hpp>
+#include <leatherman/logging/logging.hpp>
+
+// Mark string for translation (alias for leatherman::locale::format)
+using leatherman::locale::_;
+
+using namespace std;
+
+namespace facter { namespace util { namespace posix {
+
+    bool utmpx_file::instance_exists = false;
+
+    utmpx_file::utmpx_file() {
+      if (utmpx_file::instance_exists) {
+        throw logic_error(_("only one utmpx_file instance can exist at a time!"));
+      }
+
+      utmpx_file::instance_exists = true;
+      reset();
+    }
+
+    utmpx_file::~utmpx_file() {
+        endutxent();
+        utmpx_file::instance_exists = false;
+    }
+
+    const utmpx* utmpx_file::query(utmpx const& query) const {
+        LOG_DEBUG(_("Reading the utmpx file ..."));
+        return getutxid(&query);
+    }
+
+    void utmpx_file::reset() const {
+        setutxent();
+    }
+}}}  // namespace facter::util::posix


### PR DESCRIPTION
Previously, we would parse the output of the `uptime` command to
get the system uptime in our POSIX resolver. Unfortunately, there
is a bug in the `uptime` command that causes the seconds entry to
update itself once the minutes entry is updated. Thus, invoking the
`uptime` command a few seconds after the previous invocation would
still show the same uptime value, which is unexpected behavior.

Our AIX and Solaris platforms rely on the POSIX resolver to determine
their uptime information. Thus, the bug in the `uptime` command meant
that the `system_uptime` fact on these platforms was not being updated
correctly.

This commit tries to calculate the uptime programmatically before
calling the `uptime` command. It does this by attempting to get the system
boot time from the utmp file, then subtracting that value from the current
system time. If it fails to read the boot time from the utmp file, then
it delegates to getting the uptime information from the `uptime` command
itself.

The new method's been verified to work on our AIX and Solaris platforms.