### PR TITLE
(FACT-1910) Remove check that mount point is physical/tmpfs

### DIFF
--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -77,8 +77,8 @@ namespace facter { namespace facts { namespace linux {
             string device = ptr->mnt_fsname;
             string mtype = ptr->mnt_type;
 
-            // Skip over anything that doesn't map to a device and is not tmpfs
-            if (!boost::starts_with(device, "/dev/") && mtype != "tmpfs") {
+            // Skip over any non-tmpfs mount under /proc or /sys
+            if (mtype != "tmpfs" && (boost::starts_with(ptr->mnt_dir, "/proc") || boost::starts_with(ptr->mnt_dir, "/sys"))) {
                 continue;
             }
 

--- a/lib/tests/facts/linux/filesystem_resolver.cc
+++ b/lib/tests/facts/linux/filesystem_resolver.cc
@@ -1,8 +1,14 @@
 #include <catch.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/map_value.hpp>
+#include <facter/facts/scalar_value.hpp>
 #include <internal/facts/linux/filesystem_resolver.hpp>
+#include "../../collection_fixture.hpp"
+#include <sstream>
 
 using namespace std;
 using namespace facter::facts::linux;
+using namespace facter::testing;
 
 SCENARIO("blkid output with non-printable ASCII characters") {
     REQUIRE(filesystem_resolver::safe_convert("") == "");
@@ -10,4 +16,26 @@ SCENARIO("blkid output with non-printable ASCII characters") {
     REQUIRE(filesystem_resolver::safe_convert("\"hello\"") == "\\\"hello\\\"");
     REQUIRE(filesystem_resolver::safe_convert("\\hello\\") == "\\\\hello\\\\");
     REQUIRE(filesystem_resolver::safe_convert("i am \xE0\xB2\xA0\x5F\xE0\xB2\xA0") == "i am M-`M-2M- _M-`M-2M- ");
+}
+
+SCENARIO("using the filesystem resolver") {
+  // Create fact struct to store results
+  collection_fixture facts;
+  WHEN("populating facts") {
+    // Add filesystem resolver
+    facts.add(make_shared<filesystem_resolver>());
+    THEN("filesystem, mountpoints, and partition facts should resolve") {
+      REQUIRE(facts.size() != 0u);
+      REQUIRE(facts.query<facter::facts::string_value>("filesystems"));
+      REQUIRE(facts.query<facter::facts::map_value>("mountpoints"));
+      REQUIRE(facts.query<facter::facts::map_value>("partitions"));
+    }
+    THEN("non-tmpfs proc and sys mounts should not exist") {
+      REQUIRE_FALSE(facts.query<facter::facts::map_value>("mountpoints./proc/"));
+      REQUIRE_FALSE(facts.query<facter::facts::map_value>("mountpoints./sys/"));
+    }
+    THEN("non-tmpfs mounts should exist") {
+      REQUIRE(facts.query<facter::facts::map_value>("mountpoints./"));
+    }
+  }
 }


### PR DESCRIPTION
While running puppet I noticed that overlayfs mountpoints are not being picked up by facter. Looking through the code it appears that only physical and tmpfs mounts are currently being loaded into the mountpoint facts (https://github.com/puppetlabs/facter/blob/master/lib/src/facts/linux/filesystem_resolver.cc#L79-L82).

 

For me, the expected return for the mountpoint facts are all mount points, not just physical or tmpfs mounts. It appears that others have a similar desire (FACT-1519). Is it possible to remove this check? It was necessary when the partition data was populated within the filesystem_resolver::collect_mountpoint_data function, but it has been since moved to a separate function and is no longer necessary. This was also the original suggestion for FACT-1418.