### PR TITLE
FACT-1905 do not test dhcp on rhel-8

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -46,7 +46,7 @@ test_name 'C59029: networking facts should be fully populated' do
       expected_bindings.delete("networking.interfaces.#{primary_interface}.bindings6.0.network")
     end
 
-    if agent['platform'] =~ /aix|sparc|cisco|huawei|sles|s390x/
+    if agent['platform'] =~ /aix|sparc|cisco|huawei|sles|s390x|el-8/
       # some of our testing platforms do not use DHCP
       expected_networking.delete("networking.dhcp")
     end


### PR DESCRIPTION
Since redhat-8 is not using dhcp, this test was failing
https://github.com/sebastian-miclea/puppetlabs-packer/blob/eea826c428ebabf17a2bdb2d5d2ff61ad3ccf169/manifests/modules/packer/manifests/vsphere/networking.pp#L22-L34

Skipped dhcp test on rhel-8