### PR TITLE
(FACT-2799) Fix fact loading for nested fact calls

### DIFF
--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -20,45 +20,48 @@ module Facter
 
       @facts = []
       @external_facts = []
-      load_internal_facts(options)
-      load_external_facts(options)
 
-      @facts
+      @internal_facts = load_internal_facts(options)
+      @external_facts = load_external_facts(options)
+
+      @facts = @internal_facts + @external_facts
     end
 
     private
 
     def load_internal_facts(options)
       @log.debug('Loading internal facts')
+      internal_facts = []
 
       if options[:user_query] || options[:show_legacy]
         # if we have a user query, then we must search in core facts and legacy facts
         @log.debug('Loading all internal facts')
-        @internal_facts = @internal_loader.facts
+        internal_facts = @internal_loader.facts
       else
         @log.debug('Load only core facts')
-        @internal_facts = @internal_loader.core_facts
+        internal_facts = @internal_loader.core_facts
       end
 
-      @internal_facts = block_facts(@internal_facts, options)
-      @facts.concat(@internal_facts)
+      block_facts(internal_facts, options)
     end
 
     def load_external_facts(options)
       @log.debug('Loading external facts')
+      external_facts = []
+
       if options[:custom_facts]
         @log.debug('Loading custom facts')
-        @external_facts.concat(@external_fact_loader.custom_facts)
+        external_facts += @external_fact_loader.custom_facts
       end
 
-      @external_facts = block_facts(@external_facts, options)
+      external_facts = block_facts(external_facts, options)
 
       if options[:external_facts]
         @log.debug('Loading external facts')
-        @external_facts.concat(@external_fact_loader.external_facts)
+        external_facts += @external_fact_loader.external_facts
       end
 
-      @facts.concat(@external_facts)
+      external_facts
     end
 
     def block_facts(facts, options)


### PR DESCRIPTION
# Problem: 
Custom fact i18ndemo_fact was not executed on ubuntu 16.04.

# Solution
The fallowing flow happened:
Puppet -> Facter (-> FactLoader -> custom fact(that called puppet again)) -> Puppet -> Facter -> (-> FactLoader -> cached custom facts (this is the reason why it was not an infinit loop))

Because Facter was called from within another Facter run, `@external_facts` object was replaced and the concat was done on an object thaw was discarded. 


# With the fix

Ubuntu 16.04
```ruby
root@gowned-decking:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# facter os
{
  architecture => "amd64",
  distro => {
    codename => "xenial",
    description => "Ubuntu 16.04.5 LTS",
    id => "Ubuntu",
    release => {
      full => "16.04",
      major => "16.04"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "Ubuntu",
  release => {
    full => "16.04",
    major => "16.04"
  },
  selinux => {
    enabled => false
  }
}
root@gowned-decking:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# rm -rf /opt/puppetlabs/puppet/cache/lib/facter/
root@gowned-decking:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter]/ensure: created
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/facter_dot_d.rb]/ensure: defined content as '{sha256}8a17c7f9b470dbaaff51e7a4f2103c4e5c4d92667c4b7396cd55d76ebcedab1b'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/i18ndemo_fact.rb]/ensure: defined content as '{sha256}970d26ac91fd7b801062e0c17dcbf6b4ef46be2dd1d4e18adcc1ba0912158006'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/package_provider.rb]/ensure: defined content as '{sha256}4f396a5e0b1016e4ceeb7e9273423171d5a51e083e489c9f8477de88f2c254b6'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/pe_version.rb]/ensure: defined content as '{sha256}9d3a1b46fd1e2d2b604a68994d4b8197b9ca1d8344fe5fa2c2797d8de5742f6f'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/puppet_settings.rb]/ensure: defined content as '{sha256}727f7e6d154cbb5773cea227f6a17019b0a3a73624bbfaa6590ed1de8314ae7b'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/root_home.rb]/ensure: defined content as '{sha256}e857cd21ee4fe14739c8e0f330de645f1f54c41229d608731d4af29a55b8d532'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/service_provider.rb]/ensure: defined content as '{sha256}1beaee8dd3c87c9d887184b9e69c3053762f2261a6ebceaa75f682dab54ba823'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/util]/ensure: created
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/util/puppet_settings.rb]/ensure: defined content as '{sha256}af86574985faba7b25893444917da5197f00bbb39182f7a56123cca6ee71e0f4'
Info: Retrieving locales
Info: Loading facts
Error: Facter: Error while resolving custom fact fact='i18ndemo_fact', resolution='<anonymous>': i18ndemo_fact: this is a raise from a custom fact from eputnam-i18ndemo
Info: Caching catalog for gowned-decking.delivery.puppetlabs.net
Info: Applying configuration version '1601280423'
Notice: Applied catalog in 0.01 seconds
```


Ubuntu 20.04
```ruby
root@gowned-boundary:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# facter os
{
  architecture => "amd64",
  distro => {
    codename => "focal",
    description => "Ubuntu 20.04 LTS",
    id => "Ubuntu",
    release => {
      full => "20.04",
      major => "20.04"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "Ubuntu",
  release => {
    full => "20.04",
    major => "20.04"
  },
  selinux => {
    enabled => false
  }
}
root@gowned-boundary:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# rm -rf /opt/puppetlabs/puppet/cache/lib/facter/
root@gowned-boundary:/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/facter# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter]/ensure: created
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/facter_dot_d.rb]/ensure: defined content as '{sha256}8a17c7f9b470dbaaff51e7a4f2103c4e5c4d92667c4b7396cd55d76ebcedab1b'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/i18ndemo_fact.rb]/ensure: defined content as '{sha256}970d26ac91fd7b801062e0c17dcbf6b4ef46be2dd1d4e18adcc1ba0912158006'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/package_provider.rb]/ensure: defined content as '{sha256}4f396a5e0b1016e4ceeb7e9273423171d5a51e083e489c9f8477de88f2c254b6'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/pe_version.rb]/ensure: defined content as '{sha256}9d3a1b46fd1e2d2b604a68994d4b8197b9ca1d8344fe5fa2c2797d8de5742f6f'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/puppet_settings.rb]/ensure: defined content as '{sha256}727f7e6d154cbb5773cea227f6a17019b0a3a73624bbfaa6590ed1de8314ae7b'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/root_home.rb]/ensure: defined content as '{sha256}e857cd21ee4fe14739c8e0f330de645f1f54c41229d608731d4af29a55b8d532'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/service_provider.rb]/ensure: defined content as '{sha256}1beaee8dd3c87c9d887184b9e69c3053762f2261a6ebceaa75f682dab54ba823'
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/util]/ensure: created
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/util/puppet_settings.rb]/ensure: defined content as '{sha256}af86574985faba7b25893444917da5197f00bbb39182f7a56123cca6ee71e0f4'
Info: Retrieving locales
Info: Loading facts
Error: Facter: Error while resolving custom fact fact='i18ndemo_fact', resolution='<anonymous>': i18ndemo_fact: this is a raise from a custom fact from eputnam-i18ndemo
Info: Caching catalog for gowned-boundary.delivery.puppetlabs.net
Info: Applying configuration version '1601280481'
Notice: Applied catalog in 0.01 seconds
```