### PR TITLE
Fix master (#556)

### DIFF
--- a/lib/resolvers/ec2.rb
+++ b/lib/resolvers/ec2.rb
@@ -57,10 +57,14 @@ module Facter
           http.read_timeout = determine_session_timeout
           http.open_timeout = EC2_CONNECTION_TIMEOUT
           resp = http.get(parsed_url.path)
-          resp.code.to_i.equal?(200) ? resp.body : ''
-        rescue Net::OpenTimeout
-          log.debug("#{url} timed out while trying to connect")
+          response_code_valid?(resp.code) ? resp.body : ''
+        rescue StandardError => e
+          log.debug("Trying to connect to #{url} but got: #{e.message}")
           ''
+        end
+
+        def response_code_valid?(http_code)
+          http_code.to_i.equal?(200)
         end
 
         def determine_session_timeout

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -70,7 +70,7 @@ describe Facter::Resolvers::Ec2 do
       ec2.resolve(:userdata)
 
       expect(log_spy).to have_received(:debug)
-        .with('http://169.254.169.254/latest/user-data/ timed out while trying to connect')
+        .with('Trying to connect to http://169.254.169.254/latest/user-data/ but got: Net::OpenTimeout')
     end
   end
 end


### PR DESCRIPTION
* (maint) Catch exception for ec2.

* (maint) Catch Errno::ENETUNREACH exception

* (maint) Return empty string when encountering Errno::ENETUNREACH exception.

* (maint) Fix rubocop.

* (maint) Rescue from a larger class of errors.

* (maint) Fix rubocop and test.