### PR TITLE
(FACT-2319) Added debugonce method

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -13,6 +13,7 @@ module Facter
   Options.init
   Log.output(STDOUT)
   @already_searched = {}
+  @debug_once = []
 
   class << self
     def clear_messages
@@ -54,6 +55,7 @@ module Facter
     # @api public
     def clear
       @already_searched = {}
+      @debug_once = []
       LegacyFacter.clear
       Options[:custom_dir] = []
       LegacyFacter.collection.invalidate_custom_facts
@@ -68,16 +70,33 @@ module Facter
       fact_collection.dig(*splitted_user_query)
     end
 
-    # Prints out a debug message when debug option is set to true
-    # @param msg [String] Message to be printed out
+    # Logs debug message when debug option is set to true
+    # @param message [Object] Message object to be logged
     #
     # @return [nil]
     #
     # @api public
-    def debug(msg)
+    def debug(message)
       return unless debugging?
 
-      logger.debug(msg)
+      logger.debug(message.to_s)
+      nil
+    end
+
+    # Logs the same debug message only once when debug option is set to true
+    # @param message [Object] Message object to be logged
+    #
+    # @return [nil]
+    #
+    # @api public
+    def debugonce(message)
+      return unless debugging?
+
+      message_string = message.to_s
+      return if @debug_once.include? message_string
+
+      @debug_once << message_string
+      logger.debug(message_string)
       nil
     end
 

--- a/lib/facter/framework/logging/logger.rb
+++ b/lib/facter/framework/logging/logger.rb
@@ -60,9 +60,7 @@ module Facter
     def debug(msg)
       return unless debugging_active?
 
-      if msg.nil? || msg.empty?
-        empty_message_error(msg)
-      elsif @@message_callback
+      if @@message_callback
         @@message_callback.call(:debug, msg)
       else
         msg = colorize(msg, CYAN) if Options[:color]

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -380,4 +380,64 @@ describe Facter do
       end
     end
   end
+
+  describe '#debugonce' do
+    context 'when debugging is active' do
+      before do
+        allow(logger).to receive(:debug)
+        Facter.debugging(true)
+      end
+
+      after do
+        Facter.debugging(false)
+      end
+
+      it 'calls logger with the debug message' do
+        message = 'Some error message'
+
+        Facter.debugonce(message)
+
+        expect(logger).to have_received(:debug).with(message)
+      end
+
+      it 'writes the same debug message only once' do
+        message = 'Some error message'
+
+        Facter.debugonce(message)
+        Facter.debugonce(message)
+
+        expect(logger).to have_received(:debug).once.with(message)
+      end
+
+      it 'writes empty message when message is nil' do
+        Facter.debugonce(nil)
+
+        expect(logger).to have_received(:debug).with('')
+      end
+
+      it 'when message is a hash' do
+        Facter.debugonce({ warn: 'message' })
+
+        expect(logger).to have_received(:debug).with('{:warn=>"message"}')
+      end
+
+      it 'returns nil' do
+        result = Facter.debugonce({ warn: 'message' })
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  context 'when debugging is inactive' do
+    before do
+      allow(logger).to receive(:debug)
+    end
+
+    it 'does not call the logger' do
+      Facter.debugonce('message')
+
+      expect(logger).not_to have_received(:debug)
+    end
+  end
 end

--- a/spec/framework/logging/logger_spec.rb
+++ b/spec/framework/logging/logger_spec.rb
@@ -29,18 +29,6 @@ describe Logger do
       end
     end
 
-    it 'logs a warn if message is nil' do
-      log.debug(nil)
-
-      expect(multi_logger_double).to have_received(:warn).with(/debug invoked with invalid message/)
-    end
-
-    it 'logs a warn if message is empty' do
-      log.debug('')
-
-      expect(multi_logger_double).to have_received(:warn).with(/debug invoked with invalid message/)
-    end
-
     shared_examples 'writes debug message' do
       it 'calls debug on multi_logger' do
         log.debug('debug_message')


### PR DESCRIPTION
Added the debugonce method to facter's API.
It prints the same debug message only once, 
when debugging is active.

Usage:
```
Facter.debugonce(<debugging message>)
```

The debug message parameter is treated as an object and
```.to_s``` is used to extract the debug message from it.