### PR TITLE
(FACT-1575) Add caching to custom facts

### DIFF
--- a/acceptance/tests/custom_facts/cached_custom_fact.rb
+++ b/acceptance/tests/custom_facts/cached_custom_fact.rb
@@ -1,0 +1,81 @@
+test_name 'ttls configured custom facts files creates cache file and reads cache file' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  custom_fact_file = 'custom_facts.rb'
+  custom_fact_name  = 'random_custom_fact'
+  custom_fact_value = 'custom fact value'
+
+  fact_content = <<-CUSTOM_FACT
+  Facter.add(:#{custom_fact_name}) do
+    setcode do
+      "#{custom_fact_value}"
+    end
+  end
+  CUSTOM_FACT
+
+  cached_file_content = <<~CACHED_FILE
+    {
+      "#{custom_fact_name}": "#{custom_fact_value}"
+    }
+  CACHED_FILE
+
+  config_data = <<~FACTER_CONF
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+      cached-custom-facts : [ "#{custom_fact_name}" ]
+    }
+  FACTER_CONF
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    fact_dir = agent.tmpdir('facter')
+    env = { 'FACTERLIB' => fact_dir }
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+
+    step "Agent #{agent}: create config file" do
+      on(agent, "mkdir -p '#{config_dir}'")
+      create_remote_file(agent, config_file, config_data)
+      fact_file = File.join(fact_dir, custom_fact_file)
+      create_remote_file(agent, fact_file, fact_content)
+    end
+
+    teardown do
+      on(agent, "rm -rf '#{fact_dir}'")
+      on(agent, "rm -rf #{cache_folder}/*")
+      on(agent, "rm -rf '#{config_file}'")
+    end
+
+    step "should log that it creates cache file and it caches custom facts found in facter.conf" do
+      on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
+        assert_equal(custom_fact_value, facter_result.stdout.chomp, "#{custom_fact_name} value changed")
+        assert_match(/Custom facts cache file expired\/missing. Refreshing/, facter_result.stderr,
+                     'Expected debug message to state that custom facts cache file is missing or expired')
+        assert_match(/Saving cached custom facts to ".+"/, facter_result.stderr,
+                     'Expected debug message to state that custom facts will be cached')
+      end
+    end
+
+    step "should create a cached-custom-facts cache file that containt fact information" do
+      on(agent, "test -f #{cache_folder}/cached-custom-facts && echo \"Cache file exists\"") do |file_check_output|
+        assert_equal('Cache file exists', file_check_output.stdout.chomp, "Cache file does not exists in #{cache_folder}")
+      end
+      on(agent, "cat #{cache_folder}/cached-custom-facts", acceptable_exit_codes: [0]) do |cat_output|
+        assert_match(cached_file_content.chomp, cat_output.stdout, 'Expected cached custom fact file to contain fact information')
+      end
+    end
+
+    step 'should read from the cached file for a custom fact that has been cached' do
+      on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
+        assert_match(/Loading cached custom facts from file ".+"/, facter_result.stderr,
+                     'Expected debug message to state that cached custom facts are read from file')
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
+++ b/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
@@ -1,0 +1,93 @@
+test_name 'ttls configured weighted custom facts files creates cache file and reads cache file depending on weight' do
+  tag 'risk:medium'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  custom_fact_file = 'custom_facts.rb'
+  duplicate_custom_fact_name  = 'random_custom_fact'
+  custom_fact_value = 'custom fact value with weight:'
+
+  fact_content = <<-CUSTOM_FACT
+  Facter.add(:#{duplicate_custom_fact_name}) do
+    has_weight 90
+    setcode do
+      "#{custom_fact_value} 90"
+    end
+  end
+  Facter.add(:#{duplicate_custom_fact_name}) do
+    has_weight 100
+    setcode do
+      "#{custom_fact_value} 100"
+    end
+  end
+  Facter.add(:#{duplicate_custom_fact_name}) do
+    has_weight 110
+    setcode do
+      "#{custom_fact_value} 110"
+    end
+  end
+  CUSTOM_FACT
+
+  cached_file_content_highest_weight = <<~CACHED_FILE
+    {
+      "#{duplicate_custom_fact_name}": "#{custom_fact_value} 110"
+    }
+  CACHED_FILE
+
+  config_data = <<~FACTER_CONF
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+      cached-custom-facts : [ "#{duplicate_custom_fact_name}" ]
+    }
+  FACTER_CONF
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], agent['version'])
+    fact_dir = agent.tmpdir('facter')
+    env = { 'FACTERLIB' => fact_dir }
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+
+    step "Agent #{agent}: create config file" do
+      on(agent, "mkdir -p '#{config_dir}'")
+      create_remote_file(agent, config_file, config_data)
+      fact_file = File.join(fact_dir, custom_fact_file)
+      create_remote_file(agent, fact_file, fact_content)
+    end
+
+    teardown do
+      on(agent, "rm -rf '#{fact_dir}'")
+      on(agent, "rm -rf #{cache_folder}/*")
+      on(agent, "rm -rf #{config_dir}/facter.conf")
+    end
+
+    step "should log that it creates cache file and it caches custom facts found in facter.conf with the highest weight" do
+      on(agent, facter("#{duplicate_custom_fact_name} --debug", environment: env)) do |facter_result|
+        assert_equal(custom_fact_value + " 110", facter_result.stdout.chomp, "#{duplicate_custom_fact_name} value changed")
+        assert_match(/Custom facts cache file expired\/missing. Refreshing/, facter_result.stderr,
+                     'Expected debug message to state that custom facts cache file is missing or expired')
+        assert_match(/Saving cached custom facts to ".+"/, facter_result.stderr,
+                     'Expected debug message to state that custom facts will be cached')
+      end
+    end
+
+    step "should create a cached-custom-facts cache file that containt fact information from the highest weight fact" do
+      on(agent, "test -f #{cache_folder}/cached-custom-facts && echo \"Cache file exists\"") do |file_check_output|
+        assert_equal('Cache file exists', file_check_output.stdout.chomp, "Cache file does not exists in #{cache_folder}")
+      end
+      on(agent, "cat #{cache_folder}/cached-custom-facts", acceptable_exit_codes: [0]) do |cat_output|
+        assert_match(cached_file_content_highest_weight.chomp, cat_output.stdout, 'Expected cached custom fact file to contain fact information from the highest weight fact')
+      end
+    end
+
+    step 'should read from the cached file for a custom fact that has been cached' do
+      on(agent, facter("#{duplicate_custom_fact_name} --debug", environment: env)) do |facter_result|
+        assert_match(/Loading cached custom facts from file ".+"/, facter_result.stderr,
+                     'Expected debug message to state that cached custom facts are read from file')
+      end
+    end
+  end
+end

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -21,6 +21,8 @@
 
 namespace facter { namespace facts {
 
+    static const std::string cached_custom_facts("cached-custom-facts");
+
     /**
      * The supported output format for the fact collection.
      */
@@ -294,6 +296,12 @@ namespace facter { namespace facts {
          * @return a map of group names to their associated fact names
          */
         std::map<std::string, std::vector<std::string>> get_fact_groups();
+
+        /**
+         * Returns the time-to-live time for each fact from the facter.conf file
+         * @return a map of fact names to their associated time-to-live value
+         */
+        const std::unordered_map<std::string, int64_t>& get_ttls();
 
         /**
          * Returns the names of all blockable resolvers currently in the collection,

--- a/lib/inc/internal/facts/cache.hpp
+++ b/lib/inc/internal/facts/cache.hpp
@@ -51,7 +51,7 @@ namespace facter { namespace facts { namespace cache {
      * @param file_path the path to the cache file
      * @param fact_name the name of the fact to cache
      */
-    void write_json_cache_file(collection& facts, boost::filesystem::path const& file_path, std::vector<std::string> const& fact_names);
+    void write_json_cache_file(const collection& facts, boost::filesystem::path const& file_path, std::vector<std::string> const& fact_names);
 
     /**
      * Returns the timespan in seconds since the file was last modified.
@@ -68,4 +68,19 @@ namespace facter { namespace facts { namespace cache {
      */
     void clean_cache(std::unordered_map<std::string, int64_t> const& facts_to_cache,
             std::string cache_location = fact_cache_location());
+
+    /**
+     * Caches the custom facts from cached_facts
+     * @param collection the collection of facts to which to add
+     * @param ttls the duration in seconds for which the cached custom facts file is considered valid
+     */
+    bool load_cached_custom_facts(collection& collection, int64_t ttl);
+
+    /**
+     * Creates a cache file for the given custom facts list in JSON format.
+     * @param facts the collection of facts
+     * @param cached_custom_facts_list the name of the facts to cache
+     */
+    void write_cached_custom_facts(const collection& facts, const std::vector<std::string>& cached_custom_facts_list);
+
 }}}  // namespace facter::facts::cache

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -335,6 +335,10 @@ namespace facter { namespace facts {
         return _facts.size();
     }
 
+    const std::unordered_map<std::string, int64_t>& collection::get_ttls() {
+        return _ttls;
+    }
+
     value const* collection::operator[](string const& name)
     {
         return get_value(name);

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -61,7 +61,8 @@ namespace facter { namespace util { namespace config {
     po::options_description fact_config_options() {
         po::options_description fact_settings("");
         fact_settings.add_options()
-            ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
+            ("blocklist", po::value<vector<string>>(), "A set of facts to block.")
+            ("cached-custom-facts", po::value<vector<string>>(), "A list of custom facts to be cached.");
         return fact_settings;
     }
 


### PR DESCRIPTION
This PR adds ability to cache custom facts based on facter.conf file.

facter.conf example that caches random_custom_fact and custom_fact2 for
3 days, and saves the cache values in a custom_facts_to_cache file, in
cached_facts directory
```
facts : {
  ttls : [
      { "cached-custom-facts" : 3 days }
  ]
  cached-custom-facts : [ "random_custom_fact", "custom_fact2" ]
}
```