### PR TITLE
Add FreeBSD memory facts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -180,7 +180,7 @@ RSpec/SubjectStub:
     - 'spec/custom_facts/util/fact_spec.rb'
     - 'spec/custom_facts/util/resolution_spec.rb'
 
-# Offense count: 134
+# Offense count: 138
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Exclude:
@@ -191,6 +191,10 @@ RSpec/VerifiedDoubles:
     - 'spec/custom_facts/util/fact_spec.rb'
     - 'spec/custom_facts/util/resolution_spec.rb'
     - 'spec/facter/facts/aix/ssh_spec.rb'
+    - 'spec/facter/facts/freebsd/memory/swap/capacity_spec.rb'
+    - 'spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb'
+    - 'spec/facter/facts/freebsd/memory/system/capacity_spec.rb'
+    - 'spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb'
     - 'spec/facter/facts/macosx/memory/swap/capacity_spec.rb'
     - 'spec/facter/facts/macosx/memory/swap/used_bytes_spec.rb'
     - 'spec/facter/facts/macosx/memory/system/capacity_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -180,7 +180,7 @@ RSpec/SubjectStub:
     - 'spec/custom_facts/util/fact_spec.rb'
     - 'spec/custom_facts/util/resolution_spec.rb'
 
-# Offense count: 138
+# Offense count: 134
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Exclude:
@@ -191,10 +191,6 @@ RSpec/VerifiedDoubles:
     - 'spec/custom_facts/util/fact_spec.rb'
     - 'spec/custom_facts/util/resolution_spec.rb'
     - 'spec/facter/facts/aix/ssh_spec.rb'
-    - 'spec/facter/facts/freebsd/memory/swap/capacity_spec.rb'
-    - 'spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb'
-    - 'spec/facter/facts/freebsd/memory/system/capacity_spec.rb'
-    - 'spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb'
     - 'spec/facter/facts/macosx/memory/swap/capacity_spec.rb'
     - 'spec/facter/facts/macosx/memory/swap/used_bytes_spec.rb'
     - 'spec/facter/facts/macosx/memory/system/capacity_spec.rb'

--- a/lib/facter/facts/freebsd/memory/swap/available.rb
+++ b/lib/facter/facts/freebsd/memory/swap/available.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class Available
+          FACT_NAME = 'memory.swap.available'
+          ALIASES = 'swapfree'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:available_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/available_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/swap/available_bytes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class AvailableBytes
+          FACT_NAME = 'memory.swap.available_bytes'
+          ALIASES = 'swapfree_mb'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:available_bytes)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/capacity.rb
+++ b/lib/facter/facts/freebsd/memory/swap/capacity.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class Capacity
+          FACT_NAME = 'memory.swap.capacity'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:capacity)
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/encrypted.rb
+++ b/lib/facter/facts/freebsd/memory/swap/encrypted.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class Encrypted
+          FACT_NAME = 'memory.swap.encrypted'
+          ALIASES = 'swapencrypted'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:encrypted)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/total.rb
+++ b/lib/facter/facts/freebsd/memory/swap/total.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class Total
+          FACT_NAME = 'memory.swap.total'
+          ALIASES = 'swapsize'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:total_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/total_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/swap/total_bytes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class TotalBytes
+          FACT_NAME = 'memory.swap.total_bytes'
+          ALIASES = 'swapsize_mb'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:total_bytes)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/used.rb
+++ b/lib/facter/facts/freebsd/memory/swap/used.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class Used
+          FACT_NAME = 'memory.swap.used'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:used_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/swap/used_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/swap/used_bytes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module Swap
+        class UsedBytes
+          FACT_NAME = 'memory.swap.used_bytes'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SwapMemory.resolve(:used_bytes)
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/available.rb
+++ b/lib/facter/facts/freebsd/memory/system/available.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class Available
+          FACT_NAME = 'memory.system.available'
+          ALIASES = 'memoryfree'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:available_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/available_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/system/available_bytes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class AvailableBytes
+          FACT_NAME = 'memory.system.available_bytes'
+          ALIASES = 'memoryfree_mb'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:available_bytes)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/capacity.rb
+++ b/lib/facter/facts/freebsd/memory/system/capacity.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class Capacity
+          FACT_NAME = 'memory.system.capacity'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:capacity)
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/total.rb
+++ b/lib/facter/facts/freebsd/memory/system/total.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class Total
+          FACT_NAME = 'memory.system.total'
+          ALIASES = 'memorysize'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:total_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/total_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/system/total_bytes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class TotalBytes
+          FACT_NAME = 'memory.system.total_bytes'
+          ALIASES = 'memorysize_mb'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:total_bytes)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/used.rb
+++ b/lib/facter/facts/freebsd/memory/system/used.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class Used
+          FACT_NAME = 'memory.system.used'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:used_bytes)
+            fact_value = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(fact_value)
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/memory/system/used_bytes.rb
+++ b/lib/facter/facts/freebsd/memory/system/used_bytes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Memory
+      module System
+        class UsedBytes
+          FACT_NAME = 'memory.system.used_bytes'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::SystemMemory.resolve(:used_bytes)
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/freebsd/swap_memory_resolver.rb
+++ b/lib/facter/resolvers/freebsd/swap_memory_resolver.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class SwapMemory < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        class << self
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { read_swap_memory(fact_name) }
+          end
+
+          def read_swap_memory(fact_name) # rubocop:disable Metrics/AbcSize
+            output = Facter::Core::Execution.execute('swapinfo -k', logger: log)
+            data = output.split("\n")[1..-1].map { |line| line.split(/\s+/) }
+
+            unless data.empty?
+              @fact_list[:total_bytes]     = kilobytes_to_bytes(data.map { |line| line[1].to_i }.inject(:+))
+              @fact_list[:used_bytes]      = kilobytes_to_bytes(data.map { |line| line[2].to_i }.inject(:+))
+              @fact_list[:available_bytes] = kilobytes_to_bytes(data.map { |line| line[3].to_i }.inject(:+))
+              @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+              @fact_list[:encrypted] = data.map { |line| line[0].end_with?('.eli') }.all?
+            end
+
+            @fact_list[fact_name]
+          end
+
+          def kilobytes_to_bytes(quantity)
+            (quantity.to_f * 1024).to_i
+          end
+
+          def compute_capacity(used, total)
+            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/freebsd/swap_memory_resolver.rb
+++ b/lib/facter/resolvers/freebsd/swap_memory_resolver.rb
@@ -21,7 +21,8 @@ module Facter
               @fact_list[:total_bytes]     = kilobytes_to_bytes(data.map { |line| line[1].to_i }.inject(:+))
               @fact_list[:used_bytes]      = kilobytes_to_bytes(data.map { |line| line[2].to_i }.inject(:+))
               @fact_list[:available_bytes] = kilobytes_to_bytes(data.map { |line| line[3].to_i }.inject(:+))
-              @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+              @fact_list[:capacity] = FilesystemHelper.compute_capacity(@fact_list[:used_bytes],
+                                                                        @fact_list[:total_bytes])
               @fact_list[:encrypted] = data.map { |line| line[0].end_with?('.eli') }.all?
             end
 
@@ -30,10 +31,6 @@ module Facter
 
           def kilobytes_to_bytes(quantity)
             (quantity.to_f * 1024).to_i
-          end
-
-          def compute_capacity(used, total)
-            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
           end
         end
       end

--- a/lib/facter/resolvers/freebsd/system_memory_resolver.rb
+++ b/lib/facter/resolvers/freebsd/system_memory_resolver.rb
@@ -24,12 +24,9 @@ module Facter
           end
 
           def read_available_memory_in_bytes
-            output = Facter::Core::Execution.execute('vmstat -H', logger: log)
-            if (data = output.split("\n")[-1].match(/^\s*\d+\s*\d+\s*\d+\s*\d+\s*(\d+)/))
-              @fact_list[:available_bytes] = data[1].to_i * 1024
-            end
-
-            @fact_list[:available_bytes]
+            output = Facter::Core::Execution.execute('vmstat -H --libxo json', logger: log)
+            data = JSON.parse(output)
+            @fact_list[:available_bytes] = data['memory']['free-memory'] * 1024
           end
 
           def read_total_memory_in_bytes

--- a/lib/facter/resolvers/freebsd/system_memory_resolver.rb
+++ b/lib/facter/resolvers/freebsd/system_memory_resolver.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class SystemMemory < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        class << self
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { calculate_system_memory(fact_name) }
+          end
+
+          def calculate_system_memory(fact_name)
+            read_total_memory_in_bytes
+            read_available_memory_in_bytes
+
+            @fact_list[:used_bytes] = @fact_list[:total_bytes] - @fact_list[:available_bytes]
+            @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+
+            @fact_list[fact_name]
+          end
+
+          def read_available_memory_in_bytes
+            output = Facter::Core::Execution.execute('vmstat -H', logger: log)
+            if (data = output.split("\n")[-1].match(/^\s*\d+\s*\d+\s*\d+\s*\d+\s*(\d+)/))
+              @fact_list[:available_bytes] = data[1].to_i * 1024
+            end
+
+            @fact_list[:available_bytes]
+          end
+
+          def read_total_memory_in_bytes
+            require_relative 'ffi/ffi_helper'
+
+            @fact_list[:total_bytes] = Facter::Freebsd::FfiHelper.sysctl_by_name(:long, 'hw.physmem')
+          end
+
+          def compute_capacity(used, total)
+            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/freebsd/system_memory_resolver.rb
+++ b/lib/facter/resolvers/freebsd/system_memory_resolver.rb
@@ -18,7 +18,7 @@ module Facter
             read_available_memory_in_bytes
 
             @fact_list[:used_bytes] = @fact_list[:total_bytes] - @fact_list[:available_bytes]
-            @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+            @fact_list[:capacity] = FilesystemHelper.compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
 
             @fact_list[fact_name]
           end
@@ -33,10 +33,6 @@ module Facter
             require_relative 'ffi/ffi_helper'
 
             @fact_list[:total_bytes] = Facter::Freebsd::FfiHelper.sysctl_by_name(:long, 'hw.physmem')
-          end
-
-          def compute_capacity(used, total)
-            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
           end
         end
       end

--- a/spec/facter/facts/freebsd/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/available_bytes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::AvailableBytes do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::AvailableBytes.new }
+
+    let(:value) { 1024 * 1024 }
+    let(:value_mb) { 1 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:available_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.available_bytes', value: value),
+                        an_object_having_attributes(name: 'swapfree_mb', value: value_mb, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/available_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/available_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::Available do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::Available.new }
+
+    let(:value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:available_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.available', value: value),
+                        an_object_having_attributes(name: 'swapfree', value: value, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/capacity_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/capacity_spec.rb
@@ -2,14 +2,22 @@
 
 describe Facts::Freebsd::Memory::Swap::Capacity do
   describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::Capacity.new }
+
+    let(:value) { 1024 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:capacity).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:capacity)
+    end
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.capacity', value: 1024)
-
-      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:capacity).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.capacity', 1024).and_return(expected_fact)
-
-      fact = Facts::Freebsd::Memory::Swap::Capacity.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.swap.capacity', value: value)
     end
   end
 end

--- a/spec/facter/facts/freebsd/memory/swap/capacity_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/capacity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::Capacity do
+  describe '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.capacity', value: 1024)
+
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:capacity).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.capacity', 1024).and_return(expected_fact)
+
+      fact = Facts::Freebsd::Memory::Swap::Capacity.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/encrypted_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/encrypted_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::Encrypted do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::Encrypted.new }
+
+    let(:value) { true }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:encrypted).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:encrypted)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.encrypted', value: value),
+                        an_object_having_attributes(name: 'swapencrypted', value: value, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/total_bytes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::TotalBytes do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::TotalBytes.new }
+
+    let(:value) { 1024 * 1024 }
+    let(:value_mb) { 1 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:total_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.total_bytes', value: value),
+                        an_object_having_attributes(name: 'swapsize_mb', value: value_mb, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/total_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/total_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::Total do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::Total.new }
+
+    let(:value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:total_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.total', value: value),
+                        an_object_having_attributes(name: 'swapsize', value: value, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb
@@ -2,14 +2,22 @@
 
 describe Facts::Freebsd::Memory::Swap::UsedBytes do
   describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::UsedBytes.new }
+
+    let(:value) { 1024 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:used_bytes)
+    end
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used_bytes', value: 1024)
-
-      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used_bytes', 1024).and_return(expected_fact)
-
-      fact = Facts::Freebsd::Memory::Swap::UsedBytes.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.swap.used_bytes', value: value)
     end
   end
 end

--- a/spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/used_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::UsedBytes do
+  describe '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used_bytes', 1024).and_return(expected_fact)
+
+      fact = Facts::Freebsd::Memory::Swap::UsedBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/swap/used_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/used_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::Swap::Used do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::Swap::Used.new }
+
+    let(:resolver_result) { 1024 }
+    let(:fact_value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(resolver_result)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SwapMemory).to have_received(:resolve).with(:used_bytes)
+    end
+
+    it 'returns a memory.swap.used fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.swap.used', value: fact_value)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/available_bytes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::AvailableBytes do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::AvailableBytes.new }
+
+    let(:value) { 1024 * 1024 }
+    let(:value_mb) { 1 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:available_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.system.available_bytes', value: value),
+                        an_object_having_attributes(name: 'memoryfree_mb', value: value_mb, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/available_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/available_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::Available do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::Available.new }
+
+    let(:value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:available_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.system.available', value: value),
+                        an_object_having_attributes(name: 'memoryfree', value: value, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/capacity_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/capacity_spec.rb
@@ -2,14 +2,22 @@
 
 describe Facts::Freebsd::Memory::System::Capacity do
   describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::Capacity.new }
+
+    let(:value) { '15.53%' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:capacity).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:capacity)
+    end
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.capacity', value: '15.53%')
-
-      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:capacity).and_return('15.53%')
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.capacity', '15.53%').and_return(expected_fact)
-
-      fact = Facts::Freebsd::Memory::System::Capacity.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.system.capacity', value: value)
     end
   end
 end

--- a/spec/facter/facts/freebsd/memory/system/capacity_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/capacity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::Capacity do
+  describe '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.capacity', value: '15.53%')
+
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:capacity).and_return('15.53%')
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.capacity', '15.53%').and_return(expected_fact)
+
+      fact = Facts::Freebsd::Memory::System::Capacity.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/total_bytes_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::TotalBytes do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::TotalBytes.new }
+
+    let(:value) { 1024 * 1024 }
+    let(:value_mb) { 1 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:total_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.system.total_bytes', value: value),
+                        an_object_having_attributes(name: 'memorysize_mb', value: value_mb, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/total_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/total_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::Total do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::Total.new }
+
+    let(:value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:total_bytes)
+    end
+
+    it 'returns a fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'memory.system.total', value: value),
+                        an_object_having_attributes(name: 'memorysize', value: value, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb
@@ -2,14 +2,22 @@
 
 describe Facts::Freebsd::Memory::System::UsedBytes do
   describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::UsedBytes.new }
+
+    let(:value) { 1024 }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SystemMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:used_bytes)
+    end
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used_bytes', value: 1024)
-
-      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used_bytes', 1024).and_return(expected_fact)
-
-      fact = Facts::Freebsd::Memory::System::UsedBytes.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.system.used_bytes', value: value)
     end
   end
 end

--- a/spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/used_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::UsedBytes do
+  describe '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used_bytes', 1024).and_return(expected_fact)
+
+      fact = Facts::Freebsd::Memory::System::UsedBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/memory/system/used_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/used_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Memory::System::Used do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Memory::System::Used.new }
+
+    let(:resolver_result) { 1024 }
+    let(:fact_value) { '1.00 KiB' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(resolver_result)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::SwapMemory' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::SystemMemory).to have_received(:resolve).with(:used_bytes)
+    end
+
+    it 'returns a memory.system.used fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'memory.system.used', value: fact_value)
+    end
+  end
+end

--- a/spec/facter/resolvers/freebsd/swap_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/swap_memory_resolver_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Resolvers::Freebsd::SwapMemory do
   let(:available_bytes) { 4_294_967_296 }
   let(:total_bytes) { 4_294_967_296 }
   let(:used_bytes) { 0 }
-  let(:capacity) { '0.00%' }
+  let(:capacity) { '0%' }
   let(:encrypted) { true }
 
   before do

--- a/spec/facter/resolvers/freebsd/swap_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/swap_memory_resolver_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::SwapMemory do
+  subject(:swap_memory) { Facter::Resolvers::Freebsd::SwapMemory }
+
+  let(:log_spy) { instance_spy(Facter::Log) }
+  let(:available_bytes) { 4_294_967_296 }
+  let(:total_bytes) { 4_294_967_296 }
+  let(:used_bytes) { 0 }
+  let(:capacity) { '0.00%' }
+  let(:encrypted) { true }
+
+  before do
+    swap_memory.instance_variable_set(:@log, log_spy)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('swapinfo -k', logger: log_spy)
+      .and_return(load_fixture('freebsd_swapinfo').read)
+  end
+
+  it 'returns available swap memory in bytes' do
+    expect(swap_memory.resolve(:available_bytes)).to eq(available_bytes)
+  end
+
+  it 'returns total swap memory in bytes' do
+    expect(swap_memory.resolve(:total_bytes)).to eq(total_bytes)
+  end
+
+  it 'returns used swap memory in bytes' do
+    expect(swap_memory.resolve(:used_bytes)).to eq(used_bytes)
+  end
+
+  it 'returns capacity of swap memory' do
+    expect(swap_memory.resolve(:capacity)).to eq(capacity)
+  end
+
+  it 'returns true because swap memory is encrypted' do
+    expect(swap_memory.resolve(:encrypted)).to eq(encrypted)
+  end
+end

--- a/spec/facter/resolvers/freebsd/system_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/system_memory_resolver_spec.rb
@@ -16,7 +16,7 @@ describe Facter::Resolvers::Freebsd::SystemMemory do
       .and_return(17_043_554_304)
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('vmstat -H', logger: log_spy)
+      .with('vmstat -H --libxo json', logger: log_spy)
       .and_return(load_fixture('freebsd_vmstat').read)
   end
 

--- a/spec/facter/resolvers/freebsd/system_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/system_memory_resolver_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::SystemMemory do
+  subject(:system_memory) { Facter::Resolvers::Freebsd::SystemMemory }
+
+  let(:log_spy) { instance_spy(Facter::Log) }
+  let(:available_bytes) { 2_696_462_336 }
+  let(:total_bytes) { 17_043_554_304 }
+  let(:used_bytes) { 14_347_091_968 }
+  let(:capacity) { '84.18%' }
+
+  before do
+    system_memory.instance_variable_set(:@log, log_spy)
+    allow(Facter::Freebsd::FfiHelper).to receive(:sysctl_by_name)
+      .with(:long, 'hw.physmem')
+      .and_return(17_043_554_304)
+
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('vmstat -H', logger: log_spy)
+      .and_return(load_fixture('freebsd_vmstat').read)
+  end
+
+  it 'returns available system memory in bytes' do
+    expect(system_memory.resolve(:available_bytes)).to eq(available_bytes)
+  end
+
+  it 'returns total system memory in bytes' do
+    expect(system_memory.resolve(:total_bytes)).to eq(total_bytes)
+  end
+
+  it 'returns used system memory in bytes' do
+    expect(system_memory.resolve(:used_bytes)).to eq(used_bytes)
+  end
+
+  it 'returns memory capacity' do
+    expect(system_memory.resolve(:capacity)).to eq(capacity)
+  end
+end

--- a/spec/fixtures/freebsd_swapinfo
+++ b/spec/fixtures/freebsd_swapinfo
@@ -1,0 +1,3 @@
+Device          1K-blocks     Used    Avail Capacity
+/dev/ada0p2.eli   2097152        0  2097152     0%
+/dev/ada1p2.eli   2097152        0  2097152     0%

--- a/spec/fixtures/freebsd_vmstat
+++ b/spec/fixtures/freebsd_vmstat
@@ -1,0 +1,3 @@
+procs     memory        page                    disks     faults         cpu
+r b w     avm     fre  flt  re  pi  po    fr   sr ad0 pa0   in    sy    cs us sy id
+2 14 0 66587624 2633264  1211   0   0   0  1131  814   0   0 3563 13432  9998  4  3 93

--- a/spec/fixtures/freebsd_vmstat
+++ b/spec/fixtures/freebsd_vmstat
@@ -1,3 +1,6 @@
-procs     memory        page                    disks     faults         cpu
-r b w     avm     fre  flt  re  pi  po    fr   sr ad0 pa0   in    sy    cs us sy id
-2 14 0 66587624 2633264  1211   0   0   0  1131  814   0   0 3563 13432  9998  4  3 93
+{"__version": "1", "processes": {"runnable":2,"waiting":14,"swapped-out":0}
+, "memory": {"available-memory":62672436,"free-memory":2633264,"total-page-faults":1972}
+, "paging-rates": {"page-reactivated":0,"paged-in":1,"paged-out":0,"freed":1831,"scanned":841}
+, "device": [{"name":"ad0","transfers":"0"}, {"name":"pa0","transfers":"0"}], "fault-rates": {"interrupts":3495,"system-calls":17391,"context-switches":11777}
+, "cpu-statistics": {"user":" 5","system":" 3","idle":"92"}
+}


### PR DESCRIPTION
Collect system and swap memory information on FreeBSD

:gift: @igalic

The memory facts where not provided by Facter 4.  With this PR, Facter returns the same facts as Facter 3 does.