### PR TITLE
(maint) Fix processor's speed fact for linux ppc

### DIFF
--- a/lib/inc/internal/facts/linux/processor_resolver.hpp
+++ b/lib/inc/internal/facts/linux/processor_resolver.hpp
@@ -51,7 +51,7 @@ namespace facter { namespace facts { namespace linux {
         virtual data collect_data(collection& facts) override;
 
      private:
-        void maybe_add_speed(data& data, std::string const& speed);
+        void maybe_add_speed(data& data, std::string const& speed, int);
         bool compute_cpu_counts(data& data, std::string const& root, std::function<bool(std::string const&)> is_valid_id);
         bool add_x86_cpu_data(data& data, std::string const& root = "");
         bool add_power_cpu_data(data& data, std::string const& root = "");

--- a/lib/src/facts/linux/processor_resolver.cc
+++ b/lib/src/facts/linux/processor_resolver.cc
@@ -95,11 +95,11 @@ namespace facter { namespace facts { namespace linux {
         return cpu0_valid;
     }
 
-    void processor_resolver::maybe_add_speed(data& data, std::string const& speed)
+    void processor_resolver::maybe_add_speed(data& data, std::string const& speed, int magnitude)
     {
         auto maybe_speed = maybe_stoi(speed);
         if (maybe_speed && maybe_speed.get() > 0) {
-            data.speed = maybe_speed.get() * static_cast<int64_t>(1000);
+            data.speed = maybe_speed.get() * static_cast<int64_t>(magnitude);
         }
     }
 
@@ -168,7 +168,7 @@ namespace facter { namespace facts { namespace linux {
                 // Parse out the processor speed (in MHz)
                 string speed;
                 if (lth_util::re_search(value, boost::regex("^(\\d+).*MHz"), &speed)) {
-                    maybe_add_speed(data, speed);
+                    maybe_add_speed(data, speed, 1000000);
                 }
             }
             return true;
@@ -190,7 +190,7 @@ namespace facter { namespace facts { namespace linux {
         // Read in the max speed from the first cpu
         // The speed is in kHz
         string speed = lth_file::read(root + "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
-        maybe_add_speed(data, speed);
+        maybe_add_speed(data, speed, 1000);
     }
 
     processor_resolver::data processor_resolver::collect_data(collection& facts)

--- a/lib/tests/facts/linux/processor_resolver.cc
+++ b/lib/tests/facts/linux/processor_resolver.cc
@@ -243,7 +243,7 @@ SCENARIO("resolving processor-specific facts for linux machines") {
             THEN("the processor facts are correctly resolved, with the speed being read from the 'clock' entry") {
                 fixture.reset(architecture_type::POWER);
 
-                // here, speed is in KHz
+                // here, speed is in MHz
                 vector<cpu_param> cpu_params({
                     // ensure that speed is read from the "clock" entry
                     make_tuple("Model A", "0", "0", boost::optional<int64_t>()),
@@ -273,7 +273,7 @@ SCENARIO("resolving processor-specific facts for linux machines") {
                     REQUIRE(result.models[i] == EXPECTED_MODELS[i]);
                 }
 
-                REQUIRE(result.speed == 15000);
+                REQUIRE(result.speed == 15000000);
             }
         }
 
@@ -281,7 +281,7 @@ SCENARIO("resolving processor-specific facts for linux machines") {
             THEN("the processor facts are correctly resolved, but the speed is not calculated") {
                 fixture.reset(architecture_type::POWER);
 
-                // here, speed is in KHz
+                // here, speed is in MHz
                 vector<cpu_param> cpu_params({
                     make_tuple("Model A", "0", "-1", 15),
                     make_tuple("Model B", "0", "-1", -1)
@@ -310,7 +310,7 @@ SCENARIO("resolving processor-specific facts for linux machines") {
             THEN("the processor facts are correctly resolved, with the speed being read from the 'clock' entry, but the physical count is not computed") {
                 fixture.reset(architecture_type::POWER);
 
-                // here, speed is in KHz
+                // here, speed is in MHz
                 vector<cpu_param> cpu_params({
                     make_tuple("Model A", "0", "0", boost::optional<int64_t>()),
                     // ensure that duplicate CPUs are not counted twice in the
@@ -341,7 +341,7 @@ SCENARIO("resolving processor-specific facts for linux machines") {
                     REQUIRE(result.models[i] == EXPECTED_MODELS[i]);
                 }
 
-                REQUIRE(result.speed == 15000);
+                REQUIRE(result.speed == 15000000);
             }
         }
     }


### PR DESCRIPTION
**Description of the problem:** On linux power pc processors.speed fact is wrong because the order of magnitude is incorrect (MHz instead of GHz).
**Description of the fix:** Made the method that calculate the processor's speed  more configurable in order to accept the magnitude as a parameter. 