### PR TITLE
(FACT-2454) fix how used memory is calculated

### DIFF
--- a/lib/facter/resolvers/memory_resolver.rb
+++ b/lib/facter/resolvers/memory_resolver.rb
@@ -27,7 +27,7 @@ module Facter
           def read_system(output)
             @fact_list[:total] = kilobytes_to_bytes(output.match(/MemTotal:\s+(\d+)\s/)[1])
             @fact_list[:memfree] = kilobytes_to_bytes(output.match(/MemFree:\s+(\d+)\s/)[1])
-            @fact_list[:used_bytes] = compute_used(@fact_list[:total], @fact_list[:memfree])
+            @fact_list[:used_bytes] = compute_used(@fact_list[:total], reclaimable_memory(output))
             @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total])
           end
 
@@ -43,6 +43,13 @@ module Facter
 
           def kilobytes_to_bytes(quantity)
             quantity.to_i * 1024
+          end
+
+          def reclaimable_memory(output)
+            buffers = kilobytes_to_bytes(output.match(/Buffers:\s+(\d+)\s/)[1])
+            cached = kilobytes_to_bytes(output.match(/Cached:\s+(\d+)\s/)[1])
+            s_reclaimable = kilobytes_to_bytes(output.match(/SReclaimable:\s+(\d+)\s/)[1])
+            @fact_list[:memfree] + buffers + cached + s_reclaimable
           end
 
           def compute_capacity(used, total)

--- a/spec/facter/resolvers/memory_resolver_spec.rb
+++ b/spec/facter/resolvers/memory_resolver_spec.rb
@@ -17,7 +17,10 @@ describe Facter::Resolvers::Linux::Memory do
     context 'when there is swap memory' do
       let(:total) { 4_036_680 * 1024 }
       let(:free) { 3_547_792 * 1024 }
-      let(:used) { total - free }
+      let(:buffers) { 4_288 * 1024 }
+      let(:cached) { 298_624 * 1024 }
+      let(:s_reclaimable) { 29_072 * 1024 }
+      let(:used) { total - free - buffers - cached - s_reclaimable }
       let(:swap_total) { 2_097_148 * 1024 }
       let(:swap_free) { 2_097_148 * 1024 }
       let(:swap_used) { swap_total - swap_free }
@@ -63,7 +66,10 @@ describe Facter::Resolvers::Linux::Memory do
     context 'when there is not swap memory' do
       let(:total) { 4_134_510_592 }
       let(:free) { 3_465_723_904 }
-      let(:used) { total - free }
+      let(:buffers) { 2_088 * 1024 }
+      let(:cached) { 445_204 * 1024 }
+      let(:s_reclaimable) { 71_384 * 1024 }
+      let(:used) { total - free - buffers - cached - s_reclaimable }
       let(:fixture_name) { 'meminfo2' }
 
       it 'returns total memory' do


### PR DESCRIPTION
On Linux platforms we calculated the used system memory by subtracting the free memory from the total memory. 
Now we'll calculate it by subtracting the free memory, buffers, caches and SReclaimable memory from the total memory.