### PR TITLE
Explicitly require beaker hypervisor gems for acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,6 +13,7 @@ end
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem 'beaker-vagrant', *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')
 gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem 'rake', "~> 10.1.0"

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -13,6 +13,7 @@ end
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem 'beaker-vmpooler', *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")
 gem 'rake', "~> 10.1.0"
 gem "multi_json", "~> 1.8"


### PR DESCRIPTION
These are development dependencies in Beaker 4, but they should be explicitly required