### PR TITLE
(maint) Fix build with GCC on FreeBSD

### DIFF
--- a/lib/inc/internal/util/freebsd/geom.hpp
+++ b/lib/inc/internal/util/freebsd/geom.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
We need to include stdexcept to build with GCC on FreeBSD.  Most architecture default to clang where the problem is not shown, but some tier-2 architectures are still built with GCC.

Reference:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=235601