### PR TITLE
(FACT-2798) Set color to true, fix Facter.log_exception

### DIFF
--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
@@ -101,7 +101,7 @@ test_name 'Facter api works when there is an error inside a custom fact file' do
     step "Agent #{agent}: Verify that an error is outputted when custom fact file has an error" do
       create_api_call_file(test_vars, "Facter.value('custom_fact_1')")
       on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
-        assert_match(/Facter - error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
+        assert_match(/Facter.*error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
           ruby_result.stdout)
       end
     end

--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
@@ -82,7 +82,7 @@ test_name 'Facter cli works when there is an error inside a custom fact file' do
 
     step "Agent #{agent}: Verify that an error is outputted when custom fact file has an error" do
       on(agent, facter('custom_fact_4', environment: env), acceptable_exit_codes: [1]) do |facter_output|
-        assert_match(/ERROR Facter - error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
+        assert_match(/ERROR Facter.*error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
           facter_output.stderr.chomp)
       end
     end

--- a/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
+++ b/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
@@ -32,14 +32,14 @@ test_name 'Facter::Core::Execution accepts and correctly sets a time limit optio
 
     step "Facter: Logs that command of the first custom fact had timeout after setted time limit" do
       on agent, facter('--custom-dir', custom_dir, 'foo --debug') do |facter_output|
-        assert_match(/DEBUG Facter::Core::Execution.* - Timeout encounter after 2s, killing process with pid:/,
+        assert_match(/DEBUG Facter::Core::Execution.*Timeout encounter after 2s, killing process with pid:/,
                      facter_output.stderr.chomp)
       end
     end
 
     step "Facter: Logs that command of the second custom fact had timeout after befault time limit" do
       on agent, facter('--custom-dir', custom_dir, 'custom_fact --debug') do |facter_output|
-        assert_match(/DEBUG Facter::Core::Execution.* - Timeout encounter after 1.5s, killing process with pid:/,
+        assert_match(/DEBUG Facter::Core::Execution.*Timeout encounter after 1.5s, killing process with pid:/,
                      facter_output.stderr.chomp)
       end
     end

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -5,7 +5,7 @@ test_name "C99986: --verbose command-line option prints verbose information to s
   agents.each do |agent|
     step "Agent #{agent}: retrieve verbose info from stderr using --verbose option" do
       on(agent, facter('--verbose')) do
-        assert_match(/INFO .* executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
+        assert_match(/INFO .*executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
       end
     end
   end

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -311,19 +311,13 @@ module Facter
       [fact_formatter.format(resolved_facts), status || 0]
     end
 
-    def log_exception(exception, message = :default)
-      arr = []
-      if message == :default
-        arr << exception.message
-      elsif message
-        arr << message
-      end
-      if Options[:trace]
-        arr << 'backtrace:'
-        arr.concat(exception.backtrace)
-      end
+    def log_exception(exception, message = nil)
+      error_message = []
 
-      logger.error(arr.flatten.join("\n"))
+      error_message << message.to_s unless message.nil? || (message.is_a?(String) && message.empty?)
+
+      parse_exception(exception, error_message)
+      logger.error(error_message.flatten.join("\n"))
     end
 
     # Returns a list with the names of all solved facts
@@ -364,6 +358,19 @@ module Facter
     end
 
     private
+
+    def parse_exception(exception, error_message)
+      if exception.is_a?(Exception)
+        error_message << exception.message if error_message.empty?
+
+        if Options[:trace] && !exception.backtrace.nil?
+          error_message << 'backtrace:'
+          error_message.concat(exception.backtrace)
+        end
+      elsif error_message.empty?
+        error_message << exception.to_s
+      end
+    end
 
     def logger
       @logger ||= Log.new(self)

--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -22,7 +22,7 @@ module Facter
     @user_query = []
     @block_list = {}
     @fact_groups = {}
-    @color = false
+    @color = true
     @timing = false
 
     class << self

--- a/lib/facter/framework/logging/logger.rb
+++ b/lib/facter/framework/logging/logger.rb
@@ -91,9 +91,7 @@ module Facter
     def error(msg, colorize = false)
       @@has_errors = true
 
-      if msg.nil? || msg.empty?
-        empty_message_error(msg)
-      elsif @@message_callback
+      if @@message_callback
         @@message_callback.call(:error, msg)
       else
         msg = colorize(msg, RED) if colorize || Options[:color]
@@ -111,8 +109,6 @@ module Facter
     private
 
     def colorize(msg, color)
-      return msg if OsDetector.instance.identifier.eql?(:windows)
-
       "#{color}#{msg}#{RESET}"
     end
 

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -384,6 +384,89 @@ describe Facter do
   end
 
   describe '#log_exception' do
+    shared_examples 'when exception param is an exception' do
+      it 'logs exception message' do
+        exception.set_backtrace(backtrace)
+
+        Facter.log_exception(exception, message)
+
+        expect(logger).to have_received(:error).with(expected_message)
+      end
+    end
+
+    shared_examples 'when exception param is not an exception' do
+      it 'logs exception message' do
+        Facter.log_exception(exception, message)
+
+        expect(logger).to have_received(:error).with(expected_message)
+      end
+    end
+
+    context 'when trace option is false' do
+      let(:backtrace) { 'prog.rb:2:in a' }
+
+      context 'when we have an exception and a message' do
+        let(:message) { 'Some error message' }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { 'Some error message' }
+
+        it_behaves_like 'when exception param is an exception'
+      end
+
+      context 'when we have an exception and an empty message' do
+        let(:message) { '' }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { 'FlushFakeError' }
+
+        it_behaves_like 'when exception param is an exception'
+      end
+
+      context 'when we have an exception and a nil message' do
+        let(:message) { nil }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { 'FlushFakeError' }
+
+        it_behaves_like 'when exception param is an exception'
+      end
+
+      context 'when we have an exception and no message' do
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { 'FlushFakeError' }
+
+        it 'logs exception message' do
+          exception.set_backtrace(backtrace)
+
+          Facter.log_exception(exception)
+
+          expect(logger).to have_received(:error).with(expected_message)
+        end
+      end
+
+      context 'when exception and message are strings' do
+        let(:message) { 'message' }
+        let(:exception) { 'exception' }
+        let(:expected_message) { 'message' }
+
+        it_behaves_like 'when exception param is not an exception'
+      end
+
+      context 'when exception and message are nil' do
+        let(:message) { nil }
+        let(:exception) { nil }
+        let(:expected_message) { '' }
+
+        it_behaves_like 'when exception param is not an exception'
+      end
+
+      context 'when exception and message are hashes' do
+        let(:message) { { 'a': 1 } }
+        let(:exception) { { 'b': 2 } }
+        let(:expected_message) { '{:a=>1}' }
+
+        it_behaves_like 'when exception param is not an exception'
+      end
+    end
+
     context 'when trace options is true' do
       before do
         Facter.trace(true)
@@ -393,16 +476,78 @@ describe Facter do
         Facter.trace(false)
       end
 
-      let(:message) { 'Some error message' }
-      let(:exception) { FlushFakeError.new }
-      let(:expected_message) { "Some error message\nbacktrace:\nprog.rb:2:in `a'" }
+      let(:backtrace) { 'prog.rb:2:in a' }
 
-      it 'format exception to display backtrace' do
-        exception.set_backtrace("prog.rb:2:in `a'")
+      context 'when we have an exception and a message' do
+        let(:message) { 'Some error message' }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { "Some error message\nbacktrace:\nprog.rb:2:in a" }
 
-        Facter.log_exception(exception, message)
+        it_behaves_like 'when exception param is an exception'
+      end
 
-        expect(logger).to have_received(:error).with(expected_message)
+      context 'when we have an exception and an empty message' do
+        let(:message) { '' }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { "FlushFakeError\nbacktrace:\nprog.rb:2:in a" }
+
+        it_behaves_like 'when exception param is an exception'
+      end
+
+      context 'when we have an exception and a nil message' do
+        let(:message) { nil }
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { "FlushFakeError\nbacktrace:\nprog.rb:2:in a" }
+
+        it_behaves_like 'when exception param is an exception'
+      end
+
+      context 'when we have an exception and no message' do
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { "FlushFakeError\nbacktrace:\nprog.rb:2:in a" }
+
+        it 'logs exception message' do
+          exception.set_backtrace(backtrace)
+
+          Facter.log_exception(exception)
+
+          expect(logger).to have_received(:error).with(expected_message)
+        end
+      end
+
+      context 'when we have an exception with no backtrace' do
+        let(:exception) { FlushFakeError.new }
+        let(:expected_message) { 'FlushFakeError' }
+
+        it 'logs exception message' do
+          Facter.log_exception(exception)
+
+          expect(logger).to have_received(:error).with(expected_message)
+        end
+      end
+
+      context 'when exception and message are strings' do
+        let(:message) { 'message' }
+        let(:exception) { 'exception' }
+        let(:expected_message) { 'message' }
+
+        it_behaves_like 'when exception param is not an exception'
+      end
+
+      context 'when exception and message are nil' do
+        let(:message) { nil }
+        let(:exception) { nil }
+        let(:expected_message) { '' }
+
+        it_behaves_like 'when exception param is not an exception'
+      end
+
+      context 'when exception and message are hashes' do
+        let(:message) { { 'a': 1 } }
+        let(:exception) { { 'b': 2 } }
+        let(:expected_message) { '{:a=>1}' }
+
+        it_behaves_like 'when exception param is not an exception'
       end
     end
   end

--- a/spec/facter/util/file_helper_spec.rb
+++ b/spec/facter/util/file_helper_spec.rb
@@ -5,7 +5,9 @@ describe Facter::Util::FileHelper do
 
   let(:path) { '/Users/admin/file.txt' }
   let(:content) { 'file content' }
-  let(:error_message) { 'Facter::Util::FileHelper - File at: /Users/admin/file.txt is not accessible.' }
+  let(:error_message) do
+    "Facter::Util::FileHelper - #{Facter::CYAN}File at: /Users/admin/file.txt is not accessible.#{Facter::RESET}"
+  end
   let(:array_content) { ['line 1', 'line 2', 'line 3'] }
   let(:logger_double) { instance_spy(Logger) }
 

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -34,7 +34,7 @@ describe Facter::OptionStore do
         verbose: false,
         config: nil,
         cache: true,
-        color: false,
+        color: true,
         trace: false,
         timing: false
       )

--- a/spec/framework/logging/logger_spec.rb
+++ b/spec/framework/logging/logger_spec.rb
@@ -29,7 +29,7 @@ describe Logger do
       end
     end
 
-    shared_examples 'writes debug message' do
+    shared_examples 'writes debug message with no color' do
       it 'calls debug on multi_logger' do
         log.debug('debug_message')
 
@@ -37,7 +37,16 @@ describe Logger do
       end
     end
 
-    it_behaves_like 'writes debug message'
+    shared_examples 'writes debug message with color' do
+      it 'calls debug on multi_logger' do
+        log.debug('debug_message')
+
+        expect(multi_logger_double).to have_received(:debug)
+          .with("Class - #{Facter::CYAN}debug_message#{Facter::RESET}")
+      end
+    end
+
+    it_behaves_like 'writes debug message with no color'
 
     context 'when message callback is provided' do
       after do
@@ -61,7 +70,7 @@ describe Logger do
         allow(Facter).to receive(:respond_to?).with(:debugging?).and_return(false)
       end
 
-      it_behaves_like 'writes debug message'
+      it_behaves_like 'writes debug message with no color'
 
       it 'does not call Facter.debugging?' do
         log.debug('debug_message')
@@ -80,13 +89,7 @@ describe Logger do
           Facter::Options[:color] = true
         end
 
-        it 'print CYAN (36) debug message' do
-          log.debug('debug_message')
-
-          expect(multi_logger_double)
-            .to have_received(:debug)
-            .with("Class - #{Facter::CYAN}debug_message#{Facter::RESET}")
-        end
+        it_behaves_like 'writes debug message with color'
       end
     end
 
@@ -100,11 +103,7 @@ describe Logger do
           Facter::Options[:color] = true
         end
 
-        it 'print debug message' do
-          log.debug('debug_message')
-
-          expect(multi_logger_double).to have_received(:debug).with('Class - debug_message')
-        end
+        it_behaves_like 'writes debug message with color'
       end
     end
   end
@@ -149,7 +148,8 @@ describe Logger do
         it 'print info message' do
           log.info('info_message')
 
-          expect(multi_logger_double).to have_received(:info).with('Class - info_message')
+          expect(multi_logger_double).to have_received(:info)
+            .with("Class - #{Facter::GREEN}info_message#{Facter::RESET}")
         end
       end
     end
@@ -195,7 +195,8 @@ describe Logger do
         it 'print warn message' do
           log.warn('warn_message')
 
-          expect(multi_logger_double).to have_received(:warn).with('Class - warn_message')
+          expect(multi_logger_double).to have_received(:warn)
+            .with("Class - #{Facter::YELLOW}warn_message#{Facter::RESET}")
         end
       end
     end
@@ -210,12 +211,12 @@ describe Logger do
       expect(multi_logger_double).to have_received(:error).with("Class - #{Facter::RED}error_message#{Facter::RESET}")
     end
 
-    it 'writes error message not colorized on Windows' do
+    it 'writes error message colorized on Windows' do
       allow(OsDetector.instance).to receive(:identifier).and_return(:windows)
 
       log.error('error_message', true)
 
-      expect(multi_logger_double).to have_received(:error).with('Class - error_message')
+      expect(multi_logger_double).to have_received(:error).with("Class - #{Facter::RED}error_message#{Facter::RESET}")
     end
 
     it 'writes error message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,8 +31,6 @@ SimpleCov.start do
 end
 
 def colorize(str, color)
-  return str if OsDetector.instance.identifier.eql?(:windows)
-
   "#{color}#{str}#{Facter::RESET}"
 end
 


### PR DESCRIPTION
**Added:** 
Now by default all messages are colored.
Colored messages on Windows are enabled.

**Fixed:** 
Setting color option to true on Centos 6, breaks facter.
Facter.log_exception now accepts any kind of message objects, 
exceptions with or without backtrace.
