### PR TITLE
(packaging) Use packaging as a gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,39 +4,5 @@ $LOAD_PATH << File.join(RAKE_ROOT, 'tasks')
 require 'rake'
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-build_defs_file = File.join(RAKE_ROOT, 'ext', 'build_defaults.yaml')
-if File.exist?(build_defs_file)
-  begin
-    require 'yaml'
-    @build_defaults ||= YAML.load_file(build_defs_file)
-  rescue Exception => e
-    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
-    raise e
-  end
-  @packaging_url  = @build_defaults['packaging_url']
-  @packaging_repo = @build_defaults['packaging_repo']
-  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
-  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
-
-  namespace :package do
-    desc "Bootstrap packaging automation, e.g. clone into packaging repo"
-    task :bootstrap do
-      if File.exist?(File.join(RAKE_ROOT, "ext", @packaging_repo))
-        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
-      else
-        cd File.join(RAKE_ROOT, 'ext') do
-          %x{git clone #{@packaging_url}}
-        end
-      end
-    end
-    desc "Remove all cloned packaging automation"
-    task :implode do
-      rm_rf File.join(RAKE_ROOT, "ext", @packaging_repo)
-    end
-  end
-end
-
-begin
-  load File.join(RAKE_ROOT, 'ext', 'packaging', 'packaging.rake')
-rescue LoadError
-end
+require 'packaging'
+Pkg::Util::RakeUtils.load_packaging_tasks

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,4 @@
 ---
-packaging_url: 'git@github.com:puppetlabs/packaging --branch=master'
-packaging_repo: 'packaging'
 deb_build_mirrors:
   - deb http://pl-build-tools.delivery.puppetlabs.net/debian __DIST__ main
 packager: 'puppetlabs'


### PR DESCRIPTION
This commit removes the packaging bootstrap and implode rake tasks and replaces
them with the packaging gem. Since this project doesn't have a top-level
Gemfile, we must install the packaging gem ourselves (in a job, locally, etc.)
in order to make use of the packaging rake tasks (which should only be needed
at ship time for this project).