### PR TITLE
(FACT-2699) Revert "(FACT-2699) Catch augeas exception in resolver."

### DIFF
--- a/lib/facter/resolvers/augeas_resolver.rb
+++ b/lib/facter/resolvers/augeas_resolver.rb
@@ -34,9 +34,6 @@ module Facter
             # it is used for legacy augeas <= 0.5.0 (ruby-augeas gem)
             ::Augeas.open { |aug| aug.get('/augeas/version') }
           end
-        rescue LoadError
-          log.debug('augeas is not available')
-          nil
         end
       end
     end

--- a/spec/facter/resolvers/augeas_resolver_spec.rb
+++ b/spec/facter/resolvers/augeas_resolver_spec.rb
@@ -64,7 +64,7 @@ describe Facter::Resolvers::Augeas do
       it 'raises a LoadError error' do
         augeas.resolve(:augeas_version)
 
-        expect(log_spy).to have_received(:debug).with('augeas is not available')
+        expect(log_spy).to have_received(:debug).with('resolving fact augeas_version, but load_error_message')
       end
     end
   end


### PR DESCRIPTION
This reverts commit dbd91560b64e7f2220f785e85ed74c4606e15a05. The acceptance test form puppet agent was changed, and this change is no longer required.