### PR TITLE
(FACT-2072) Update the regex to get Infiniband MAC and IP address on CentOS 7.x platform

### DIFF
--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -161,7 +161,7 @@ module Facter::Util::IP
       output = Facter::Util::IP.ifconfig_interface(interface)
     when 'Linux'
       ifconfig_output = Facter::Util::IP.ifconfig_interface(interface)
-      if interface =~ /^ib.*/ then
+      if interface =~ /^ib/ then
         real_mac_address = get_infiniband_macaddress(interface)
         output = ifconfig_output.sub(%r{(?:ether|HWaddr|infiniband)\s+((\w{1,2}:){5,}\w{1,2})}, "HWaddr #{real_mac_address}")
       else

--- a/lib/facter/util/ip.rb
+++ b/lib/facter/util/ip.rb
@@ -161,9 +161,9 @@ module Facter::Util::IP
       output = Facter::Util::IP.ifconfig_interface(interface)
     when 'Linux'
       ifconfig_output = Facter::Util::IP.ifconfig_interface(interface)
-      if interface =~ /^ib/ then
+      if interface =~ /^ib.*/ then
         real_mac_address = get_infiniband_macaddress(interface)
-        output = ifconfig_output.sub(%r{(?:ether|HWaddr)\s+((\w{1,2}:){5,}\w{1,2})}, "HWaddr #{real_mac_address}")
+        output = ifconfig_output.sub(%r{(?:ether|HWaddr|infiniband)\s+((\w{1,2}:){5,}\w{1,2})}, "HWaddr #{real_mac_address}")
       else
         output = ifconfig_output
       end

--- a/spec/fixtures/unit/util/ip/linux_get_single_interface_ib0_centos7
+++ b/spec/fixtures/unit/util/ip/linux_get_single_interface_ib0_centos7
@@ -1,0 +1,8 @@
+ib0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 2044
+        inet 10.55.200.50  netmask 255.255.0.0  broadcast 10.55.255.255
+Infiniband hardware address can be incorrect! Please read BUGS section in ifconfig(8).
+        HWaddr 80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:6f:02:fe  txqueuelen 256  (InfiniBand)
+        RX packets 26603237  bytes 15921365732 (14.8 GiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 22735277  bytes 4196650455 (3.9 GiB)
+        TX errors 0  dropped 2 overruns 0  carrier 0  collisions 0

--- a/spec/fixtures/unit/util/ip/linux_ifconfig_ib0_centos7
+++ b/spec/fixtures/unit/util/ip/linux_ifconfig_ib0_centos7
@@ -1,0 +1,8 @@
+ib0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 2044
+        inet 10.55.200.50  netmask 255.255.0.0  broadcast 10.55.255.255
+Infiniband hardware address can be incorrect! Please read BUGS section in ifconfig(8).
+        infiniband 80:00:00:03:FE:80:00:00:00:00:00:00:00:00:00:00:00:00:00:00  txqueuelen 256  (InfiniBand)
+        RX packets 26603237  bytes 15921365732 (14.8 GiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 22735277  bytes 4196650455 (3.9 GiB)
+        TX errors 0  dropped 2 overruns 0  carrier 0  collisions 0

--- a/spec/unit/util/ip_spec.rb
+++ b/spec/unit/util/ip_spec.rb
@@ -176,6 +176,26 @@ describe Facter::Util::IP do
     Facter::Util::IP.get_single_interface_output("ib0").should == correct_ifconfig_interface
   end
 
+  it "should return correct macaddress information for infiniband on Linux CentOS 7" do
+    correct_ifconfig_interface = my_fixture_read("linux_get_single_interface_ib0_centos7")
+
+    Facter::Util::IP.expects(:get_single_interface_output).with("ib0").returns(correct_ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Linux")
+
+    Facter::Util::IP.get_interface_value("ib0", "macaddress").should == "80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:6f:02:fe"
+  end
+
+  it "should replace the incorrect macaddress with the correct macaddress in ifconfig for infiniband on Linux CentOS 7" do
+    ifconfig_interface = my_fixture_read("linux_ifconfig_ib0_centos7")
+    correct_ifconfig_interface = my_fixture_read("linux_get_single_interface_ib0_centos7")
+
+    Facter::Util::IP.expects(:get_infiniband_macaddress).with("ib0").returns("80:00:00:03:fe:80:00:00:00:00:00:00:00:11:75:00:00:6f:02:fe")
+    Facter::Util::IP.expects(:ifconfig_interface).with("ib0").returns(ifconfig_interface)
+    Facter.stubs(:value).with(:kernel).returns("Linux")
+
+    Facter::Util::IP.get_single_interface_output("ib0").should == correct_ifconfig_interface
+  end
+
   it "should return fake macaddress information for infiniband on Linux when neither sysfs or /sbin/ip are available" do
     ifconfig_interface = my_fixture_read("linux_ifconfig_ib0")
 


### PR DESCRIPTION
This pr updates the regular expression used to find and replace the mac address as shown by the ifconfig command.The ifconfig output changed on CentOS 7 platforms and the old regular expression did not work anymore. I've changed the conditional logic to look for ib* instead of just ib.