### PR TITLE
(FACT-2759) Fix Linux Mint 20 OS facts

### DIFF
--- a/lib/src/facts/linux/os_linux.cc
+++ b/lib/src/facts/linux/os_linux.cc
@@ -55,8 +55,12 @@ namespace facter { namespace facts { namespace linux {
         }
 
         if (is_regular_file(release_file::debian, ec)) {
-            if (distro_id == os::ubuntu || distro_id == os::linux_mint) {
-                return distro_id;
+            if (distro_id == os::ubuntu) {
+                return os::ubuntu;
+            }
+            // LinuxMint 20 shows distro_id to be Linuxmint instead of LinuxMint
+            if (boost::iequals(distro_id, string(os::linux_mint))) {
+                return os::linux_mint;
             }
             return os::debian;
         }


### PR DESCRIPTION
lsb_release on Linux Mint 20 reports Distribution ID as Linuxmint.
Previous versions (and facter) reported LinuxMint.

Change the check in facter to do a case insensitive comparison.

Before this commit:
```sh-session
> facter os
{
  architecture => "amd64",
  distro => {
    codename => "ulyana",
    description => "Linux Mint 20",
    id => "Linuxmint",
    release => {
      full => "20",
      major => "20"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "Debian",
  release => {
    full => "bullseye/sid",
    major => "bullseye/sid"
  },
  selinux => {
    enabled => false
  }
}
```

After this commit:

```sh-session
> facter os
{
  architecture => "amd64",
  distro => {
    codename => "ulyana",
    description => "Linux Mint 20",
    id => "Linuxmint",
    release => {
      full => "20",
      major => "20"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "LinuxMint",
  release => {
    full => "20",
    major => "20"
  },
  selinux => {
    enabled => false
  }
}
```