### PR TITLE
(maint) Fix expected os_version fact to distinguish 2012 and 2012 R2

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -523,7 +523,7 @@ module Facter
         elsif agent['platform'] =~ /2008/
           os_version = '2008 R2'
         elsif agent['platform'] =~ /2012/
-          os_version = '2012 R2'
+          os_version = agent['platform'] =~ /R2/ ? '2012 R2' : '2012'
         elsif agent['platform'] =~ /-10/
           os_version = '10'
         elsif agent['platform'] =~ /2016/


### PR DESCRIPTION
Previously, the acceptance tests would assume that the os_version fact
resolved to '2012 R2' for both Windows 2012 and Windows 2012 R2. This is
incorrect because on Windows 2012, the os_version fact resolves to '2012'
instead, which is correct. This failure was not detected in the agent CI
pipelines because we only test with 2012 R2.

This commit fixes the expected os_version fact in the tests to correctly
distinguish between Windows 2012 and Windows 2012 R2. [no-promote]