### PR TITLE
(FACT-1883) Fix compilation on platforms without utmpx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
 
+include(CheckIncludeFile)
+CHECK_INCLUDE_FILE(utmpx.h HAVE_UTMPX_H -DHAVE_UTMPX_H)
+
 option(YAMLCPP_STATIC "Use yaml-cpp's static libraries" OFF)
 option(BUILD_SHARED_LIBS "Build libfacter as a shared library" ON)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -91,11 +91,14 @@ if (UNIX)
         "src/facts/posix/cache.cc"
         "src/util/posix/scoped_addrinfo.cc"
         "src/util/posix/scoped_descriptor.cc"
-        "src/util/posix/utmpx_file.cc"
         "src/util/config/posix/config.cc"
     )
     if (OPENSSL_FOUND)
         set(LIBFACTER_STANDARD_SOURCES ${LIBFACTER_STANDARD_SOURCES} "src/util/posix/scoped_bio.cc")
+    endif()
+
+    if (HAVE_UTMPX_H)
+        set(LIBFACTER_STANDARD_SOURCES ${LIBFACTER_STANDARD_SOURCES} "src/util/posix/utmpx_file.cc")
     endif()
 
     if (NOT AIX)

--- a/lib/src/facts/posix/uptime_resolver.cc
+++ b/lib/src/facts/posix/uptime_resolver.cc
@@ -1,5 +1,7 @@
 #include <internal/facts/posix/uptime_resolver.hpp>
+#ifdef HAVE_UTMPX_H
 #include <internal/util/posix/utmpx_file.hpp>
+#endif
 #include <leatherman/util/regex.hpp>
 #include <leatherman/execution/execution.hpp>
 #include <leatherman/logging/logging.hpp>
@@ -13,7 +15,9 @@ using leatherman::locale::_;
 using namespace std;
 using namespace leatherman::util;
 using namespace leatherman::execution;
+#ifdef HAVE_UTMPX_H
 using namespace facter::util::posix;
+#endif
 
 namespace facter { namespace facts { namespace posix {
 
@@ -52,6 +56,7 @@ namespace facter { namespace facts { namespace posix {
 
     int64_t uptime_resolver::get_uptime()
     {
+#ifdef HAVE_UTMPX_H
         LOG_DEBUG(_("Attempting to calculate the uptime from the utmpx file"));
         utmpx query;
         query.ut_type = BOOT_TIME;
@@ -61,6 +66,7 @@ namespace facter { namespace facts { namespace posix {
           return time(NULL) - ent->ut_tv.tv_sec;
         }
         LOG_DEBUG(_("Could not calculate the uptime from the utmpx file"));
+#endif
 
         auto exec = execute("uptime");
         if (!exec.success) {


### PR DESCRIPTION
On systems, that don't have utmpx.h, i.e. OpenBSD, don't use it.
Looking at utmpx for the uptime resolver was introduced
in 3.11.4, but the fallback to just run the uptime command
is still there. So if no utmpx is around, only run the
uptime command.