### PR TITLE
(FACT-1415) Use RtlGetVersion to get the Windows OS version

### DIFF
--- a/lib/src/facts/windows/kernel_resolver.cc
+++ b/lib/src/facts/windows/kernel_resolver.cc
@@ -1,60 +1,42 @@
+#include <leatherman/dynamic_library/dynamic_library.hpp>
 #include <internal/facts/windows/kernel_resolver.hpp>
-#include <leatherman/windows/system_error.hpp>
-#include <leatherman/windows/windows.hpp>
 #include <facter/facts/os.hpp>
 #include <leatherman/logging/logging.hpp>
+
 #include <boost/optional.hpp>
-#include <boost/algorithm/string/trim.hpp>
 #include <boost/format.hpp>
-#include <boost/nowide/convert.hpp>
+#include <windows.h>
+#include <ntstatus.h>
 
 using namespace std;
-using namespace leatherman::windows;
+using namespace leatherman::dynamic_library;
+using RtlGetVersionPtr = NTSTATUS (WINAPI *)(PRTL_OSVERSIONINFOW);
 
 namespace facter { namespace facts { namespace windows {
 
     static boost::optional<string> get_release()
     {
-        // GetVersionEx requires the manifest is correct, and is essentially deprecated.
-        // Another method of getting the OS version can be found at
-        // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724429(v=vs.85).aspx
-        // and is what we use here.
-        auto fileName = L"Kernel32.dll";
-        auto fileVerSize = GetFileVersionInfoSizeW(fileName, nullptr);
-        if (fileVerSize == 0) {
-            return boost::none;
+        dynamic_library ntoskrnl;
+        if (! ntoskrnl.load("ntoskrnl.exe")) {
+          return boost::none;
         }
 
-        vector<wchar_t> buffer(fileVerSize);
-        if (!GetFileVersionInfoW(fileName, 0, fileVerSize, buffer.data())) {
-            return boost::none;
+        auto rtlGetVersion = reinterpret_cast<RtlGetVersionPtr>(
+            ntoskrnl.find_symbol("RtlGetVersion"));
+        if (! rtlGetVersion) {
+          return boost::none;
         }
 
-        struct LANGANDCODEPAGE {
-            WORD wLanguage, wCodePage;
-        } *lpTranslate;
-        UINT cbTranslate;
-
-        if (!VerQueryValueW(buffer.data(), L"\\VarFileinfo\\Translation",
-            reinterpret_cast<LPVOID*>(&lpTranslate), &cbTranslate)) {
-            return boost::none;
+        OSVERSIONINFOW versionInfo;
+        if (rtlGetVersion(&versionInfo) != STATUS_SUCCESS) {
+          LOG_DEBUG("failed to get the OS version information from RtlGetVersion");
+          return boost::none;
         }
 
-        // Use the 1st language found, as ProductVersion should be language-independent.
-        wstring subBlock = str(boost::wformat(L"\\StringFileInfo\\%04x%04x\\ProductVersion")
-            % lpTranslate->wLanguage % lpTranslate->wCodePage);
-
-        wchar_t *version;
-        UINT versionLen;
-        if (!VerQueryValueW(buffer.data(), subBlock.c_str(), reinterpret_cast<LPVOID*>(&version), &versionLen)) {
-            return boost::none;
-        }
-
-        // Strip the last (file version) token to get just the OS version.
-        wstring versionStrW(version, versionLen);
-        auto versionStr = boost::nowide::narrow(versionStrW);
-        boost::trim_right_if(versionStr, [](char c) { return c != '.'; });  // Remove everything after '.'
-        boost::trim_right_if(versionStr, [](char c) { return c == '.'; });  // Remove '.'
+        auto versionStr = (boost::format("%1%.%2%.%3%")
+            % versionInfo.dwMajorVersion
+            % versionInfo.dwMinorVersion
+            % versionInfo.dwBuildNumber).str();
 
         return versionStr;
     }
@@ -67,8 +49,6 @@ namespace facter { namespace facts { namespace windows {
         if (release) {
             result.release = move(*release);
             result.version = result.release;
-        } else {
-            LOG_DEBUG("failed to retrieve kernel facts: {1}", leatherman::windows::system_error());
         }
 
         result.name = os::windows;


### PR DESCRIPTION
Previously, we would use the version for kernel32.dll as the OS
version. However, there were some uncertainties around whether
this was the best path forward.

Facter 2.x gets the OS version using the kernel call RtlGetVersion
from ntoskrnl.exe, which will return the correct versions of the
kernel. This commit modifies the Windows kernel resolver to also
use RtlGetVersion.