### PR TITLE
(FACT-2320) Added warnonce method

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -14,6 +14,7 @@ module Facter
   Log.output(STDOUT)
   @already_searched = {}
   @debug_once = []
+  @warn_once = []
 
   class << self
     def clear_messages
@@ -56,6 +57,7 @@ module Facter
     def clear
       @already_searched = {}
       @debug_once = []
+      @warn_once = []
       LegacyFacter.clear
       Options[:custom_dir] = []
       LegacyFacter.collection.invalidate_custom_facts
@@ -288,6 +290,22 @@ module Facter
     # @api public
     def list
       to_hash.keys.sort
+    end
+
+    # Logs only once the same warning message.
+    #
+    # @param message [Object] the warning message object
+    #
+    # @return [nil]
+    #
+    # @api public
+    def warnonce(message)
+      message_string = message.to_s
+      return if @warn_once.include? message_string
+
+      @warn_once << message_string
+      logger.warn(message_string)
+      nil
     end
 
     private

--- a/lib/facter/framework/logging/logger.rb
+++ b/lib/facter/framework/logging/logger.rb
@@ -80,9 +80,7 @@ module Facter
     end
 
     def warn(msg)
-      if msg.nil? || msg.empty?
-        empty_message_error(msg)
-      elsif @@message_callback
+      if @@message_callback
         @@message_callback.call(:warn, msg)
       else
         msg = colorize(msg, YELLOW) if Options[:color]

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -452,4 +452,45 @@ describe Facter do
       expect(result).to eq(%w[timezone up_time virtual])
     end
   end
+
+  describe '#warnonce' do
+    before do
+      allow(logger).to receive(:warn)
+    end
+
+    it 'calls logger with the warning message' do
+      message = 'Some error message'
+
+      Facter.warnonce(message)
+
+      expect(logger).to have_received(:warn).with(message)
+    end
+
+    it 'writes the same warning message only once' do
+      message = 'Some error message'
+
+      Facter.warnonce(message)
+      Facter.warnonce(message)
+
+      expect(logger).to have_received(:warn).once.with(message)
+    end
+
+    it 'writes empty message when message is nil' do
+      Facter.warnonce(nil)
+
+      expect(logger).to have_received(:warn).with('')
+    end
+
+    it 'when message is a hash' do
+      Facter.warnonce({ warn: 'message' })
+
+      expect(logger).to have_received(:warn).with('{:warn=>"message"}')
+    end
+
+    it 'returns nil' do
+      result = Facter.warnonce({ warn: 'message' })
+
+      expect(result).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Added the warnonce method to facter's API.
It prints the same warning message only once.

Usage:
```
Facter.warnonce(<warning message>)
```
The warning message parameter is treated as an object and
```.to_s``` is used to extract the warning message from it.