### PR TITLE
(maint) error log format fix

### DIFF
--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -235,7 +235,9 @@ namespace facter { namespace facts {
                     kvp.second->resolve(*this);
                 }
                 catch (external::external_fact_exception& ex) {
-                    LOG_ERROR("error while processing \"%1%\" for external facts: %2%", kvp.first, ex.what());
+                  LOG_ERROR(
+                      "error while processing \"{1}\" for external facts: {2}",
+                      kvp.first, ex.what());
                 }
             }
         }


### PR DESCRIPTION
Before this change, the log message format is wrong and the following
is logged in case external facts file is not proper executable:

```
2020-04-09 15:07:49.499276 ERROR puppetlabs.facter - error while processing "%1%" for external facts: %2%
```

After this fix, the proper message will be logged
```
2020-04-09 15:10:49.546980 ERROR puppetlabs.facter - error while processing "/opt/puppetlabs/facter/facts.d/a.sh" for external facts: child process returned non-zero exit status (8).
```