### PR TITLE
(maint) Merge up 3.13.x to master

### DIFF
--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -138,7 +138,7 @@ namespace facter { namespace ruby {
 
         // Helper functions
         static module* from_self(leatherman::ruby::VALUE self);
-        static leatherman::ruby::VALUE execute_command(std::string const& command, leatherman::ruby::VALUE failure_default, bool raise, uint32_t timeout = 0);
+        static leatherman::ruby::VALUE execute_command(std::string const& command, leatherman::ruby::VALUE failure_default, bool raise, uint32_t timeout = 0, bool expand = true);
 
         void initialize_search_paths(std::vector<std::string> const& paths);
         leatherman::ruby::VALUE load_fact(leatherman::ruby::VALUE value);

--- a/lib/inc/internal/util/agent.hpp
+++ b/lib/inc/internal/util/agent.hpp
@@ -18,11 +18,22 @@ namespace facter { namespace util { namespace agent {
      */
     inline std::string which(const std::string& exe) {
 #ifdef FACTER_PATH
-        std::string fixed = leatherman::execution::which(exe, {FACTER_PATH});
+    std::string fixed = leatherman::execution::which(exe, {FACTER_PATH}, true);
+    if (!fixed.empty()) {
+        return fixed;
+    }
+    LOG_WARNING("{1} not found at configured location {2}, using PATH instead", exe, FACTER_PATH);
+#endif
+    return exe;
+}
+
+    inline std::string which(const std::string& exe, bool expand) {
+#ifdef FACTER_PATH
+        std::string fixed = leatherman::execution::which(exe, {FACTER_PATH}, expand);
         if (!fixed.empty()) {
             return fixed;
         }
-        LOG_WARNING("{1} not found at configured location {2}, using PATH instead", exe, FACTER_PATH);
+        LOG_WARNING("{1} not found at configured location {2}, using PATH instead, parameter expand is {3}", exe, FACTER_PATH, expand);
 #endif
         return exe;
     }

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -883,7 +883,14 @@ namespace facter { namespace ruby {
                 raise = true;
                 fail_option = ruby.nil_value();
             }
-            return execute_command(ruby.to_string(argv[0]), fail_option, raise, timeout);
+
+            bool expand = true;
+            volatile VALUE expand_option = ruby.rb_hash_lookup2(argv[1], ruby.to_symbol("expand"), ruby.true_value());
+            if (ruby.is_false(expand_option)) {
+                expand = false;
+            }
+
+            return execute_command(ruby.to_string(argv[0]), fail_option, raise, timeout, expand);
         });
     }
 
@@ -908,12 +915,12 @@ namespace facter { namespace ruby {
         return it->second;
     }
 
-    VALUE module::execute_command(std::string const& command, VALUE failure_default, bool raise, uint32_t timeout)
+    VALUE module::execute_command(std::string const& command, VALUE failure_default, bool raise, uint32_t timeout, bool expand)
     {
         auto const& ruby = api::instance();
 
-        // Expand the command
-        auto expanded = expand_command(command);
+        // Expand the command only if expand is true,
+        auto expanded = expand_command(command, leatherman::util::environment::search_paths(), expand);
 
         if (!expanded.empty()) {
             try {

--- a/lib/tests/fixtures/ruby/execute_expand_false.rb
+++ b/lib/tests/fixtures/ruby/execute_expand_false.rb
@@ -1,0 +1,5 @@
+Facter.add(:foo) do
+  setcode do
+    Facter::Core::Execution.execute("cd /opt/puppetlabs && ls", {:expand => false})
+  end
+end

--- a/lib/tests/fixtures/ruby/execute_expand_true.rb
+++ b/lib/tests/fixtures/ruby/execute_expand_true.rb
@@ -1,0 +1,5 @@
+Facter.add(:zoo) do
+  setcode do
+    Facter::Core::Execution.execute("cd /opt/puppetlabs && ls", {:expand => true})
+  end
+end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -497,6 +497,25 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - .* command timed out after 1 seconds")));
         }
     }
+    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with expand value set to true") {
+        log_capture capture(level::debug);
+        REQUIRE(load_custom_fact("execute_expand_true.rb", facts));
+        THEN("first command should be expanded to absolute path") {
+            auto output = capture.result();
+            CAPTURE(output);
+            REQUIRE(re_search(output, boost::regex("cd /opt/puppetlabs && ls")));
+        }
+    }
+    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with expand value set to false") {
+        log_capture capture(level::debug);
+        REQUIRE(load_custom_fact("execute_expand_false.rb", facts));
+        THEN("first command should not be expanded to absolute path") {
+            auto output = capture.result();
+            CAPTURE(output);
+            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) != "\"\"");
+            REQUIRE(re_search(output, boost::regex("bin/sh -c cd /opt/puppetlabs && ls")));
+        }
+    }
     GIVEN("a fact that uses timeout") {
         log_capture capture(level::warning);
         REQUIRE(load_custom_fact("timeout.rb", facts));

--- a/locales/FACTER.pot
+++ b/locales/FACTER.pot
@@ -234,6 +234,13 @@ msgstr ""
 msgid "{1} not found at configured location {2}, using PATH instead"
 msgstr ""
 
+#. warning
+#: lib/inc/internal/util/agent.hpp
+msgid ""
+"{1} not found at configured location {2}, using PATH instead, parameter "
+"expand is {3}"
+msgstr ""
+
 #: lib/inc/internal/util/aix/odm.hpp
 msgid "failed to retrieve ODM error message"
 msgstr ""


### PR DESCRIPTION
```
* upstream/3.13.x:
  (packaging) Updating the FACTER.pot file
  travis
  (FACT-2054) Facter::Core::Execution.execute expands shell builtins
  (maint) Bump leatherman to 1.6.3 on travis and appveyor
  (maint) Bump leatherman to 1.4.9 in appveyor
  (maint) bump leatherman to 1.4.9 in travis
```

Conflicts:
	.travis.yml
	appveyor.yml