### PR TITLE
(FACT-1914) Expose noop Facter.reset method in JRuby

### DIFF
--- a/lib/facter.rb.in
+++ b/lib/facter.rb.in
@@ -16,6 +16,10 @@ module Facter
       # No-op; we don't support custom facts under JRuby
     end
 
+    def self.reset()
+      # No-op; we treat facts as immutable under JRuby
+    end
+
     def self.version
       Java::ComPuppetlabs::Facter.lookup("facterversion")
     end


### PR DESCRIPTION
The PAL layer calls `Facter.reset`, so this method is needed for
compatibility with PAL. We leave it unimplemented, since facts are
treated as immutable in JRuby and custom facts are ignored.

If we ever do need to properly reset, we will need to figure out how
to properly implement thread safety and environment isolation for the
Facter java bindings.