### PR TITLE
(maint) Enhance FreeBSD os.release facts

### DIFF
--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -61,6 +61,22 @@ namespace facter { namespace facts { namespace resolvers {
         };
 
         /**
+         * Represents information about FreeBSD.
+         */
+        struct freebsd_data
+        {
+            /**
+             * Stores FreeBSD branch.
+             */
+            std::string branch;
+
+            /**
+             * Stores FreeBSD patchlevel.
+             */
+            std::string patchlevel;
+        };
+
+        /**
          * Represents information about Mac OSX.
          */
         struct mac
@@ -209,6 +225,11 @@ namespace facter { namespace facts { namespace resolvers {
              * Stores information about the OS distribution.
              */
             distribution distro;
+
+            /**
+             * Stores information about FreeBSD.
+             */
+            freebsd_data freebsd;
 
             /**
              * Stores information about Mac OSX.

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1184,6 +1184,12 @@ os:
                 minor:
                     type: string
                     description: The minor release of the operating system.
+                patchlevel:
+                    type: string
+                    description: The patchlevel of the operating system.
+                branch:
+                    type: string
+                    description: The branch the operating system was cut from.
         selinux:
             type: map
             description: Represents information about Security-Enhanced Linux (SELinux).

--- a/lib/src/facts/freebsd/operating_system_resolver.cc
+++ b/lib/src/facts/freebsd/operating_system_resolver.cc
@@ -1,9 +1,11 @@
 #include <leatherman/execution/execution.hpp>
+#include <leatherman/util/regex.hpp>
 
 #include <internal/facts/freebsd/operating_system_resolver.hpp>
 
 using namespace std;
 using namespace leatherman::execution;
+using namespace leatherman::util;
 
 namespace facter { namespace facts { namespace freebsd {
 
@@ -12,6 +14,16 @@ namespace facter { namespace facts { namespace freebsd {
         auto exec = execute("freebsd-version");
         if (exec.success) {
             result.release = exec.output;
+
+            string major, minor, branch;
+            re_search(exec.output, boost::regex("(\\d+)\\.(\\d+)-(.*)"), &major, &minor, &branch);
+            result.major = move(major);
+            result.minor = move(minor);
+            result.freebsd.branch = move(branch);
+
+            string patchlevel;
+            re_search(result.freebsd.branch, boost::regex("RELEASE-p(\\d+)"), &patchlevel);
+            result.freebsd.patchlevel = move(patchlevel);
         }
     }
 } } }  // namespace facter::facts::freebsd

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -81,6 +81,15 @@ namespace facter { namespace facts { namespace resolvers {
             facts.add(fact::operating_system_release, make_value<string_value>(data.release, true));
             value->add("full", make_value<string_value>(move(data.release)));
 
+            // Populate FreeBSD-specific data
+            if (!data.freebsd.branch.empty()) {
+                value->add("branch", make_value<string_value>(move(data.freebsd.branch)));
+            }
+
+            if (!data.freebsd.patchlevel.empty()) {
+                value->add("patchlevel", make_value<string_value>(move(data.freebsd.patchlevel)));
+            }
+
             os->add("release", move(value));
         }
 

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -266,6 +266,8 @@ struct operating_system_resolver : resolvers::operating_system_resolver
         result.distro.release = "1.2.3";
         result.distro.codename = "codename";
         result.distro.description = "description";
+        result.freebsd.branch = "BRANCH";
+        result.freebsd.patchlevel = "4";
         result.osx.product = "product";
         result.osx.build = "build";
         result.osx.version = "10.10";


### PR DESCRIPTION
So far, facter reported the following for FreeBSD `os.release` fact:

```
{
  full => "12.1-RELEASE-p1",
  major => "12",
  minor => "1-RELEASE-p1"
}
```

The `full` and `major` information definitively makes sense, but the `minor` field is a bit confusing because if contains 3 different information:
 1. The actual minor release;
 2. The "branch" this FreeBSD release commes from (one of "CURRENT", "STABLE" or "RELEASE-pX");
 3. The "patchlevel" if the branch is a RELEASE one.

Add two new fields to store the branch and patchlevel so that all valid FreeBSD versions report nice and consistent data.

```
{
  branch => "RELEASE-p1",
  full => "12.1-RELEASE-p1",
  major => "12",
  minor => "1",
  patchlevel => "1"
}
```