### PR TITLE
Interfaces and mountpoints filters

### DIFF
--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -61,7 +61,9 @@ namespace facter { namespace util { namespace config {
     po::options_description fact_config_options() {
         po::options_description fact_settings("");
         fact_settings.add_options()
-            ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
+            ("blocklist", po::value<vector<string>>(), "A set of facts to block.")
+            ("interface_filter", po::value<string>(), "Regex to exclude interfaces.")
+            ("mountpoint_filter", po::value<string>(), "Regex to exclude mountpoints.");
         return fact_settings;
     }
 


### PR DESCRIPTION
Introduces 2 new facter.conf parameters which allow to filter-out network interfaces and mountpoints:
```
facts : {
    blocklist : [ "EC2" ],
    interface_filter : "^veth[0-9a-f]+|^docker.+",
    mountpoint_filter : ".+/docker/.+",
}
```
Useful for servers with docker/kubernetes/virtualization where you are not interested in virtual interfaces/mountpoints.