### PR TITLE
(FACT-2723) --list-*-groups also displays external facts

### DIFF
--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -138,14 +138,26 @@ module Facter
 
     desc '--list-block-groups', 'List block groups', hide: true
     map ['--list-block-groups'] => :list_block_groups
-    def list_block_groups(*_args)
-      puts Facter::FactGroups.new.groups.to_yaml.lines[1..-1].join
+    def list_block_groups(*args)
+      options = @options.map { |(k, v)| [k.to_sym, v] }.to_h
+      Facter::Options.init_from_cli(options, args)
+
+      block_groups = Facter::FactGroups.new.groups.to_yaml.lines[1..-1].join
+      block_groups.gsub!(/:\s*\n/, "\n")
+
+      puts block_groups
     end
 
     desc '--list-cache-groups', 'List cache groups', hide: true
     map ['--list-cache-groups'] => :list_cache_groups
-    def list_cache_groups(*_args)
-      puts Facter::FactGroups.new.groups.to_yaml.lines[1..-1].join
+    def list_cache_groups(*args)
+      options = @options.map { |(k, v)| [k.to_sym, v] }.to_h
+      Facter::Options.init_from_cli(options, args)
+
+      cache_groups = Facter::FactGroups.new.groups.to_yaml.lines[1..-1].join
+      cache_groups.gsub!(/:\s*\n/, "\n")
+
+      puts cache_groups
     end
 
     def self.exit_on_failure?

--- a/lib/facter/framework/config/fact_groups.rb
+++ b/lib/facter/framework/config/fact_groups.rb
@@ -13,6 +13,7 @@ module Facter
       @groups_file_path = group_list_path || default_path
       @groups ||= File.readable?(@groups_file_path) ? Hocon.load(@groups_file_path) : {}
       load_groups
+      load_groups_from_options
     end
 
     # Breakes down blocked groups in blocked facts
@@ -41,6 +42,18 @@ module Facter
     end
 
     private
+
+    def load_groups_from_options
+      Options.external_dir.each do |dir|
+        next unless Dir.exist?(dir)
+
+        ext_facts = Dir.entries(dir)
+        ext_facts.reject! { |ef| ef =~ /^(\.|\.\.)$/ }
+        ext_facts.each do |ef|
+          @groups[ef] = nil
+        end
+      end
+    end
 
     def load_groups
       config = ConfigReader.init(Options[:config])

--- a/spec/framework/config/fact_groups_spec.rb
+++ b/spec/framework/config/fact_groups_spec.rb
@@ -34,6 +34,16 @@ describe Facter::FactGroups do
       expect(fct_grp.instance_variable_get(:@groups)).to include('foo' => 'bar')
     end
 
+    it 'merges external facts' do
+      external_path = '/path/to/external'
+      allow(Facter::Options).to receive(:external_dir).and_return([external_path])
+      allow(Dir).to receive(:exist?).with(external_path).and_return true
+      allow(Dir).to receive(:entries).with(external_path).and_return(['.', '..', 'external.sh'])
+      fct_grp = fact_groups.new
+
+      expect(fct_grp.instance_variable_get(:@groups)).to include('external.sh' => nil)
+    end
+
     it 'merges groups from facter.conf with default group override' do
       allow(Hocon).to receive(:load)
         .with(File.join(ROOT_DIR, 'lib', 'facter', 'framework', 'config', '..', '..', 'fact_groups.conf'))


### PR DESCRIPTION
When using --list-cache-groups or --list-block-groups, both custom and external facts are displayed