### PR TITLE
(FACT-2748) Fix fact types on all platforms-Part 1

### DIFF
--- a/lib/facter/facts/aix/hypervisors/lpar.rb
+++ b/lib/facter/facts/aix/hypervisors/lpar.rb
@@ -11,7 +11,7 @@ module Facts
           return Facter::ResolvedFact.new(FACT_NAME, nil) unless lpar_partition_number&.positive?
 
           Facter::ResolvedFact.new(FACT_NAME,
-                                   partition_number: lpar_partition_number,
+                                   partition_number: lpar_partition_number.to_s,
                                    partition_name: Facter::Resolvers::Lpar.resolve(:lpar_partition_name))
         end
       end

--- a/lib/facter/facts/linux/identity/gid.rb
+++ b/lib/facter/facts/linux/identity/gid.rb
@@ -8,6 +8,7 @@ module Facts
 
         def call_the_resolver
           fact_value = Facter::Resolvers::PosxIdentity.resolve(:gid)
+          fact_value = fact_value ? fact_value.to_s : nil
           Facter::ResolvedFact.new(FACT_NAME, fact_value)
         end
       end

--- a/lib/facter/facts/linux/identity/uid.rb
+++ b/lib/facter/facts/linux/identity/uid.rb
@@ -8,6 +8,7 @@ module Facts
 
         def call_the_resolver
           fact_value = Facter::Resolvers::PosxIdentity.resolve(:uid)
+          fact_value = fact_value ? fact_value.to_s : nil
           Facter::ResolvedFact.new(FACT_NAME, fact_value)
         end
       end

--- a/lib/facter/facts/linux/is_virtual.rb
+++ b/lib/facter/facts/linux/is_virtual.rb
@@ -57,7 +57,7 @@ module Facts
       end
 
       def check_if_virtual(found_vm)
-        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?
+        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?.to_s
       end
     end
   end

--- a/lib/facter/facts/linux/memory/swap/available_bytes.rb
+++ b/lib/facter/facts/linux/memory/swap/available_bytes.rb
@@ -10,8 +10,9 @@ module Facts
 
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_free)
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value.to_s),
              Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
           end
         end

--- a/lib/facter/facts/linux/memory/swap/total_bytes.rb
+++ b/lib/facter/facts/linux/memory/swap/total_bytes.rb
@@ -10,7 +10,9 @@ module Facts
 
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_total)
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value.to_s),
              Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::UnitConverter.bytes_to_mb(fact_value), :legacy)]
           end
         end

--- a/lib/facter/facts/linux/memory/swap/used_bytes.rb
+++ b/lib/facter/facts/linux/memory/swap/used_bytes.rb
@@ -9,7 +9,9 @@ module Facts
 
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_used_bytes)
-            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value.to_s)
           end
         end
       end

--- a/lib/facter/facts_utils/unit_converter.rb
+++ b/lib/facter/facts_utils/unit_converter.rb
@@ -9,7 +9,7 @@ module Facter
 
           value_in_bytes = value_in_bytes.to_i
 
-          (value_in_bytes / (1024.0 * 1024.0)).round(2)
+          (value_in_bytes / (1024.0 * 1024.0)).round(2).to_s
         end
 
         def hertz_to_human_readable(speed)

--- a/lib/facter/resolvers/fips_enabled_resolver.rb
+++ b/lib/facter/resolvers/fips_enabled_resolver.rb
@@ -16,7 +16,7 @@ module Facter
 
           def read_fips_file(fact_name)
             file_output = Util::FileHelper.safe_read('/proc/sys/crypto/fips_enabled')
-            @fact_list[:fips_enabled] = file_output.strip == '1'
+            @fact_list[:fips_enabled] = (file_output.strip == '1').to_s
             @fact_list[fact_name]
           end
         end

--- a/lib/facter/resolvers/identity_resolver.rb
+++ b/lib/facter/resolvers/identity_resolver.rb
@@ -19,7 +19,7 @@ module Facter
           login_info = Etc.getpwuid
           @fact_list[:gid] = login_info.gid
           @fact_list[:group] = Etc.getgrgid(login_info.gid).name
-          @fact_list[:privileged] = login_info.uid.zero?
+          @fact_list[:privileged] = login_info.uid.zero?.to_s
           @fact_list[:uid] = login_info.uid
           @fact_list[:user] = login_info.name
           @fact_list[fact_name]

--- a/lib/facter/resolvers/linux/load_averages.rb
+++ b/lib/facter/resolvers/linux/load_averages.rb
@@ -14,7 +14,7 @@ module Facter
 
           def read_load_averages_file(fact_name)
             output = Util::FileHelper.safe_read('/proc/loadavg')
-            @fact_list[:load_averages] = {}.tap { |h| h['1m'], h['5m'], h['15m'], = output.split.map(&:to_f) }
+            @fact_list[:load_averages] = {}.tap { |h| h['1m'], h['5m'], h['15m'], = output.split }
 
             @fact_list[fact_name]
           end

--- a/lib/facter/resolvers/memory_resolver.rb
+++ b/lib/facter/resolvers/memory_resolver.rb
@@ -57,7 +57,10 @@ module Facter
           end
 
           def compute_capacity(used, total)
-            format('%<computed_capacity>.2f', computed_capacity: (used / total.to_f * 100)) + '%'
+            capacity = (used / total.to_f * 100)
+            return '0%' if capacity.zero?
+
+            format('%<computed_capacity>.2f', computed_capacity: capacity) + '%'
           end
 
           def compute_used(total, free)

--- a/spec/facter/facts/aix/hypervisors/lpar_spec.rb
+++ b/spec/facter/facts/aix/hypervisors/lpar_spec.rb
@@ -5,6 +5,7 @@ describe Facts::Aix::Hypervisors::Lpar do
     subject(:fact) { Facts::Aix::Hypervisors::Lpar.new }
 
     let(:value) { { 'partition_number' => 13, 'partition_name' => 'aix6-7' } }
+    let(:result) { { 'partition_number' => '13', 'partition_name' => 'aix6-7' } }
 
     before do
       allow(Facter::Resolvers::Lpar).to receive(:resolve).with(:lpar_partition_number)
@@ -25,7 +26,7 @@ describe Facts::Aix::Hypervisors::Lpar do
 
     it 'returns a hypervisors.lpar fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-        have_attributes(name: 'hypervisors.lpar', value: value)
+        have_attributes(name: 'hypervisors.lpar', value: result)
     end
   end
 end

--- a/spec/facter/facts/aix/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/swap/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::Swap::AvailableBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/swap/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::Swap::TotalBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/system/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::System::AvailableBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/system/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::System::TotalBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/freebsd/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Freebsd::Memory::Swap::AvailableBytes do
     subject(:fact) { Facts::Freebsd::Memory::Swap::AvailableBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(value)

--- a/spec/facter/facts/freebsd/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/swap/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Freebsd::Memory::Swap::TotalBytes do
     subject(:fact) { Facts::Freebsd::Memory::Swap::TotalBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Freebsd::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(value)

--- a/spec/facter/facts/freebsd/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Freebsd::Memory::System::AvailableBytes do
     subject(:fact) { Facts::Freebsd::Memory::System::AvailableBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(value)

--- a/spec/facter/facts/freebsd/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/freebsd/memory/system/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Freebsd::Memory::System::TotalBytes do
     subject(:fact) { Facts::Freebsd::Memory::System::TotalBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Freebsd::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(value)

--- a/spec/facter/facts/linux/is_virtual_spec.rb
+++ b/spec/facter/facts/linux/is_virtual_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::IsVirtual do
     subject(:fact) { Facts::Linux::IsVirtual.new }
 
     let(:vm) { 'docker' }
-    let(:value) { true }
+    let(:value) { 'true' }
 
     before do
       allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(vm)
@@ -23,7 +23,7 @@ describe Facts::Linux::IsVirtual do
 
     context 'when is gce' do
       let(:vm) { nil }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('Google Engine')
@@ -38,7 +38,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is vmware' do
       let(:vm) { nil }
       let(:vmware_value) { 'vmware_fusion' }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(vmware_value)
@@ -53,7 +53,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is xen-hvm' do
       let(:vm) { nil }
       let(:virtwhat_value) { 'xenhvm' }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
@@ -69,7 +69,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is openVz' do
       let(:vm) { nil }
       let(:openvz_value) { 'openvzve' }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(openvz_value)
@@ -84,7 +84,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is vserver' do
       let(:vm) { nil }
       let(:virtwhat_value) { 'vserver_host' }
-      let(:value) { false }
+      let(:value) { 'false' }
 
       before do
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
@@ -100,7 +100,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is xen priviledged' do
       let(:vm) { nil }
       let(:xen_value) { 'xen0' }
-      let(:value) { false }
+      let(:value) { 'false' }
 
       before do
         allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(xen_value)
@@ -114,7 +114,7 @@ describe Facts::Linux::IsVirtual do
 
     context 'when is bochs discovered with dmi product_name' do
       let(:vm) { nil }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
@@ -130,7 +130,7 @@ describe Facts::Linux::IsVirtual do
     context 'when is hyper-v discovered with lspci' do
       let(:vm) { nil }
       let(:lspci_value) { 'hyperv' }
-      let(:value) { true }
+      let(:value) { 'true' }
 
       before do
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(lspci_value)
@@ -143,9 +143,10 @@ describe Facts::Linux::IsVirtual do
     end
 
     context 'when resolvers return nil ' do
-      let(:vm) { false }
+      let(:vm) { 'false' }
 
       before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
@@ -158,7 +159,7 @@ describe Facts::Linux::IsVirtual do
     end
 
     context 'when product name is not found in the HYPERVISORS_HASH' do
-      let(:vm) { false }
+      let(:vm) { 'false' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)

--- a/spec/facter/facts/linux/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/swap/available_bytes_spec.rb
@@ -7,6 +7,9 @@ describe Facts::Linux::Memory::Swap::AvailableBytes do
     let(:value) { 2_332_425 }
     let(:value_mb) { 2.22 }
 
+    let(:result) { '2332425' }
+    let(:result_mb) { '2.22' }
+
     before do
       allow(Facter::Resolvers::Linux::Memory).to \
         receive(:resolve).with(:swap_free).and_return(value)
@@ -19,17 +22,16 @@ describe Facts::Linux::Memory::Swap::AvailableBytes do
 
     it 'returns swap available bytes fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'memory.swap.available_bytes', value: value),
-                        an_object_having_attributes(name: 'swapfree_mb', value: value_mb, type: :legacy))
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.available_bytes', value: result),
+                        an_object_having_attributes(name: 'swapfree_mb', value: result_mb, type: :legacy))
     end
 
     describe '#call_the_resolver when resolver returns nil' do
       let(:value) { nil }
 
       it 'returns swap available memory in bytes fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'memory.swap.available_bytes', value: value),
-                          an_object_having_attributes(name: 'swapfree_mb', value: value, type: :legacy))
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'memory.swap.available_bytes', value: value)
       end
     end
   end

--- a/spec/facter/facts/linux/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/swap/total_bytes_spec.rb
@@ -5,7 +5,8 @@ describe Facts::Linux::Memory::Swap::TotalBytes do
     subject(:fact) { Facts::Linux::Memory::Swap::TotalBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:result) { '2332425' }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \
@@ -19,7 +20,7 @@ describe Facts::Linux::Memory::Swap::TotalBytes do
 
     it 'returns swap total memory in bytes fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'memory.swap.total_bytes', value: value),
+        contain_exactly(an_object_having_attributes(name: 'memory.swap.total_bytes', value: result),
                         an_object_having_attributes(name: 'swapsize_mb', value: value_mb, type: :legacy))
     end
 
@@ -27,9 +28,8 @@ describe Facts::Linux::Memory::Swap::TotalBytes do
       let(:value) { nil }
 
       it 'returns swap total memory in bytes fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'memory.swap.total_bytes', value: value),
-                          an_object_having_attributes(name: 'swapsize_mb', value: value, type: :legacy))
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'memory.swap.total_bytes', value: value)
       end
     end
   end

--- a/spec/facter/facts/linux/memory/swap/used_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/swap/used_bytes_spec.rb
@@ -5,6 +5,7 @@ describe Facts::Linux::Memory::Swap::UsedBytes do
     subject(:fact) { Facts::Linux::Memory::Swap::UsedBytes.new }
 
     let(:value) { 1024 }
+    let(:result) { '1024' }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \
@@ -18,7 +19,7 @@ describe Facts::Linux::Memory::Swap::UsedBytes do
 
     it 'returns swap used memory in bytes fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-        have_attributes(name: 'memory.swap.used_bytes', value: value)
+        have_attributes(name: 'memory.swap.used_bytes', value: result)
     end
   end
 end

--- a/spec/facter/facts/linux/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/system/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::System::AvailableBytes do
     subject(:fact) { Facts::Linux::Memory::System::AvailableBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/linux/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/system/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::System::TotalBytes do
     subject(:fact) { Facts::Linux::Memory::System::TotalBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/macosx/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Macosx::Memory::Swap::AvailableBytes do
     subject(:fact) { Facts::Macosx::Memory::Swap::AvailableBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(value)

--- a/spec/facter/facts/macosx/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Macosx::Memory::Swap::TotalBytes do
     subject(:fact) { Facts::Macosx::Memory::Swap::TotalBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(value)

--- a/spec/facter/facts/macosx/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Macosx::Memory::System::AvailableBytes do
     subject(:fact) { Facts::Macosx::Memory::System::AvailableBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(value)

--- a/spec/facter/facts/macosx/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Macosx::Memory::System::TotalBytes do
     subject(:fact) { Facts::Macosx::Memory::System::TotalBytes.new }
 
     let(:value) { 1024 * 1024 }
-    let(:value_mb) { 1 }
+    let(:value_mb) { '1.0' }
 
     before do
       allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(value)

--- a/spec/facter/facts/solaris/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/swap/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::Swap::AvailableBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/swap/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::Swap::TotalBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/system/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::System::AvailableBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/system/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::System::TotalBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { '2.22' }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/windows/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/windows/memory/system/available_bytes_spec.rb
@@ -9,7 +9,7 @@ describe Facts::Windows::Memory::System::AvailableBytes do
 
   describe '#call_the_resolver' do
     let(:value) { 3_331_551_232 }
-    let(:value_mb) { 3177.21 }
+    let(:value_mb) { '3177.21' }
 
     it 'calls Facter::Resolvers::Memory' do
       expect(Facter::Resolvers::Memory).to receive(:resolve).with(:available_bytes)

--- a/spec/facter/facts/windows/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/windows/memory/system/total_bytes_spec.rb
@@ -9,7 +9,7 @@ describe Facts::Windows::Memory::System::TotalBytes do
 
   describe '#call_the_resolver' do
     let(:value) { 3_331_551_232 }
-    let(:value_mb) { 3177.21 }
+    let(:value_mb) { '3177.21' }
 
     it 'calls Facter::Resolvers::Memory' do
       expect(Facter::Resolvers::Memory).to receive(:resolve).with(:total_bytes)

--- a/spec/facter/facts_utils/unit_converter_spec.rb
+++ b/spec/facter/facts_utils/unit_converter_spec.rb
@@ -5,7 +5,7 @@ describe Facter::FactsUtils::UnitConverter do
 
   describe '#bytes_to_mb' do
     it 'converts bytes to mega bytes' do
-      expect(converter.bytes_to_mb(256_586_343)).to eq(244.7)
+      expect(converter.bytes_to_mb(256_586_343)).to eq('244.7')
     end
 
     it 'returns nil if value is nil' do
@@ -13,11 +13,11 @@ describe Facter::FactsUtils::UnitConverter do
     end
 
     it 'converts bytes if value is string' do
-      expect(converter.bytes_to_mb('2343455')).to eq(2.23)
+      expect(converter.bytes_to_mb('2343455')).to eq('2.23')
     end
 
     it 'returns 0 if value is 0' do
-      expect(converter.bytes_to_mb(0)).to eq(0.0)
+      expect(converter.bytes_to_mb(0)).to eq('0.0')
     end
   end
 

--- a/spec/facter/resolvers/fips_enabled_resolver_spec.rb
+++ b/spec/facter/resolvers/fips_enabled_resolver_spec.rb
@@ -17,7 +17,7 @@ describe Facter::Resolvers::Linux::FipsEnabled do
       it 'returns fips is not enabled' do
         result = Facter::Resolvers::Linux::FipsEnabled.resolve(:fips_enabled)
 
-        expect(result).to eq(false)
+        expect(result).to eq('false')
       end
     end
 
@@ -27,7 +27,7 @@ describe Facter::Resolvers::Linux::FipsEnabled do
       it 'returns fips is not enabled' do
         result = Facter::Resolvers::Linux::FipsEnabled.resolve(:fips_enabled)
 
-        expect(result).to eq(false)
+        expect(result).to eq('false')
       end
     end
 
@@ -37,7 +37,7 @@ describe Facter::Resolvers::Linux::FipsEnabled do
       it 'returns fips is enabled' do
         result = Facter::Resolvers::Linux::FipsEnabled.resolve(:fips_enabled)
 
-        expect(result).to eq(true)
+        expect(result).to eq('true')
       end
     end
   end

--- a/spec/facter/resolvers/identity_resolver_spec.rb
+++ b/spec/facter/resolvers/identity_resolver_spec.rb
@@ -39,7 +39,7 @@ describe Facter::Resolvers::PosxIdentity do
   end
 
   describe 'PRIVILEGED' do
-    it_behaves_like 'a resolved fact', :privileged, false
+    it_behaves_like 'a resolved fact', :privileged, 'false'
   end
 
   describe 'UID' do

--- a/spec/facter/resolvers/linux/load_averages_spec.rb
+++ b/spec/facter/resolvers/linux/load_averages_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Linux::LoadAverages do
-  let(:load_averages) { { '1m' => 0.00, '5m' => 0.03, '15m' => 0.03 } }
+  let(:load_averages) { { '1m' => '0.00', '5m' => '0.03', '15m' => '0.03' } }
   let(:no_load_averages) { { '1m' => nil, '5m' => nil, '15m' => nil } }
 
   after do

--- a/spec/facter/resolvers/memory_resolver_spec.rb
+++ b/spec/facter/resolvers/memory_resolver_spec.rb
@@ -43,7 +43,7 @@ describe Facter::Resolvers::Linux::Memory do
       end
 
       it 'returns swap capacity' do
-        swap_capacity = format('%<swap_capacity>.2f', swap_capacity: (swap_used / swap_total.to_f * 100)) + '%'
+        swap_capacity = '0%'
 
         expect(resolver.resolve(:swap_capacity)).to eq(swap_capacity)
       end
@@ -115,7 +115,7 @@ describe Facter::Resolvers::Linux::Memory do
       let(:s_reclaimable) { 0 }
       let(:used) { total - free - buffers - cached - s_reclaimable }
       let(:swap_total) { 2_097_148 * 1024 }
-      let(:swap_free) { 2_097_148 * 1024 }
+      let(:swap_free) { 2_097_100 * 1024 }
       let(:swap_used) { swap_total - swap_free }
       let(:fixture_name) { 'rhel5_memory' }
 

--- a/spec/fixtures/rhel5_memory
+++ b/spec/fixtures/rhel5_memory
@@ -7,7 +7,7 @@ SwapCached:            0 kB
 Active:            81968 kB
 Inactive:         255516 kB
 SwapTotal:       2097148 kB
-SwapFree:        2097148 kB
+SwapFree:        2097100 kB
 Dirty:               216 kB
 Writeback:             0 kB
 AnonPages:         34656 kB


### PR DESCRIPTION
**Fixed output for:**
"fips_enabled" 
"identity.gid" 
"identity.privileged"
"identity.uid"
"is_virtual"
load_averages.15m" 
"load_averages.1m" 
"load_averages.5m"
"memory.swap.available_bytes"
"memory.swap.capacity"
"memory.swap.total_bytes"
"memory.swap.used_bytes"
**On linux**
"hypervisors.lpar.partition_number"
**On Aix**
"swapfree_mb"
"swapsize_mb"
**On all platforms**