### PR TITLE
(FACT-2737) facter uptime shows host uptime inside docker container

### DIFF
--- a/lib/facter/facts/linux/system_uptime/days.rb
+++ b/lib/facter/facts/linux/system_uptime/days.rb
@@ -8,7 +8,13 @@ module Facts
         ALIASES = 'uptime_days'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Uptime.resolve(:days)
+          hypervisors = Facter::Resolvers::Containers.resolve(:hypervisor)
+
+          fact_value = if hypervisors && hypervisors[:docker]
+                         Facter::Resolvers::Linux::DockerUptime.resolve(:days)
+                       else
+                         Facter::Resolvers::Uptime.resolve(:days)
+                       end
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/facts/linux/system_uptime/hours.rb
+++ b/lib/facter/facts/linux/system_uptime/hours.rb
@@ -8,7 +8,13 @@ module Facts
         ALIASES = 'uptime_hours'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Uptime.resolve(:hours)
+          hypervisors = Facter::Resolvers::Containers.resolve(:hypervisor)
+
+          fact_value = if hypervisors && hypervisors[:docker]
+                         Facter::Resolvers::Linux::DockerUptime.resolve(:hours)
+                       else
+                         Facter::Resolvers::Uptime.resolve(:hours)
+                       end
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/facts/linux/system_uptime/seconds.rb
+++ b/lib/facter/facts/linux/system_uptime/seconds.rb
@@ -8,7 +8,13 @@ module Facts
         ALIASES = 'uptime_seconds'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Uptime.resolve(:seconds)
+          hypervisors = Facter::Resolvers::Containers.resolve(:hypervisor)
+
+          fact_value = if hypervisors && hypervisors[:docker]
+                         Facter::Resolvers::Linux::DockerUptime.resolve(:seconds)
+                       else
+                         Facter::Resolvers::Uptime.resolve(:seconds)
+                       end
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/facts/linux/system_uptime/uptime.rb
+++ b/lib/facter/facts/linux/system_uptime/uptime.rb
@@ -8,7 +8,13 @@ module Facts
         ALIASES = 'uptime'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Uptime.resolve(:uptime)
+          hypervisors = Facter::Resolvers::Containers.resolve(:hypervisor)
+
+          fact_value = if hypervisors && hypervisors[:docker]
+                         Facter::Resolvers::Linux::DockerUptime.resolve(:uptime)
+                       else
+                         Facter::Resolvers::Uptime.resolve(:uptime)
+                       end
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/resolvers/linux/docker_uptime.rb
+++ b/lib/facter/resolvers/linux/docker_uptime.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Linux
+      class DockerUptime < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        class << self
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { detect_uptime(fact_name) }
+          end
+
+          def detect_uptime(fact_name)
+            days, hours, minutes, seconds = extract_uptime_from_docker
+            total_seconds = convert_to_seconds(days, hours, minutes, seconds)
+            @fact_list = Utils::UptimeHelper.create_uptime_hash(total_seconds)
+
+            @fact_list[fact_name]
+          end
+
+          def extract_uptime_from_docker
+            # time format [dd-][hh:]mm:ss
+            time = Facter::Core::Execution.execute('ps -o etime= -p "1"', logger: log)
+            extracted_time = time.split(/[-:]/)
+
+            reversed_time = extracted_time.reverse
+            seconds = reversed_time[0].to_i
+            minutes = reversed_time[1].to_i
+            hours = reversed_time[2].to_i
+            days = reversed_time[3].to_i
+
+            [days, hours, minutes, seconds]
+          end
+
+          def convert_to_seconds(days, hours, minutes, seconds)
+            days * 24 * 3600 + hours * 3600 + minutes * 60 + seconds
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/linux/load_averages.rb
+++ b/lib/facter/resolvers/linux/load_averages.rb
@@ -4,7 +4,6 @@ module Facter
   module Resolvers
     module Linux
       class LoadAverages < BaseResolver
-        @log = Facter::Log.new(self)
         @semaphore = Mutex.new
         @fact_list ||= {}
         class << self

--- a/lib/facter/resolvers/uptime_resolver.rb
+++ b/lib/facter/resolvers/uptime_resolver.rb
@@ -23,33 +23,7 @@ module Facter
         def build_fact_list(seconds)
           return @fact_list[:uptime] = 'unknown' unless seconds
 
-          uptime_hash = create_uptime_hash(seconds)
-
-          @fact_list[:seconds] = uptime_hash[:seconds]
-          @fact_list[:hours]   = uptime_hash[:hours]
-          @fact_list[:days]    = uptime_hash[:days]
-          @fact_list[:uptime]  = uptime_hash[:uptime]
-        end
-
-        def create_uptime_hash(seconds)
-          results = {}
-          minutes = (seconds / 60) % 60
-
-          results[:seconds] = seconds
-          results[:hours]   = seconds / (60 * 60)
-          results[:days]    = results[:hours] / 24
-          results[:uptime]  = build_uptime_text(results[:days], results[:hours], minutes)
-
-          results
-        end
-
-        def build_uptime_text(days, hours, minutes)
-          case days
-          when 0 then "#{hours}:#{format('%<minutes>02d', minutes: minutes)} hours"
-          when 1 then '1 day'
-          else
-            "#{days} days"
-          end
+          @fact_list = Utils::UptimeHelper.create_uptime_hash(seconds)
         end
       end
     end

--- a/lib/facter/resolvers/utils/uptime_helper.rb
+++ b/lib/facter/resolvers/utils/uptime_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Utils
+      module UptimeHelper
+        class << self
+          def create_uptime_hash(seconds)
+            results = {}
+            minutes = (seconds / 60) % 60
+
+            results[:seconds] = seconds
+            results[:hours]   = seconds / (60 * 60)
+            results[:days]    = results[:hours] / 24
+            results[:uptime]  = build_uptime_text(results[:days], results[:hours], minutes)
+
+            results
+          end
+
+          def build_uptime_text(days, hours, minutes)
+            case days
+            when 0 then "#{hours}:#{format('%<minutes>02d', minutes: minutes)} hours"
+            when 1 then '1 day'
+            else
+              "#{days} days"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/linux/system_uptime/days_spec.rb
+++ b/spec/facter/facts/linux/system_uptime/days_spec.rb
@@ -6,19 +6,40 @@ describe Facts::Linux::SystemUptime::Days do
 
     let(:value) { '2' }
 
-    before do
-      allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:days).and_return(value)
+    context 'when on linux' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return(nil)
+        allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:days).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:days)
+      end
+
+      it 'returns days since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.days', value: value),
+                          an_object_having_attributes(name: 'uptime_days', value: value, type: :legacy))
+      end
     end
 
-    it 'calls Facter::Resolvers::Uptime' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:days)
-    end
+    context 'when in docker container' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return({ docker: '123' })
+        allow(Facter::Resolvers::Linux::DockerUptime).to receive(:resolve).with(:days).and_return(value)
+      end
 
-    it 'returns days since last boot' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'system_uptime.days', value: value),
-                        an_object_having_attributes(name: 'uptime_days', value: value, type: :legacy))
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Linux::DockerUptime).to have_received(:resolve).with(:days)
+      end
+
+      it 'returns days since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.days', value: value),
+                          an_object_having_attributes(name: 'uptime_days', value: value, type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/facts/linux/system_uptime/hours_spec.rb
+++ b/spec/facter/facts/linux/system_uptime/hours_spec.rb
@@ -6,19 +6,40 @@ describe Facts::Linux::SystemUptime::Hours do
 
     let(:value) { '2' }
 
-    before do
-      allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:hours).and_return(value)
+    context 'when on linux' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return(nil)
+        allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:hours).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:hours)
+      end
+
+      it 'returns hours since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.hours', value: value),
+                          an_object_having_attributes(name: 'uptime_hours', value: value, type: :legacy))
+      end
     end
 
-    it 'calls Facter::Resolvers::Uptime' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:hours)
-    end
+    context 'when in docker container' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return({ docker: '123' })
+        allow(Facter::Resolvers::Linux::DockerUptime).to receive(:resolve).with(:hours).and_return(value)
+      end
 
-    it 'returns hours since last boot' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'system_uptime.hours', value: value),
-                        an_object_having_attributes(name: 'uptime_hours', value: value, type: :legacy))
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Linux::DockerUptime).to have_received(:resolve).with(:hours)
+      end
+
+      it 'returns hours since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.hours', value: value),
+                          an_object_having_attributes(name: 'uptime_hours', value: value, type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/facts/linux/system_uptime/seconds_spec.rb
+++ b/spec/facter/facts/linux/system_uptime/seconds_spec.rb
@@ -6,19 +6,40 @@ describe Facts::Linux::SystemUptime::Seconds do
 
     let(:value) { 3600 }
 
-    before do
-      allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:seconds).and_return(value)
+    context 'when on linux' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return(nil)
+        allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:seconds).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:seconds)
+      end
+
+      it 'returns minutes since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.seconds', value: value),
+                          an_object_having_attributes(name: 'uptime_seconds', value: value, type: :legacy))
+      end
     end
 
-    it 'calls Facter::Resolvers::Uptime' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:seconds)
-    end
+    context 'when in docker container' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return({ docker: '123' })
+        allow(Facter::Resolvers::Linux::DockerUptime).to receive(:resolve).with(:seconds).and_return(value)
+      end
 
-    it 'returns minutes since last boot' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'system_uptime.seconds', value: value),
-                        an_object_having_attributes(name: 'uptime_seconds', value: value, type: :legacy))
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Linux::DockerUptime).to have_received(:resolve).with(:seconds)
+      end
+
+      it 'returns minutes since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.seconds', value: value),
+                          an_object_having_attributes(name: 'uptime_seconds', value: value, type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/facts/linux/system_uptime/uptime_spec.rb
+++ b/spec/facter/facts/linux/system_uptime/uptime_spec.rb
@@ -6,19 +6,40 @@ describe Facts::Linux::SystemUptime::Uptime do
 
     let(:value) { '6 days' }
 
-    before do
-      allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:uptime).and_return(value)
+    context 'when on linux' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return(nil)
+        allow(Facter::Resolvers::Uptime).to receive(:resolve).with(:uptime).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:uptime)
+      end
+
+      it 'returns total uptime since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.uptime', value: value),
+                          an_object_having_attributes(name: 'uptime', value: value, type: :legacy))
+      end
     end
 
-    it 'calls Facter::Resolvers::Uptime' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Uptime).to have_received(:resolve).with(:uptime)
-    end
+    context 'when in docker container' do
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve) .with(:hypervisor).and_return({ docker: '123' })
+        allow(Facter::Resolvers::Linux::DockerUptime).to receive(:resolve).with(:uptime).and_return(value)
+      end
 
-    it 'returns total uptime since last boot' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'system_uptime.uptime', value: value),
-                        an_object_having_attributes(name: 'uptime', value: value, type: :legacy))
+      it 'calls Facter::Resolvers::DockerUptime' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Linux::DockerUptime).to have_received(:resolve).with(:uptime)
+      end
+
+      it 'returns total uptime since last boot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'system_uptime.uptime', value: value),
+                          an_object_having_attributes(name: 'uptime', value: value, type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/resolvers/linux/docker_uptime_spec.rb
+++ b/spec/facter/resolvers/linux/docker_uptime_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Linux::DockerUptime do
+  subject(:resolver) { Facter::Resolvers::Linux::DockerUptime }
+
+  let(:log_spy) { instance_spy(Facter::Log) }
+
+  after { Facter::Resolvers::Linux::DockerUptime.invalidate_cache }
+
+  before do
+    resolver.instance_variable_set(:@log, log_spy)
+  end
+
+  context 'when the uptime is less than 1 minutes' do
+    before do
+      allow(Facter::Core::Execution)
+        .to receive(:execute)
+        .with('ps -o etime= -p "1"', logger: log_spy)
+        .and_return('20')
+
+      allow(Facter::Resolvers::Utils::UptimeHelper)
+        .to receive(:create_uptime_hash)
+        .with(20)
+        .and_return({ days: 0, hours: 0, seconds: 20, uptime: '0:00 hours' })
+    end
+
+    it 'returns 0 days' do
+      expect(resolver.resolve(:days)).to eq(0)
+    end
+
+    it 'returns 0 hours' do
+      expect(resolver.resolve(:hours)).to eq(0)
+    end
+
+    it 'returns 20 seconds' do
+      expect(resolver.resolve(:seconds)).to eq(20)
+    end
+
+    it 'returns 0:00 hours for uptime' do
+      expect(resolver.resolve(:uptime)).to eq('0:00 hours')
+    end
+  end
+
+  context 'when the uptime is more than 1 minute and less than 1 hour' do
+    before do
+      allow(Facter::Core::Execution)
+        .to receive(:execute)
+        .with('ps -o etime= -p "1"', logger: log_spy)
+        .and_return('10:20')
+
+      allow(Facter::Resolvers::Utils::UptimeHelper)
+        .to receive(:create_uptime_hash)
+        .with(620)
+        .and_return({ days: 0, hours: 0, seconds: 620, uptime: '0:10 hours' })
+    end
+
+    it 'returns 0 days' do
+      expect(resolver.resolve(:days)).to eq(0)
+    end
+
+    it 'returns 0 hours' do
+      expect(resolver.resolve(:hours)).to eq(0)
+    end
+
+    it 'returns 620 seconds' do
+      expect(resolver.resolve(:seconds)).to eq(620)
+    end
+
+    it 'returns 0:10 hours for uptime' do
+      expect(resolver.resolve(:uptime)).to eq('0:10 hours')
+    end
+  end
+
+  context 'when the uptime is more than 1 hour but less than 1 day' do
+    before do
+      allow(Facter::Core::Execution)
+        .to receive(:execute)
+        .with('ps -o etime= -p "1"', logger: log_spy)
+        .and_return('3:10:20')
+
+      allow(Facter::Resolvers::Utils::UptimeHelper)
+        .to receive(:create_uptime_hash)
+        .with(11_420)
+        .and_return({ days: 0, hours: 3, seconds: 11_420, uptime: '3:10 hours' })
+    end
+
+    it 'returns 0 days' do
+      expect(resolver.resolve(:days)).to eq(0)
+    end
+
+    it 'returns 3 hours' do
+      expect(resolver.resolve(:hours)).to eq(3)
+    end
+
+    it 'returns 11420 seconds' do
+      expect(resolver.resolve(:seconds)).to eq(11_420)
+    end
+
+    it 'returns 3:10 hours for uptime' do
+      expect(resolver.resolve(:uptime)).to eq('3:10 hours')
+    end
+  end
+
+  context 'when the uptime is 1 day' do
+    before do
+      allow(Facter::Core::Execution)
+        .to receive(:execute)
+        .with('ps -o etime= -p "1"', logger: log_spy)
+        .and_return('1-3:10:20')
+
+      allow(Facter::Resolvers::Utils::UptimeHelper)
+        .to receive(:create_uptime_hash)
+        .with(97_820)
+        .and_return({ days: 1, hours: 27, seconds: 97_820, uptime: '1 day' })
+    end
+
+    it 'returns 1 day' do
+      expect(resolver.resolve(:days)).to eq(1)
+    end
+
+    it 'returns 27 hours' do
+      expect(resolver.resolve(:hours)).to eq(27)
+    end
+
+    it 'returns 97820 seconds' do
+      expect(resolver.resolve(:seconds)).to eq(97_820)
+    end
+
+    it 'returns 1 day for uptime' do
+      expect(resolver.resolve(:uptime)).to eq('1 day')
+    end
+  end
+
+  context 'when the uptime is more than 2 day' do
+    before do
+      allow(Facter::Core::Execution)
+        .to receive(:execute)
+        .with('ps -o etime= -p "1"', logger: log_spy)
+        .and_return('2-3:10:20')
+
+      allow(Facter::Resolvers::Utils::UptimeHelper)
+        .to receive(:create_uptime_hash)
+        .with(184_220)
+        .and_return({ days: 2, hours: 51, seconds: 184_220, uptime: '2 days' })
+    end
+
+    it 'returns 2 days' do
+      expect(resolver.resolve(:days)).to eq(2)
+    end
+
+    it 'returns 51 hours' do
+      expect(resolver.resolve(:hours)).to eq(51)
+    end
+
+    it 'returns 184220 seconds' do
+      expect(resolver.resolve(:seconds)).to eq(184_220)
+    end
+
+    it 'returns 2 days for uptime' do
+      expect(resolver.resolve(:uptime)).to eq('2 days')
+    end
+  end
+end

--- a/spec/facter/resolvers/utils/uptime_helper_spec.rb
+++ b/spec/facter/resolvers/utils/uptime_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Utils::UptimeHelper do
+  subject(:helper) { Facter::Resolvers::Utils::UptimeHelper }
+
+  context 'when the uptime is less than 1 minutes' do
+    let(:expected_result) { { days: 0, hours: 0, seconds: 20, uptime: '0:00 hours' } }
+
+    it 'returns response hash' do
+      expect(helper.create_uptime_hash(20)).to eq(expected_result)
+    end
+  end
+
+  context 'when the uptime is more than 1 minute and less than 1 hour' do
+    let(:expected_result) { { days: 0, hours: 0, seconds: 620, uptime: '0:10 hours' } }
+
+    it 'returns response hash' do
+      expect(helper.create_uptime_hash(620)).to eq(expected_result)
+    end
+  end
+
+  context 'when the uptime is more than 1 hour but less than 1 day' do
+    let(:expected_result) { { days: 0, hours: 3, seconds: 11_420, uptime: '3:10 hours' } }
+
+    it 'returns response hash' do
+      expect(helper.create_uptime_hash(11_420)).to eq(expected_result)
+    end
+  end
+
+  context 'when the uptime is 1 day' do
+    let(:expected_result) { { days: 1, hours: 27, seconds: 97_820, uptime: '1 day' } }
+
+    it 'returns response hash' do
+      expect(helper.create_uptime_hash(97_820)).to eq(expected_result)
+    end
+  end
+
+  context 'when the uptime is more than 2 day' do
+    let(:expected_result) { { days: 2, hours: 51, seconds: 184_220, uptime: '2 days' } }
+
+    it 'returns response hash' do
+      expect(helper.create_uptime_hash(184_220)).to eq(expected_result)
+    end
+  end
+end


### PR DESCRIPTION
All uptime facts in docker were reporting host uptime. In order to fix this `ps -o etime= -p "1"` is used inside docker container to determine it's uptime.

With the fix

- on linux 
```
./facter facterversion system_uptime
--
facterversion => 4.0.34
system_uptime => {
days => 3,
hours => 73,
seconds => 264126,
uptime => "3 days"
```

- in docker container
```
./facter facterversion system_uptime
--
facterversion => 4.0.34
system_uptime => {
days => 0,
hours => 0,
seconds => 682,
uptime => "0:11 hours"
}
```

