### PR TITLE
(FACT-2699-2) Catch augeas exception in resolver.

### DIFF
--- a/lib/facter/resolvers/augeas_resolver.rb
+++ b/lib/facter/resolvers/augeas_resolver.rb
@@ -34,6 +34,9 @@ module Facter
             # it is used for legacy augeas <= 0.5.0 (ruby-augeas gem)
             ::Augeas.open { |aug| aug.get('/augeas/version') }
           end
+        rescue LoadError
+          log.debug('augeas is not available')
+          nil
         end
       end
     end

--- a/spec/facter/resolvers/augeas_resolver_spec.rb
+++ b/spec/facter/resolvers/augeas_resolver_spec.rb
@@ -64,7 +64,7 @@ describe Facter::Resolvers::Augeas do
       it 'raises a LoadError error' do
         augeas.resolve(:augeas_version)
 
-        expect(log_spy).to have_received(:debug).with('resolving fact augeas_version, but load_error_message')
+        expect(log_spy).to have_received(:debug).with('augeas is not available')
       end
     end
   end


### PR DESCRIPTION
We catch the load error in the resolver, because on `windows`, there is no `augeas` gem and the exception will always be thrown. Puppet agent test for load errors in 
https://github.com/puppetlabs/puppet-agent/blob/7a2f2400952f2bab3dc23f07ce64f1287e1fb9ea/acceptance/tests/ensure_puppet_facts_can_use_facter_ng.rb#L21 
acceptance test. 