### PR TITLE
(maint) Bump leatherman on Travis and AppVeyor to 1.6.1 (3.13.x) [no-promote]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 
 env:
   global:
-    - LEATHERMAN_VERSION=1.4.4
+    - LEATHERMAN_VERSION=1.6.1
     - CPPHOCON_VERSION=0.1.8
   matrix:
     - TARGET=cpplint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 3.1.0.{build}
 clone_depth: 10
 environment:
-  LEATHERMAN_VERSION: 1.4.4
+  LEATHERMAN_VERSION: 1.6.1
   CPPHOCON_VERSION: 0.1.8
 
 init:


### PR DESCRIPTION
Facter 3.13.x tracks Leatherman 1.6.x. We should build against the proper streams.