### PR TITLE
Revert "(maint) Ubuntu 20.04 adaptation"

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -492,7 +492,7 @@ module Facter
         expected_facts = {
             'os.architecture'          => os_arch,
             'os.distro.codename'       => /\w+/,
-            'os.distro.description'    => agent['platform'] == 'ubuntu-20.04-amd64' ? 'Ubuntu Focal Fossa (development branch)' : /Ubuntu #{os_version}/,
+            'os.distro.description'    => /Ubuntu #{os_version}/,
             'os.distro.id'             => 'Ubuntu',
             'os.distro.release.full'   => os_version,
             'os.distro.release.major'  => os_version,


### PR DESCRIPTION
This reverts commit 4a34d874d1ef3b815b8f6813b4e8d9d61b4279fa.
It is no longer needed in released Ubuntu 20.04 LTS