### PR TITLE
Revert "(FACT-1810) Fix open timeout for fetching ec2 metadata"

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -25,7 +25,7 @@ module Facter
         attempts = 0
 
         begin
-          open(@baseurl, :proxy => nil, :read_timeout => timeout, :open_timeout => timeout).read
+          open(@baseurl, :proxy => nil, :read_timeout => timeout).read
           able_to_connect = true
         rescue OpenURI::HTTPError => e
           if e.message.match /404 Not Found/i


### PR DESCRIPTION
Confining open_timeout for the AWS metadata service seems to break the AWS fact. Reverting 