### PR TITLE
(FACT-1870) Redirect Ruby stdout to stderr for structured output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,33 @@
-language: cpp
-compiler:
-  - gcc
-dist: precise
-sudo: false
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libboost-filesystem1.55-dev
-      - libboost-program-options1.55-dev
-      - libboost-regex1.55-dev
-      - libboost-date-time1.55-dev
-      - libboost-thread1.55-dev
-      - libboost-log1.55-dev
-      - libboost-locale1.55-dev
-      - libboost-chrono1.55-dev
-      - libblkid1
+sudo: required
+services:
+  - docker
 
 before_install:
-  # Use a predefined install location; cppcheck requires the cfg location is defined at compile-time.
-  - mkdir -p $USERDIR
-  # grab a pre-built cmake 3.2.3
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/cmake-3.2.3-Linux-x86_64.tar.gz
-  - tar xzvf cmake-3.2.3-Linux-x86_64.tar.gz --strip 1 -C $USERDIR
-  # Install dependencies of facter
-  - wget https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1_install.tar.bz2
-  - tar xjvf yaml-cpp-0.5.1_install.tar.bz2 --strip 1 -C $USERDIR
-  - wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman.tar.gz
-  - tar xzvf leatherman.tar.gz -C $USERDIR
-  - wget https://github.com/puppetlabs/cpp-hocon/releases/download/${CPPHOCON_VERSION}/cpp-hocon.tar.gz
-  - tar xzvf cpp-hocon.tar.gz -C $USERDIR
+  - docker pull gcr.io/cpp-projects/cpp-ci:1
 
-script: ./scripts/travis_target.sh
+script:
+  - >
+    docker run -v `pwd`:/facter gcr.io/cpp-projects/cpp-ci:1 /bin/bash -c "
+    wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman-dynamic.tar.gz &&
+    tar xzvf leatherman-dynamic.tar.gz --strip 1 -C / &&
+    wget https://github.com/puppetlabs/cpp-hocon/releases/download/${CPPHOCON_VERSION}/cpp-hocon-dynamic.tar.gz &&
+    tar xzvf cpp-hocon-dynamic.tar.gz --strip 1 -C / &&
+    cd /facter &&
+    cmake $EXTRA_VARS . &&
+    mkdir dest &&
+    make $TARGET DESTDIR=/facter/dest VERBOSE=1 -j2 &&
+    { [[ '$COVERALLS' != 'ON' ]] || coveralls --gcov-options '\-lp' -r . -b . -e src -e vendor >/dev/null || true; }
+    "
 
 env:
   global:
-    - USERDIR=/tmp/userdir
-    - PYTHONUSERBASE=$USERDIR
-    - PATH=$USERDIR/bin:$PATH
-    - LD_LIBRARY_PATH=$USERDIR/lib:$LD_LIBRARY_PATH
-    - LEATHERMAN_VERSION=0.99.0
-    - CPPHOCON_VERSION=0.1.4
+    - LEATHERMAN_VERSION=1.4.4
+    - CPPHOCON_VERSION=0.1.8
   matrix:
-    - TRAVIS_TARGET=COMMITS
-    - TRAVIS_TARGET=DOXYGEN
-    - TRAVIS_TARGET=CPPLINT
-    - TRAVIS_TARGET=CPPCHECK
-    - TRAVIS_TARGET=RELEASE
-    - TRAVIS_TARGET=DEBUG
+    - TARGET=cpplint
+    - TARGET=cppcheck
+    - TARGET="all test install ARGS=-V" EXTRA_VARS=""
+    - TARGET="all test install ARGS=-V" EXTRA_VARS="-DCMAKE_BUILD_TYPE=Debug -DCOVERALLS=ON" COVERALLS=ON
+
+notifications:
+  email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 3.1.0.{build}
 clone_depth: 10
 environment:
-  LEATHERMAN_VERSION: 0.99.0
-  CPPHOCON_VERSION: 0.1.4
+  LEATHERMAN_VERSION: 1.4.3
+  CPPHOCON_VERSION: 0.1.7
 
 init:
   - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,21 @@
 version: 3.1.0.{build}
 clone_depth: 10
 environment:
-  LEATHERMAN_VERSION: 1.4.3
-  CPPHOCON_VERSION: 0.1.7
+  LEATHERMAN_VERSION: 1.4.4
+  CPPHOCON_VERSION: 0.1.8
 
 init:
   - |
-      choco install mingw-w64 -y -Version 4.8.3 -source https://www.myget.org/F/puppetlabs
+      choco install -y mingw-w64 -Version 5.2.0 -source https://www.myget.org/F/puppetlabs
+      choco install -y cmake -Version 3.2.2 -source https://www.myget.org/F/puppetlabs
       choco install -y gettext -Version 0.19.6 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-toolchain-x64 -Version 2015.12.01.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-boost-x64 -Version 1.58.0.2 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-openssl-x64 -Version 1.0.24.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-curl-x64 -Version 7.46.0.1 -source https://www.myget.org/F/puppetlabs
+      choco install -y pl-yaml-cpp-x64 -Version 0.5.1.2 -source https://www.myget.org/F/puppetlabs
       cmake --version
   - ps: |
-      $env:PATH = $env:PATH.Replace("Git\bin", "Git\cmd")
-      $env:PATH = $env:PATH.Replace("Git\usr\bin", "Git\cmd")
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\boost.7z"
-      7z.exe x $env:temp\boost.7z -oC:\tools | FIND /V "ing  "
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\yaml-cpp.7z"
-      7z.exe x $env:temp\yaml-cpp.7z -oC:\tools | FIND /V "ing  "
-
-      wget 'https://s3.amazonaws.com/kylo-pl-bucket/curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z' -OutFile "$env:temp\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z"
-      7z.exe x "$env:temp\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh.7z" -oC:\tools | FIND /V "ing "
-
       wget "https://github.com/puppetlabs/leatherman/releases/download/$env:LEATHERMAN_VERSION/leatherman.7z" -OutFile "$env:temp\leatherman.7z"
       7z.exe x $env:temp\leatherman.7z -oC:\tools | FIND /V "ing "
 
@@ -29,12 +23,15 @@ init:
       7z.exe x $env:temp\cpp-hocon.7z -oC:\tools | FIND /V "ing "
 
 install:
-  - SET PATH=C:\Ruby21-x64\bin;C:\tools\mingw64\bin;C:\Program Files\gettext-iconv;%PATH%
+    # Minimize environment polution; previously we were linking against the wrong OpenSSL DLLs.
+    # Include Ruby and Powershell for unit tests.
+  - SET PATH=C:\tools\pl-build-tools\bin;C:\tools\mingw64\bin;C:\ProgramData\chocolatey\bin;C:\Ruby22-x64\bin;C:\Program Files\7-Zip;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;C:\Program Files\gettext-iconv
+  - ps: rm -r C:\OpenSSL-Win64
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:
   - ps: |
-      cmake -G "MinGW Makefiles" -DBOOST_ROOT="C:\tools\boost_1_57_0-x86_64_mingw-w64_4.8.3_win32_seh" -DYAMLCPP_ROOT="C:\tools\yaml-cpp-0.5.1-x86_64_mingw-w64_4.8.3_win32_seh" -DBOOST_STATIC=ON -DCURL_STATIC=ON -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\curl-7.42.1-x86_64_mingw-w64_4.8.3_win32_seh;C:\tools\cpp-hocon" .
+      cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\cpp-hocon" -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DBOOST_STATIC=ON .
       mingw32-make -j2
 
 test_script:

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -332,7 +332,8 @@ int main(int argc, char **argv)
             if (vm.count("custom-dir")) {
                 custom_directories = vm["custom-dir"].as<vector<string>>();
             }
-            facter::ruby::load_custom_facts(facts, vm.count("puppet"), custom_directories);
+            bool redirect_ruby_stdout = vm.count("json") || vm.count("yaml");
+            facter::ruby::load_custom_facts(facts, vm.count("puppet"), redirect_ruby_stdout, custom_directories);
         }
 
         if (!vm["no-external-facts"].as<bool>()) {

--- a/lib/inc/facter/ruby/ruby.hpp
+++ b/lib/inc/facter/ruby/ruby.hpp
@@ -27,6 +27,17 @@ namespace facter { namespace ruby {
      * Calling this function from an arbitrary stack depth may result in segfaults during Ruby GC.
      * @param facts The collection to populate with custom facts.
      * @param initialize_puppet Whether puppet should be loaded to find additional facts.
+     * @param redirect_stdout Whether Ruby's stdout should be redirected to stderr
+     * @param paths The paths to search for custom facts.
+     */
+    LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, bool initialize_puppet, bool redirect_stdout, std::vector<std::string> const& paths = {});
+
+    /**
+     * Loads custom facts into the given collection.
+     * Important: this function should be called from main().
+     * Calling this function from an arbitrary stack depth may result in segfaults during Ruby GC.
+     * @param facts The collection to populate with custom facts.
+     * @param initialize_puppet Whether puppet should be loaded to find additional facts.
      * @param paths The paths to search for custom facts.
      */
     LIBFACTER_EXPORT void load_custom_facts(facter::facts::collection& facts, bool initialize_puppet, std::vector<std::string> const& paths = {});

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -309,6 +309,8 @@ namespace facter { namespace facts {
     {
         resolve_facts();
 
+        // We intentionally are using find_if with no return value as a "map until" construct.
+        // cppcheck-suppress ignoredReturnValue
         find_if(begin(_facts), end(_facts), [&func](map<string, unique_ptr<value>>::value_type const& it) {
             return !func(it.first, it.second.get());
         });

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LIBFACTER_TESTS_COMMON_SOURCES
     "logging/logging.cc"
     "log_capture.cc"
     "main.cc"
+    "mock_server.cc"
     "util/string.cc"
     "fixtures.cc"
     "collection_fixture.cc"
@@ -127,37 +128,20 @@ include_directories(
     ${CPPHOCON_INCLUDE_DIRS}
 )
 
-# On EL 4, we run into a linking error when trying to create libraries or
-# executables that link in a static library with code using threads. As I
-# described in https://gcc.gnu.org/ml/gcc-help/2015-08/msg00035.html, we get
-# the error undefined reference to symbol '__tls_get_addr@@GLIBC_2.3'.
-# Build mock_server as a separate shared library to avoid this error.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-add_library(mock-server SHARED mock_server.cc)
-target_link_libraries(mock-server PRIVATE
-    ${Boost_THREAD_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
+if (WIN32)
+    # On Windows with GCC 5.2, Boost.System emits warnings that aren't correctly
+    # suppressed by pragmas. Explicitly skip them.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
+endif()
 
 add_executable(libfacter_test $<TARGET_OBJECTS:libfactersrc>
     ${LIBFACTER_TESTS_COMMON_SOURCES}
     ${LIBFACTER_TESTS_PLATFORM_SOURCES}
     ${LIBFACTER_TESTS_CATEGORY_SOURCES})
-# On Windows, mock-server comes after Boost libraries to avoid double
-# definition of boost::system::system_category() on Windows. On Linux, it
-# comes before to avoid picking up incomplete Boost.Asio symbols included
-# by Boost.Log in Leatherman logging.
-if (WIN32)
-    target_link_libraries(libfacter_test
-        ${LIBS}
-        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES}
-        mock-server)
-else()
-    target_link_libraries(libfacter_test
-        mock-server
-        ${LIBS}
-        ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
-endif()
+target_link_libraries(libfacter_test
+    ${LIBS}
+    ${LIBFACTER_TESTS_PLATFORM_LIBRARIES})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND BOOST_STATIC AND LEATHERMAN_USE_LOCALES)
     target_link_libraries(libfacter_test iconv)

--- a/lib/tests/facts/collection.cc
+++ b/lib/tests/facts/collection.cc
@@ -67,7 +67,7 @@ struct multi_resolver : facter::facts::resolver
 
 struct temp_variable
 {
-    temp_variable(string name, string const& value) :
+    temp_variable(string&& name, string const& value) :
         _name(move(name))
     {
         environment::set(_name, value);


### PR DESCRIPTION
Previously, any output to `stdout` in a custom fact would be echoed to
the terminal as-is, since Facter did nothing special with its output
streams. This caused problems when outputting structured data (json or
yaml), since anything printed to stdout would end up in the structure,
possibly corrupting it.

Facter now redirects the Ruby interpreter's stdout to stderr when
resolving custom facts for structured output. This means that the
output isn't lost, just put someplace less annoying.