### PR TITLE
(FACT-2102) Update GCE metadata endpoint for 2.x

### DIFF
--- a/lib/facter/gce/metadata.rb
+++ b/lib/facter/gce/metadata.rb
@@ -17,7 +17,7 @@ module Facter
         Timeout::Error,
       ]
 
-      METADATA_URL = "http://metadata/computeMetadata/v1beta1/?recursive=true&alt=json"
+      METADATA_URL = "http://metadata/computeMetadata/v1/?recursive=true&alt=json"
 
       def initialize(url = METADATA_URL)
         @url = url
@@ -45,7 +45,7 @@ module Facter
 
         begin
           Timeout.timeout(timeout) do
-            body = open(@url, :proxy => nil).read
+            body = open(@url, options={:proxy => nil, "Metadata-Flavor" => "Google"}).read
           end
         rescue *CONNECTION_ERRORS => e
           attempts = attempts + 1


### PR DESCRIPTION
The Google Compute Engine team will be deprecating the older `v1beta1` and `v0.1` metadata endpoints in April 2020. This is an update to use the correct `v1` endpoint and includes the required custom HTTP header.

Once merged, please update and release a new gem https://rubygems.org/gems/facter/ so that users have time to upgrade before April.

_NOTE: This fix has already been applied to the 3.x version of Facter in [FACT-2018](https://tickets.puppetlabs.com/browse/FACT-2018) and released in version 3.14.5._