### PR TITLE
(FACT-2802) Fix Cloud resolver

### DIFF
--- a/lib/facter/resolvers/cloud.rb
+++ b/lib/facter/resolvers/cloud.rb
@@ -17,7 +17,7 @@ module Facter
         def detect_azure(fact_name)
           search_dirs = %w[/var/lib/dhcp /var/lib/NetworkManager]
           search_dirs.each do |path|
-            next unless File.directory?(path)
+            next if !File.readable?(path) || !File.directory?(path)
 
             files = Dir.entries(path)
             files.select! { |filename| filename =~ /^dhclient.*lease.*$/ }

--- a/spec/facter/resolvers/cloud_spec.rb
+++ b/spec/facter/resolvers/cloud_spec.rb
@@ -7,6 +7,7 @@ describe Facter::Resolvers::Cloud do
 
   before do
     cloud_resolver.instance_variable_set(:@log, log_spy)
+    allow(File).to receive(:readable?)
     allow(File).to receive(:directory?)
     allow(Dir).to receive(:entries)
   end
@@ -17,6 +18,7 @@ describe Facter::Resolvers::Cloud do
 
   context 'when lease files are not found' do
     before do
+      allow(File).to receive(:readable?).with('/var/lib/dhcp').and_return(true)
       allow(File).to receive(:directory?).with('/var/lib/dhcp').and_return(true)
       allow(Dir).to receive(:entries).with('/var/lib/dhcp').and_return('.')
     end
@@ -30,6 +32,7 @@ describe Facter::Resolvers::Cloud do
     let(:content) { load_fixture('dhclient_rhel_lease_8').read }
 
     before do
+      allow(File).to receive(:readable?).with('/var/lib/dhcp').and_return(true)
       allow(File).to receive(:directory?).with('/var/lib/dhcp').and_return(true)
       allow(Facter::Util::FileHelper)
         .to receive(:safe_read)
@@ -47,6 +50,7 @@ describe Facter::Resolvers::Cloud do
     let(:content) { load_fixture('dhcp_lease').read }
 
     before do
+      allow(File).to receive(:readable?).with('/var/lib/dhcp').and_return(true)
       allow(File).to receive(:directory?).with('/var/lib/dhcp').and_return(true)
       allow(Facter::Util::FileHelper)
         .to receive(:safe_read)
@@ -64,12 +68,26 @@ describe Facter::Resolvers::Cloud do
     let(:content) { '' }
 
     before do
+      allow(File).to receive(:readable?).with('/var/lib/dhcp').and_return(true)
       allow(File).to receive(:directory?).with('/var/lib/dhcp').and_return(true)
       allow(Facter::Util::FileHelper)
         .to receive(:safe_read)
         .with('/var/lib/dhcp/dhclient.rhel.lease.8')
-        .and_return(content)
+        .and_return([])
       allow(Dir).to receive(:entries).with('/var/lib/dhcp').and_return(['.', 'dhclient.rhel.lease.8'])
+    end
+
+    it 'returns nil' do
+      expect(cloud_resolver.resolve(:cloud_provider)).to be_nil
+    end
+  end
+
+  context 'when we do not have read permissions for /var/lib/dhcp ' do
+    let(:content) { '' }
+
+    before do
+      allow(File).to receive(:readable?).with('/var/lib/dhcp').and_return(false)
+      allow(File).to receive(:directory?).with('/var/lib/dhcp').and_return(true)
     end
 
     it 'returns nil' do


### PR DESCRIPTION
When calling the cloud fact using a non root user, 
an error is logged, because we attempt to access a privileged folder.

The fix skips folders which don't have a read permission.