### PR TITLE
(FACT-1992) Skip over autofs mountpoints

### DIFF
--- a/lib/src/facts/linux/filesystem_resolver.cc
+++ b/lib/src/facts/linux/filesystem_resolver.cc
@@ -83,6 +83,11 @@ namespace facter { namespace facts { namespace linux {
                 continue;
             }
 
+            // Skip over automounts
+            if (mtype == "autofs") {
+                continue;
+            }
+
             // If the "root" device, lookup the actual device from the kernel options
             // This is done because not all systems symlink /dev/root
             if (device == "/dev/root") {


### PR DESCRIPTION
When Facter stats a mountpoint to get the size and available space, it
causes mountpoints of type `autofs` to be automatically mounted, which
is not the intended behavior.

This commit makes Facter skip `autofs` when resolving mountpoints.