### PR TITLE
(maint) Fix facter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 script:
   - >
     docker run -v `pwd`:/facter gcr.io/cpp-projects/cpp-ci:1 /bin/bash -c "
-    apk add --no-cache openjdk8 &&
+    apk add --no-cache openjdk8 ruby ruby-dev &&
     export JAVA_HOME=/usr/lib/jvm/default-jvm &&
     wget https://github.com/puppetlabs/leatherman/releases/download/${LEATHERMAN_VERSION}/leatherman-dynamic.tar.gz &&
     tar xzvf leatherman-dynamic.tar.gz --strip 1 -C / &&

--- a/acceptance/tests/custom_facts/expand_command.rb
+++ b/acceptance/tests/custom_facts/expand_command.rb
@@ -1,0 +1,30 @@
+test_name 'FACT-2054: Custom facts that execute a shell command should expand it' do
+  tag 'risk:low'
+
+confine :to, :platform => /el-7/
+
+  content = <<-EOM
+    Facter.add(:foo) do
+      setcode do
+        Facter::Core::Execution.execute("cd /opt/puppetlabs && pwd")
+      end
+    end
+  EOM
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('facter')
+    fact_file = File.join(fact_dir, 'test_facts.rb')
+    create_remote_file(agent, fact_file, content)
+    env = {'FACTERLIB' => fact_dir}
+
+    teardown do
+      on(agent, "rm -rf '#{fact_dir}'")
+    end
+
+    step "Agent: Verify that command is expanded" do
+      on(agent, facter('foo', :environment => env)) do |facter_result|
+        refute_equal('/opt/puppetlabs', facter_result.stdout.chomp, 'command was not expanded')
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/not_expand_command.rb
+++ b/acceptance/tests/custom_facts/not_expand_command.rb
@@ -1,0 +1,30 @@
+test_name 'FACT-2054: Custom facts that execute a shell command should not expand it' do
+  tag 'risk:low'
+
+confine :to, :platform => /el-7/
+
+  content = <<-EOM
+    Facter.add(:foo) do
+      setcode do
+        Facter::Core::Execution.execute("cd /opt/puppetlabs && pwd", {:expand => false})
+      end
+    end
+  EOM
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('facter')
+    fact_file = File.join(fact_dir, 'test_facts.rb')
+    create_remote_file(agent, fact_file, content)
+    env = {'FACTERLIB' => fact_dir}
+
+    teardown do
+      on(agent, "rm -rf '#{fact_dir}'")
+    end
+
+    step "Agent: Verify that command is not expanded" do
+      on(agent, facter('foo', :environment => env)) do |facter_result|
+        assert_equal('/opt/puppetlabs', facter_result.stdout.chomp, 'command was expanded')
+      end
+    end
+  end
+end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,9 @@ install:
   - bundle install --jobs 4 --retry 2 --gemfile=lib/Gemfile --quiet
 
 build_script:
-  - ps: |
-      cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\cpp-hocon" -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DBOOST_STATIC=ON .
-      mingw32-make -j2
+  - ps: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="C:\tools\pl-build-tools\pl-build-toolchain.cmake" -DCMAKE_PREFIX_PATH="C:\tools\leatherman;C:\tools\cpp-hocon" -DCMAKE_INSTALL_PREFIX="C:\Program Files\FACTER" -DBOOST_STATIC=ON .
+  - mingw32-make -j2
 
 test_script:
-  - ps: |
-      ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }
-      mingw32-make install
+  - ps: ctest -V 2>&1 | %{ if ($_ -is [System.Management.Automation.ErrorRecord]) { $_ | c++filt } else { $_ } }
+  - ps: mingw32-make install

--- a/lib/tests/fixtures/ruby/execute_expand_false.rb
+++ b/lib/tests/fixtures/ruby/execute_expand_false.rb
@@ -1,5 +1,0 @@
-Facter.add(:foo) do
-  setcode do
-    Facter::Core::Execution.execute("cd /opt/puppetlabs && ls", {:expand => false})
-  end
-end

--- a/lib/tests/fixtures/ruby/execute_expand_true.rb
+++ b/lib/tests/fixtures/ruby/execute_expand_true.rb
@@ -1,5 +1,0 @@
-Facter.add(:zoo) do
-  setcode do
-    Facter::Core::Execution.execute("cd /opt/puppetlabs && ls", {:expand => true})
-  end
-end

--- a/lib/tests/ruby/ruby.cc
+++ b/lib/tests/ruby/ruby.cc
@@ -497,25 +497,6 @@ SCENARIO("custom facts written in Ruby") {
             REQUIRE(re_search(output, boost::regex("ERROR puppetlabs\\.facter - .* command timed out after 1 seconds")));
         }
     }
-    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with expand value set to true") {
-        log_capture capture(level::debug);
-        REQUIRE(load_custom_fact("execute_expand_true.rb", facts));
-        THEN("first command should be expanded to absolute path") {
-            auto output = capture.result();
-            CAPTURE(output);
-            REQUIRE(re_search(output, boost::regex("cd /opt/puppetlabs && ls")));
-        }
-    }
-    GIVEN("a fact resolution that uses Facter::Core::Execution#execute with expand value set to false") {
-        log_capture capture(level::debug);
-        REQUIRE(load_custom_fact("execute_expand_false.rb", facts));
-        THEN("first command should not be expanded to absolute path") {
-            auto output = capture.result();
-            CAPTURE(output);
-            REQUIRE(ruby_value_to_string(facts.get<ruby_value>("foo")) != "\"\"");
-            REQUIRE(re_search(output, boost::regex("bin/sh -c cd /opt/puppetlabs && ls")));
-        }
-    }
     GIVEN("a fact that uses timeout") {
         log_capture capture(level::warning);
         REQUIRE(load_custom_fact("timeout.rb", facts));


### PR DESCRIPTION
This PR enables:

- Appveyor build (lately tests were failing but build was passed)
- Travis to run unit tests regarding ruby
- Two unit tests regarding FACT-2054 that were failing on windows and travis. Those were deleted and rewritten as acceptance tests.