### PR TITLE
[FACT-1881] Include additional OS release facts for Windows 10

### DIFF
--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -427,6 +427,26 @@ namespace facter { namespace facts {
         constexpr static char const* macosx_productversion_minor = "macosx_productversion_minor";
 
         /**
+        * The fact for Windows to specify if is Server or Desktop Edition variant 
+        */
+        constexpr static char const* windows_edition_id = "windows_edition_id";
+
+        /**
+        * The fact for Windows to differentiate Server, Server Core, Client (Desktop)
+        */
+        constexpr static char const* windows_installation_type = "windows_installation_type";
+
+        /**
+        * The fact for Windows textual product name
+        */
+        constexpr static char const* windows_product_name = "windows_product_name";
+
+        /**
+         * The fact for Windows Build Version.
+         */
+        constexpr static char const* windows_release_id = "windows_release_id";
+
+        /**
          * The fact for Windows native system32 directory.
          */
         constexpr static char const* windows_system32 = "system32";

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -85,6 +85,22 @@ namespace facter { namespace facts { namespace resolvers {
         struct windows
         {
             /**
+             * Stores the Windows Server or Desktop Edition variant 
+             */
+            std::string edition_id;
+            /**
+             * Stores the Windows differentiate Server, Server Core, Client (Desktop)
+             */
+            std::string installation_type;
+            /**
+             * Stores the Windows textual product name
+             */
+            std::string product_name;
+            /**
+             * Stores the Windows Build Version.
+             */
+            std::string release_id;
+            /**
              * Stores the native system32 directory, the location native OS executables can be found.
              * For 32-bit facter on 32-bit Windows, typically: 'C:\\Windows\\system32'.
              * For 32-bit facter on 64-bit Windows, typically: 'C:\\Windows\\sysnative'.

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1202,6 +1202,18 @@ os:
             type: map
             description: Represents information about Windows.
             elements:
+                edition_id:
+                    type: string
+                    description: Specify the edition variant. (ServerStandard|Professional|Enterprise)
+                installation_type:
+                    type: string
+                    description: Specify the installation type. (Server|Server Core|Client)
+                product_name:
+                    type: string
+                    description: Specify the textual product name.
+                release_id:
+                    type: string
+                    description: Windows Build Version of the form YYMM.
                 system32:
                     type: string
                     description: The path to the System32 directory.
@@ -1631,6 +1643,34 @@ swapsize_mb:
         Linux: parse the contents of `/proc/meminfo` to retrieve the total swap memory.
         Mac OSX: use the `sysctl` function to retrieve the total swap memory.
         Solaris: use the `swapctl` function to retrieve the total swap memory.
+
+windows_edition_id:
+    type: string
+    hidden: true
+    description: Return the type of Windows edition, Server or Desktop Edition variant.
+    resolution: |
+        Windows: query the registry to retrieve the type of edition (ServerStandard|Professional|Enterprise).
+
+windows_installation_type:
+    type: string
+    hidden: true
+    description: Return Windows installation type (Server|Server Core|Client).
+    resolution: |
+        Windows: query the registry to retrive data to differentiate Server, Server Core, Client.
+
+windows_product_name:
+    type: string
+    hidden: true
+    description: Return Windows textual product name.
+    resolution: |
+        Windows: uery the registry to retrive textual product name.
+
+windows_release_id:
+    type: string
+    hidden: true
+    description: Return Windows Build Version of the form YYMM.
+    resolution: |
+        Windows: query the registry to retrieve the build version number.
 
 system32:
     type: string

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -36,6 +36,10 @@ namespace facter { namespace facts { namespace resolvers {
                 fact::macosx_productversion,
                 fact::macosx_productversion_major,
                 fact::macosx_productversion_minor,
+                fact::windows_edition_id,
+                fact::windows_installation_type,
+                fact::windows_product_name,
+                fact::windows_release_id,
                 fact::windows_system32,
                 fact::selinux,
                 fact::selinux_enforced,
@@ -186,6 +190,26 @@ namespace facter { namespace facts { namespace resolvers {
 
         // Populate Windows-specific data
         auto windows = make_value<map_value>();
+        if (!data.win.edition_id.empty()) {
+            facts.add(fact::windows_edition_id, make_value<string_value>(data.win.edition_id, true));
+            windows->add("edition_id", make_value<string_value>(move(data.win.edition_id)));
+        }
+
+        if (!data.win.installation_type.empty()) {
+            facts.add(fact::windows_installation_type, make_value<string_value>(data.win.installation_type, true));
+            windows->add("installation_type", make_value<string_value>(move(data.win.installation_type)));
+        }
+
+        if (!data.win.product_name.empty()) {
+            facts.add(fact::windows_product_name, make_value<string_value>(data.win.product_name, true));
+            windows->add("product_name", make_value<string_value>(move(data.win.product_name)));
+        }
+
+        if (!data.win.release_id.empty()) {
+            facts.add(fact::windows_release_id, make_value<string_value>(data.win.release_id, true));
+            windows->add("release_id", make_value<string_value>(move(data.win.release_id)));
+        }
+
         if (!data.win.system32.empty()) {
             facts.add(fact::windows_system32, make_value<string_value>(data.win.system32, true));
             windows->add("system32", make_value<string_value>(move(data.win.system32)));

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -1,4 +1,5 @@
 #include <internal/facts/windows/operating_system_resolver.hpp>
+#include <leatherman/windows/registry.hpp>
 #include <leatherman/windows/system_error.hpp>
 #include <leatherman/windows/wmi.hpp>
 #include <leatherman/windows/windows.hpp>
@@ -76,6 +77,55 @@ namespace facter { namespace facts { namespace windows {
         }
     }
 
+    static string get_release_id()
+    {
+        string releaseID;
+        try {
+            releaseID = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "ReleaseId");
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting ReleaseId: {1}", e.what());
+        }
+        return releaseID;
+    }
+
+    static string get_edition_id()
+    {
+        string editionID;
+        try {
+            editionID = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "EditionID");
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting EditionID: {1}", e.what());
+        }
+        return editionID;
+    }
+
+    static string get_installation_type()
+    {
+        string installation_type;
+        try {
+            installation_type = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "InstallationType");
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting InstallationType: {1}", e.what());
+        }
+        return installation_type;
+    }
+
+    static string get_product_name()
+    {
+        string product_name;
+        try {
+            product_name = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "ProductName");
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting ProductName: {1}", e.what());
+        }
+        return product_name;
+    }
+
+
     operating_system_resolver::operating_system_resolver(shared_ptr<wmi> wmi_conn) :
         resolvers::operating_system_resolver(),
         _wmi(move(wmi_conn))
@@ -91,6 +141,10 @@ namespace facter { namespace facts { namespace windows {
         result.hardware = get_hardware();
         result.architecture = get_architecture(result.hardware);
         result.win.system32 = get_system32();
+        result.win.release_id = get_release_id();
+        result.win.edition_id = get_edition_id();
+        result.win.installation_type = get_installation_type();
+        result.win.product_name = get_product_name();
 
         auto lastDot = result.release.rfind('.');
         if (lastDot == string::npos) {

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -37,6 +37,10 @@ struct test_os_resolver : operating_system_resolver
         result.osx.product = "Mac OS X";
         result.osx.build = "14A388b";
         result.osx.version = "10.10";
+        result.win.release_id = "1904";
+        result.win.edition_id = "ServerStandard";
+        result.win.installation_type = "Server";
+        result.win.product_name = "Windows 2019 Standard Edition";
         result.win.system32 = "C:\\WINDOWS\\sysnative";
         result.architecture = "amd64";
         result.hardware = "x86-64";
@@ -61,7 +65,7 @@ SCENARIO("using the operating system resolver") {
     }
     WHEN("data is present") {
         facts.add(make_shared<test_os_resolver>());
-        REQUIRE(facts.size() == 26u);
+        REQUIRE(facts.size() == 30u);
         THEN("a structured fact is added") {
             auto os = facts.get<map_value>(fact::os);
             REQUIRE(os);
@@ -140,7 +144,19 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(minor->value() == "0");
             auto windows = os->get<map_value>("windows");
             REQUIRE(windows);
-            REQUIRE(windows->size() == 1u);
+            REQUIRE(windows->size() == 5u);
+            auto edition_id = facts.get<string_value>(fact::windows_edition_id);
+            REQUIRE(edition_id);
+            REQUIRE(edition_id->value() == "ServerStandard");
+            auto installation_type = facts.get<string_value>(fact::windows_installation_type);
+            REQUIRE(installation_type);
+            REQUIRE(installation_type->value() == "Server");
+            auto product_name = facts.get<string_value>(fact::windows_product_name);
+            REQUIRE(product_name);
+            REQUIRE(product_name->value() == "Windows 2019 Standard Edition");
+            auto release_id = facts.get<string_value>(fact::windows_release_id);
+            REQUIRE(release_id);
+            REQUIRE(release_id->value() == "1904");
             auto system32 = windows->get<string_value>("system32");
             REQUIRE(system32);
             REQUIRE(system32->value() == "C:\\WINDOWS\\sysnative");
@@ -221,6 +237,18 @@ SCENARIO("using the operating system resolver") {
             minor = facts.get<string_value>(fact::macosx_productversion_minor);
             REQUIRE(minor);
             REQUIRE(minor->value() == "0");
+            auto edition_id = facts.get<string_value>(fact::windows_edition_id);
+            REQUIRE(edition_id);
+            REQUIRE(edition_id->value() == "ServerStandard");
+            auto installation_type = facts.get<string_value>(fact::windows_installation_type);
+            REQUIRE(installation_type);
+            REQUIRE(installation_type->value() == "Server");
+            auto product_name = facts.get<string_value>(fact::windows_product_name);
+            REQUIRE(product_name);
+            REQUIRE(product_name->value() == "Windows 2019 Standard Edition");
+            auto release_id = facts.get<string_value>(fact::windows_release_id);
+            REQUIRE(release_id);
+            REQUIRE(release_id->value() == "1904");
             auto system32 = facts.get<string_value>(fact::windows_system32);
             REQUIRE(system32);
             REQUIRE(system32->value() == "C:\\WINDOWS\\sysnative");

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -268,6 +268,10 @@ struct operating_system_resolver : resolvers::operating_system_resolver
         result.osx.product = "product";
         result.osx.build = "build";
         result.osx.version = "10.10";
+        result.win.release_id = "1904";
+        result.win.edition_id = "ServerStandard";
+        result.win.installation_type = "Server";
+        result.win.product_name = "Windows 2019 Standard Edition";
         result.win.system32 = "system32";
         result.architecture = "arch";
         result.hardware = "hardware";


### PR DESCRIPTION
Facter adds the Build Number for Windows 10/2016+ (ReleaseID and also returns some other attributes from this key as follows:

- ReleaseID - The 4 digit Windows Build Version of the form YYMM
- InstallationType - Differentiates Server, Server Core, Client (Desktop), e.g. (Server|Server Core|Client )
- EditionID - Server or Desktop Edition variant - (ServerStandard|Professional|Enterprise)
- ProductName - Textual Product Name