### PR TITLE
(FACT-2515) Accept facter 4 log messages for custom facts cache

### DIFF
--- a/acceptance/tests/custom_facts/cached_custom_fact.rb
+++ b/acceptance/tests/custom_facts/cached_custom_fact.rb
@@ -57,9 +57,9 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
     step "should log that it creates cache file and it caches custom facts found in facter.conf" do
       on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
         assert_equal(custom_fact_value, facter_result.stdout.chomp, "#{custom_fact_name} value changed")
-        assert_match(/Custom facts cache file expired\/missing. Refreshing/, facter_result.stderr,
+        assert_match(/facts cache file expired\/missing/, facter_result.stderr,
                      'Expected debug message to state that custom facts cache file is missing or expired')
-        assert_match(/Saving cached custom facts to ".+"/, facter_result.stderr,
+        assert_match(/Saving cached custom facts to ".+"|caching values for cached-custom-facts facts/, facter_result.stderr,
                      'Expected debug message to state that custom facts will be cached')
       end
     end
@@ -75,7 +75,7 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
 
     step 'should read from the cached file for a custom fact that has been cached' do
       on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
-        assert_match(/Loading cached custom facts from file ".+"/, facter_result.stderr,
+        assert_match(/Loading cached custom facts from file ".+"|loading cached values for cached-custom-facts facts/, facter_result.stderr,
                      'Expected debug message to state that cached custom facts are read from file')
       end
     end


### PR DESCRIPTION
Facter 4 has slightly different log messages. This change makes sure the test passes on both facter 3 and 4.