### PR TITLE
(FACT-2703) Return nil when product name is not recognized

### DIFF
--- a/lib/facter/facts/linux/is_virtual.rb
+++ b/lib/facter/facts/linux/is_virtual.rb
@@ -50,6 +50,8 @@ module Facts
         return unless product_name
 
         Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
+
+        nil
       end
 
       def check_lspci

--- a/lib/facter/facts/linux/virtual.rb
+++ b/lib/facter/facts/linux/virtual.rb
@@ -48,6 +48,8 @@ module Facts
         return unless product_name
 
         Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
+
+        nil
       end
 
       def check_lspci

--- a/spec/facter/facts/linux/is_virtual_spec.rb
+++ b/spec/facter/facts/linux/is_virtual_spec.rb
@@ -8,8 +8,7 @@ describe Facts::Linux::IsVirtual do
     let(:value) { true }
 
     before do
-      allow(Facter::Resolvers::Containers).to \
-        receive(:resolve).with(:vm).and_return(vm)
+      allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(vm)
     end
 
     it 'calls Facter::Resolvers::Containers' do
@@ -153,6 +152,22 @@ describe Facts::Linux::IsVirtual do
       end
 
       it 'returns virtual fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'is_virtual', value: vm)
+      end
+    end
+
+    context 'when product name is not found in the HYPERVISORS_HASH' do
+      let(:vm) { false }
+
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('unknown')
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
+      end
+
+      it 'returns virtual fact as physical' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'is_virtual', value: vm)
       end

--- a/spec/facter/facts/linux/virtual_spec.rb
+++ b/spec/facter/facts/linux/virtual_spec.rb
@@ -7,8 +7,7 @@ describe Facts::Linux::Virtual do
     let(:vm) { 'docker' }
 
     before do
-      allow(Facter::Resolvers::Containers).to \
-        receive(:resolve).with(:vm).and_return(vm)
+      allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(vm)
     end
 
     it 'calls Facter::Resolvers::Containers' do
@@ -146,6 +145,22 @@ describe Facts::Linux::Virtual do
       end
 
       it 'returns virtual fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'virtual', value: vm)
+      end
+    end
+
+    context 'when product name is not found in the HYPERVISORS_HASH' do
+      let(:vm) { 'physical' }
+
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('unknown')
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
+      end
+
+      it 'returns virtual fact as physical' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'virtual', value: vm)
       end


### PR DESCRIPTION
When product name is not a known hypervisor, nil is returned.