### PR TITLE
(FACT-1968) unpin rake dependency for tests

### DIFF
--- a/lib/Gemfile
+++ b/lib/Gemfile
@@ -1,9 +1,9 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :test do
-    gem 'rake', "~> 10.1.0"
-    gem 'rspec', "~> 2.11.0"
-    gem 'mocha', "~> 0.10.5"
+    gem 'rake'
+    gem 'rspec'
+    gem 'mocha'
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
Currently rake is pinned to version 10, which is quite old. This PR
unpins it so it works with the latest ruby version.