### PR TITLE
(FACT-2785) partitions.<partition_name>.mount has wrong value on sles15-64

### DIFF
--- a/lib/facter/facts/linux/partitions.rb
+++ b/lib/facter/facts/linux/partitions.rb
@@ -14,7 +14,7 @@ module Facts
         mountpoints = Facter::Resolvers::Mountpoints.resolve(:mountpoints)
         return parts unless mountpoints
 
-        mountpoints.each do |mnt|
+        mountpoints.reverse_each do |mnt|
           next unless parts[mnt[:device]]
 
           parts[mnt[:device]].merge!(mount: mnt[:path])

--- a/spec/facter/facts/linux/partitions_spec.rb
+++ b/spec/facter/facts/linux/partitions_spec.rb
@@ -76,5 +76,82 @@ describe Facts::Linux::Partitions do
           have_attributes(name: 'partitions', value: nil)
       end
     end
+
+    context 'when the same device is mounted in multiple places' do
+      let(:mountpoints_resolver_output) do
+        [{
+          device: '/dev/sda2',
+          filesystem: 'btrfs',
+          path: '/',
+          options: ['rw', 'relatime', 'space_cache', 'subvolid=267', 'subvol=/@/.snapshots/1/snapshot'],
+          available: '10.74 GiB',
+          available_bytes: 11_534_614_528,
+          size: '13.09 GiB',
+          size_bytes: 14_050_918_400,
+          used: '1.96 GiB',
+          used_bytes: 2_101_231_616,
+          capacity: '15.41%'
+        }, {
+          device: '/dev/sda2',
+          filesystem: 'btrfs',
+          path: '/boot/grub2/x86_64-efi',
+          options: ['rw', 'relatime', 'space_cache', 'subvolid=264', 'subvol=/@/boot/grub2/x86_64-efi'],
+          available: '10.74 GiB',
+          available_bytes: 11_534_614_528,
+          size: '13.09 GiB',
+          size_bytes: 14_050_918_400,
+          used: '1.96 GiB',
+          used_bytes: 2_101_231_616,
+          capacity: '15.41%'
+        }]
+      end
+
+      let(:partitions_resolver_output) do
+        {
+          '/dev/sda2' => {
+            size_bytes: 14_050_918_400,
+            size: '13.09 GiB',
+            filesystem: 'btrfs',
+            uuid: 'bbc18fba-8191-48c8-b8bd-30373654bb3e',
+            partuuid: 'c96cd2ea-1046-461c-b0fe-1e5aa19aba61'
+          }
+        }
+      end
+
+      let(:final_result) do
+        {
+          '/dev/sda2' => {
+            'size_bytes' => 14_050_918_400,
+            'size' => '13.09 GiB',
+            'filesystem' => 'btrfs',
+            'uuid' => 'bbc18fba-8191-48c8-b8bd-30373654bb3e',
+            'partuuid' => 'c96cd2ea-1046-461c-b0fe-1e5aa19aba61',
+            'mount' => '/'
+          }
+        }
+      end
+
+      before do
+        allow(Facter::Resolvers::Mountpoints).to receive(:resolve).with(:mountpoints)
+                                                                  .and_return(mountpoints_resolver_output)
+        allow(Facter::Resolvers::Partitions).to receive(:resolve).with(:partitions)
+                                                                 .and_return(partitions_resolver_output)
+      end
+
+      it 'calls Facter::Resolvers::Mountpoints' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Mountpoints).to have_received(:resolve).with(:mountpoints)
+      end
+
+      it 'calls Facter::Resolvers::Partitions' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Partitions).to have_received(:resolve).with(:partitions)
+      end
+
+      it 'returns partitions information from the first mountpoint' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'partitions', value: final_result)
+      end
+    end
   end
 end


### PR DESCRIPTION
The same device can be mounted in multiple locations. In this case, Facter 3 picked the first location https://github.com/puppetlabs/facter/blob/f118571fd7fe6298544266f294324b5097ec792f/lib/src/facts/linux/filesystem_resolver.cc#L282. The fix picks the first location instead of the last one.