### PR TITLE
(FACT-2580) Updated tests to use specific methods 

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4.22")
 gem 'beaker-puppet', *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.5")

--- a/acceptance/tests/custom_facts/cached_custom_fact.rb
+++ b/acceptance/tests/custom_facts/cached_custom_fact.rb
@@ -42,16 +42,16 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
     config_file = File.join(config_dir, 'facter.conf')
 
     step "Agent #{agent}: create config file" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config_data)
       fact_file = File.join(fact_dir, custom_fact_file)
       create_remote_file(agent, fact_file, fact_content)
     end
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
-      on(agent, "rm -rf #{cache_folder}/*")
-      on(agent, "rm -rf '#{config_file}'")
+      agent.rm_rf(fact_dir)
+      agent.rm_rf("#{cache_folder}/*")
+      agent.rm_rf(config_file)
     end
 
     step "should log that it creates cache file and it caches custom facts found in facter.conf" do

--- a/acceptance/tests/custom_facts/conflicts_with_builtin_fact.rb
+++ b/acceptance/tests/custom_facts/conflicts_with_builtin_fact.rb
@@ -11,20 +11,20 @@ Facter.add(:#{fact[:name]}) do
 end
 CUSTOM_FACT
 
-    fact_file_path = File.join(custom_fact_dir, fact_file_name) 
+    fact_file_path = File.join(custom_fact_dir, fact_file_name)
     create_remote_file(host, fact_file_path, fact_file_contents)
   end
 
   def clear_custom_facts_on(host, custom_fact_dir)
     step "Clean-up the previous test's custom facts" do
-      on(agent, "rm -f #{custom_fact_dir}/*")
+      agent.rm_rf("#{custom_fact_dir}/*")
     end
   end
 
   agents.each do |agent|
     custom_fact_dir = agent.tmpdir('facter')
     teardown do
-      on(agent, "rm -rf '#{custom_fact_dir}'")
+      agent.rm_rf(custom_fact_dir)
     end
 
     fact_name = 'timezone'

--- a/acceptance/tests/custom_facts/custom_fact_with_10001_weight_overrides_external_fact.rb
+++ b/acceptance/tests/custom_facts/custom_fact_with_10001_weight_overrides_external_fact.rb
@@ -16,7 +16,7 @@ test_name "C100153: custom fact with weight of >= 10001 overrides an external fa
     create_remote_file(agent, cust_fact_path, custom_fact_content(fact_name, 'CUSTOM', "has_weight 10001"))
 
     teardown do
-      on(agent, "rm -rf '#{facts_dir}'")
+      agent.rm_rf(facts_dir)
     end
 
     # Custom fact with weight >= 10001 should override an external fact

--- a/acceptance/tests/custom_facts/expand_command.rb
+++ b/acceptance/tests/custom_facts/expand_command.rb
@@ -18,7 +18,7 @@ test_name 'FACT-2054: Custom facts that execute a shell command should expand it
     env = {'FACTERLIB' => fact_dir}
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
+      agent.rm_rf(fact_dir)
     end
 
     step "Agent: Verify that command is expanded" do

--- a/acceptance/tests/custom_facts/having_multiple_facts_in_one_file.rb
+++ b/acceptance/tests/custom_facts/having_multiple_facts_in_one_file.rb
@@ -22,7 +22,7 @@ test_name 'C14893: Facter should handle multiple facts in a single file' do
     env = {'FACTERLIB' => fact_dir}
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
+      agent.rm_rf(fact_dir)
     end
 
     step "Agent: Verify test_fact1 from #{fact_file}" do

--- a/acceptance/tests/custom_facts/not_expand_command.rb
+++ b/acceptance/tests/custom_facts/not_expand_command.rb
@@ -18,7 +18,7 @@ confine :to, :platform => /el-7/
     env = {'FACTERLIB' => fact_dir}
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
+      agent.rm_rf(fact_dir)
     end
 
     step "Agent: Verify that command is not expanded" do

--- a/acceptance/tests/custom_facts/using_win32ole_should_not_hang.rb
+++ b/acceptance/tests/custom_facts/using_win32ole_should_not_hang.rb
@@ -20,7 +20,7 @@ test_name 'C92060: Custom facts should not hang Facter when using win32ole' do
     create_remote_file(agent, custom_fact, content)
 
     teardown do
-      on(agent, "rm -rf '#{custom_dir}'")
+      agent.rm_rf(custom_dir)
     end
 
     # Test is assumed to have hung if it takes longer than 5 seconds.

--- a/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
+++ b/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
@@ -54,16 +54,16 @@ test_name 'ttls configured weighted custom facts files creates cache file and re
     config_file = File.join(config_dir, 'facter.conf')
 
     step "Agent #{agent}: create config file" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config_data)
       fact_file = File.join(fact_dir, custom_fact_file)
       create_remote_file(agent, fact_file, fact_content)
     end
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
-      on(agent, "rm -rf #{cache_folder}/*")
-      on(agent, "rm -rf #{config_dir}/facter.conf")
+      agent.rm_rf(fact_dir)
+      agent.rm_rf("#{cache_folder}/*")
+      agent.rm_rf("#{config_dir}/facter.conf")
     end
 
     step "should log that it creates cache file and it caches custom facts found in facter.conf with the highest weight" do

--- a/acceptance/tests/custom_facts/windows_not_expand_command.rb
+++ b/acceptance/tests/custom_facts/windows_not_expand_command.rb
@@ -18,7 +18,7 @@ test_name 'FACT-2054: Execute on Windows with expand => false should raise an er
     env = {'FACTERLIB' => fact_dir}
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
+      agent.rm_rf(fact_dir)
     end
 
     step "Agent: Verify that exception is raised" do

--- a/acceptance/tests/external_facts/env_var_overrides_external_fact.rb
+++ b/acceptance/tests/external_facts/env_var_overrides_external_fact.rb
@@ -13,15 +13,15 @@ test_name 'C100537: FACTER_ env var should override external fact' do
                                "#{fact_name}#{get_external_fact_script_extension(agent['platform'])}")
 
     teardown do
-      on(agent, "rm -rf '#{external_dir}'")
+      agent.rm_rf(external_dir)
     end
 
     step "Agent #{agent}: setup external fact" do
-      on(agent, "mkdir -p '#{external_dir}'")
+      agent.mkdir_p(external_dir)
       create_remote_file(agent,
                          fact_file,
                          external_fact_content(agent['platform'], fact_name, fact_value))
-      on(agent, "chmod +x '#{fact_file}'")
+      agent.chmod('+x', fact_file)
     end
 
     step "Agent: #{agent}: ensure external fact resolves correctly" do

--- a/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
+++ b/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
@@ -15,14 +15,16 @@ test_name "C100154: --external-dir fact overrides fact in default facts.d direct
     override_content = external_fact_content(agent['platform'], 'external_fact', 'OVERRIDE_value')
 
     teardown do
-      on(agent, "rm -f '#{fact_file}' '#{override_fact_file}'")
+      agent.rm_rf(fact_file)
+      agent.rm_rf(override_fact_file)
     end
 
     step "Agent #{agent}: setup default external facts directories and the test facts" do
-      on(agent, "mkdir -p '#{factsd}'")
+      agent.mkdir_p(factsd)
       create_remote_file(agent, fact_file, content)
       create_remote_file(agent, override_fact_file, override_content)
-      on(agent, "chmod +x '#{fact_file}' '#{override_fact_file}'")
+      agent.chmod('+x', fact_file)
+      agent.chmod('+x', override_fact_file)
     end
 
     step "Agent #{agent}: the fact value from the custom external dir should override that of facts.d" do

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact.rb
@@ -16,7 +16,7 @@ test_name "C100150: external fact overrides custom fact without a weight" do
     create_remote_file(agent, ext_fact_path, ext_fact)
 
     teardown do
-      on(agent, "rm -rf '#{facts_dir}'")
+      agent.rm_rf(facts_dir)
     end
 
     step "Agent #{agent}: resolve an external fact over a custom fact" do

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_10000_weight_or_less.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_10000_weight_or_less.rb
@@ -16,7 +16,7 @@ test_name "C100151: external fact overrides a custom fact of weight 10000 or les
     create_remote_file(agent, cust_fact_path, custom_fact_content(fact_name, 'CUSTOM', "has_weight 10000"))
 
     teardown do
-      on(agent, "rm -rf '#{facts_dir}'")
+      agent.rm_rf(facts_dir)
     end
 
     # Custom fact with weight <= 10000 should give precedence to the EXTERNAL fact

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_confine.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_confine.rb
@@ -20,7 +20,7 @@ test_name "C100152: external fact overrides a custom fact with a confine" do
                        custom_fact_content(fact_name, 'CUSTOM', "confine :kernel=>'#{agent_kernel}'"))
 
     teardown do
-      on(agent, "rm -rf '#{facts_dir}'")
+      agent.rm_rf(facts_dir)
     end
 
     # External fact should take precedence over a custom fact with a confine

--- a/acceptance/tests/external_facts/external_fact_stderr_messages_output_to_stderr.rb
+++ b/acceptance/tests/external_facts/external_fact_stderr_messages_output_to_stderr.rb
@@ -23,13 +23,13 @@ EOM
     end
 
     teardown do
-      on(agent, "rm -f '#{ext_fact}'")
+      agent.rm_rf(ext_fact)
     end
 
     step "Agent #{agent}: create facts.d directory and fact" do
-      on(agent, "mkdir -p '#{factsd}'")
+      agent.mkdir_p(factsd)
       create_remote_file(agent, ext_fact, content)
-      on(agent, "chmod +x '#{ext_fact}'")
+      agent.chmod('+x', ext_fact)
     end
 
     step "Agent #{agent}: external fact stderr messages should appear on stderr from facter" do

--- a/acceptance/tests/external_facts/external_facts_only_run_once.rb
+++ b/acceptance/tests/external_facts/external_facts_only_run_once.rb
@@ -23,13 +23,13 @@ EOM
     end
 
     teardown do
-      on(agent, "rm -f '#{ext_fact}'")
+      agent.rm_rf(ext_fact)
     end
 
     step "Agent #{agent}: create facts.d directory and fact" do
-      on(agent, "mkdir -p '#{factsd}'")
+      agent.mkdir_p(factsd)
       create_remote_file(agent, ext_fact, content)
-      on(agent, "chmod +x '#{ext_fact}'")
+      agent.chmod('+x', ext_fact)
     end
 
     step "Agent #{agent}: ensure the fact is only executed once" do

--- a/acceptance/tests/external_facts/fact_directory_precedence.rb
+++ b/acceptance/tests/external_facts/fact_directory_precedence.rb
@@ -28,13 +28,15 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     etc_puppetlabs_factsd_path = "#{etc_puppetlabs_factsd_dir}/test.yaml"
 
     teardown do
-      on(agent, "rm -rf '#{factsd_dir}' '#{etc_factsd_dir}' '#{etc_puppetlabs_factsd_dir}'")
+      agent.rm_rf(factsd_dir)
+      agent.rm_rf(etc_factsd_dir)
+      agent.rm_rf(etc_puppetlabs_factsd_dir)
     end
 
     # ensure the fact directory we want to use exists
     step "Agent #{agent}: create facts directory (#{etc_puppetlabs_factsd_dir})" do
-      on(agent, "rm -rf '#{etc_puppetlabs_factsd_dir}'")
-      on(agent, "mkdir -p '#{etc_puppetlabs_factsd_dir}'")
+      agent.rm_rf(etc_puppetlabs_factsd_dir)
+      agent.mkdir_p(etc_puppetlabs_factsd_dir)
     end
 
     # A fact in the etc_puppetlabs_factsd_dir directory should resolve to the fact
@@ -47,13 +49,13 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
 
     # remove the fact
     step "Agent #{agent}: remove the fact in #{etc_puppetlabs_factsd_dir}" do
-      on(agent, "rm -f '#{etc_puppetlabs_factsd_path}'")
+      agent.rm_rf(etc_puppetlabs_factsd_path)
     end
 
     # ensure the fact directory we want to use exists
     step "Agent #{agent}: create facts directory (#{etc_factsd_dir})" do
-      on(agent, "rm -rf '#{etc_factsd_dir}'")
-      on(agent, "mkdir -p '#{etc_factsd_dir}'")
+      agent.rm_rf(etc_factsd_dir)
+      agent.mkdir_p(etc_factsd_dir)
     end
 
     # A fact in the etc_factsd_dir directory should resolve to the fact
@@ -66,13 +68,13 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
 
     # remove the fact
     step "Agent #{agent}: remove the fact in #{etc_factsd_dir}" do
-      on(agent, "rm -f '#{etc_factsd_path}'")
+      agent.rm_rf(etc_factsd_path)
     end
 
     # ensure the fact directory we want to use exists
     step "Agent #{agent}: create facts directory (#{factsd_dir})" do
-      on(agent, "rm -rf '#{factsd_dir}'")
-      on(agent, "mkdir -p '#{factsd_dir}'")
+      agent.rm_rf(factsd_dir)
+      agent.mkdir_p(factsd_dir)
     end
 
     # A fact in the factsd_dir directory should resolve to the fact
@@ -85,7 +87,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
 
     # remove the fact
     step "Agent #{agent}: remove the fact in #{factsd_dir}" do
-      on(agent, "rm -f '#{factsd_path}'")
+      agent.rm_rf(factsd_path)
     end
 
     # A fact in the etc_factsd_dir directory should take precedence over the same fact in factsd_dir

--- a/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
+++ b/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
@@ -27,7 +27,9 @@ test_name 'Should handle same filename in two external directories only if ttl i
     config_file = File.join(config_dir, 'facter.conf')
 
     teardown do
-      on(agent, "rm -rf '#{external_dir1}' '#{external_dir2}' '#{config_file}'")
+      agent.rm_rf(external_dir1)
+      agent.rm_rf(external_dir2)
+      agent.rm_rf(config_file)
     end
 
     step 'works if ttl is not enabled' do
@@ -45,7 +47,7 @@ facts : {
     ]
 }
 EOM
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
       on(agent, facter("--external-dir '#{external_dir1}' --external-dir '#{external_dir2}' --debug #{fact1} #{fact2}"), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/ERROR.*Caching is enabled for group "#{external_filename}" while there are at least two external facts files with the same filename/, stderr, 'Expected error message')

--- a/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
+++ b/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
@@ -75,13 +75,14 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     facter_path = on(agent, "which facter").stdout.chomp
 
     teardown do
-      on(agent, "rm -rf '#{user_base_facts_dir}' '#{user_base_puppetlabs_dir}'")
+      agent.rm_rf(user_base_facts_dir)
+      agent.rm_rf(user_base_puppetlabs_dir)
       on(agent, puppet("resource user #{non_root_user} ensure=absent managehome=true"))
     end
 
     step "Agent #{agent}: create facts directory (#{user_facts_dir})" do
-      on(agent, "rm -rf '#{user_facts_dir}'")
-      on(agent, "mkdir -p '#{user_facts_dir}'")
+      agent.rm_rf(user_facts_dir)
+      agent.mkdir_p(user_facts_dir)
     end
 
     step "Agent #{agent}: create and resolve a custom fact in #{user_facts_dir}" do
@@ -89,8 +90,8 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: chown and chmod the facts to the user #{non_root_user}" do
-      on(agent, "chown -R #{non_root_user} '#{user_base_facts_dir}'")
-      on(agent, "chmod -R a+rx '#{user_base_facts_dir}'")
+      agent.chown(non_root_user, user_base_facts_dir, true)
+      agent.chmod('a+rx', user_base_facts_dir, true)
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and make sure we get the fact" do
@@ -100,12 +101,12 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: remove #{user_facts_path}" do
-      on(agent, "rm -rf '#{user_facts_path}'")
+      agent.rm_rf(user_facts_path)
     end
 
     step "Agent #{agent}: create facts directory (#{user_puppetlabs_facts_dir})" do
-      on(agent, "rm -rf '#{user_puppetlabs_facts_dir}'")
-      on(agent, "mkdir -p '#{user_puppetlabs_facts_dir}'")
+      agent.rm_rf(user_puppetlabs_facts_dir)
+      agent.mkdir_p(user_puppetlabs_facts_dir)
     end
 
     step "Agent #{agent}: create and resolve a custom fact in #{user_puppetlabs_facts_dir}" do
@@ -113,8 +114,8 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: chown and chmod the facts to the user #{non_root_user}" do
-      on(agent, "chown -R #{non_root_user} '#{user_base_puppetlabs_dir}'")
-      on(agent, "chmod -R a+rx '#{user_base_puppetlabs_dir}'")
+      agent.chown(non_root_user, user_base_puppetlabs_dir, true)
+      agent.chmod('a+rx', user_base_puppetlabs_dir, true)
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and make sure we get the fact" do
@@ -129,8 +130,11 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: chown and chmod the facts to the user #{non_root_user}" do
-      on(agent, "chown -R #{non_root_user} '#{user_base_facts_dir}' '#{user_base_puppetlabs_dir}'")
-      on(agent, "chmod -R a+rx '#{user_base_facts_dir}' '#{user_base_puppetlabs_dir}'")
+      agent.chown(non_root_user, user_base_facts_dir, true)
+      agent.chown(non_root_user, user_base_puppetlabs_dir, true)
+      agent.chmod('a+rx', user_base_facts_dir, true)
+      agent.chmod('a+rx', user_base_puppetlabs_dir, true)
+
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and .facter will take precedence over .puppetlabs" do

--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -16,13 +16,13 @@ test_name "C87571: facter resolves facts in the default facts.d directory" do
     content = external_fact_content(agent['platform'], 'external_fact', 'external_value')
 
     teardown do
-      on(agent, "rm -f '#{fact_file}'")
+      agent.rm_rf(fact_file)
     end
 
     step "Agent #{agent}: setup default external facts directory and fact" do
-      on(agent, "mkdir -p '#{factsd}'")
+      agent.mkdir_p(factsd)
       create_remote_file(agent, fact_file, content)
-      on(agent, "chmod +x '#{fact_file}'")
+      agent.chmod('+x', fact_file)
     end
 
     step "agent #{agent}: resolve the external fact" do

--- a/acceptance/tests/external_facts/structured_executable_facts.rb
+++ b/acceptance/tests/external_facts/structured_executable_facts.rb
@@ -81,17 +81,17 @@ EOM
     end
 
     step "Agent #{agent}: setup default external facts directory (facts.d)" do
-      on(agent, "mkdir -p '#{factsd}'")
+      agent.mkdir_p(factsd)
     end
 
     teardown do
-      on(agent, "rm -rf '#{factsd}'")
+      agent.rm_rf(factsd)
     end
 
     step "Agent #{agent}: create an executable yaml fact in default facts.d" do
       yaml_fact = File.join(factsd, "yaml_fact#{ext}")
       create_remote_file(agent, yaml_fact, yaml_content)
-      on(agent, "chmod +x '#{yaml_fact}'")
+      agent.chmod('+x', yaml_fact)
 
       step "YAML output should produce a structured fact" do
         on(agent, facter("yaml_fact")) do
@@ -103,7 +103,7 @@ EOM
     step "Agent #{agent}: create an executable json fact in default facts.d" do
       json_fact = File.join(factsd, "json_fact#{ext}")
       create_remote_file(agent, json_fact, json_content)
-      on(agent, "chmod +x '#{json_fact}'")
+      agent.chmod('+x', json_fact)
 
       step "JSON output should produce a structured fact" do
         on(agent, facter("json_fact")) do
@@ -115,7 +115,7 @@ EOM
     step "Agent #{agent}: create an executable key-value fact in default facts.d" do
       kv_fact = File.join(factsd, "kv_fact#{ext}")
       create_remote_file(agent, kv_fact, kv_content)
-      on(agent, "chmod +x '#{kv_fact}'")
+      agent.chmod('+x', kv_fact)
 
       step "output that is neither yaml nor json should not produce a structured fact" do
         on(agent, facter("kv_fact")) do
@@ -127,7 +127,7 @@ EOM
     step "Agent #{agent}: create a malformed executable fact in default facts.d" do
       bad_fact = File.join(factsd, "bad_fact#{ext}")
       create_remote_file(agent, bad_fact, bad_fact_content)
-      on(agent, "chmod +x '#{bad_fact}'")
+      agent.chmod('+x', bad_fact)
 
       step "should error when output is not in a supported format" do
         on(agent, facter("bad_fact --debug")) do

--- a/acceptance/tests/facts/operatingsystem_detection_after_clear_on_ubuntu.rb
+++ b/acceptance/tests/facts/operatingsystem_detection_after_clear_on_ubuntu.rb
@@ -18,7 +18,7 @@ test_name 'C14891: Facter should properly detect operatingsystem on Ubuntu after
     create_remote_file(agent, script_name, script_contents)
 
     teardown do
-      on(agent, "rm -rf '#{script_dir}'")
+      agent.rm_rf(script_dir)
     end
 
     on(agent, "#{Puppet::Acceptance::CommandUtils.ruby_command(agent)} #{script_name}", :acceptable_exit_codes => 0)

--- a/acceptance/tests/facts/ssh_key.rb
+++ b/acceptance/tests/facts/ssh_key.rb
@@ -26,19 +26,11 @@ test_name 'SSH publick key' do
       )
       if rc.exit_code == 0
         # It's present, so restore the original
-        on(
-          agent,
-          "mv -fv #{ssh_tmp_host_rsa_key_file} #{ssh_host_rsa_key_file}",
-          accept_all_exit_codes: true,
-        )
+        agent.mv(ssh_tmp_host_rsa_key_file, ssh_host_rsa_key_file)
       else
         # It's missing, which means there wasn't one to backup; just
         # delete the one we laid down
-        on(
-          agent,
-          "rm -fv #{ssh_host_rsa_key_file}",
-          accept_all_exit_codes: true,
-        )
+        agent.rm_rf(ssh_host_rsa_key_file)
       end
     end
 

--- a/acceptance/tests/facts/verify_tmpfs_file_system.rb
+++ b/acceptance/tests/facts/verify_tmpfs_file_system.rb
@@ -28,12 +28,13 @@ test_name 'C98163: mountpoints fact should show mounts on tmpfs' do
         atboot  => true,
       }
     FILE
-    on(agent, "mkdir -p #{mount_point}")
+    agent.mkdir_p(mount_point)
     create_remote_file(agent, manifest, manifest_content)
 
     teardown do
       on(agent, "umount #{mount_point}")
-      on(agent, "rm -rf #{mount_point} #{manifest_dir}")
+      agent.rm_rf(mount_point)
+      agent.rm_rf(manifest_dir)
     end
 
     step "Apply the manifest to mount directory '#{mount_point}'" do

--- a/acceptance/tests/load_libfacter.rb
+++ b/acceptance/tests/load_libfacter.rb
@@ -39,7 +39,7 @@ test_name 'C100161: Ruby can load libfacter without raising an error' do
     create_remote_file(agent, fact_program, fact_content)
 
     teardown do
-      on(agent, "rm -rf '#{fact_dir}'")
+      agent.rm_rf(fact_dir)
     end
 
     if agent['platform'] =~ /windows/

--- a/acceptance/tests/options/config.rb
+++ b/acceptance/tests/options/config.rb
@@ -14,7 +14,7 @@ test_name "C100014: --config command-line option designates the location of the 
       FILE
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
       end
 
       step "setting --config should cause the config file to be loaded from the specified location" do

--- a/acceptance/tests/options/config_file/blocklist.rb
+++ b/acceptance/tests/options/config_file/blocklist.rb
@@ -16,7 +16,7 @@ test_name "C99972: facts can be blocked via a blocklist in the config file" do
       FILE
 
       teardown do
-        on(agent, "rm -rf '#{custom_conf_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(custom_conf_dir)
       end
 
       step "blocked facts should not be resolved" do

--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -13,12 +13,12 @@ test_name "C100036: when run from puppet facts, facts can be blocked via a list 
       facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
       teardown do
-        on(agent, "rm -rf '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(facter_conf_default_dir)
       end
 
       step "Agent #{agent}: create default config file" do
         # create the directories
-        on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+        agent.mkdir_p(facter_conf_default_dir)
         create_remote_file(agent, facter_conf_default_path, <<-FILE)
         facts : { blocklist : [ "file system", "EC2" ] }
         FILE

--- a/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
+++ b/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
@@ -41,7 +41,9 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_config_dir}' '#{custom_cli_dir}' '#{config_dir}'")
+        agent.rm_rf(custom_config_dir)
+        agent.rm_rf(custom_cli_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact from the command line custom-dir and not the config file" do

--- a/acceptance/tests/options/config_file/custom_facts.rb
+++ b/acceptance/tests/options/config_file/custom_facts.rb
@@ -29,7 +29,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir}' '#{config_dir}'")
+        agent.rm_rf(custom_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact from the configured custom-dir path" do

--- a/acceptance/tests/options/config_file/custom_facts_list.rb
+++ b/acceptance/tests/options/config_file/custom_facts_list.rb
@@ -41,7 +41,9 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir_1}' '#{custom_dir_2}' '#{config_dir}'")
+        agent.rm_rf(custom_dir_1)
+        agent.rm_rf(custom_dir_2)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact from each configured custom-dir path" do

--- a/acceptance/tests/options/config_file/debug.rb
+++ b/acceptance/tests/options/config_file/debug.rb
@@ -16,11 +16,11 @@ EOM
     step "Agent #{agent}: create config file" do
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        agent.rm_rf(config_dir)
       end
 
       step "debug output should print when config file is loaded" do

--- a/acceptance/tests/options/config_file/debug_override_config_file.rb
+++ b/acceptance/tests/options/config_file/debug_override_config_file.rb
@@ -17,11 +17,11 @@ EOM
     config_file = File.join(config_dir, "facter.conf")
 
     teardown do
-      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(config_dir)
     end
 
     step "Agent #{agent}: create config file in default location" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
     end
 

--- a/acceptance/tests/options/config_file/default_file_location.rb
+++ b/acceptance/tests/options/config_file/default_file_location.rb
@@ -15,16 +15,17 @@ EOM
     step "Agent #{agent}: create config file" do
       if agent['platform'] =~ /windows/
         config_dir = 'C:\\ProgramData\\PuppetLabs\\facter\\etc'
+        config_file = "#{config_dir}\\facter.conf"
      else
-        config_dir = "/etc/puppetlabs/facter"
+        config_dir = '/etc/puppetlabs/facter'
+        config_file = "#{config_dir}/facter.conf"
       end
 
-      on(agent, "mkdir -p '#{config_dir}'")
-      config_file = File.join(config_dir, "facter.conf")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        agent.rm_rf(config_dir)
       end
 
       step "config file should be loaded automatically and turn DEBUG output on" do

--- a/acceptance/tests/options/config_file/external_dir_conflicts_with_cli_no_external_facts.rb
+++ b/acceptance/tests/options/config_file/external_dir_conflicts_with_cli_no_external_facts.rb
@@ -20,11 +20,11 @@ EOM
     config_file = File.join(config_dir, "facter.conf")
 
     teardown do
-      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(config_dir)
     end
 
     step "Agent #{agent}: create config file in default location" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
     end
 

--- a/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
+++ b/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
@@ -25,7 +25,9 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{external_config_dir}' '#{external_cli_dir}' '#{config_dir}'")
+        agent.rm_rf(external_config_dir)
+        agent.rm_rf(external_cli_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact from the command line external-dir and not the config file" do

--- a/acceptance/tests/options/config_file/external_facts.rb
+++ b/acceptance/tests/options/config_file/external_facts.rb
@@ -12,7 +12,7 @@ test_name "C98142: config external-dir allows single external fact directory" do
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact = File.join(external_dir, "external_fact#{ext}")
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'single_fact', 'external_value'))
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
 
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
@@ -24,7 +24,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
+        agent.rm_rf(external_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact in the external-dir in the configuration file" do

--- a/acceptance/tests/options/config_file/external_facts_list.rb
+++ b/acceptance/tests/options/config_file/external_facts_list.rb
@@ -16,7 +16,9 @@ test_name "C99995: config file supports external-dir for multiple fact directori
       external_fact_2 = File.join(external_dir_2, "external_fact#{ext}")
       create_remote_file(agent, external_fact_1, external_fact_content(agent['platform'], 'external_fact_1', 'external_value_1'))
       create_remote_file(agent, external_fact_2, external_fact_content(agent['platform'], 'external_fact_2', 'external_value_2'))
-      on(agent, "chmod +x '#{external_fact_1}' '#{external_fact_2}'")
+      agent.chmod('+x', external_fact_1)
+      agent.chmod('+x', external_fact_2)
+
 
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
@@ -28,7 +30,9 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir_1}' '#{external_dir_2}' '#{config_dir}'")
+        agent.rm_rf(external_dir_1)
+        agent.rm_rf(external_dir_2)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: resolve a fact from each configured external-dir path" do

--- a/acceptance/tests/options/config_file/load_from_ruby.rb
+++ b/acceptance/tests/options/config_file/load_from_ruby.rb
@@ -29,12 +29,16 @@ test_name "C98141: config file is loaded when Facter is run from Puppet" do
     cust_path     = File.join(cust_fact_dir, "custom_fact.rb")
 
     teardown do
-      on(agent, "rm -rf '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'",
-          :acceptable_exit_codes => [0,1])
+      agent.rm_rf(facter_conf_default_dir)
+      agent.rm_rf(ext_fact_dir1)
+      agent.rm_rf(ext_fact_dir2)
+      agent.rm_rf(cust_fact_dir)
     end
 
     # create the directories
-    on(agent, "mkdir -p '#{facter_conf_default_dir}' '#{ext_fact_dir1}' '#{ext_fact_dir2}' '#{cust_fact_dir}'")
+    [facter_conf_default_dir, ext_fact_dir1, ext_fact_dir2, cust_fact_dir].each do |dir|
+      agent.mkdir_p(dir)
+    end
 
     step "Agent #{agent}: create facter.conf, external fact, and custom fact files" do
 

--- a/acceptance/tests/options/config_file/log_level.rb
+++ b/acceptance/tests/options/config_file/log_level.rb
@@ -17,11 +17,11 @@ EOM
     step "Agent #{agent}: create config file" do
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
       end
 
       step "log-level set to debug should print DEBUG output to stderr" do

--- a/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
@@ -30,7 +30,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_fact}' '#{config_dir}'")
+        agent.rm_rf(custom_fact)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: config option no-custom-facts : true and custom-dir should result in an options conflict error" do

--- a/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
@@ -30,7 +30,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{facterlib_dir}' '#{config_dir}'")
+        agent.rm_rf(facterlib_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: no-custom-facts should ignore the FACTERLIB environment variable" do

--- a/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
@@ -22,7 +22,7 @@ EOM
     step("Agent #{agent}: determine the load path and create a custom facter directory on it and a config file") do
       ruby_path = on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'").stdout.chomp
       load_path_facter_dir = File.join(ruby_path, 'facter')
-      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      agent.mkdir_p(load_path_facter_dir)
       custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
 
@@ -36,7 +36,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{load_path_facter_dir}' '#{config_dir}'")
+        agent.rm_rf(load_path_facter_dir)
+        agent.rm_rf(config_dir)
       end
 
       step("Agent #{agent}: using config no-custom-facts : true should not resolve facts in facter directories on the $LOAD_PATH") do

--- a/acceptance/tests/options/config_file/no_external_facts.rb
+++ b/acceptance/tests/options/config_file/no_external_facts.rb
@@ -12,7 +12,8 @@ test_name "C99962: config no-external-facts : true does not load external facts"
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact = File.join(external_dir, "external_fact#{ext}")
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'external_fact', 'external_value'))
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
+
 
       config_dir = agent.tmpdir("config_dir")
       config_file = File.join(config_dir, "facter.conf")
@@ -25,7 +26,8 @@ EOM
 
 
       teardown do
-        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
+        agent.rm_rf(external_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: --no-external-facts option should not load external facts" do

--- a/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
@@ -21,7 +21,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir}' '#{config_dir}'")
+        agent.rm_rf(external_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "Agent #{agent}: config option no-external-facts : true and external-dir should result in an options conflict error" do

--- a/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
+++ b/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
@@ -24,22 +24,22 @@ EOM
     step "Agent #{agent}: create config file" do
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        agent.rm_rf(config_dir)
       end
 
       step "no-ruby option should disable custom facts" do
         step "Agent #{agent}: create custom fact directory and custom fact" do
           custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-          on(agent, "mkdir -p '#{custom_dir}'")
+          agent.mkdir_p(custom_dir)
           custom_fact = File.join(custom_dir, 'custom_fact.rb')
           create_remote_file(agent, custom_fact, custom_fact_content)
 
           teardown do
-            on(agent, "rm -rf '#{custom_dir}'", :acceptable_exit_codes => [0,1])
+            agent.rm_rf(custom_dir)
           end
 
           on(agent, facter("custom_fact", :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|

--- a/acceptance/tests/options/config_file/no_ruby_disables_ruby_facts.rb
+++ b/acceptance/tests/options/config_file/no_ruby_disables_ruby_facts.rb
@@ -16,11 +16,11 @@ EOM
     step "Agent #{agent}: create config file" do
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        agent.rm_rf(config_dir)
       end
 
       step "no-ruby option should disable Ruby and facts requiring Ruby" do

--- a/acceptance/tests/options/config_file/trace.rb
+++ b/acceptance/tests/options/config_file/trace.rb
@@ -23,18 +23,20 @@ EOM
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and executable custom fact" do
       custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-      on(agent, "mkdir -p '#{custom_dir}'")
+      agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, "custom_fact.rb")
       create_remote_file(agent, custom_fact, erroring_custom_fact)
-      on(agent, "chmod +x '#{custom_fact}'")
+      agent.chmod('+x', custom_fact)
+
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir}' '#{config_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(custom_dir)
+        agent.rm_rf(config_dir)
       end
 
       step "trace setting should provide a backtrace for a custom fact with errors" do

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
@@ -37,7 +37,8 @@ EOF
 EOM
       end
       create_remote_file(agent, external_fact, external_fact_content)
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
+
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
@@ -46,7 +47,7 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -63,11 +64,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -77,7 +80,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
@@ -19,7 +19,8 @@ test_name "ttls configured cached external execution resolver with text output c
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact = File.join(external_dir, "#{external_cachegroup}#{ext}")
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], cached_fact_name, initial_fact_value))
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
+
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
@@ -28,7 +29,7 @@ test_name "ttls configured cached external execution resolver with text output c
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -45,11 +46,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -59,7 +62,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
@@ -33,7 +33,7 @@ EOF
 EOM
       end
       create_remote_file(agent, external_fact, external_fact_content)
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
@@ -42,7 +42,7 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -59,11 +59,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -73,7 +75,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
@@ -33,7 +33,7 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -50,11 +50,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -64,7 +66,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
@@ -22,7 +22,7 @@ test_name "ttls configured cached external text resolver creates and read json c
       external_fact_content = <<EOM
 #{cached_fact_name}=#{initial_fact_value}
 EOM
-      
+
       create_remote_file(agent, external_fact, external_fact_content)
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
@@ -32,7 +32,7 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -49,11 +49,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -63,7 +65,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
@@ -22,7 +22,7 @@ test_name "ttls configured cached external yaml resolver creates and read json c
       external_fact_content = <<EOM
 #{cached_fact_name}: "#{initial_fact_value}"
 EOM
-      
+
       create_remote_file(agent, external_fact, external_fact_content)
 
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
@@ -32,7 +32,7 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       cached_fact_content = <<EOM
 {
   "#{cached_fact_name}": "#{cached_fact_value}"
@@ -49,11 +49,13 @@ EOM
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}' '#{cached_facts_dir}' '#{external_dir}'")
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(external_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
@@ -63,7 +65,7 @@ EOM
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'")
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--external-dir '#{external_dir}' --debug #{cached_fact_name}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)

--- a/acceptance/tests/options/config_file/ttls_cached_facts_clear_by_empty_ttls_cache_list.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_clear_by_empty_ttls_cache_list.rb
@@ -39,17 +39,17 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "Agent #{agent}: create config file with no cached facts" do
         # Set up a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
       end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
@@ -26,16 +26,16 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter("--debug")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
@@ -33,21 +33,21 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should not read from a cached JSON file for a fact that has been cached but the TTL expired" do
         # Setup a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
         # Change the modified date to sometime in the far distant past
-        on(agent, "touch -mt 198001010000 '#{cached_fact_file}'")
+        agent.modified_at(cached_fact_file, '198001010000')
 
         on(agent, facter("#{cached_factname}")) do |facter_output|
           assert_not_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to not match the cached fact file")

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
@@ -33,21 +33,21 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should refresh an expired cached fact" do
         # Setup a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
         # Change the modified date to sometime in the far distant past
-        on(agent, "touch -mt 198001010000 '#{cached_fact_file}'")
+        agent.modified_at(cached_fact_file, '198001010000')
         # Force facter to recache
         on(agent, facter("#{cached_factname}"))
 

--- a/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
@@ -33,17 +33,17 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
         # Setup a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
@@ -26,17 +26,17 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should refresh a cached fact if cache file is corrupt" do
         # Setup a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         # Corrupt the cached fact file
         create_remote_file(agent, cached_fact_file, 'ThisIsNotvalidJSON')

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
@@ -30,17 +30,17 @@ EOM
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       # Setup facter conf
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(config_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should return an empty string for an empty JSON document" do
         # Setup a known cached fact
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, empty_cached_fact_content)
 

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
@@ -24,15 +24,16 @@ EOM
       cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
-      on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+      agent.mkdir_p(facter_conf_default_dir)
       create_remote_file(agent, facter_conf_default_path, config)
 
       teardown do
-        on(agent, "rm -rf '#{cached_facts_dir}' '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(facter_conf_default_dir)
+        agent.rm_rf(cached_facts_dir)
       end
 
       step "should create a JSON file for a fact that is to be cached" do
-        on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
         on(agent, puppet("facts --debug")) do |pupppet_fact_output|
           assert_match(/caching values for .+ facts/, pupppet_fact_output.stdout, "Expected debug message to state that values will be cached")
         end

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -30,16 +30,17 @@ EOM
       cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
-      on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+      agent.mkdir_p(facter_conf_default_dir)
       create_remote_file(agent, facter_conf_default_path, config)
 
       teardown do
-        on(agent, "rm -rf '#{cached_facts_dir}' '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+        agent.rm_rf(cached_facts_dir)
+        agent.rm_rf(facter_conf_default_dir)
       end
 
       step "should read from a cached JSON file for a fact that has been cached" do
         step "call puppet facts to setup the cached fact" do
-          on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+          agent.rm_rf(cached_facts_dir)
           on(agent, puppet("facts"))
           create_remote_file(agent, cached_fact_file, cached_fact_content)
         end

--- a/acceptance/tests/options/config_file/verbose.rb
+++ b/acceptance/tests/options/config_file/verbose.rb
@@ -1,4 +1,4 @@
-# This test is intended to demonstrate that setting cli.verbose to true in the 
+# This test is intended to demonstrate that setting cli.verbose to true in the
 # config file causes INFO level logging to output to stderr.
 test_name "C99989: verbose config field prints verbose information to stderr" do
   tag 'risk:medium'
@@ -16,11 +16,11 @@ EOM
     step "Agent #{agent}: create config file" do
       config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
 
       teardown do
-        on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0,1])
+        agent.rm_rf(config_dir)
       end
 
       step "debug output should print when config file is loaded" do

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -21,7 +21,7 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir}'")
+        agent.rm_rf(custom_dir)
       end
 
       step "Agent #{agent}: --custom-dir option should resolve custom facts from the specific directory" do

--- a/acceptance/tests/options/custom_facts_facterlib.rb
+++ b/acceptance/tests/options/custom_facts_facterlib.rb
@@ -20,7 +20,7 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir}'")
+        agent.rm_rf(custom_dir)
       end
 
       step "Agent #{agent}: facter should resolve a fact from the directory specified by the environment variable FACTERLIB" do

--- a/acceptance/tests/options/custom_facts_list.rb
+++ b/acceptance/tests/options/custom_facts_list.rb
@@ -33,7 +33,8 @@ EOM
       create_remote_file(agent, custom_fact_2, content_2)
 
       teardown do
-        on(agent, "rm -rf '#{custom_dir_1}' '#{custom_dir_2}'")
+        agent.rm_rf(custom_dir_1)
+        agent.rm_rf(custom_dir_2)
       end
 
       step "Agent #{agent}: resolve a fact from each specified --custom-dir option" do

--- a/acceptance/tests/options/custom_facts_load_path.rb
+++ b/acceptance/tests/options/custom_facts_load_path.rb
@@ -25,12 +25,12 @@ EOM
     step "Agent #{agent}: determine $LOAD_PATH and create custom fact" do
       on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'")
       load_path_facter_dir = File.join(stdout.chomp, 'facter')
-      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      agent.mkdir_p(load_path_facter_dir)
       custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -rf '#{load_path_facter_dir}'")
+        agent.rm_rf(load_path_facter_dir)
       end
 
       step("Agent #{agent}: resolve the custom fact that is in a facter directory on the $LOAD_PATH")

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -12,10 +12,10 @@ test_name "C99974: external fact commandline options --external-dir resolves an 
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact = File.join(external_dir, "external_fact#{ext}")
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'single_fact', 'external_value'))
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir}'")
+        agent.rm_rf(external_dir)
       end
 
       step "Agent #{agent}: resolve a fact from each specified --external_dir option" do

--- a/acceptance/tests/options/external_facts_list.rb
+++ b/acceptance/tests/options/external_facts_list.rb
@@ -17,10 +17,12 @@ test_name "C99998: external fact commandline option --external-dir can be specif
       external_fact_2 = File.join(external_dir_2, "external_fact#{ext}")
       create_remote_file(agent, external_fact_1, external_fact_content(agent['platform'], 'external_fact_1', 'external_value_1'))
       create_remote_file(agent, external_fact_2, external_fact_content(agent['platform'], 'external_fact_2', 'external_value_2'))
-      on(agent, "chmod +x '#{external_fact_1}' '#{external_fact_2}'")
+      agent.chmod('+x', external_fact_1)
+      agent.chmod('+x', external_fact_2)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir_1}' '#{external_dir_2}'")
+        agent.rm_rf(external_dir_1)
+        agent.rm_rf(external_dir_2)
       end
 
       step "Agent #{agent}: resolve a fact from each specified --external_dir option" do

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -20,12 +20,12 @@ EOM
     step "Agent #{agent}: create a structured custom fact" do
       custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
-      on(agent, "mkdir -p '#{custom_dir}'")
+      agent.mkdir_p(custom_dir)
       create_remote_file(agent, custom_fact, content)
-      on(agent, "chmod +x '#{custom_fact}'")
+      agent.chmod('+x', custom_fact)
 
       teardown do
-        on(agent, "rm -f '#{custom_fact}'")
+        agent.rm_rf(custom_fact)
       end
 
       step "Agent #{agent}: retrieve output using the --json option" do

--- a/acceptance/tests/options/list_cache_groups.rb
+++ b/acceptance/tests/options/list_cache_groups.rb
@@ -13,7 +13,8 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
     etc_factsd_path = "#{etc_factsd_dir}/#{filename}"
 
     teardown do
-      on(agent, "rm -rf '#{external_dir}' '#{etc_factsd_path}'")
+      agent.rm_rf(external_dir)
+      agent.rm_rf(etc_factsd_path)
     end
 
     step "the various cache groups should be listed" do
@@ -30,7 +31,7 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact_script = File.join(external_dir, "#{external_filename}#{ext}")
       create_remote_file(agent, external_fact_script, external_fact_content(agent['platform'], "a", "b"))
-      on(agent, "chmod +x '#{external_fact_script}'")
+      agent.chmod('+x', external_fact_script)
 
       external_fact_script_txt = File.join(external_dir, "#{external_filename}.txt")
       create_remote_file(agent, external_fact_script_txt, '')
@@ -47,11 +48,11 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
         assert_match(/#{external_filename}.json/, facter_output.stdout, "external facts json files should be listed as cacheable")
         assert_match(/#{external_filename}.yaml/, facter_output.stdout, "external facts yaml files should be listed as cacheable")
       end
-      on(agent, "rm -rf '#{external_dir}'")
+      agent.rm_rf(external_dir)
     end
 
     step "external facts groups should be listed only without --no-external-facts" do
-      on(agent, "mkdir -p '#{etc_factsd_dir}'")
+      agent.mkdir_p(etc_factsd_dir)
       create_remote_file(agent, etc_factsd_path, 'test_fact: test_value')
       on(agent, facter("--list-cache-groups")) do |facter_output|
         assert_match(/#{filename}/, facter_output.stdout, "external facts script files should be listed as cacheable")
@@ -59,7 +60,7 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
       on(agent, facter("--list-cache-groups --no-external-facts")) do |facter_output|
         assert_no_match(/#{filename}/, facter_output.stdout, "external facts script files should now be listed as cacheable when --no-external-facts is used")
       end
-      on(agent, "rm -f '#{etc_factsd_path}'")
+      agent.rm_rf(etc_factsd_path)
     end
   end
 end

--- a/acceptance/tests/options/no_block.rb
+++ b/acceptance/tests/options/no_block.rb
@@ -12,11 +12,11 @@ test_name "C99971: the `--no-block` command line flag prevents facts from being 
     facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
     teardown do
-      on(agent, "rm -rf '#{facter_conf_default_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(facter_conf_default_dir)
     end
 
     # create the directories
-    on(agent, "mkdir -p '#{facter_conf_default_dir}'")
+    agent.mkdir_p(facter_conf_default_dir)
 
     step "Agent #{agent}: create config file" do
       create_remote_file(agent, facter_conf_default_path, <<-FILE)

--- a/acceptance/tests/options/no_cache_should_not_cache_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_cache_facts.rb
@@ -22,15 +22,15 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
     cached_facts_dir = get_cached_facts_dir(agent['platform'], kernel_version)
     cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
-    on(agent, "rm -f '#{cached_fact_file}'", :acceptable_exit_codes => [0, 1])
+    agent.rm_rf(cached_fact_file)
 
     teardown do
-      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cached_facts_dir)
     end
 
     step "Agent #{agent}: create config file in default location" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
     end
 

--- a/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
@@ -11,7 +11,7 @@ test_name "C100123: --no-cache command-line option does not load facts from the 
   cached_fact_name = "uptime"
   bad_cached_fact_value = "CACHED_FACT_VALUE"
   bad_cached_content = <<EOM
-{ 
+{
   "#{cached_fact_name}": "fake #{bad_cached_fact_value}"
 }
 EOM
@@ -31,18 +31,18 @@ EOM
     cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
     teardown do
-      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cached_facts_dir)
     end
 
     step "Agent #{agent}: create config file in default location" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
     end
 
     step "facter should not load facts from the cache when --no-cache is specified" do
       # clear the fact cache
-      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(cached_facts_dir)
 
       # run once to cache the uptime fact
       on(agent, facter(""))

--- a/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
@@ -11,7 +11,7 @@ test_name "C100124: --no-cache does not refresh expired cached facts" do
   cached_fact_name = "uptime"
   bad_cached_fact_value = "CACHED_FACT_VALUE"
   bad_cached_content = <<EOM
-{ 
+{
   "#{cached_fact_name}": "fake #{bad_cached_fact_value}"
 }
 EOM
@@ -30,18 +30,18 @@ FILE
     cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
     teardown do
-      on(agent, "rm -rf '#{config_dir}'", :acceptable_exit_codes => [0, 1])
-      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cached_facts_dir)
     end
 
     step "Agent #{agent}: create config file in default location" do
-      on(agent, "mkdir -p '#{config_dir}'")
+      agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
     end
 
     step "facter should not refresh an expired cache when --no-cache is specified" do
       # clear the fact cache
-      on(agent, "rm -rf '#{cached_facts_dir}'", :acceptable_exit_codes => [0, 1])
+      agent.rm_rf(cached_facts_dir)
 
       # run once to cache the uptime fact
       on(agent, facter(""))
@@ -49,7 +49,7 @@ FILE
       # override cached content
       create_remote_file(agent, cached_fact_file, bad_cached_content)
       # update the modify time on the new cached fact to prompt a refresh
-      on(agent, "touch -mt 0301010000 '#{cached_fact_file}'")
+      agent.modified_at(cached_fact_file, '198001010000')
 
       on(agent, facter("--no-cache")) do |facter_output|
         assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to refresh the cache")

--- a/acceptance/tests/options/no_custom_facts.rb
+++ b/acceptance/tests/options/no_custom_facts.rb
@@ -16,12 +16,12 @@ EOM
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and custom fact" do
       custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-      on(agent, "mkdir -p '#{custom_dir}'")
+      agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -f '#{custom_fact}'")
+        agent.rm_rf(custom_fact)
       end
 
       step "Agent #{agent}: --no-custom-facts option should not load custom facts" do

--- a/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
@@ -7,7 +7,7 @@ test_name "C100001: custom fact commandline options --no-custom-facts together w
     custom_dir = agent.tmpdir('custom_dir')
 
     teardown do
-      on(agent, "rm -rf '#{custom_dir}'")
+      agent.rm_rf(custom_dir)
     end
 
     step "Agent #{agent}: --no-custom-facts and --custom-dir options should result in a error" do

--- a/acceptance/tests/options/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/no_custom_facts_and_facterlib.rb
@@ -21,7 +21,7 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -rf '#{facterlib_dir}'")
+        agent.rm_rf(facterlib_dir)
       end
 
       step "Agent #{agent}: --no-custom-facts should ignore the FACTERLIB environment variable" do

--- a/acceptance/tests/options/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/no_custom_facts_and_load_path.rb
@@ -25,12 +25,12 @@ EOM
     step("Agent #{agent}: determine the load path and create a custom facter directory on it") do
       on(agent, "#{ruby_command(agent)} -e 'puts $LOAD_PATH[0]'")
       load_path_facter_dir = File.join(stdout.chomp, 'facter')
-      on(agent, "mkdir -p \"#{load_path_facter_dir}\"")
+      agent.mkdir_p(load_path_facter_dir)
       custom_fact = File.join(load_path_facter_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        on(agent, "rm -rf '#{load_path_facter_dir}'")
+        agent.rm_rf(load_path_facter_dir)
       end
 
       step("Agent #{agent}: using --no-custom-facts should not resolve facts on the $LOAD_PATH") do

--- a/acceptance/tests/options/no_external_facts.rb
+++ b/acceptance/tests/options/no_external_facts.rb
@@ -12,10 +12,10 @@ test_name "C99961: external fact command line option --no-external-facts does no
       ext = get_external_fact_script_extension(agent['platform'])
       external_fact = File.join(external_dir, "external_fact#{ext}")
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], 'external_fact', 'external_value'))
-      on(agent, "chmod +x '#{external_fact}'")
+      agent.chmod('+x', external_fact)
 
       teardown do
-        on(agent, "rm -rf '#{external_dir}'")
+        agent.rm_rf(external_dir)
       end
 
       step "Agent #{agent}: --no-external-facts option should not load external facts" do

--- a/acceptance/tests/options/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/no_external_facts_and_external_dir.rb
@@ -7,7 +7,7 @@ test_name "C100002: external fact commandline options --no-external-facts togeth
     external_dir = agent.tmpdir('external_dir')
 
     teardown do
-      on(agent, "rm -rf '#{external_dir}'")
+      agent.rm_rf(external_dir)
     end
 
     step "Agent #{agent}: --no-external-facts and --external-dir options should result in a error" do

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -27,12 +27,12 @@ EOM
     step "--no-ruby option should disable custom facts" do
       step "Agent #{agent}: create custom fact directory and custom fact" do
         custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-        on(agent, "mkdir -p '#{custom_dir}'")
+        agent.mkdir_p(custom_dir)
         custom_fact = File.join(custom_dir, 'custom_fact.rb')
         create_remote_file(agent, custom_fact, content)
 
         teardown do
-          on(agent, "rm -f '#{custom_fact}'")
+          agent.rm_rf(custom_fact)
         end
 
         on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do

--- a/acceptance/tests/options/puppet_facts.rb
+++ b/acceptance/tests/options/puppet_facts.rb
@@ -9,16 +9,17 @@ test_name "C14783: facter -p loads facts from puppet" do
     custom_file = "#{custom_dir}/custom.rb"
 
     teardown do
-      on agent, "rm -f '#{external_file}' '#{custom_file}'"
+      agent.rm_rf(external_file)
+      agent.rm_rf(custom_dir)
     end
 
     step "Agent #{agent}: create external fact" do
-      on agent, "mkdir -p '#{external_dir}'"
+      agent.mkdir_p(external_dir)
       create_remote_file(agent, external_file, "external=external")
     end
 
     step "Agent #{agent}: create custom fact" do
-      on agent, "mkdir -p '#{custom_dir}'"
+      agent.mkdir_p(custom_dir)
       create_remote_file(agent, custom_file, "Facter.add(:custom) { setcode { 'custom' } }")
     end
 

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -17,13 +17,13 @@ EOM
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and executable custom fact" do
       custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
-      on(agent, "mkdir -p '#{custom_dir}'")
+      agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
-      on(agent, "chmod +x '#{custom_fact}'")
+      agent.chmod('+x', custom_fact)
 
       teardown do
-        on(agent, "rm -f '#{custom_fact}'")
+        agent.rm_rf(custom_fact)
       end
 
       step "--trace option should provide a backtrace for a custom fact with errors" do

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -20,12 +20,12 @@ EOM
     step "Agent #{agent}: create a structured custom fact" do
       custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
-      on(agent, "mkdir -p '#{custom_dir}'")
+      agent.mkdir_p(custom_dir)
       create_remote_file(agent, custom_fact, content)
-      on(agent, "chmod +x '#{custom_fact}'")
+      agent.chmod('+x', custom_fact)
 
       teardown do
-        on(agent, "rm -f '#{custom_fact}'")
+        agent.rm_rf(custom_fact)
       end
 
       step "Agent #{agent}: retrieve output using the --yaml option" do


### PR DESCRIPTION
In order to be platform flexible when running tests we need to have methods to be able to run chmod and update the modified date on files on hosts.

These requirements were found in Facter acceptance tests.
-chmod - change permissions on files/dirs
-modified_at - updating the modification date on a file
-rm_rf - for deleting files/dirs
-mkdir_p - create directory structure

At the moment these were used running linux based commands (chmod, touch, mkdir, rm) that are not compatible with windows cmd or powershell.