### PR TITLE
(maint) Facter reports wrong minor version for Debian 10

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -137,7 +137,7 @@ module Facter
 
       # Debian
       def debian_expected_facts(agent)
-        version = agent['platform'].match(/debian-(\d)/)
+        version = agent['platform'].match(/debian-(\d{1,2})/)
         if version.nil?
           os_version = /\d+/
         else
@@ -154,7 +154,7 @@ module Facter
         expected_facts = {
             'os.architecture'          => os_arch,
             'os.distro.codename'       => /\w+/,
-            'os.distro.description'    => /Debian GNU\/Linux #{os_version}\.\d/,
+            'os.distro.description'    => /Debian GNU\/Linux #{os_version}(\.\d)?/,
             'os.distro.id'             => 'Debian',
             'os.distro.release.full'   => /#{os_version}\.\d+/,
             'os.distro.release.major'  => os_version,

--- a/lib/src/facts/linux/operating_system_resolver.cc
+++ b/lib/src/facts/linux/operating_system_resolver.cc
@@ -144,6 +144,9 @@ namespace facter { namespace facts { namespace linux {
 
         auto release = implementation->get_release(result.name, result.distro.release);
         if (!release.empty()) {
+            if (result.name == os::debian) {  // on debian 10 final iso, versions from lsb_release and /etc/debian_version are different
+                result.distro.release = release;
+            }
             result.release = move(release);
             tie(result.major, result.minor) = implementation->parse_release(result.name, result.release);
         }


### PR DESCRIPTION
Use /etc/debian_version for release major minor instead of lsb_release starting with Debian 10