### PR TITLE
Add "anycast" to known_route_types

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -138,6 +138,7 @@ namespace facter { namespace facts { namespace linux {
         }
 
         unordered_set<string> known_route_types {
+            "anycast",
             "unicast",
             "broadcast",
             "local",


### PR DESCRIPTION
Without this facter would fail to correctly parse anycast routes.