### PR TITLE
(FACT-1919) Make the EC2 HTTP session timeout configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,19 @@ enable_cppcheck()
 # Pull in helper macros for working with leatherman libraries
 include(leatherman)
 
+set(CMAKE_REQUIRED_LIBRARIES ${LEATHERMAN_LIBRARIES})
+CHECK_CXX_SOURCE_COMPILES("
+#include <leatherman/util/environment.hpp>
+int main() {
+    int a = leatherman::util::environment::get_int(\"A\", 1000);
+    return 0;
+}
+" HAS_LTH_GET_INT)
+
+if (HAS_LTH_GET_INT)
+    add_definitions(-DHAS_LTH_GET_INT)
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(exe)
 add_subdirectory(locales)

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -35,7 +35,11 @@ namespace facter { namespace facts { namespace resolvers {
     static const char* EC2_METADATA_ROOT_URL = "http://169.254.169.254/latest/meta-data/";
     static const char* EC2_USERDATA_ROOT_URL = "http://169.254.169.254/latest/user-data/";
     static const unsigned int EC2_CONNECTION_TIMEOUT = 600;
+#ifdef HAS_LTH_GET_INT
     static const unsigned int EC2_SESSION_TIMEOUT = environment::get_int("EC2_SESSION_TIMEOUT", 5000);
+#else
+    static const unsigned int EC2_SESSION_TIMEOUT = 5000;
+#endif
 
     static void query_metadata_value(lth_curl::client& cli, map_value& value, string const& url, string const& name, string const& http_langs)
     {

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -5,6 +5,7 @@
 #include <facter/facts/fact.hpp>
 #include <facter/facts/vm.hpp>
 #include <facter/util/string.hpp>
+#include <leatherman/util/environment.hpp>
 #include <leatherman/util/regex.hpp>
 #include <leatherman/logging/logging.hpp>
 #include <boost/algorithm/string.hpp>
@@ -34,7 +35,7 @@ namespace facter { namespace facts { namespace resolvers {
     static const char* EC2_METADATA_ROOT_URL = "http://169.254.169.254/latest/meta-data/";
     static const char* EC2_USERDATA_ROOT_URL = "http://169.254.169.254/latest/user-data/";
     static const unsigned int EC2_CONNECTION_TIMEOUT = 600;
-    static const unsigned int EC2_SESSION_TIMEOUT = 5000;
+    static const unsigned int EC2_SESSION_TIMEOUT = environment::get_int("EC2_SESSION_TIMEOUT", 5000);
 
     static void query_metadata_value(lth_curl::client& cli, map_value& value, string const& url, string const& name, string const& http_langs)
     {


### PR DESCRIPTION
Make the EC2 session timeout configurable through an user-set environment variable (EC2_SESSION_TIMEOUT).

If the variable is unset or is not in integer format, Facter will default it to 5000 (5 seconds).

Depends on https://github.com/puppetlabs/leatherman/pull/301.