### PR TITLE
(maint) add support for redhat-8-arm64 (main)

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -10,7 +10,7 @@ test_name 'C59029: networking facts should be fully populated' do
   @netmask_regex  = /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/
 
   expected_networking = {
-      "networking.dhcp"     => agent['platform'] =~ /fedora-32/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+      "networking.dhcp"     => agent['platform'] =~ /fedora-32|el-8-aarch64/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       "networking.ip"       => @ip_regex,
       "networking.ip6"      => /[a-f0-9]+:+/,
       "networking.mac"      => /[a-f0-9]{2}:/,


### PR DESCRIPTION
redhat-8-arm64 ami is using NetworkManager 1.22 which is using
nettools plugin by default and provides incomplete dhcp information
(https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426)

