### PR TITLE
(FACT-1824) Offline CPUs count as physical CPUs

### DIFF
--- a/lib/src/facts/linux/processor_resolver.cc
+++ b/lib/src/facts/linux/processor_resolver.cc
@@ -74,15 +74,18 @@ namespace facter { namespace facts { namespace linux {
         bool cpu0_valid = false;
 
         lth_file::each_subdirectory(root + "/sys/devices/system/cpu", [&](string const& cpu_directory) {
-            bool at_cpu0 = data.logical_count == 0;
-            data.logical_count++;
-            string id = lth_file::read((path(cpu_directory) / "/topology/physical_package_id").string());
-            boost::trim(id);
-            if (id.empty() || (is_valid_id(id) && cpus.emplace(move(id)).second)) {
-                // Haven't seen this processor before
-                ++data.physical_count;
-                if (at_cpu0) {
-                    cpu0_valid = true;
+            string physical_id_path = (path(cpu_directory) / "/topology/physical_package_id").string();
+            if (lth_file::file_readable(physical_id_path)) {
+                bool at_cpu0 = data.logical_count == 0;
+                data.logical_count++;
+                string id = lth_file::read(physical_id_path);
+                boost::trim(id);
+                if ((is_valid_id(id) && cpus.emplace(move(id)).second)) {
+                    // Haven't seen this processor before
+                    ++data.physical_count;
+                    if (at_cpu0) {
+                        cpu0_valid = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
If a CPU is set to offline, the /sys/devices/system/cpu/cpu/topology
folder will be removed, and the topology folder contains informations
needed for processor fact.

Now facter will check if the file that contains informations is readable
before reading it. As the file does not exist for offline CPUs, the file
will not be readable and will not cause the bug.