### PR TITLE
(FACT-2489) external facts files log update

### DIFF
--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -174,11 +174,7 @@ namespace facter { namespace facts {
                 auto resolver = erf.get_resolver(path);
                 files.push_back(make_pair(path, resolver));
             } catch (external::external_fact_no_resolver& e) {
-                if (warn) {
-                    LOG_WARNING("skipping file \"{1}\": {2}", path, e.what());
-                } else {
-                    LOG_DEBUG("skipping file \"{1}\": {2}", path, e.what());
-                }
+                LOG_DEBUG("skipping file \"{1}\": {2}", path, e.what());
             }
             return true;
         });


### PR DESCRIPTION
When there is no appropriate external facts resolver for a file
in `puppet/cache/facts.d` or other external facts dir, a warning
message is logged. This leads to many warning messages in case
multi OS external facts files are in the same directory.

With this change, a debug log message is  logged instead a warning
in case there is no appropriate external facts resolver selected.