### PR TITLE
(FACT-2666) Add load_external ruby method

### DIFF
--- a/lib/inc/internal/ruby/module.hpp
+++ b/lib/inc/internal/ruby/module.hpp
@@ -135,6 +135,7 @@ namespace facter { namespace ruby {
         static leatherman::ruby::VALUE ruby_exec(leatherman::ruby::VALUE self, leatherman::ruby::VALUE command);
         static leatherman::ruby::VALUE ruby_execute(int argc, leatherman::ruby::VALUE* argv, leatherman::ruby::VALUE self);
         static leatherman::ruby::VALUE ruby_on_message(leatherman::ruby::VALUE self);
+        static leatherman::ruby::VALUE ruby_load_external(leatherman::ruby::VALUE self, leatherman::ruby::VALUE name);
 
         // Helper functions
         static module* from_self(leatherman::ruby::VALUE self);
@@ -156,6 +157,7 @@ namespace facter { namespace ruby {
         std::vector<std::string> _external_search_paths;
         std::set<std::string> _loaded_files;
         bool _loaded_all;
+        bool _load_external = true;
         leatherman::ruby::VALUE _self;
         leatherman::ruby::VALUE _on_message_block;
 

--- a/lib/spec/unit/facter_spec.rb
+++ b/lib/spec/unit/facter_spec.rb
@@ -133,4 +133,27 @@ describe Facter do
     end
   end
 
+  describe '.load_external' do
+    context 'when set to false' do
+      it 'skips resolving external facts' do
+        Facter.search_external([
+          File.expand_path('../../../lib/tests/fixtures/facts/external/yaml'),
+        ])
+        Facter.load_external(false);
+        facts = Facter.to_hash
+        expect(facts['yaml_fact1']).to be_nil
+      end
+    end
+
+    context 'when set to true' do
+      it 'resolves external facts' do
+        Facter.search_external([
+          File.expand_path('../../../lib/tests/fixtures/facts/external/yaml'),
+        ])
+        Facter.load_external(true);
+        facts = Facter.to_hash
+        expect(facts['yaml_fact1'] == "foo")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Facter.load_external(<boolean>) will set a flag in facter that will
cause the run to skip loading of external facts.

This method is usefull when we only want to get core facts, and we
do not want external facts to be loaded.
Puppet uses this setting when evaluating default settings that require
Facter to provide the core fact value. Loading the external facts is not
needed.