### PR TITLE
(FACT-2171) Allow other class names in verbose log test

### DIFF
--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -5,7 +5,7 @@ test_name "C99986: --verbose command-line option prints verbose information to s
   agents.each do |agent|
     step "Agent #{agent}: retrieve verbose info from stderr using --verbose option" do
       on(agent, facter('--verbose')) do
-        assert_match(/INFO  puppetlabs.facter - executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
+        assert_match(/INFO .* executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
       end
     end
   end


### PR DESCRIPTION
This would allow the test to be executed successfully against facter 4