### PR TITLE
(FACT-1900) Only check for `sysnative` if we are running under Wow64

### DIFF
--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -63,15 +63,17 @@ namespace facter { namespace facts { namespace windows {
             LOG_DEBUG("error finding SYSTEMROOT: {1}", leatherman::windows::system_error());
         }
 
-        auto pathNative = path(szPath) / "sysnative";
-        boost::system::error_code ec;
-        if (is_directory(pathNative, ec)) {
-            return pathNative.string();
+        BOOL isWow = FALSE;
+
+        if (!IsWow64Process(GetCurrentProcess(), &isWow)) {
+            LOG_DEBUG("Could not determine if we are running in WOW64: {1}", leatherman::windows::system_error());
         }
 
-        LOG_TRACE("sysnative path does not exist");
-        auto path32 = path(szPath) / "system32";
-        return path32.string();
+        if (isWow) {
+            return ((path(szPath) / "sysnative").string());
+        } else {
+            return ((path(szPath) / "system32").string());
+        }
     }
 
     operating_system_resolver::operating_system_resolver(shared_ptr<wmi> wmi_conn) :


### PR DESCRIPTION
Previously, facter would check for the existence of
`%sysroot%\sysnative` and assume it was the correct system32 directory
if it exists. This is incorrect if that directory has somehow been
created as a normal directory in the normal filesystem.

Instead, we should just check for whether we are running under WOW64,
and spit out the correct directory based on that query. We don't use
IsWow64Process2, since we need to support versions of Windows which do
not have it available.