### PR TITLE
(FACT-2732) OracleLinux 7 and Scientific Linux 7 OS facts incorrect in Facter 4.0.30

### DIFF
--- a/lib/facter/os_hierarchy.json
+++ b/lib/facter/os_hierarchy.json
@@ -12,7 +12,9 @@
         "Rhel": [
           "Fedora",
           "Amzn",
-          "Centos"
+          "Centos",
+          "Ol",
+          "Scientific"
         ]
       },
       {

--- a/lib/facter/resolvers/os_release_resolver.rb
+++ b/lib/facter/resolvers/os_release_resolver.rb
@@ -56,7 +56,7 @@ module Facter
         def process_name
           return unless @fact_list[:name]
 
-          @fact_list[:name] = if @fact_list[:name].downcase.start_with?('red')
+          @fact_list[:name] = if @fact_list[:name].downcase.start_with?('red', 'oracle')
                                 @fact_list[:name].split(' ')[0..1].join
                               else
                                 @fact_list[:name].split(' ')[0].strip

--- a/spec/facter/resolvers/os_release_resolver_spec.rb
+++ b/spec/facter/resolvers/os_release_resolver_spec.rb
@@ -56,7 +56,7 @@ describe Facter::Resolvers::OsRelease do
   end
 
   context 'when on Debian' do
-    let(:os_release_content) { load_fixture('debian_os_release').readlines }
+    let(:os_release_content) { load_fixture('os_release_debian').readlines }
 
     it 'returns os NAME' do
       result = Facter::Resolvers::OsRelease.resolve(:name)
@@ -106,6 +106,16 @@ describe Facter::Resolvers::OsRelease do
 
         expect(result).to eq('opensuse')
       end
+    end
+  end
+
+  context 'when on Oracle Linux' do
+    let(:os_release_content) { load_fixture('os_release_oracle_linux').readlines }
+
+    it 'returns os NAME' do
+      result = Facter::Resolvers::OsRelease.resolve(:name)
+
+      expect(result).to eq('OracleLinux')
     end
   end
 end

--- a/spec/fixtures/debian_os_release
+++ b/spec/fixtures/debian_os_release
@@ -1,9 +1,0 @@
-PRETTY_NAME="Debian GNU/Linux 10 (buster)"
-NAME="Debian GNU/Linux"
-VERSION_ID="10"
-VERSION="10 (buster)"
-VERSION_CODENAME=buster
-ID=debian
-HOME_URL="https://www.debian.org/"
-SUPPORT_URL="https://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"

--- a/spec/fixtures/os_release_oracle_linux
+++ b/spec/fixtures/os_release_oracle_linux
@@ -1,0 +1,14 @@
+NAME="Oracle Linux Server"
+VERSION="7.2"
+ID="ol"
+VERSION_ID="7.2"
+PRETTY_NAME="Oracle Linux Server 7.2"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:7:2:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.2
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=7.2


### PR DESCRIPTION
Added Oracle and Scientific Linux to `os_hierarchy.json` under Red Hat Enterprise Linux. Before the addition, they were considered default linux distributions.