### PR TITLE
(maint) handle Time and Symbol in executable facts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,10 +13,6 @@ require:
 Layout/LineLength:
   Max: 120
 
-Lint/RescueException:
-  Exclude:
-    - 'lib/facter/custom_facts/util/parser.rb'
-
 Lint/RaiseException:
   Enabled: true
 

--- a/lib/facter/custom_facts/util/parser.rb
+++ b/lib/facter/custom_facts/util/parser.rb
@@ -68,7 +68,7 @@ module LegacyFacter
         def parse_executable_output(output)
           res = nil
           begin
-            res = YAML.safe_load output
+            res = YAML.safe_load(output, [Symbol, Time])
           rescue Exception => e
             Facter.debug("Could not parse executable fact output as YAML or JSON (#{e.message})")
           end

--- a/lib/facter/custom_facts/util/parser.rb
+++ b/lib/facter/custom_facts/util/parser.rb
@@ -56,7 +56,7 @@ module LegacyFacter
         # wrapper.
         def results
           parse_results
-        rescue Exception => e
+        rescue StandardError => e
           Facter.log_exception(e, "Failed to handle #{filename} as #{self.class} facts: #{e.message}")
           nil
         end
@@ -69,7 +69,7 @@ module LegacyFacter
           res = nil
           begin
             res = YAML.safe_load(output, [Symbol, Time])
-          rescue Exception => e
+          rescue StandardError => e
             Facter.debug("Could not parse executable fact output as YAML or JSON (#{e.message})")
           end
           res = KeyValuePairOutputFormat.parse output unless res.is_a?(Hash)

--- a/spec/custom_facts/util/parser_spec.rb
+++ b/spec/custom_facts/util/parser_spec.rb
@@ -162,6 +162,21 @@ describe LegacyFacter::Util::Parser do
       expects_script_to_return(cmd, yaml_data, data)
     end
 
+    it 'handles Symbol correctly' do
+      yaml_data = "---\n:one: :two\nthree: four\n"
+      exptected_data = { :one => :two, 'three' => 'four' }
+      expects_script_to_return(cmd, yaml_data, exptected_data)
+    end
+
+    it 'handles Time correctly' do
+      yaml_data = "---\nfirst: 2020-07-15 05:38:12.427678398 +00:00\n"
+      allow(Facter::Core::Execution).to receive(:exec).with(cmd).and_return(yaml_data)
+      allow(File).to receive(:executable?).with(cmd).and_return(true)
+      allow(FileTest).to receive(:file?).with(cmd).and_return(true)
+
+      expect(LegacyFacter::Util::Parser.parser_for(cmd).results['first']).to be_a(Time)
+    end
+
     it 'returns an empty hash when the script returns nil' do
       expects_script_to_return(cmd, nil, {})
     end


### PR DESCRIPTION
Executable facts can produce structured facts if they
produce a YAML output, when parsing the output script,
YAML.safe_load does not know to handle Time and Symbol.

This commit allow YAML to load Time and Symbol from output.