### PR TITLE
(FACT-2544) Moved cached-custom-facts in puppet.conf

### DIFF
--- a/acceptance/tests/custom_facts/cached_custom_fact.rb
+++ b/acceptance/tests/custom_facts/cached_custom_fact.rb
@@ -27,7 +27,9 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
       ttls : [
           { "cached-custom-facts" : 3 days }
       ]
-      cached-custom-facts : [ "#{custom_fact_name}" ]
+    }
+    fact-groups : {
+      cached-custom-facts : ["#{custom_fact_name}"],
     }
   FACTER_CONF
 

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -204,6 +204,7 @@ int main(int argc, char **argv)
                 load_global_settings(hocon_conf, vm);
                 load_cli_settings(hocon_conf, vm);
                 load_fact_settings(hocon_conf, vm);
+                load_fact_groups_settings(hocon_conf, vm);
                 ttls = load_ttls(hocon_conf);
             }
 

--- a/lib/inc/facter/util/config.hpp
+++ b/lib/inc/facter/util/config.hpp
@@ -51,6 +51,13 @@ namespace facter { namespace util { namespace config {
     LIBFACTER_EXPORT void load_fact_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
 
     /**
+     * Loads the "fact-groups" section of the config file into the settings map.
+     * @param hocon_config the config object representing the parsed config file
+     * @param vm the key-value map in which to store the settings
+     */
+    LIBFACTER_EXPORT void load_fact_groups_settings(hocon::shared_config hocon_config, boost::program_options::variables_map& vm);
+
+    /**
      * Returns a schema of the valid global options that can appear in the config file.
      * @return names, values, and descriptions of global Facter options
      */
@@ -67,6 +74,12 @@ namespace facter { namespace util { namespace config {
      * @return names, values, and descriptions of fact blocking config options
      */
     LIBFACTER_EXPORT boost::program_options::options_description fact_config_options();
+
+    /**
+     * Returns a schema for options dealing with block fact groups collection.
+     * @return names, values, and descriptions of fact groups config options
+     */
+    LIBFACTER_EXPORT boost::program_options::options_description fact_groups_config_options();
 
     /**
      * Returns a map of resolver names and durations (in milliseconds). The listed resolvers will

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -358,7 +358,7 @@ namespace facter { namespace ruby {
         LOG_DEBUG(_("loading external fact directories from config file"));
         boost::program_options::variables_map vm;
         auto hocon_conf = load_default_config_file();
-        load_fact_settings(hocon_conf, vm);
+        load_fact_groups_settings(hocon_conf, vm);
         vector<string> cached_custom_facts_list;
         if (vm.count(cached_custom_facts)) {
             auto facts_to_cache = vm[cached_custom_facts].as<vector<string>>();

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -37,6 +37,13 @@ namespace facter { namespace util { namespace config {
         }
     }
 
+    void load_fact_groups_settings(shared_config hocon_config, po::variables_map& vm) {
+        if (hocon_config && hocon_config->has_path("fact-groups")) {
+            auto fact_groups_settings = hocon_config->get_object("fact-groups")->to_config();
+            po::store(hocon::program_options::parse_hocon<char>(fact_groups_settings, fact_groups_config_options(), true), vm);
+        }
+    }
+
     po::options_description global_config_options() {
         po::options_description global_options("");
         global_options.add_options()
@@ -61,9 +68,15 @@ namespace facter { namespace util { namespace config {
     po::options_description fact_config_options() {
         po::options_description fact_settings("");
         fact_settings.add_options()
-            ("blocklist", po::value<vector<string>>(), "A set of facts to block.")
-            ("cached-custom-facts", po::value<vector<string>>(), "A list of custom facts to be cached.");
+            ("blocklist", po::value<vector<string>>(), "A set of facts to block.");
         return fact_settings;
+    }
+
+    po::options_description fact_groups_config_options() {
+        po::options_description fact_groups_settings("");
+        fact_groups_settings.add_options()
+            ("cached-custom-facts", po::value<vector<string>>(), "A list of custom facts to be cached.");
+        return fact_groups_settings;
     }
 
     unordered_map<string, int64_t> load_ttls(shared_config hocon_config) {


### PR DESCRIPTION
Moved cached-custom-facts to a newly created section 'fact-groups'

facter.conf example for caching custom facts:

facts : {
   ttls : [
      { "cached-custom-facts" : 3 days }
  ]
}
fact-groups : {
  cached-custom-facts : ["test_fact1","fact_name2"],
}