### PR TITLE
(FACT-1935) facter ipaddress6 without interface id

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -73,4 +73,21 @@ test_name 'C59029: networking facts should be fully populated' do
       end
     end
   end
+
+  # Verify that IP Address v6 and network v6 is retrieved correctly and does not contain the interface identifier
+  agents.each do |agent|
+    if agent['platform'] =~ /windows/
+      step("verify that ipaddress6 is retrieved correctly") do
+        on(agent, facter("ipaddress6")) do |facter_result|
+          assert_match(/^[a-fA-F0-9:]+$/, facter_result.stdout.chomp)
+        end
+      end
+
+      step("verify that network6 is retrieved correctly") do
+        on(agent, facter("network6")) do |facter_result|
+          assert_match(/([a-fA-F0-9:]+)?:([a-fA-F0-9:]+)?$/, facter_result.stdout.chomp)
+        end
+      end
+    end
+  end
 end

--- a/lib/src/facts/windows/networking_resolver.cc
+++ b/lib/src/facts/windows/networking_resolver.cc
@@ -172,7 +172,9 @@ namespace facter { namespace facts { namespace windows {
                     bool ipv6 = it->Address.lpSockaddr->sa_family == AF_INET6;
 
                     binding b;
-                    b.address = addr;
+
+                    // IpAddress6 contains interface identifier, and should be removed when returning the ipaddress6
+                    b.address = ipv6 ? addr.substr(0, addr.find('%')) : addr;
 
                     // Need to do lookup based on the structure length.
                     auto adapterAddr = reinterpret_cast<IP_ADAPTER_UNICAST_ADDRESS_LH&>(*it);
@@ -181,6 +183,8 @@ namespace facter { namespace facts { namespace windows {
                         auto masked = mask_ipv6_address(it->Address.lpSockaddr, mask);
                         b.netmask = winsock.address_to_string(mask);
                         b.network = winsock.address_to_string(masked);
+                    // Network6 also contains the interface identifier, so it should be removed
+                        b.network = b.network.substr(0, b.network.find('%'));
                     } else {
                         auto mask = create_ipv4_mask(adapterAddr.OnLinkPrefixLength);
                         auto masked = mask_ipv4_address(it->Address.lpSockaddr, mask);


### PR DESCRIPTION
Prior to this fix, when "facter ipaddress6" was run on windows servers,
it returned the ipv6 and the interface identifier.
Now it correctly returns only the ipaddress without the interface id.