### PR TITLE
(maint) Fix gcc 8 compilation

### DIFF
--- a/lib/src/facts/linux/networking_resolver.cc
+++ b/lib/src/facts/linux/networking_resolver.cc
@@ -88,7 +88,7 @@ namespace facter { namespace facts { namespace linux {
         // Nothing useful for us, so we need to use ioctl to query the MTU
         ifreq req;
         memset(&req, 0, sizeof(req));
-        strncpy(req.ifr_name, interface.c_str(), sizeof(req.ifr_name));
+        strncpy(req.ifr_name, interface.c_str(), sizeof(req.ifr_name) - 1);
 
         scoped_descriptor sock(socket(AF_INET, SOCK_DGRAM, 0));
         if (static_cast<int>(sock) < 0) {

--- a/lib/tests/facts/array_value.cc
+++ b/lib/tests/facts/array_value.cc
@@ -21,7 +21,7 @@ SCENARIO("using an array fact value") {
     }
     GIVEN("an out of range index") {
         THEN("get() raises out_of_range") {
-            REQUIRE_THROWS_AS(value.get<string_value>(0), std::out_of_range);
+            REQUIRE_THROWS_AS(value.get<string_value>(0), std::out_of_range&);
         }
         THEN("operator[] returns nullptr") {
             REQUIRE_FALSE(value[42]);

--- a/lib/tests/facts/external/json_resolver.cc
+++ b/lib/tests/facts/external/json_resolver.cc
@@ -28,12 +28,12 @@ SCENARIO("resolving external JSON facts") {
     }
     GIVEN("a non-existent file to resolve") {
         THEN("it should throw an exception") {
-            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.json", facts), external_fact_exception);
+            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.json", facts), external_fact_exception&);
         }
     }
     GIVEN("invalid JSON") {
         THEN("it should throw an exception") {
-            REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/json/invalid.json", facts), external_fact_exception);
+            REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/json/invalid.json", facts), external_fact_exception&);
         }
     }
     GIVEN("valid JSON") {

--- a/lib/tests/facts/external/posix/execution_resolver.cc
+++ b/lib/tests/facts/external/posix/execution_resolver.cc
@@ -27,7 +27,7 @@ SCENARIO("resolving external executable facts") {
     GIVEN("an executable file") {
         WHEN("the execution fails") {
             THEN("an exception is thrown") {
-                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/failed", facts), external_fact_exception);
+                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/posix/execution/failed", facts), external_fact_exception&);
             }
         }
         WHEN("the execution succeeds") {

--- a/lib/tests/facts/external/text_resolver.cc
+++ b/lib/tests/facts/external/text_resolver.cc
@@ -26,7 +26,7 @@ SCENARIO("resolving external text facts") {
     }
     GIVEN("a non-existent file to resolve") {
         THEN("it should throw an exception") {
-            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.txt", facts), external_fact_exception);
+            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.txt", facts), external_fact_exception&);
         }
     }
     GIVEN("a text file to resolve") {

--- a/lib/tests/facts/external/windows/execution_resolver.cc
+++ b/lib/tests/facts/external/windows/execution_resolver.cc
@@ -27,7 +27,7 @@ SCENARIO("resolving external executable facts") {
     GIVEN("an executable file") {
         WHEN("the execution fails") {
             THEN("an exception is thrown") {
-                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/failed.cmd", facts), external_fact_exception);
+                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/execution/failed.cmd", facts), external_fact_exception&);
             }
         }
         WHEN("the execution succeeds") {

--- a/lib/tests/facts/external/windows/powershell_resolver.cc
+++ b/lib/tests/facts/external/windows/powershell_resolver.cc
@@ -28,7 +28,7 @@ SCENARIO("resolving external powershell facts") {
     GIVEN("a powershell file") {
         WHEN("the execution fails") {
             THEN("an exception is thrown") {
-                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/powershell/failed.ps1", facts), external_fact_exception);
+                REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/windows/powershell/failed.ps1", facts), external_fact_exception&);
             }
         }
         WHEN("the execution succeeds") {

--- a/lib/tests/facts/external/yaml_resolver.cc
+++ b/lib/tests/facts/external/yaml_resolver.cc
@@ -28,12 +28,12 @@ SCENARIO("resolving external YAML facts") {
     }
     GIVEN("a non-existent file to resolve") {
         THEN("it should throw an exception") {
-            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.yaml", facts), external_fact_exception);
+            REQUIRE_THROWS_AS(resolver.resolve("doesnotexist.yaml", facts), external_fact_exception&);
         }
     }
     GIVEN("invalid YAML") {
         THEN("it should throw an exception") {
-            REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/yaml/invalid.yaml", facts), external_fact_exception);
+            REQUIRE_THROWS_AS(resolver.resolve(LIBFACTER_TESTS_DIRECTORY "/fixtures/facts/external/yaml/invalid.yaml", facts), external_fact_exception&);
         }
     }
     GIVEN("valid YAML") {


### PR DESCRIPTION
This commit fixes GCC 8-enforced stringop-truncation and catching polymorphic type by value warnings, which are treated as errors and cause compilation to fail.