### PR TITLE
(maint) remove check of networking.dhcp fact on fedora 32

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -10,7 +10,7 @@ test_name 'C59029: networking facts should be fully populated' do
   @netmask_regex  = /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/
 
   expected_networking = {
-      "networking.dhcp"     => @ip_regex,
+      "networking.dhcp"     => agent['platform'] =~ /fedora-32/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       "networking.ip"       => @ip_regex,
       "networking.ip6"      => /[a-f0-9]+:+/,
       "networking.mac"      => /[a-f0-9]{2}:/,


### PR DESCRIPTION
 Fedora 32 is using version Network Manager > 1.22
 Starting with version 1.22, Network Manager defaults to nettools dhcp client
 that is no longer setting dhcp server in lease file, hence the fact
 cannot be read anymore as the respective information is no longer
 available on the system.

 There is already a ticket for this and other missing info:
 https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426

 One solution could be to create PR on networking manager/nettools dhcp
 to add code handle dhcp_server_identifier parameter and then update
 `networking.dhcp` fact to read it using `nmcli connection show "<interface>"`