### PR TITLE
Explicitly require hypervisor beaker gems, for non-CI contexts

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,6 +14,7 @@ gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
+gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"
 

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,6 +14,7 @@ gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"


### PR DESCRIPTION
These are no longer built into beaker 4