### PR TITLE
(FACT-2146) Use `route` to get primary interface on Solaris

### DIFF
--- a/lib/src/facts/solaris/networking_resolver.cc
+++ b/lib/src/facts/solaris/networking_resolver.cc
@@ -146,18 +146,18 @@ namespace facter { namespace facts { namespace solaris {
 
     string networking_resolver::get_primary_interface() const
     {
-        string value;
-        each_line("netstat", { "-rn"}, [&value](string& line) {
+        string interface;
+        each_line("route", { "-n", "get",  "default" }, [&interface](string& line){
             boost::trim(line);
-            if (boost::starts_with(line, "default")) {
-                vector<string> fields;
-                boost::split(fields, line, boost::is_space(), boost::token_compress_on);
-                value = fields.size() < 6 ? "" : fields[5];
+            if (boost::starts_with(line, "interface: ")) {
+                interface = line.substr(11);
+                boost::trim(interface);
                 return false;
             }
             return true;
         });
-        return value;
+        LOG_DEBUG("got primary interface: \"{1}\"", interface);
+        return interface;
     }
 
     bool networking_resolver::is_link_address(const sockaddr* addr) const


### PR DESCRIPTION


In some cases, `netstat -rn` on Solaris does not show the network
interface for the default route. This can happen after removing and
readding the default route.

```sh-session
> netstat -rn

Routing Table: IPv4
  Destination           Gateway           Flags  Ref     Use     Interface
-------------------- -------------------- ----- ----- ---------- ---------
default              10.32.112.1          UG        1         11 vmxnet3s0
10.32.112.0          10.32.124.44         U         1          3 vmxnet3s0
224.0.0.0            10.32.124.44         U         1          0 vmxnet3s0
127.0.0.1            127.0.0.1            UH        1         63 lo0
> route del default 10.32.112.1
delete net default: gateway 10.32.112.1
> route add default 10.32.112.1
add net default: gateway 10.32.112.1
> netstat -rn

Routing Table: IPv4
  Destination           Gateway           Flags  Ref     Use     Interface
-------------------- -------------------- ----- ----- ---------- ---------
default              10.32.112.1          UG        1         11
10.32.112.0          10.32.124.44         U         1          3 vmxnet3s0
224.0.0.0            10.32.124.44         U         1          0 vmxnet3s0
127.0.0.1            127.0.0.1            UH        1         63 lo0
```

The `route` command can be used as a reliable replacement for `netstat`:

```sh-session
> route -n get default
   route to: default
destination: default
       mask: default
    gateway: 10.32.112.1
  interface: vmxnet3s0
      flags: <UP,GATEWAY,DONE,STATIC>
 recvpipe  sendpipe  ssthresh    rtt,ms rttvar,ms  hopcount      mtu     expire
       0         0         0         0         0         0      1500         0
```