### PR TITLE
(FACT-1930) Relax ffi dependency for Windows Ruby 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,12 @@ mingw << :x64_mingw if Bundler::Dsl::VALID_PLATFORMS.include?(:x64_mingw)
 platform(*mingw) do
   # FFI dropped 1.9.3 support in 1.9.16, and 1.9.15 was an incomplete release.
   # 1.9.18 is required to support Ruby 2.4
-  if RUBY_VERSION < '2.0.0'
+  if RUBY_VERSION.to_f < 2.0
     gem 'ffi', '<= 1.9.14', :require => false
-  else
+  elsif RUBY_VERSION.to_f < 2.6
     gem 'ffi', '~> 1.9.18', :require => false
+  else
+    gem 'ffi', '~> 1.10', :require => false
   end
 end
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -19,10 +19,10 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.5'
+      ffi: '~> 1.9'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: '~> 1.9.5'
+      ffi: '~> 1.9'
 bundle_platforms:
   universal-darwin: ruby
   x86-mingw32: mingw


### PR DESCRIPTION
Ruby facter cannot be installed on Windows Ruby 2.6 because it is pinned to
ffi 1.9.x, and ffi didn't add ruby 2.6 support until 1.10.

Update the Gemfile to require ffi 1.10 or greater, but less than 2. The Gemfile
is used when running facter from source. Also use `to_f` when comparing version
numbers to avoid issues like "10" < "2".

Update `project_data.yaml` to >= 1.9, < 2 for all ruby versions on Windows.
This is used when building facter as a gem.