### PR TITLE
(maint) fix File.expand_path error on Windows github actions

### DIFF
--- a/spec/custom_facts/util/config_spec.rb
+++ b/spec/custom_facts/util/config_spec.rb
@@ -84,8 +84,8 @@ describe LegacyFacter::Util::Config do
       allow(LegacyFacter::Util::Root).to receive(:root?).and_return(false)
       LegacyFacter::Util::Config.setup_default_ext_facts_dirs
       expect(LegacyFacter::Util::Config.external_facts_dirs)
-        .to eq [File.expand_path(File.join('~', '.facter', 'facts.d')),
-                File.expand_path(File.join('~', '.puppetlabs', 'opt', 'facter', 'facts.d'))]
+        .to eq [File.join(ENV['HOME'], '.facter', 'facts.d'),
+                File.join(ENV['HOME'], '.puppetlabs', 'opt', 'facter', 'facts.d')]
     end
 
     it 'includes additional values when user appends to the list' do


### PR DESCRIPTION
On github actions windows vm, File.expand_path combined with File.join,
results in a mix of forward and back slashes.
File.join merges paths using forward-slashes, and File.expand_path uses back-slashes.
So, instead of generating a path like this: C:/Users/runneradmin/.facter/facts.d,
this gets generated instead: C:\\Users\\runneradmin/.facter/facts.d.

So, the fix is to replace File.expand_path with File.join(ENV['HOME'], ...)