### PR TITLE
Add FreeBSD dmi facts

### DIFF
--- a/lib/facter/facts/freebsd/dmi/bios/release_date.rb
+++ b/lib/facter/facts/freebsd/dmi/bios/release_date.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Bios
+        class ReleaseDate
+          FACT_NAME = 'dmi.bios.release_date'
+          ALIASES = 'bios_release_date'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:bios_date)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/bios/vendor.rb
+++ b/lib/facter/facts/freebsd/dmi/bios/vendor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Bios
+        class Vendor
+          FACT_NAME = 'dmi.bios.vendor'
+          ALIASES = 'bios_vendor'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:bios_vendor)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/bios/version.rb
+++ b/lib/facter/facts/freebsd/dmi/bios/version.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Bios
+        class Version
+          FACT_NAME = 'dmi.bios.version'
+          ALIASES = 'bios_version'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:bios_version)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/manufacturer.rb
+++ b/lib/facter/facts/freebsd/dmi/manufacturer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      class Manufacturer
+        FACT_NAME = 'dmi.manufacturer'
+        ALIASES = 'manufacturer'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:sys_vendor)
+          [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/product/name.rb
+++ b/lib/facter/facts/freebsd/dmi/product/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Product
+        class Name
+          FACT_NAME = 'dmi.product.name'
+          ALIASES = 'productname'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:product_name)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/product/serial_number.rb
+++ b/lib/facter/facts/freebsd/dmi/product/serial_number.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Product
+        class SerialNumber
+          FACT_NAME = 'dmi.product.serial_number'
+          ALIASES = 'serialnumber'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:product_serial)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/dmi/product/uuid.rb
+++ b/lib/facter/facts/freebsd/dmi/product/uuid.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Dmi
+      module Product
+        class Uuid
+          FACT_NAME = 'dmi.product.uuid'
+          ALIASES = 'uuid'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::Freebsd::DmiBios.resolve(:product_uuid)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/freebsd/dmi_resolver.rb
+++ b/lib/facter/resolvers/freebsd/dmi_resolver.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class DmiBios < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+
+        class << self
+          #:model
+
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { read_facts(fact_name) }
+          end
+
+          def read_facts(fact_name)
+            require_relative 'ffi/ffi_helper'
+
+            @fact_list[:bios_date]    = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.bios.reldate')
+            @fact_list[:bios_vendor]  = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.bios.vendor')
+            @fact_list[:bios_version] = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.bios.version')
+
+            @fact_list[:product_name]   = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.system.product')
+            @fact_list[:product_serial] = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.system.serial')
+            @fact_list[:product_uuid]   = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.system.uuid')
+
+            @fact_list[:sys_vendor] = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.system.maker')
+
+            @fact_list[fact_name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/freebsd/ffi/ffi_helper.rb
+++ b/lib/facter/resolvers/freebsd/ffi/ffi_helper.rb
@@ -8,8 +8,27 @@ module Facter
       module Libc
         extend FFI::Library
 
+        KENV_GET = 0
+
+        KENV_MVALLEN = 128
+
         ffi_lib 'c'
+        attach_function :kenv, %i[int string pointer int], :int
         attach_function :sysctlbyname, %i[string pointer pointer pointer size_t], :int
+      end
+
+      def self.kenv(action, name, value = nil)
+        case action
+        when :get
+          len = Libc::KENV_MVALLEN + 1
+          value = FFI::MemoryPointer.new(:char, len)
+          res = Libc.kenv(Libc::KENV_GET, name, value, len)
+          return nil if res.negative?
+
+          value.read_string(res).chomp("\0")
+        else
+          raise "Action #{action} not supported"
+        end
       end
 
       def self.sysctl_by_name(type, name)

--- a/spec/facter/facts/freebsd/dmi/bios/release_date_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/bios/release_date_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Bios::ReleaseDate do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Bios::ReleaseDate.new }
+
+    let(:date) { '07/03/2018' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:bios_date).and_return(date)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:bios_date)
+    end
+
+    it 'returns bios release date fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.bios.release_date', value: date),
+                        an_object_having_attributes(name: 'bios_release_date', value: date, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/bios/vendor_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/bios/vendor_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Bios::Vendor do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Bios::Vendor.new }
+
+    let(:vendor) { 'Phoenix Technologies LTD' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:bios_vendor).and_return(vendor)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:bios_vendor)
+    end
+
+    it 'returns bios vendor fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.bios.vendor', value: vendor),
+                        an_object_having_attributes(name: 'bios_vendor', value: vendor, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/bios/version_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/bios/version_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Bios::Version do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Bios::Version.new }
+
+    let(:version) { '6.00' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:bios_version).and_return(version)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:bios_version)
+    end
+
+    it 'returns bios version fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.bios.version', value: version),
+                        an_object_having_attributes(name: 'bios_version', value: version, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/manufacturer_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/manufacturer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Manufacturer do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Manufacturer.new }
+
+    let(:sys_vendor) { 'VMware, Inc.' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:sys_vendor).and_return(sys_vendor)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:sys_vendor)
+    end
+
+    it 'returns manufacturer fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.manufacturer', value: sys_vendor),
+                        an_object_having_attributes(name: 'manufacturer', value: sys_vendor, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/product/name_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/product/name_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Product::Name do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Product::Name.new }
+
+    let(:product_name) { 'VMware Virtual Platform' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:product_name).and_return(product_name)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:product_name)
+    end
+
+    it 'returns product name fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.product.name', value: product_name),
+                        an_object_having_attributes(name: 'productname', value: product_name, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/product/serial_number_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/product/serial_number_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Product::SerialNumber do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Product::SerialNumber.new }
+
+    let(:serial_number) { 'VMware-42 1a a9 29 31 8f fa e9-7d 69 2e 23 21 b0 0c 45' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:product_serial).and_return(serial_number)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:product_serial)
+    end
+
+    it 'returns resolved facts' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.product.serial_number', value: serial_number),
+                        an_object_having_attributes(name: 'serialnumber', value: serial_number, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/dmi/product/uuid_spec.rb
+++ b/spec/facter/facts/freebsd/dmi/product/uuid_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Dmi::Product::Uuid do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Dmi::Product::Uuid.new }
+
+    let(:product_uuid) { '421aa929-318f-fae9-7d69-2e2321b00c45' }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::DmiBios).to \
+        receive(:resolve).with(:product_uuid).and_return(product_uuid)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::DmiBios' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::DmiBios).to have_received(:resolve).with(:product_uuid)
+    end
+
+    it 'returns resolved facts' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.product.uuid', value: product_uuid),
+                        an_object_having_attributes(name: 'uuid', value: product_uuid, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/resolvers/freebsd/dmi_bios_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/dmi_bios_resolver_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::DmiBios do
+  describe '#resolve' do
+    subject(:resolver) { Facter::Resolvers::Freebsd::DmiBios }
+
+    let(:bios_date) { '12/12/2018' }
+    let(:bios_vendor) { 'Phoenix Technologies LTD' }
+    let(:bios_version) { '6.00' }
+    let(:product_name) { 'VMware Virtual Platform' }
+    let(:product_serial) { 'VMware-42 1a 02 ea e6 27 76 b8-a1 23 a7 8a d3 12 ee cf' }
+    let(:product_uuid) { 'ea021a42-27e6-b876-a123-a78ad312eecf' }
+    let(:sys_vendor) { 'VMware, Inc.' }
+
+    before do
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.bios.reldate')
+        .and_return(bios_date)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.bios.vendor')
+        .and_return(bios_vendor)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.bios.version')
+        .and_return(bios_version)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.system.product')
+        .and_return(product_name)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.system.serial')
+        .and_return(product_serial)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.system.uuid')
+        .and_return(product_uuid)
+      allow(Facter::Freebsd::FfiHelper).to receive(:kenv)
+        .with(:get, 'smbios.system.maker')
+        .and_return(sys_vendor)
+    end
+
+    after do
+      Facter::Resolvers::Freebsd::DmiBios.invalidate_cache
+    end
+
+    context 'when bios_date is available' do
+      it 'returns bios_release_date' do
+        expect(resolver.resolve(:bios_date)).to eq(bios_date)
+      end
+    end
+
+    context 'when bios_vendor is available' do
+      it 'returns bios_release_date' do
+        expect(resolver.resolve(:bios_vendor)).to eq(bios_vendor)
+      end
+    end
+
+    context 'when bios_version is available' do
+      it 'returns bios_version' do
+        expect(resolver.resolve(:bios_version)).to eq(bios_version)
+      end
+    end
+
+    context 'when sys_vendor is available' do
+      it ' returns sys_vendor' do
+        expect(resolver.resolve(:sys_vendor)).to eq(sys_vendor)
+      end
+    end
+
+    context 'when product_name is available' do
+      it 'returns product_name' do
+        expect(resolver.resolve(:product_name)).to eq(product_name)
+      end
+    end
+
+    context 'when product_serial is available' do
+      it 'returns product_serial_number' do
+        expect(resolver.resolve(:product_serial)).to eq(product_serial)
+      end
+    end
+
+    context 'when product_uuid is available' do
+      it 'returns product_uuid' do
+        expect(resolver.resolve(:product_uuid)).to eq(product_uuid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The dmi facts where not provided by Facter 4.  With this PR, Facter returns the same facts as Facter 3 does.