### PR TITLE
(maint) Silent solaris_zones facts on FreeBSD

### DIFF
--- a/lib/facts/freebsd/solaris_zones/current.rb
+++ b/lib/facts/freebsd/solaris_zones/current.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module SolarisZones
+      class Current
+        FACT_NAME = 'solaris_zones.current'
+
+        def call_the_resolver
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/facts/freebsd/solaris_zones/zone.rb
+++ b/lib/facts/freebsd/solaris_zones/zone.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module SolarisZones
+      class Zone
+        FACT_NAME = 'solaris_zones.zones'
+
+        def call_the_resolver
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The FreeBSD platform inherits from the Solaris one, but FreeBSD does not
have zones, and the Solaris resolver will fail on FreeBSD.

```
[2020-07-02 05:53:23.809860 ] ERROR Facter::InternalFactManager - /usr/home/romain/Projects/facter/lib/resolvers/solaris/solaris_zone_name.rb:19:in `build_current_zone_name_fact'
/usr/home/romain/Projects/facter/lib/resolvers/solaris/solaris_zone_name.rb:12:in `block in post_resolve'
/usr/home/romain/Projects/facter/lib/resolvers/solaris/solaris_zone_name.rb:12:in `fetch'
/usr/home/romain/Projects/facter/lib/resolvers/solaris/solaris_zone_name.rb:12:in `post_resolve'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:21:in `block in resolve'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:19:in `synchronize'
/usr/home/romain/Projects/facter/lib/resolvers/base_resolver.rb:19:in `resolve'
/usr/home/romain/Projects/facter/lib/facts/solaris/solaris_zones/current.rb:11:in `call_the_resolver'
/usr/home/romain/Projects/facter/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
/usr/home/romain/Projects/facter/lib/framework/core/fact/internal/internal_fact_manager.rb:41:in `block (2 levels) in start_threads'
```

As a workaround, override the solaris_zones facts with dummy ones on
FreeBSD.