### PR TITLE
(FACT-2417) fix noisy logging

### DIFF
--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -174,7 +174,11 @@ namespace facter { namespace facts {
                 auto resolver = erf.get_resolver(path);
                 files.push_back(make_pair(path, resolver));
             } catch (external::external_fact_no_resolver& e) {
-                LOG_WARNING("skipping file \"{1}\": {2}", path, e.what());
+                if (warn) {
+                    LOG_WARNING("skipping file \"{1}\": {2}", path, e.what());
+                } else {
+                    LOG_DEBUG("skipping file \"{1}\": {2}", path, e.what());
+                }
             }
             return true;
         });


### PR DESCRIPTION
 Log "No resolver for external facts file" as warning only for user
 specified external dirs, use debug otherwise