### PR TITLE
(FACT-2537) Add guard for Leatherman function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,11 @@ enable_cppcheck()
 # Pull in helper macros for working with leatherman libraries
 include(leatherman)
 
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 set(CMAKE_REQUIRED_LIBRARIES ${LEATHERMAN_LIBRARIES})
+set(CMAKE_REQUIRED_INCLUDES ${LEATHERMAN_INCLUDE_DIRS})
+
+# Guards to make sure we don't compile what we don't have in Leatherman
 CHECK_CXX_SOURCE_COMPILES("
 #include <leatherman/util/environment.hpp>
 int main() {
@@ -177,10 +181,22 @@ if (HAS_LTH_GET_INT)
     add_definitions(-DHAS_LTH_GET_INT)
 endif()
 
-    # Guard to make sure we don't compile what we don't have in Leatherman
+CHECK_CXX_SOURCE_COMPILES("
+#include \"leatherman/execution/execution.hpp\"
+
+using namespace leatherman::execution;
+using namespace std;
+int main() {
+    vector<string> paths;
+    expand_command(\"command\", paths, false);
+    return 0;
+}
+" HAS_LTH_EXPAND)
+
+if (HAS_LTH_EXPAND)
+  add_definitions(-DHAS_LTH_EXPAND)
+endif()
 if (WIN32)
-    set(CMAKE_REQUIRED_INCLUDES ${LEATHERMAN_INCLUDE_DIRS})
-    set(CMAKE_REQUIRED_FLAGS "-std=c++11")
     CHECK_CXX_SOURCE_COMPILES("
     #include \"leatherman/windows/registry.hpp\"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Facter 4
 ============
-Facter 4 is the newest version of Facter that is written in Ruby and compatible with Facter 3. Currenly Facter 4 is maintained in a separate git repository https://github.com/puppetlabs/facter-ng, but it will me moved to this repository later on.
+Facter 4 is the newest version of Facter that is written in Ruby and compatible with Facter 3. Currenly Facter 4 is maintained in a separate git repository https://github.com/puppetlabs/facter-ng, but it will be moved to this repository later on.
 
 Native Facter
 =============
@@ -21,7 +21,7 @@ Build Requirements
 * CMake >= 3.2.2
 * Boost C++ Libraries >= 1.54
 * yaml-cpp >= 0.5.1
-* [leatherman](https://github.com/puppetlabs/leatherman) >= 1.0.0
+* [leatherman](https://github.com/puppetlabs/leatherman) >= 1.4.3
 * [cpp-hocon](https://github.com/puppetlabs/cpp-hocon) >= 0.1.0
 
 Optional Build Libraries

--- a/acceptance/tests/custom_facts/expand_command.rb
+++ b/acceptance/tests/custom_facts/expand_command.rb
@@ -1,7 +1,7 @@
 test_name 'FACT-2054: Custom facts that execute a shell command should expand it' do
-  tag 'risk:low'
+  tag 'risk:high'
 
-confine :to, :platform => /el-7/
+  confine :to, :platform => /el-7/
 
   content = <<-EOM
     Facter.add(:foo) do

--- a/acceptance/tests/custom_facts/not_expand_command.rb
+++ b/acceptance/tests/custom_facts/not_expand_command.rb
@@ -1,5 +1,5 @@
 test_name 'FACT-2054: Custom facts that execute a shell command should not expand it' do
-  tag 'risk:low'
+  tag 'risk:high'
 
 confine :to, :platform => /el-7/
 

--- a/acceptance/tests/custom_facts/windows_not_expand_command.rb
+++ b/acceptance/tests/custom_facts/windows_not_expand_command.rb
@@ -1,5 +1,5 @@
 test_name 'FACT-2054: Execute on Windows with expand => false should raise an error' do
-  tag 'risk:low'
+  tag 'risk:high'
 
   confine :to, :platform => /windows/
 

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -946,8 +946,13 @@ namespace facter { namespace ruby {
 
         // Expand the command only if expand is true,
         std::string expanded;
-        try{
+        try {
+#ifdef HAS_LTH_EXPAND
             expanded = expand_command(command, leatherman::util::environment::search_paths(), expand);
+#else
+            expanded = expand_command(command);
+            LOG_DEBUG("Facter was compiled with a Leatherman version that cannot expand shell builtins. Falling back to the default behavior.");
+#endif
         } catch (const std::invalid_argument &ex) {
             ruby.rb_raise(*ruby.rb_eArgError, _("Cause: {1}",  ex.what()).c_str());
         }


### PR DESCRIPTION
Add guard for `leatherman::execution::expand_command`.

Fix readme typo and update minimum required version of Leatherman. 1.4.3 is needed due to the change in puppetlabs/leatherman#281. Bump severity of related acceptance tests, so they run in CI.

Passing acceptance:
![image](https://user-images.githubusercontent.com/25789827/79452758-55b51c80-7ff1-11ea-9709-69a1d4c93d6b.png)
