### PR TITLE
(maint) Add changelog for 4.0.38 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [4.0.38](https://github.com/puppetlabs/facter/tree/4.0.38) (2020-09-16)
+
+[Full Changelog](https://github.com/puppetlabs/facter/compare/4.0.37...4.0.38)
+
+### Added
+
+- (FACT-2319) Added debugonce method [#2085](https://github.com/puppetlabs/facter/pull/2085) ([Filipovici-Andrei](https://github.com/Filipovici-Andrei))
+- (FACT-2327) added list method [#2088](https://github.com/puppetlabs/facter/pull/2088) ([Filipovici-Andrei](https://github.com/Filipovici-Andrei))
+- (FACT-2320) Added warnonce method [#2084](https://github.com/puppetlabs/facter/pull/2084) ([Filipovici-Andrei](https://github.com/Filipovici-Andrei))
+- (FACT-2315) Added warn method to facter api [#2083](https://github.com/puppetlabs/facter/pull/2083) ([Filipovici-Andrei](https://github.com/Filipovici-Andrei))
+
+### Fixed
+
+- (FACT-2784) Fixed rhel os release fact [#2086](https://github.com/puppetlabs/facter/pull/2086) ([sebastian-miclea](https://github.com/sebastian-miclea))
+
+
 ## [4.0.37](https://github.com/puppetlabs/facter/tree/4.0.37) (2020-09-09)
 
 [Full Changelog](https://github.com/puppetlabs/facter/compare/4.0.36-fixed...4.0.37)


### PR DESCRIPTION
In preparation for the `4.0.38` release, we generate the change-log.
