### PR TITLE
(FACT-2724) Confine blocks behave differently with Facter 4, causing spec tests to suddenly fail

### DIFF
--- a/lib/facter/facts/macosx/virtual.rb
+++ b/lib/facter/facts/macosx/virtual.rb
@@ -6,7 +6,7 @@ module Facts
       FACT_NAME = 'virtual'
 
       def call_the_resolver
-        fact_value = check_vmware || check_virtualbox || check_parallels
+        fact_value = check_vmware || check_virtualbox || check_parallels || 'physical'
 
         Facter::ResolvedFact.new(FACT_NAME, fact_value)
       end

--- a/spec/facter/facts/macosx/virtual_spec.rb
+++ b/spec/facter/facts/macosx/virtual_spec.rb
@@ -40,7 +40,7 @@ describe Facts::Macosx::Virtual do
       it 'returns resolved fact with true value' do
         expect(fact.call_the_resolver)
           .to be_an_instance_of(Facter::ResolvedFact)
-          .and have_attributes(name: 'virtual', value: nil)
+          .and have_attributes(name: 'virtual', value: 'physical')
 
         fact.call_the_resolver
       end


### PR DESCRIPTION
## problem
`virtual` fact was returning nil on `physical` macOS hosts. The test mocked virtual fact by using 
```
allow(Facter.fact(:virtual)).to receive(:value).and_return('physical')
```
and because `Facter.fact(:virtual)` returned `nil` on physical macOS hosts, the mock was basically
```
allow(nil).to receive(:value).and_return('physical')
```

## fix
on macOS physiscal host, facter will return `virtual => physical`