### PR TITLE
(FACT-1978) support major only release version for amazon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
   email: false
 rvm:
   - 1.9.3
-  - 1.8.7-p374
   - 2.0.0
   - 2.1.5
   - 2.2.0
@@ -15,3 +14,5 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
+git:
+  depth: false

--- a/lib/facter/operatingsystem/linux.rb
+++ b/lib/facter/operatingsystem/linux.rb
@@ -389,7 +389,7 @@ module Facter
           lsbdistrelease
         else
           if release = Facter::Util::FileRead.read('/etc/system-release')
-            if match = /\d+\.\d+/.match(release)
+            if match = /\d+\.?\d*/.match(release)
               match[0]
             end
           end

--- a/spec/unit/operatingsystem/linux_spec.rb
+++ b/spec/unit/operatingsystem/linux_spec.rb
@@ -278,6 +278,15 @@ describe Facter::Operatingsystem::Linux do
       expect(release).to eq "2014.03"
     end
 
+    it "should parse major release only from /etc/system-release" do
+      subject.expects(:get_operatingsystem).returns("Amazon")
+      subject.expects(:get_lsbdistrelease).returns(nil)
+      Facter::Util::FileRead.expects(:read).with('/etc/system-release').returns("Amazon Linux release 2 (Karoo)")
+      release = subject.get_operatingsystemrelease
+      expect(release).to eq "2"
+    end
+
+    
     it "should fall back to kernelrelease fact for gnu/kfreebsd" do
       Facter.fact(:kernelrelease).stubs(:value).returns("1.2.3")
       subject.expects(:get_operatingsystem).returns("GNU/kFreeBSD")


### PR DESCRIPTION
Support for recent AMI versions of Amazon Linux 2 where /etc/system-release contains only the major version
`Amazon Linux release 2 (Karoo)`



