### PR TITLE
(FACT-2018) Update GCE metadata endpoint

### DIFF
--- a/lib/src/facts/resolvers/gce_resolver.cc
+++ b/lib/src/facts/resolvers/gce_resolver.cc
@@ -240,7 +240,8 @@ namespace facter { namespace facts { namespace resolvers {
 
         try
         {
-            lth_curl::request req("http://metadata.google.internal/computeMetadata/v1beta1/?recursive=true&alt=json");
+            lth_curl::request req("http://metadata.google.internal/computeMetadata/v1/?recursive=true&alt=json");
+            req.add_header("Metadata-Flavor", "Google");
             req.connection_timeout(GCE_CONNECTION_TIMEOUT);
             req.timeout(GCE_SESSION_TIMEOUT);
             if (!http_langs().empty())


### PR DESCRIPTION
Google Compute Engine's internal metadata service will be deprecating the 'v1beta1' endpoint sometime before end of calendar year 2019. This commit updates the GCE resolver to use the 'v1' endpoint instead.

Using the 'v1' endpoint also requires setting a custom User-Agent header that was not necessary in the old 'v1beta1' endpoint.

For more details about GCE metadata, please see https://cloud.google.com/compute/docs/storing-retrieving-metadata