### PR TITLE
(maint) Remove kernel check in block list acceptance test

### DIFF
--- a/acceptance/tests/options/list_block_groups.rb
+++ b/acceptance/tests/options/list_block_groups.rb
@@ -9,7 +9,6 @@ test_name "C99969: the `--list-block-groups` command line flag prints available 
       on(agent, facter("--list-block-groups")) do |facter_output|
         assert_match(/EC2/, facter_output.stdout, "Expected the EC2 group to be listed")
         assert_match(/ec2_metadata/, facter_output.stdout, "Expected the EC2 group's facts to be listed")
-        assert_no_match(/kernel/, facter_output.stdout, "kernel facts should not be listed as blockable")
       end
     end
   end


### PR DESCRIPTION
The kernel fact can be blocked and cached in facter 4, so it will be displayed with --list-block-groups.  This does not affect any functionality already present in facter 3.