### PR TITLE
(FACT-2748) Fixed type for blockdevice_*_size

### DIFF
--- a/lib/facter/facts/linux/disks.rb
+++ b/lib/facter/facts/linux/disks.rb
@@ -25,7 +25,7 @@ module Facts
       def add_legacy_facts(disks, facts)
         disks.each do |disk_name, disk_info|
           facts.push(Facter::ResolvedFact.new("blockdevice_#{disk_name}_model", disk_info[:model], :legacy))
-          facts.push(Facter::ResolvedFact.new("blockdevice_#{disk_name}_size", disk_info[:size_bytes].to_s, :legacy))
+          facts.push(Facter::ResolvedFact.new("blockdevice_#{disk_name}_size", disk_info[:size_bytes], :legacy))
           facts.push(Facter::ResolvedFact.new("blockdevice_#{disk_name}_vendor", disk_info[:vendor], :legacy))
         end
       end

--- a/spec/facter/facts/linux/disks_spec.rb
+++ b/spec/facter/facts/linux/disks_spec.rb
@@ -42,7 +42,7 @@ describe Facts::Linux::Disks do
           an_object_having_attributes(name: 'disks', value: expecte_response),
           an_object_having_attributes(name: 'blockdevices', value: 'sda'),
           an_object_having_attributes(name: 'blockdevice_sda_model', value: 'Virtual disk', type: :legacy),
-          an_object_having_attributes(name: 'blockdevice_sda_size', value: '21474836480', type: :legacy),
+          an_object_having_attributes(name: 'blockdevice_sda_size', value: 21_474_836_480, type: :legacy),
           an_object_having_attributes(name: 'blockdevice_sda_vendor', value: 'VMware', type: :legacy)
         )
     end


### PR DESCRIPTION
We've added a test that compares output from versions 3 and 4 of Facter, this was the only fact that had a difference in type. 
Having differences in the output types could be potentially breaking.