### PR TITLE
(FACT-1918) Use more permissive ruby binding for facter gem

### DIFF
--- a/lib/gemspec.in
+++ b/lib/gemspec.in
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Facter, a system inventory tool"
   s.specification_version = 3
-  s.required_ruby_version = '~> 2.1.7'
+  s.required_ruby_version = '~> 2.1'
 
 end


### PR DESCRIPTION
Puppet-agent starting with 5.0.0 use ruby >= 2.4.1, so we need to update
the binding to work with newer rubies.