### PR TITLE
(FACT-2733) Fix networking on Fedora 32

### DIFF
--- a/lib/facter/resolvers/networking_linux_resolver.rb
+++ b/lib/facter/resolvers/networking_linux_resolver.rb
@@ -85,7 +85,11 @@ module Facter
           return unless lease_file
 
           dhcp = Util::FileHelper.safe_read("/var/lib/NetworkManager/#{lease_file}", nil)
-          dhcp ? dhcp.match(/SERVER_ADDRESS=(.*)/)[1] : nil
+
+          return unless dhcp
+
+          dhcp = dhcp.match(/SERVER_ADDRESS=(.*)/)
+          dhcp[1] if dhcp
         end
 
         def fill_ip_v4_info!(ip_tokens, network_info)


### PR DESCRIPTION
Description of the problem: On Fedora 32 dhcp information is not available anymore. Facter throws exception when the assumption that NetworkManager contain a lease file with dhcp address fails.

Description of the fix: Added an additional check for Facter to not assume that the file read contains dhcp address.