### PR TITLE
(FACT-1899) Set OS facts for ubuntu from os-release

### DIFF
--- a/lib/inc/internal/facts/linux/os_osrelease.hpp
+++ b/lib/inc/internal/facts/linux/os_osrelease.hpp
@@ -45,6 +45,8 @@ namespace facter { namespace facts { namespace linux {
                     return os::suse_enterprise_desktop;
                 } else if (id == "sles") {
                     return os::suse_enterprise_server;
+                } else if (id == "ubuntu") {
+                    return os::ubuntu;
                 }
             }
             return std::string();
@@ -68,6 +70,8 @@ namespace facter { namespace facts { namespace linux {
                     return os_family::debian;
                 } else if (id == "opensuse" || id == "opensuse-leap" || id == "sled" || id == "sles") {
                     return os_family::suse;
+                } else if (id == "ubuntu") {
+                    return os_family::debian;
                 }
             }
             return std::string();

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -31,7 +31,7 @@ namespace facter { namespace facts { namespace linux {
         auto release_info = os_linux::key_value_file(release_file::os, {"ID", "CISCO_RELEASE_INFO"});
         auto const& id = release_info["ID"];
         if (id == "coreos" || id == "cumulus-linux" || id == "opensuse" ||
-            id == "opensuse-leap" || id== "sled" || id == "sles") {
+            id == "opensuse-leap" || id== "sled" || id == "sles" || id == "ubuntu") {
             return unique_ptr<os_linux>(new os_osrelease());
         } else {
             auto const& cisco = release_info["CISCO_RELEASE_INFO"];


### PR DESCRIPTION
This commit handles the case where `/etc/os-release` contains the OS {name,family,release} for `ubuntu` targets. Previously if a target system did not contain the `lsb_release` executable the OS facts for a 16.04 machine would be Debain stretch/sid (from `/etc/debian_release`). The base ubuntu {16,18}.04 docker images do not ship with the `lsb_release` executable but contain the relevant details in `/etc/os-release`.