### PR TITLE
(FACT-2065) Add FIPS enabled fact for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,30 @@ enable_cppcheck()
 # Pull in helper macros for working with leatherman libraries
 include(leatherman)
 
+# Guard to make sure we don't compile what we don't have in Leatherman
+if (WIN32)
+    set(CMAKE_REQUIRED_INCLUDES ${LEATHERMAN_INCLUDE_DIRS})
+    set(CMAKE_REQUIRED_LIBRARIES ${LEATHERMAN_LIBRARIES})
+    set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+    CHECK_CXX_SOURCE_COMPILES("
+    #include \"leatherman/windows/registry.hpp\"
+
+    using namespace leatherman::windows;
+    int main() {
+		int test = 0;
+        try {
+            test = registry::get_registry_dword(registry::HKEY::LOCAL_MACHINE, \"RandomSubkey\", \"RandomValue\");
+        } catch (registry_exception &e) {
+            return test;
+        }
+    }
+    " HAS_LTH_GET_DWORD)
+
+    if (HAS_LTH_GET_DWORD)
+        add_definitions(-DHAS_LTH_GET_DWORD)
+    endif()
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(exe)
 add_subdirectory(locales)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -251,6 +251,12 @@ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         "src/util/config/windows/config.cc"
     )
 
+    if (HAS_LTH_GET_DWORD)
+        set(LIBFACTER_PLATFORM_SOURCES
+            ${LIBFACTER_PLATFORM_SOURCES}
+            "src/facts/windows/fips_resolver.cc"
+        )
+    endif()
     # The GetPerformanceInfo symbol has moved around a lot between Windows versions;
     # these options tie it to the backwards-compatible version.
     set(LIBFACTER_PLATFORM_LIBRARIES

--- a/lib/inc/internal/facts/windows/fips_resolver.hpp
+++ b/lib/inc/internal/facts/windows/fips_resolver.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Declares the Windows fips fact resolver.
+ */
+#pragma once
+
+#include "../resolvers/fips_resolver.hpp"
+
+namespace facter { namespace facts { namespace windows {
+
+    /**
+     * Responsible for resolving fips-related facts.
+     */
+    struct fips_resolver : resolvers::fips_resolver
+    {
+     protected:
+        /**
+         * The check consists of the following.
+         *   (1) Examining the contents of
+         *   HKEY_LOCAL_MACHINE/System/CurrentControlSet/Control/Lsa/FipsAlgorithmPolicy/Enabled
+         *
+         *   If it is 1 then fips mode is enabled.
+         */
+
+        /**
+         * Collects the resolver data.
+         * @param facts The fact collection that is resolving facts.
+         * @return Returns the resolver data.
+         */
+        virtual data collect_data(collection& facts) override;
+    };
+
+}}}  // namespace facter::facts::windows

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -374,6 +374,7 @@ fips_enabled:
     description: Return whether the platform is in FIPS mode
     resolution: |
         Linux: parse the contents of `/proc/sys/crypto/fips_enabled` which if non-zero indicates fips mode has been enabled.
+        Windows: check if key `HKEY_LOCAL_MACHINE/System/CurrentControlSet/Control/Lsa/FipsAlgorithmPolicy/Enabled` is 1 or 0
     caveats: |
         Linux: Limited to linux redhat family only
 

--- a/lib/src/facts/windows/collection.cc
+++ b/lib/src/facts/windows/collection.cc
@@ -5,6 +5,7 @@
 #include <internal/facts/external/execution_resolver.hpp>
 #include <internal/facts/external/windows/powershell_resolver.hpp>
 #include <internal/facts/windows/dmi_resolver.hpp>
+#include <internal/facts/windows/fips_resolver.hpp>
 #include <internal/facts/windows/identity_resolver.hpp>
 #include <internal/facts/windows/kernel_resolver.hpp>
 #include <internal/facts/windows/memory_resolver.hpp>
@@ -70,6 +71,9 @@ namespace facter { namespace facts {
 
     void collection::add_platform_facts()
     {
+#ifdef HAS_LTH_GET_DWORD
+        add(make_shared<windows::fips_resolver>());
+#endif
         add(make_shared<windows::identity_resolver>());
         add(make_shared<windows::kernel_resolver>());
         add(make_shared<windows::memory_resolver>());

--- a/lib/src/facts/windows/fips_resolver.cc
+++ b/lib/src/facts/windows/fips_resolver.cc
@@ -1,0 +1,31 @@
+#include <internal/facts/windows/fips_resolver.hpp>
+#include <leatherman/windows/registry.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <boost/lexical_cast.hpp>
+
+using namespace std;
+
+using boost::lexical_cast;
+using boost::bad_lexical_cast;
+using namespace leatherman::windows;
+
+namespace facter { namespace facts { namespace windows {
+
+    fips_resolver::data fips_resolver::collect_data(collection& facts)
+    {
+        data result;
+
+        // Set a safe default
+        result.is_fips_mode_enabled = false;
+        unsigned long enabled;
+        try {
+            enabled = registry::get_registry_dword(registry::HKEY::LOCAL_MACHINE,
+                "System\\CurrentControlSet\\Control\\Lsa\\FipsAlgorithmPolicy\\", "Enabled");
+            result.is_fips_mode_enabled = enabled != 0;
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting fips_mode: {1}", e.what());
+        }
+        return result;
+    }
+
+}}}  // namespace facter::facts::windows


### PR DESCRIPTION
This commit adds a `fips_enabled` fact for Windows. To get this information, Facter queries the
`HKEY_LOCAL_MACHINE/System/CurrentControlSet/Control/Lsa/FipsAlgorithmPolicy/Enabled`
registry key using Leatherman's `get_registry_dword` function.

A compile guard was also added to ensure we don't compile the file if we don't have the function in our Leatherman build.