### PR TITLE
(FACT-2346) Check for `ai_canonname` before comparing

### DIFF
--- a/acceptance/tests/facts/osx_numeric_hostname.rb
+++ b/acceptance/tests/facts/osx_numeric_hostname.rb
@@ -1,0 +1,23 @@
+test_name 'Querying the fqdn with a numeric hostname should not fail' do
+
+  # calling getaddrinfo with a numeric value on OS X does not fill the
+  # ai_canonname field of the addrinfo structure
+  confine :to, :platform => /^osx-/
+
+  agents.each do |agent|
+    original_hostname = agent.hostname.split('.').first
+    numeric_hostname = 42
+
+    teardown do
+      on(agent, "scutil --set HostName #{original_hostname}")
+    end
+
+    step "Change hostname from '#{original_hostname}' to '#{numeric_hostname}'" do
+      on(agent, "scutil --set HostName #{numeric_hostname}")
+    end
+
+    step 'Verify fqdn fact does not fail' do
+      on(agent, facter('fqdn'))
+    end
+  end
+end

--- a/lib/src/facts/posix/networking_resolver.cc
+++ b/lib/src/facts/posix/networking_resolver.cc
@@ -93,7 +93,7 @@ namespace facter { namespace facts { namespace posix {
             scoped_addrinfo info(result.hostname);
             if (info.result() != 0 && info.result() != EAI_NONAME) {
                 LOG_WARNING("getaddrinfo failed: {1} ({2}): hostname may not be externally resolvable.", gai_strerror(info.result()), info.result());
-            } else if (!info || info.result() == EAI_NONAME || result.hostname == static_cast<addrinfo*>(info)->ai_canonname) {
+            } else if (!info || info.result() == EAI_NONAME || !static_cast<addrinfo*>(info)->ai_canonname || result.hostname == static_cast<addrinfo*>(info)->ai_canonname) {
                 LOG_DEBUG("hostname \"{1}\" could not be resolved: hostname may not be externally resolvable.", result.hostname);
             } else {
                 result.fqdn = static_cast<addrinfo*>(info)->ai_canonname;


### PR DESCRIPTION
On OS X (and probably more BSD-based systems), calling `getaddrinfo` with a numeric value does not fill the `ai_canonname` field of the `addrinfo` struct, causing any facter call that queries the networking resolver to segfault. This happens if the user has a fully numeric hostname.

From the `getaddrinfo` manpage:

> If the AI_CANONNAME bit is set, a successful call to getaddrinfo()
> will return a NUL-terminated string containing the canonical name of
> the specified hostname in the ai_canonname element of the first
> addrinfo structure returned.

Side-note: `getaddrinfo` will treat any numeric value as an IP, so numeric hostnames cannot be reliably looked up. The GNU libc implementation of `getaddrinfo` always fills the `ai_canonname` field, so this hasn't been a problem on Linux systems.