### PR TITLE
(maint) Add link to Facter 4 repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Facter 4
+============
+Facter 4 is the newest version of Facter that is written in Ruby and compatible with Facter 3. Currenly Facter 4 is maintained in a separate git repository https://github.com/puppetlabs/facter-ng, but it will me moved to this repository later on.
+
 Native Facter
 =============
 


### PR DESCRIPTION
The documentation from rubygems https://rubygems.org/gems/facter points to Facter 3 repo, but Facter 4 is maintained at the moment in a different repository. Until we migrate Facter 4 to this repository we should have a short description for people interested in Facter 4 source code.