### PR TITLE
(FACT-2735) virtual not working on EXADATA baremetal

### DIFF
--- a/lib/facter/facts/linux/virtual.rb
+++ b/lib/facter/facts/linux/virtual.rb
@@ -5,43 +5,59 @@ module Facts
     class Virtual
       FACT_NAME = 'virtual'
 
+      def initialize
+        @log = Facter::Log.new(self)
+      end
+
       def call_the_resolver # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        @log.debug('Linux Virtual Resolver')
+
         fact_value = check_docker_lxc || check_gce || retrieve_from_virt_what || check_vmware
         fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+
+        @log.debug("Fact value is: #{fact_value}")
 
         Facter::ResolvedFact.new(FACT_NAME, fact_value)
       end
 
       def check_gce
+        @log.debug('Checking GCE')
         bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
         'gce' if bios_vendor&.include?('Google')
       end
 
       def check_docker_lxc
+        @log.debug('Checking Docker and LXC')
         Facter::Resolvers::Containers.resolve(:vm)
       end
 
       def check_vmware
+        @log.debug('Checking VMware')
         Facter::Resolvers::Vmware.resolve(:vm)
       end
 
       def retrieve_from_virt_what
+        @log.debug('Checking virtual_what')
         Facter::Resolvers::VirtWhat.resolve(:vm)
       end
 
       def check_open_vz
+        @log.debug('Checking OpenVZ')
         Facter::Resolvers::OpenVz.resolve(:vm)
       end
 
       def check_vserver
+        @log.debug('Checking VServer')
         Facter::Resolvers::VirtWhat.resolve(:vserver)
       end
 
       def check_xen
+        @log.debug('Checking XEN')
         Facter::Resolvers::Xen.resolve(:vm)
       end
 
       def check_other_facts
+        @log.debug('Checking others')
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
         bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
         return 'kvm' if bios_vendor&.include?('Amazon EC2')
@@ -53,6 +69,7 @@ module Facts
       end
 
       def check_lspci
+        @log.debug('Checking lspci')
         Facter::Resolvers::Lspci.resolve(:vm)
       end
     end

--- a/lib/facter/resolvers/lspci.rb
+++ b/lib/facter/resolvers/lspci.rb
@@ -28,6 +28,8 @@ module Facter
 
         def retrieve_vm(output)
           output.each_line { |line| REGEX_VALUES.each { |key, value| return value if line =~ /#{key}/ } }
+
+          nil
         end
       end
     end

--- a/spec/facter/resolvers/lspci_spec.rb
+++ b/spec/facter/resolvers/lspci_spec.rb
@@ -37,4 +37,12 @@ describe Facter::Resolvers::Lspci do
       expect(lspci_resolver.resolve(:vm)).to eq('xenhvm')
     end
   end
+
+  context 'when lspci does not detect any hypervisor' do
+    let(:output) { 'lspci output with no hypervisor' }
+
+    it 'returns nil' do
+      expect(lspci_resolver.resolve(:vm)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
`each_line` returns the initial string, in our case the output of `lspci`.

```ruby 
 "example string".each_line{ |line| }
 => "example string"
```

In case no hypervisor match is found, we want to return `nil`.