### PR TITLE
(FACT-2327) added list method

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -281,6 +281,15 @@ module Facter
       logger.error(arr.flatten.join("\n"))
     end
 
+    # Returns a list with the names of all solved facts
+    #
+    # @return [Array] the list with all the fact names
+    #
+    # @api public
+    def list
+      to_hash.keys.sort
+    end
+
     private
 
     def logger

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -440,4 +440,16 @@ describe Facter do
       expect(logger).not_to have_received(:debug)
     end
   end
+
+  describe '#list' do
+    before do
+      allow(Facter).to receive(:to_hash).and_return({ 'up_time' => 235, 'timezone' => 'EEST', 'virtual' => 'physical' })
+    end
+
+    it 'returns the resolved fact names' do
+      result = Facter.list
+
+      expect(result).to eq(%w[timezone up_time virtual])
+    end
+  end
 end


### PR DESCRIPTION
Added the list method to facter's API.
It returns in an array with the names of all facts
returned by Facter.to_hash, in alphabetical order.

Usage:
```
Facter.list
```