### PR TITLE
(FACT-1916): fix route parsing on Linux

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -159,28 +159,14 @@ namespace facter { namespace facts { namespace linux {
                 return true;
             }
 
-            // remove trailing "onlink" or "pervasive" flags
-            while (parts.size() > 0) {
-                std::string last_token(parts.back().begin(), parts.back().end());
-                if (last_token == "onlink" || last_token == "pervasive")
-                    parts.pop_back();
-                else
-                    break;
-            }
-
-            size_t dst_idx = 0;
-            if (parts.size() % 2 == 0) {
-                std::string route_type(parts[0].begin(), parts[0].end());
-                if (known_route_types.find(route_type) == known_route_types.end()) {
-                    LOG_WARNING("Could not process routing table entry: Expected a destination followed by key/value pairs, got '{1}'", line);
-                    return true;
-                } else {
-                    dst_idx = 1;
-                }
+            // FACT-1282
+            std::string route_type(parts[0].begin(), parts[0].end());
+            if (known_route_types.find(route_type) != known_route_types.end()) {
+                parts.erase(parts.begin());
             }
 
             route r;
-            r.destination.assign(parts[dst_idx].begin(), parts[dst_idx].end());
+            r.destination.assign(parts[0].begin(), parts[0].end());
 
             // Check if we queried for the IPV6 routing tables. If yes, then check if our
             // destination address is missing a ':'. If yes, then IPV6 is disabled since
@@ -195,7 +181,7 @@ namespace facter { namespace facts { namespace linux {
 
             // Iterate over key/value pairs and add the ones we care
             // about to our routes entries
-            for (size_t i = dst_idx+1; i < parts.size(); i += 2) {
+            for (size_t i = 1; i < parts.size(); i += 2) {
                 std::string key(parts[i].begin(), parts[i].end());
                 if (key == "dev") {
                     r.interface.assign(parts[i+1].begin(), parts[i+1].end());


### PR DESCRIPTION
This PR removes the assumption that all values in the output of
`ip route show` includes a key value pairs.  #1283 first introduced this
assumption fixing where the `ip` command will optionally show the route type.  

This PR also removes the patch for FACT-1405 introduced
in #1372 as it is no longer needed.  

one could further remove the code from #1464 to address FACT-1394 
as that seems to be caused by the same issue, however i have left that 
in as one dosen't need to parse linkdown routes.

Currently the known cases of values which are not key value pairs are
 * flags: linkdown, pervasive, onlink
 * parameters with optional values:  mtu [lock] value

 We could add something like the following to the loop at
https://github.com/puppetlabs/facter/blob/master/lib/src/facts/linux/networking_resolver.cc#L198
however this may be overkill as the flags and mtu always come after the
`dev` and `src` parameters.

```c++
unordered_set<string> route_flags {
  "linkdown",
  "pervasive",
  "onlink"
}
size_t step = 2;
for (size_t i = dst_idx+1; i < parts.size(); i += step) {
    std::string key(parts[i].begin(), parts[i].end());
    std::string value(parts[i+1].begin(), parts[i+1].end());
    step = 2;
    if route_flags.find(key) {
      step = 1;
      continue;
    } else if (key == "mtu" and value == "lock"){
      step = 3;
      continue;
    }
    if (key == "dev") {
        r.interface.assign(value);
    }
    if (key == "src") {
        r.source.assign(value);
    }
}
```

I also wonder if its worth always passing `-d` to `ip route show` to
ensure the route_type is always included but i'm unsure if that flag is
available on all linux