### PR TITLE
(FACT-2742) Exclude net/https when running on jruby FIPS

### DIFF
--- a/lib/facter/resolvers/base_resolver.rb
+++ b/lib/facter/resolvers/base_resolver.rb
@@ -20,7 +20,7 @@ module Facter
           subscribe_to_manager
           post_resolve(fact_name)
         end
-      rescue LoadError => e
+      rescue LoadError, NameError => e
         log.debug("resolving fact #{fact_name}, but #{e}")
         @fact_list[fact_name] = nil
       end

--- a/lib/facter/resolvers/ec2.rb
+++ b/lib/facter/resolvers/ec2.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'net/http'
-
 module Facter
   module Resolvers
     class Ec2 < BaseResolver
@@ -52,6 +50,8 @@ module Facter
         end
 
         def get_data_from(url)
+          require 'net/http'
+
           parsed_url = URI.parse(url)
           http = Net::HTTP.new(parsed_url.host)
           http.read_timeout = determine_session_timeout


### PR DESCRIPTION
`net/http` uses `openssl` which is not FIPS compliant on jRuby.  We can use the same mechanism that is used for missing gems to detect this case and log an error message, but continue to provide the facts we can resolve.