### PR TITLE
(FACT-2734) Return nil codename if we cannot determine it from /etc/redhat_release

### DIFF
--- a/lib/facter/resolvers/redhat_release_resolver.rb
+++ b/lib/facter/resolvers/redhat_release_resolver.rb
@@ -32,9 +32,10 @@ module Facter
           version_codename = output_strings[1].split(' ')
 
           @fact_list[:name] = name(output_strings[0])
-          @fact_list[:version] = version_codename[0].strip
-          codename = version_codename[1].strip
-          @fact_list[:codename] = codename.gsub(/[()]/, '')
+          @fact_list[:version] = version_codename[0]&.strip
+
+          codename = version_codename[1]&.strip
+          @fact_list[:codename] = codename ? codename.gsub(/[()]/, '') : nil
 
           @fact_list[:identifier] = identifier(@fact_list[:name])
         end

--- a/spec/facter/resolvers/redhat_release_resolver_spec.rb
+++ b/spec/facter/resolvers/redhat_release_resolver_spec.rb
@@ -5,21 +5,47 @@ describe Facter::Resolvers::RedHatRelease do
 
   let(:log_spy) { instance_spy(Facter::Log) }
 
-  before do
-    allow(Facter::Util::FileHelper).to receive(:safe_read)
-      .with('/etc/redhat-release', nil)
-      .and_return("Red Hat Enterprise Linux Server release 5.10 (Tikanga)\n")
+  after do
+    Facter::Resolvers::RedHatRelease.invalidate_cache
   end
 
-  it 'returns os NAME' do
-    expect(redhat_release.resolve(:name)).to eq('RedHat')
+  context 'when redhat-realse has codename' do
+    before do
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/etc/redhat-release', nil)
+        .and_return("Red Hat Enterprise Linux Server release 5.10 (Tikanga)\n")
+    end
+
+    it 'returns os NAME' do
+      expect(redhat_release.resolve(:name)).to eq('RedHat')
+    end
+
+    it 'returns os VERSION_ID' do
+      expect(redhat_release.resolve(:version)).to eq('5.10')
+    end
+
+    it 'returns os VERSION_CODENAME' do
+      expect(redhat_release.resolve(:codename)).to eq('Tikanga')
+    end
   end
 
-  it 'returns os VERSION_ID' do
-    expect(redhat_release.resolve(:version)).to eq('5.10')
-  end
+  context 'when redhat-relase does not have codename' do
+    before do
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/etc/redhat-release', nil)
+        .and_return("Oracle VM server release 3.4.4\n")
+    end
 
-  it 'returns os VERSION_CODENAME' do
-    expect(redhat_release.resolve(:codename)).to eq('Tikanga')
+    it 'returns os NAME' do
+      expect(redhat_release.resolve(:name)).to eq('OracleVM')
+    end
+
+    it 'returns os VERSION_ID' do
+      expect(redhat_release.resolve(:version)).to eq('3.4.4')
+    end
+
+    it 'returns os VERSION_CODENAME' do
+      expect(redhat_release.resolve(:codename)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
The old implementation assumed that `/etc/redhat-release` always contains `codename`, but there might be cases when it does not. When this happened, and we were running on an os that did not have `/etc/os-release` Facter, would try `/etc/redhat-release` and would fail to start.

The `fix` returns nil when there is no codename in `/etc/redhat-relase`. This allows Facter to start even when there is no `codename`.