### PR TITLE
(FACT-2004) use also nm lease files for azure fact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install:
 script:
   - >
     docker run -v `pwd`:/facter gcr.io/cpp-projects/cpp-ci:1 /bin/bash -c "
+    apk add --no-cache openjdk8 &&
+    export JAVA_HOME=/usr/lib/jvm/default-jvm &&
     wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman-dynamic.tar.gz &&
     tar xzvf leatherman-dynamic.tar.gz --strip 1 -C / &&
     wget https://github.com/puppetlabs/cpp-hocon/releases/download/${CPPHOCON_VERSION}/cpp-hocon-dynamic.tar.gz &&

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -283,10 +283,10 @@ if (JRUBY_SUPPORT)
     # JDK versions after 9 don't provide javah. Use javac in these cases
 
     if(Java_VERSION VERSION_LESS "10")
-	    set(JAVAH_COMMAND javah)
+	    set(JAVAH_COMMAND ${Java_JAVAH_EXECUTABLE})
 	    set(JAVAH_ARG -classpath facter.jar -d "${CMAKE_CURRENT_LIST_DIR}/src/java" com.puppetlabs.Facter)
     else()
-	    set(JAVAH_COMMAND javac)
+	    set(JAVAH_COMMAND ${Java_JAVAC_EXECUTABLE})
 	    set(JAVAH_ARG -h  "${CMAKE_CURRENT_LIST_DIR}/src/java" com/puppetlabs/Facter.java)
     endif()
 

--- a/lib/inc/internal/facts/linux/virtualization_resolver.hpp
+++ b/lib/inc/internal/facts/linux/virtualization_resolver.hpp
@@ -30,11 +30,16 @@ namespace facter { namespace facts { namespace linux {
 
         /**
          * Gets whether the machine is running in Azure.
-         * @param facts The fact collection that is resolving facts.
-         * @param leases_file The location of where the leases file exists.
          * @return Returns "azure" if running on azure, otherwise an empty string.
          */
-        static std::string get_azure(collection& facts, std::string const& leases_file = "/var/lib/dhcp/dhclient.eth0.leases");
+        static std::string get_azure();
+
+        /**
+         * Checks whether the azure dhcp option (245) is present in leases_file file.
+         * @param leases_file The file containing leases information.
+         * @return Returns "azure" if found, otherwise an empty string.
+         */
+        static std::string get_azure_from_leases_file(std::string leases_file);
 
      private:
         static std::string get_cgroup_vm();

--- a/lib/tests/facts/linux/virtualization_resolver.cc
+++ b/lib/tests/facts/linux/virtualization_resolver.cc
@@ -12,35 +12,35 @@ using namespace facter::testing;
 
 struct peek_resolver : linux::virtualization_resolver
 {
-    using virtualization_resolver::get_azure;
+    using virtualization_resolver::get_azure_from_leases_file;
 };
 
 SCENARIO("azure") {
     collection_fixture facts;
 
     WHEN("leases file does not exist") {
-        auto result = peek_resolver::get_azure(facts, "does-not-exist");
+        auto result = peek_resolver::get_azure_from_leases_file("does-not-exist");
         THEN("azure is empty") {
             REQUIRE(result == "");
         }
     }
 
     WHEN("leases file contains 'option 245'") {
-        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure");
+        auto result = peek_resolver::get_azure_from_leases_file(string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure");
         THEN("it reports azure") {
             REQUIRE(result == "azure");
         }
     }
 
     WHEN("leases file contains 'option unknown-245'") {
-        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure-unknown");
+        auto result = peek_resolver::get_azure_from_leases_file(string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/azure-unknown");
         THEN("it reports azure") {
             REQUIRE(result == "azure");
         }
     }
 
     WHEN("leases file does not contain correct option") {
-        auto result = peek_resolver::get_azure(facts, string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/not-azure");
+        auto result = peek_resolver::get_azure_from_leases_file(string(LIBFACTER_TESTS_DIRECTORY) + "/fixtures/facts/linux/cloud/not-azure");
         THEN("it does not report azure") {
             REQUIRE(result == "");
         }


### PR DESCRIPTION
Beside /var/lib/dhcp/dhclient.eth0.leases, now facter will look for
azure specific dhcp option in all dhclient.*lease.* files from
/var/lib/dhcp and /var/lib/NetworkManager directories