### PR TITLE
(FACT-2803) Detect hypervisors as amazon if virtwhat detects aws.

### DIFF
--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -16,9 +16,11 @@ module Facts
       private
 
       def aws_hypervisors?
-        virtual = check_virt_what || check_xen || check_product_name || check_bios_vendor || check_lspci
+        virtual =~ /kvm|xen|aws/
+      end
 
-        virtual == 'kvm' || virtual =~ /xen/
+      def virtual
+        check_virt_what || check_xen || check_product_name || check_bios_vendor || check_lspci
       end
 
       def check_virt_what

--- a/spec/facter/facts/linux/ec2_metadata_spec.rb
+++ b/spec/facter/facts/linux/ec2_metadata_spec.rb
@@ -63,5 +63,25 @@ describe Facts::Linux::Ec2Metadata do
         end
       end
     end
+
+    context 'when hypervisor is aws' do
+      let(:hypervisor) { 'aws' }
+      let(:value) { { 'info' => 'value' } }
+
+      it 'calls Facter::Resolvers::VirtWhat' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::VirtWhat).to have_received(:resolve).with(:vm)
+      end
+
+      it 'calls Facter::Resolvers::Ec2' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Ec2).to have_received(:resolve).with(:metadata)
+      end
+
+      it 'returns ec2 userdata fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'ec2_metadata', value: value)
+      end
+    end
   end
 end


### PR DESCRIPTION
On `Redhat8` `arm` architecture, ec2_metadata fact was not detecting correctly that we are on AWS and we need to resolve the fact. 

The fix considers we are on AWS if `virt_what` resolver reports `aws`