### PR TITLE
(FACT-2402) Exclude fuseblk from filesystems

### DIFF
--- a/lib/facter/resolvers/filesystems_resolver.rb
+++ b/lib/facter/resolvers/filesystems_resolver.rb
@@ -22,7 +22,7 @@ module Facter
             filesystems = []
             output.each do |line|
               tokens = line.split(' ')
-              filesystems << tokens if tokens.size == 1
+              filesystems << tokens if tokens.size == 1 && tokens.first != 'fuseblk'
             end
             @fact_list[:systems] = filesystems.sort.join(',')
             @fact_list[fact_name]

--- a/spec/fixtures/filesystems
+++ b/spec/fixtures/filesystems
@@ -20,6 +20,7 @@ nodev	hugetlbfs
 nodev	devpts
 	    ext3
 	    ext2
+	    fuseblk
 	    ext4
 nodev	autofs
 nodev	mqueue


### PR DESCRIPTION
In Facter 3.x code, _fuseblk_ is excluded from filesystems fact on Linux. In order to provide output compatibility with Facter 3.x, this needs to be excluded from Facter 4.x filesystems fact as well.