### PR TITLE
(FACT-2545) execute `oslevel` with default options

### DIFF
--- a/lib/src/facts/aix/kernel_resolver.cc
+++ b/lib/src/facts/aix/kernel_resolver.cc
@@ -15,7 +15,7 @@ namespace facter { namespace facts { namespace aix   {
     {
         data result;
 
-        auto exec = execute("/usr/bin/oslevel", {"-s"}, 0, { execution_options::trim_output, execution_options::redirect_stderr_to_stdout, execution_options::merge_environment });
+        auto exec = execute("/usr/bin/oslevel", {"-s"});
 
         result.name = "AIX";
         result.release = exec.output;


### PR DESCRIPTION
redirecting `stderr` to `stdout` in not working for `oslevel` command
executed on old AIX boxes

other commands are redirecting `stderr` to `null`, oslevel` should
do the same