### PR TITLE
(maint) Fix aio_agent_version on non AIO node

### DIFF
--- a/lib/resolvers/aio_agent_version.rb
+++ b/lib/resolvers/aio_agent_version.rb
@@ -14,7 +14,7 @@ module Facter
         end
 
         def read_agent_version
-          aio_agent_version = Util::FileHelper.safe_read('/opt/puppetlabs/puppet/VERSION', nil).chomp
+          aio_agent_version = Util::FileHelper.safe_read('/opt/puppetlabs/puppet/VERSION', nil)&.chomp
           aio_agent_version = aio_agent_version&.match(/^\d+\.\d+\.\d+(\.\d+){0,2}/)&.to_s
           @fact_list[:aio_agent_version] = aio_agent_version
         end


### PR DESCRIPTION
nil does not have a chomp method.

Fixes:
```
[2020-06-24 21:47:58.625776 ] ERROR Facter::InternalFactManager - /usr/home/romain/Projects/facter/lib/resolvers/aio_agent_version.rb:17:in `read_agent_version'
/usr/home/romain/Projects/facter/lib/resolvers/aio_agent_version.rb:13:in `block in post_resolve'
/usr/home/romain/Projects/facter/lib/resolvers/aio_agent_version.rb:13:in `fetch'
/usr/home/romain/Projects/facter/lib/resolvers/aio_agent_version.rb:13:in `post_resolve'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:21:in `block in resolve'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:19:in `synchronize'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:19:in `resolve'
/usr/home/romain/Projects/facter/lib/facts/solaris/aio_agent_version.rb:9:in `call_the_resolver'
/usr/home/romain/Projects/facter/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
/usr/home/romain/Projects/facter/lib/framework/core/fact/internal/internal_fact_manager.rb:41:in `block (2 levels) in start_threads'
```