### PR TITLE
 (FACT-2816) - Fix ec2 fact issues when on non ec2 systems

### DIFF
--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -35,7 +35,8 @@ module Facts
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
         return unless product_name
 
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
+        _, value = Facter::FactsUtils::HYPERVISORS_HASH.find { |key, _value| product_name.include?(key) }
+        value
       end
 
       def check_bios_vendor

--- a/lib/facter/facts/linux/ec2_userdata.rb
+++ b/lib/facter/facts/linux/ec2_userdata.rb
@@ -33,7 +33,8 @@ module Facts
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
         return unless product_name
 
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
+        _, value = Facter::FactsUtils::HYPERVISORS_HASH.find { |key, _value| product_name.include?(key) }
+        value
       end
 
       def check_bios_vendor

--- a/spec/facter/facts/linux/ec2_metadata_spec.rb
+++ b/spec/facter/facts/linux/ec2_metadata_spec.rb
@@ -13,6 +13,25 @@ describe Facts::Linux::Ec2Metadata do
       allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
     end
 
+    context 'when physical machine with no hypervisor' do
+      let(:hypervisor) { nil }
+      let(:value) { nil }
+
+      before do
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('MS-7A71')
+      end
+
+      it 'returns ec2 metadata fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'ec2_metadata', value: nil)
+      end
+
+      it "doesn't call Ec2 resolver" do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Ec2).not_to have_received(:resolve).with(:metadata)
+      end
+    end
+
     context 'when hypervisor is not kvm or xen' do
       let(:hypervisor) { nil }
       let(:value) { nil }

--- a/spec/facter/facts/linux/ec2_userdata_spec.rb
+++ b/spec/facter/facts/linux/ec2_userdata_spec.rb
@@ -13,6 +13,25 @@ describe Facts::Linux::Ec2Userdata do
       allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
     end
 
+    context 'when physical machine with no hypervisor' do
+      let(:hypervisor) { nil }
+      let(:value) { nil }
+
+      before do
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('MS-7A71')
+      end
+
+      it 'returns ec2 metadata fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'ec2_userdata', value: nil)
+      end
+
+      it "doesn't call Ec2 resolver" do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Ec2).not_to have_received(:resolve).with(:userdata)
+      end
+    end
+
     context 'when hypervisor is not kvm or xen' do
       let(:hypervisor) { nil }
       let(:value) { nil }


### PR DESCRIPTION
  * previously when ec2 facts are executed the check_product_name
    was run which incorrectly returned a hash of values when the product
    name did not exist in the hypervisor hash. This is an edge case
    on linux systems not in ec2.

This caused errors messages how hashes cannot be converted since the expected value was supposed to be a string. 


```
-E, [2020-09-27T18:11:08.838323 #26186] ERROR -- : Facter::InternalFactManager - undefined method `each' for nil:NilClass

lib/ruby/gems/2.7.0/gems/facter-4.0.39/lib/facter/facts/linux/ec2_userdata.rb:21: warning: deprecated Object#=~ is called on Hash; it always returns nil
E, [2020-09-27T18:11:08.916334 #26186] ERROR -- : Facter::InternalFactManager - undefined method `map' for nil:NilClass

E, [2020-09-27T18:11:08.916802 #26186] ERROR -- : Facter::InternalFactManager - undefined method `each' for nil:NilClass

```