### PR TITLE
Fixed timeout for EC2

### DIFF
--- a/lib/facter/ec2/rest.rb
+++ b/lib/facter/ec2/rest.rb
@@ -25,7 +25,7 @@ module Facter
         attempts = 0
 
         begin
-          open(@baseurl, :proxy => nil, :read_timeout => timeout).read
+          open(@baseurl, :proxy => nil, :timeout => timeout, :read_timeout => timeout).read
           able_to_connect = true
         rescue OpenURI::HTTPError => e
           if e.message.match /404 Not Found/i


### PR DESCRIPTION
Fixed timeout with the timeout param for EC2, instead of read_timeout for newer ruby versions

The bug can be reprodced on the virtual environment.