### PR TITLE
(FACT-2714) Fix dhcp on solaris 10

### DIFF
--- a/lib/facter/resolvers/solaris/ffi/ffi.rb
+++ b/lib/facter/resolvers/solaris/ffi/ffi.rb
@@ -20,6 +20,11 @@ module Facter
         INET_ADDRSTRLEN   = 16
         INET6_ADDRSTRLEN  = 46
       end
+
+      BINDINGS_KEY = {
+        FFI::AF_INET => :bindings,
+        FFI::AF_INET6 => :bindings6
+      }.freeze
     end
   end
 end

--- a/lib/facter/resolvers/solaris/networking_resolver.rb
+++ b/lib/facter/resolvers/solaris/networking_resolver.rb
@@ -12,11 +12,6 @@ module Facter
         @fact_list ||= {}
         @interfaces = {}
 
-        BINDINGS_KEY = {
-          FFI::AF_INET => :bindings,
-          FFI::AF_INET6 => :bindings6
-        }.freeze
-
         class << self
           private
 
@@ -141,7 +136,8 @@ module Facter
           end
 
           def add_dhcp(interface_name)
-            result = Facter::Core::Execution.execute("dhcpinfo -i #{interface_name} ServerID", logger: log)
+            dhcpinfo_command = Facter::Core::Execution.which('dhcpinfo') || '/sbin/dhcpinfo'
+            result = Facter::Core::Execution.execute("#{dhcpinfo_command} -i #{interface_name} ServerID", logger: log)
 
             @interfaces[interface_name][:dhcp] = result.chomp
           end


### PR DESCRIPTION
The PR uses a default location for `dhcpinfo` if it cannot find it in path. This default location is specific to `Solaris 10`.