### PR TITLE
(FACT-2739) Extend os hierarchy to consider multiple os families

### DIFF
--- a/lib/facter/framework/detector/os_detector.rb
+++ b/lib/facter/framework/detector/os_detector.rb
@@ -44,7 +44,11 @@ class OsDetector
     hierarchy = @os_hierarchy.construct_hierarchy(identifier)
     if hierarchy.empty?
       @log.debug("Could not detect hierarchy using os identifier: #{identifier} , trying with family")
-      hierarchy = @os_hierarchy.construct_hierarchy(detect_family)
+
+      detect_family.to_s.split.each do |family|
+        hierarchy = @os_hierarchy.construct_hierarchy(family)
+        return hierarchy unless hierarchy.empty?
+      end
     end
 
     if hierarchy.empty?

--- a/spec/framework/detector/os_detector_spec.rb
+++ b/spec/framework/detector/os_detector_spec.rb
@@ -198,7 +198,7 @@ describe OsDetector do
         context 'when family is known' do
           before do
             allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:id_like).and_return(:ubuntu)
-            allow(os_hierarchy).to receive(:construct_hierarchy).with(:ubuntu).and_return(%w[Linux Debian Ubuntu])
+            allow(os_hierarchy).to receive(:construct_hierarchy).with('ubuntu').and_return(%w[Linux Debian Ubuntu])
             Singleton.__init__(OsDetector)
           end
 
@@ -212,6 +212,25 @@ describe OsDetector do
             expect(logger)
               .to have_received(:debug)
               .with('Could not detect hierarchy using os identifier: my_linux_distro , trying with family')
+          end
+        end
+
+        context 'when there are multiple families' do
+          before do
+            allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:id_like).and_return('Rhel centos fedora')
+            allow(os_hierarchy).to receive(:construct_hierarchy).with('Rhel').and_return(%w[])
+            allow(os_hierarchy).to receive(:construct_hierarchy).with('centos').and_return(%w[Linux El])
+            Singleton.__init__(OsDetector)
+          end
+
+          it 'constructs hierarchy with linux and el' do
+            expect(OsDetector.instance.hierarchy).to eq(%w[Linux El])
+          end
+
+          it 'does not call construct hierarchy with fedora' do
+            OsDetector.instance
+
+            expect(os_hierarchy).not_to have_received(:construct_hierarchy).with('fedora')
           end
         end
       end


### PR DESCRIPTION
When there are multiple families detected, `facter` tries to determine a hierarchy for each of them sequentially. If it finds a hierarchy for one of the families, it stops the search and uses that hierarchy to load facts.