### PR TITLE
(FACT-2805) Read available memory from MemAvailable

### DIFF
--- a/spec/facter/resolvers/memory_resolver_spec.rb
+++ b/spec/facter/resolvers/memory_resolver_spec.rb
@@ -16,11 +16,8 @@ describe Facter::Resolvers::Linux::Memory do
 
     context 'when there is swap memory' do
       let(:total) { 4_036_680 * 1024 }
-      let(:free) { 3_547_792 * 1024 }
-      let(:buffers) { 4_288 * 1024 }
-      let(:cached) { 298_624 * 1024 }
-      let(:s_reclaimable) { 29_072 * 1024 }
-      let(:used) { total - free - buffers - cached - s_reclaimable }
+      let(:available) { 3_659_324 * 1024 }
+      let(:used) { total - available }
       let(:swap_total) { 2_097_148 * 1024 }
       let(:swap_free) { 2_097_148 * 1024 }
       let(:swap_used) { swap_total - swap_free }
@@ -31,7 +28,7 @@ describe Facter::Resolvers::Linux::Memory do
       end
 
       it 'returns memfree' do
-        expect(resolver.resolve(:memfree)).to eq(free)
+        expect(resolver.resolve(:memfree)).to eq(available)
       end
 
       it 'returns swap total' do
@@ -65,11 +62,8 @@ describe Facter::Resolvers::Linux::Memory do
 
     context 'when there is not swap memory' do
       let(:total) { 4_134_510_592 }
-      let(:free) { 3_465_723_904 }
-      let(:buffers) { 2_088 * 1024 }
-      let(:cached) { 445_204 * 1024 }
-      let(:s_reclaimable) { 71_384 * 1024 }
-      let(:used) { total - free - buffers - cached - s_reclaimable }
+      let(:available) { 3_665_024 * 1024 }
+      let(:used) { total - available }
       let(:fixture_name) { 'meminfo2' }
 
       it 'returns total memory' do
@@ -77,7 +71,7 @@ describe Facter::Resolvers::Linux::Memory do
       end
 
       it 'returns memfree' do
-        expect(resolver.resolve(:memfree)).to eq(free)
+        expect(resolver.resolve(:memfree)).to eq(available)
       end
 
       it 'returns swap total as nil' do
@@ -109,11 +103,8 @@ describe Facter::Resolvers::Linux::Memory do
 
     context 'when on Rhel 5' do
       let(:total) { 4_036_680 * 1024 }
-      let(:free) { 3_547_792 * 1024 }
-      let(:buffers) { 4_288 * 1024 }
-      let(:cached) { 298_624 * 1024 }
-      let(:s_reclaimable) { 0 }
-      let(:used) { total - free - buffers - cached - s_reclaimable }
+      let(:available) { 3_659_324 * 1024 }
+      let(:used) { total - available }
       let(:swap_total) { 2_097_148 * 1024 }
       let(:swap_free) { 2_097_148 * 1024 }
       let(:swap_used) { swap_total - swap_free }
@@ -124,7 +115,56 @@ describe Facter::Resolvers::Linux::Memory do
       end
 
       it 'returns memfree' do
-        expect(resolver.resolve(:memfree)).to eq(free)
+        expect(resolver.resolve(:memfree)).to eq(available)
+      end
+
+      it 'returns swap total' do
+        expect(resolver.resolve(:swap_total)).to eq(swap_total)
+      end
+
+      it 'returns swap available' do
+        expect(resolver.resolve(:swap_free)).to eq(swap_free)
+      end
+
+      it 'returns swap capacity' do
+        swap_capacity = format('%<swap_capacity>.2f', swap_capacity: (swap_used / swap_total.to_f * 100)) + '%'
+
+        expect(resolver.resolve(:swap_capacity)).to eq(swap_capacity)
+      end
+
+      it 'returns swap usage' do
+        expect(resolver.resolve(:swap_used_bytes)).to eq(swap_used)
+      end
+
+      it 'returns system capacity' do
+        system_capacity = format('%<capacity>.2f', capacity: (used / total.to_f * 100)) + '%'
+
+        expect(resolver.resolve(:capacity)).to eq(system_capacity)
+      end
+
+      it 'returns system usage' do
+        expect(resolver.resolve(:used_bytes)).to eq(used)
+      end
+    end
+
+    context 'when there is no available memory' do
+      let(:total) { 4_036_680 * 1024 }
+      let(:buffers) { 4_288 * 1024 }
+      let(:cached) { 298_624 * 1024 }
+      let(:free) { 3_547_792 * 1024 }
+      let(:available) { free + buffers + cached }
+      let(:used) { total - available }
+      let(:swap_total) { 2_097_148 * 1024 }
+      let(:swap_free) { 2_097_148 * 1024 }
+      let(:swap_used) { swap_total - swap_free }
+      let(:fixture_name) { 'meminfo_missing_available' }
+
+      it 'returns total memory' do
+        expect(resolver.resolve(:total)).to eq(total)
+      end
+
+      it 'returns memfree' do
+        expect(resolver.resolve(:memfree)).to eq(available)
       end
 
       it 'returns swap total' do

--- a/spec/fixtures/meminfo_missing_available
+++ b/spec/fixtures/meminfo_missing_available
@@ -1,0 +1,50 @@
+MemTotal:        4036680 kB
+MemFree:         3547792 kB
+Buffers:            4288 kB
+Cached:           298624 kB
+SwapCached:            0 kB
+Active:            81968 kB
+Inactive:         255516 kB
+Active(anon):      35056 kB
+Inactive(anon):      264 kB
+Active(file):      46912 kB
+Inactive(file):   255252 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:       2097148 kB
+SwapFree:        2097148 kB
+Dirty:               216 kB
+Writeback:             0 kB
+AnonPages:         34656 kB
+Mapped:            84464 kB
+Shmem:               680 kB
+KReclaimable:      29072 kB
+Slab:              80056 kB
+SReclaimable:      29072 kB
+SUnreclaim:        50984 kB
+KernelStack:        2688 kB
+PageTables:         1704 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     4115488 kB
+Committed_AS:     274552 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+Percpu:             1728 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:      100224 kB
+DirectMap2M:     4093952 kB
+DirectMap1G:     2097152 kB


### PR DESCRIPTION
Available memory should use the new MemAvailable info in `/proc/meminfo` when available. When not, fall back to the formula used in facter 3 (MemFree + Cached + Buffers)
For capacity, just use Total - Available