### PR TITLE
(FACT-2634) Acceptance test that verifies facter behaviour with custom files

### DIFF
--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
@@ -1,0 +1,117 @@
+test_name 'Facter api works when there is an error inside a custom fact file' do
+  tag 'risk:high'
+
+  first_file_content = <<-EOM
+    Facter.add(:custom_fact_1) do
+      setcode do
+        'custom_fact_1_value'
+      end
+    end
+     
+    # some error
+    nill.size
+     
+    Facter.add(:custom_fact_2) do
+      setcode do
+        'custom_fact_2_value'
+      end
+    end
+     
+    Facter.add(:custom_fact_3) do
+      setcode do
+        'custom_fact_3_value'
+      end
+    end
+  EOM
+
+  second_file_content = <<~EOM
+    Facter.add(:custom_fact_4) do
+      setcode do
+        'custom_fact_4_value'
+      end
+    end
+  EOM
+
+  def create_custom_fact_file(file_name, file_content, agent, folder)
+    fact_file = File.join(folder, file_name)
+    create_remote_file(agent, fact_file, file_content)
+  end
+
+  def create_api_call_file(test_vars, facter_querry)
+    file_content = <<-EOM
+      require 'facter'
+      Facter.search(\'#{test_vars[:facts_dir]}\')
+      #{facter_querry}
+    EOM
+    create_custom_fact_file(test_vars[:test_script_name], file_content, test_vars[:agent], test_vars[:script_dir])
+  end
+
+  agents.each do |agent|
+    test_vars = {}
+    test_vars[:facts_dir] = agent.tmpdir('facts_dir')
+    test_vars[:script_dir] = agent.tmpdir('script_dir')
+    test_vars[:agent] = agent
+    test_vars[:test_script_name] = 'test_custom_facts.rb'
+    test_vars[:test_script_path] = File.join(test_vars[:script_dir], test_vars[:test_script_name])
+
+    create_custom_fact_file('file1.rb', first_file_content, test_vars[:agent], test_vars[:facts_dir])
+    create_custom_fact_file('file2.rb', second_file_content, test_vars[:agent], test_vars[:facts_dir])
+
+    teardown do
+      agent.rm_rf(test_vars[:facts_dir])
+      agent.rm_rf(test_vars[:script_dir])
+    end
+
+    step "Agent #{agent}: Verify that custom fact 1 is available" do
+      create_api_call_file(test_vars, "puts Facter.value('custom_fact_1')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_match(/custom_fact_1_value/, ruby_result.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 2 is missing" do
+      create_api_call_file(test_vars, "puts Facter.value('custom_fact_2')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_no_match(/custom_fact_2_value/, ruby_result.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 3 is missing" do
+      create_api_call_file(test_vars, "puts Facter.value('custom_fact_3')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_no_match(/custom_fact_3_value/, ruby_result.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 4 is available" do
+      create_api_call_file(test_vars, "puts Facter.value('custom_fact_4')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_match(/custom_fact_4_value/, ruby_result.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that a core fact is still available" do
+      os_name = on(agent, facter('os.name')).stdout.chomp
+      create_api_call_file(test_vars, "puts Facter.value('os.name')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_match(/#{os_name}/, ruby_result.stdout)
+      end
+    end
+
+    step "Agent #{agent}: Verify that an error is outputted when custom fact file has an error" do
+      create_api_call_file(test_vars, "Facter.value('custom_fact_1')")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_match(/Facter - error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
+          ruby_result.stdout)
+      end
+    end
+
+    step "Agent #{agent}: Verify that Fact.to_hash still works" do
+      create_api_call_file(test_vars, "puts Facter.to_hash")
+      on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
+        assert_match(/os.name/, ruby_result.stdout)
+      end
+    end
+  end
+end
+

--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
@@ -1,0 +1,100 @@
+test_name 'Facter cli works when there is an error inside a custom fact file' do
+  tag 'risk:high'
+
+  first_file_content = <<-EOM
+    Facter.add(:custom_fact_1) do
+      setcode do
+        'custom_fact_1_value'
+      end
+    end
+     
+    # some error
+    nill.size
+     
+    Facter.add(:custom_fact_2) do
+      setcode do
+        'custom_fact_2_value'
+      end
+    end
+     
+    Facter.add(:custom_fact_3) do
+      setcode do
+        'custom_fact_3_value'
+      end
+    end
+  EOM
+
+  second_file_content = <<~EOM
+    Facter.add(:custom_fact_4) do
+      setcode do
+        'custom_fact_4_value'
+      end
+    end
+  EOM
+
+  def create_custom_fact_file(file_name, file_content, fact_dir, agent)
+    fact_file = File.join(fact_dir, file_name)
+    create_remote_file(agent, fact_file, file_content)
+  end
+
+  agents.each do |agent|
+    custom_facts = agent.tmpdir('custom_facts_dir')
+
+    os_name = on(agent, facter('os.name')).stdout.chomp
+
+    create_custom_fact_file('file1.rb', first_file_content, custom_facts, agent)
+    create_custom_fact_file('file2.rb', second_file_content, custom_facts, agent)
+    env = {'FACTERLIB' => custom_facts}
+
+    teardown do
+      agent.rm_rf(custom_facts)
+    end
+
+    step "Agent #{agent}: Verify that custom fact 1 is available" do
+      on(agent, facter('custom_fact_1', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_equal('custom_fact_1_value', facter_output.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 2 is not available" do
+      on(agent, facter('custom_fact_2', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 3 is not available" do
+      on(agent, facter('custom_fact_3', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that custom fact 4 is available" do
+      on(agent, facter('custom_fact_4', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_equal('custom_fact_4_value', facter_output.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that a core fact is still available" do
+      on(agent, facter('os.name', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_equal(os_name, facter_output.stdout.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that an error is outputted when custom fact file has an error" do
+      on(agent, facter('custom_fact_4', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+        assert_match(/ERROR Facter - error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
+          facter_output.stderr.chomp)
+      end
+    end
+
+    step "Agent #{agent}: Verify that most core facts are available" do
+      on(agent, facter('--json')) do |facter_output|
+        expected_keys = %w[identity memory os ruby networking system_uptime processors]
+        actual_keys = JSON.parse(facter_output.stdout).keys
+
+        assert_equal(true, (expected_keys - actual_keys).empty?)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
A custom fact file is created with an error inside it. This test checks the fallowing:
* all custom facts within that file that are created before the error, are available.
* custom facts created in other files and core facts must be available.
* an error is logged for the faulty custom fact file.
* facter exits with error code 1.
