### PR TITLE
(FACT-2824) Facter make ec2 metadata requests when on gce

### DIFF
--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -6,7 +6,6 @@ module Facts
       FACT_NAME = 'ec2_metadata'
 
       def initialize
-        @log = Facter::Log.new(self)
         @virtual = Facter::VirtualDetector.new
       end
 

--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -7,6 +7,7 @@ module Facts
 
       def initialize
         @log = Facter::Log.new(self)
+        @virtual = Facter::VirtualDetector.new
       end
 
       def call_the_resolver
@@ -20,77 +21,7 @@ module Facts
       private
 
       def aws_hypervisors?
-        virtual =~ /kvm|xen|aws/
-      end
-
-      def virtual
-        fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
-        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
-        @log.debug("Virtual is #{fact_value}")
-
-        fact_value
-      end
-
-      def check_docker_lxc
-        @log.debug('Checking Docker and LXC')
-        Facter::Resolvers::Containers.resolve(:vm)
-      end
-
-      def check_dmi
-        @log.debug('Checking DMI')
-        vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
-        @log.debug("dmi detected vendor: #{vendor}")
-        return 'aws' if vendor =~ /Amazon/
-
-        'xen' if vendor =~ /Xen/
-      end
-
-      def check_gce
-        @log.debug('Checking GCE')
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        'gce' if bios_vendor&.include?('Google')
-      end
-
-      def check_vmware
-        @log.debug('Checking VMware')
-        Facter::Resolvers::Vmware.resolve(:vm)
-      end
-
-      def retrieve_from_virt_what
-        @log.debug('Checking virtual_what')
-        Facter::Resolvers::VirtWhat.resolve(:vm)
-      end
-
-      def check_open_vz
-        @log.debug('Checking OpenVZ')
-        Facter::Resolvers::OpenVz.resolve(:vm)
-      end
-
-      def check_vserver
-        @log.debug('Checking VServer')
-        Facter::Resolvers::VirtWhat.resolve(:vserver)
-      end
-
-      def check_xen
-        @log.debug('Checking XEN')
-        Facter::Resolvers::Xen.resolve(:vm)
-      end
-
-      def check_other_facts
-        @log.debug('Checking others')
-        product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
-        bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'aws' if bios_vendor&.include?('Amazon EC2')
-        return unless product_name
-
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
-
-        nil
-      end
-
-      def check_lspci
-        @log.debug('Checking lspci')
-        Facter::Resolvers::Lspci.resolve(:vm)
+        @virtual.platform =~ /kvm|xen|aws/
       end
     end
   end

--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -5,6 +5,10 @@ module Facts
     class Ec2Metadata
       FACT_NAME = 'ec2_metadata'
 
+      def initialize
+        @log = Facter::Log.new(self)
+      end
+
       def call_the_resolver
         return Facter::ResolvedFact.new(FACT_NAME, nil) unless aws_hypervisors?
 
@@ -20,31 +24,63 @@ module Facts
       end
 
       def virtual
-        check_virt_what || check_xen || check_product_name || check_bios_vendor || check_lspci
+        fact_value = check_docker_lxc || check_gce || retrieve_from_virt_what || check_vmware
+        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+        @log.debug("Virtual is #{fact_value}")
+
+        fact_value
       end
 
-      def check_virt_what
+      def check_gce
+        @log.debug('Checking GCE')
+        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+        'gce' if bios_vendor&.include?('Google')
+      end
+
+      def check_docker_lxc
+        @log.debug('Checking Docker and LXC')
+        Facter::Resolvers::Containers.resolve(:vm)
+      end
+
+      def check_vmware
+        @log.debug('Checking VMware')
+        Facter::Resolvers::Vmware.resolve(:vm)
+      end
+
+      def retrieve_from_virt_what
+        @log.debug('Checking virtual_what')
         Facter::Resolvers::VirtWhat.resolve(:vm)
       end
 
+      def check_open_vz
+        @log.debug('Checking OpenVZ')
+        Facter::Resolvers::OpenVz.resolve(:vm)
+      end
+
+      def check_vserver
+        @log.debug('Checking VServer')
+        Facter::Resolvers::VirtWhat.resolve(:vserver)
+      end
+
       def check_xen
+        @log.debug('Checking XEN')
         Facter::Resolvers::Xen.resolve(:vm)
       end
 
-      def check_product_name
+      def check_other_facts
+        @log.debug('Checking others')
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
+        bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+        return 'kvm' if bios_vendor&.include?('Amazon EC2')
         return unless product_name
 
-        _, value = Facter::FactsUtils::HYPERVISORS_HASH.find { |key, _value| product_name.include?(key) }
-        value
-      end
+        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
 
-      def check_bios_vendor
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'kvm' if bios_vendor&.include?('Amazon EC2')
+        nil
       end
 
       def check_lspci
+        @log.debug('Checking lspci')
         Facter::Resolvers::Lspci.resolve(:vm)
       end
     end

--- a/lib/facter/facts/linux/ec2_metadata.rb
+++ b/lib/facter/facts/linux/ec2_metadata.rb
@@ -24,22 +24,31 @@ module Facts
       end
 
       def virtual
-        fact_value = check_docker_lxc || check_gce || retrieve_from_virt_what || check_vmware
+        fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
         fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
         @log.debug("Virtual is #{fact_value}")
 
         fact_value
       end
 
+      def check_docker_lxc
+        @log.debug('Checking Docker and LXC')
+        Facter::Resolvers::Containers.resolve(:vm)
+      end
+
+      def check_dmi
+        @log.debug('Checking DMI')
+        vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
+        @log.debug("dmi detected vendor: #{vendor}")
+        return 'aws' if vendor =~ /Amazon/
+
+        'xen' if vendor =~ /Xen/
+      end
+
       def check_gce
         @log.debug('Checking GCE')
         bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
         'gce' if bios_vendor&.include?('Google')
-      end
-
-      def check_docker_lxc
-        @log.debug('Checking Docker and LXC')
-        Facter::Resolvers::Containers.resolve(:vm)
       end
 
       def check_vmware
@@ -71,7 +80,7 @@ module Facts
         @log.debug('Checking others')
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
         bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'kvm' if bios_vendor&.include?('Amazon EC2')
+        return 'aws' if bios_vendor&.include?('Amazon EC2')
         return unless product_name
 
         Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }

--- a/lib/facter/facts/linux/ec2_userdata.rb
+++ b/lib/facter/facts/linux/ec2_userdata.rb
@@ -7,6 +7,7 @@ module Facts
 
       def initialize
         @log = Facter::Log.new(self)
+        @virtual = Facter::VirtualDetector.new
       end
 
       def call_the_resolver
@@ -20,77 +21,7 @@ module Facts
       private
 
       def aws_hypervisors?
-        virtual =~ /kvm|xen|aws/
-      end
-
-      def virtual
-        fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
-        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
-        @log.debug("Virtual is #{fact_value}")
-
-        fact_value
-      end
-
-      def check_docker_lxc
-        @log.debug('Checking Docker and LXC')
-        Facter::Resolvers::Containers.resolve(:vm)
-      end
-
-      def check_dmi
-        @log.debug('Checking DMI')
-        vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
-        @log.debug("dmi detected vendor: #{vendor}")
-        return 'aws' if vendor =~ /Amazon/
-
-        'xen' if vendor =~ /Xen/
-      end
-
-      def check_gce
-        @log.debug('Checking GCE')
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        'gce' if bios_vendor&.include?('Google')
-      end
-
-      def check_vmware
-        @log.debug('Checking VMware')
-        Facter::Resolvers::Vmware.resolve(:vm)
-      end
-
-      def retrieve_from_virt_what
-        @log.debug('Checking virtual_what')
-        Facter::Resolvers::VirtWhat.resolve(:vm)
-      end
-
-      def check_open_vz
-        @log.debug('Checking OpenVZ')
-        Facter::Resolvers::OpenVz.resolve(:vm)
-      end
-
-      def check_vserver
-        @log.debug('Checking VServer')
-        Facter::Resolvers::VirtWhat.resolve(:vserver)
-      end
-
-      def check_xen
-        @log.debug('Checking XEN')
-        Facter::Resolvers::Xen.resolve(:vm)
-      end
-
-      def check_other_facts
-        @log.debug('Checking others')
-        product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
-        bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'aws' if bios_vendor&.include?('Amazon EC2')
-        return unless product_name
-
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
-
-        nil
-      end
-
-      def check_lspci
-        @log.debug('Checking lspci')
-        Facter::Resolvers::Lspci.resolve(:vm)
+        @virtual.platform =~ /kvm|xen|aws/
       end
     end
   end

--- a/lib/facter/facts/linux/ec2_userdata.rb
+++ b/lib/facter/facts/linux/ec2_userdata.rb
@@ -5,6 +5,10 @@ module Facts
     class Ec2Userdata
       FACT_NAME = 'ec2_userdata'
 
+      def initialize
+        @log = Facter::Log.new(self)
+      end
+
       def call_the_resolver
         return Facter::ResolvedFact.new(FACT_NAME, nil) unless aws_hypervisors?
 
@@ -16,33 +20,76 @@ module Facts
       private
 
       def aws_hypervisors?
-        virtual = check_virt_what || check_xen || check_product_name || check_bios_vendor || check_lspci
-
-        virtual == 'kvm' || virtual =~ /xen/
+        virtual =~ /kvm|xen|aws/
       end
 
-      def check_virt_what
+      def virtual
+        fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
+        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+        @log.debug("Virtual is #{fact_value}")
+
+        fact_value
+      end
+
+      def check_docker_lxc
+        @log.debug('Checking Docker and LXC')
+        Facter::Resolvers::Containers.resolve(:vm)
+      end
+
+      def check_dmi
+        @log.debug('Checking DMI')
+        vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
+        @log.debug("dmi detected vendor: #{vendor}")
+        return 'aws' if vendor =~ /Amazon/
+
+        'xen' if vendor =~ /Xen/
+      end
+
+      def check_gce
+        @log.debug('Checking GCE')
+        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+        'gce' if bios_vendor&.include?('Google')
+      end
+
+      def check_vmware
+        @log.debug('Checking VMware')
+        Facter::Resolvers::Vmware.resolve(:vm)
+      end
+
+      def retrieve_from_virt_what
+        @log.debug('Checking virtual_what')
         Facter::Resolvers::VirtWhat.resolve(:vm)
       end
 
+      def check_open_vz
+        @log.debug('Checking OpenVZ')
+        Facter::Resolvers::OpenVz.resolve(:vm)
+      end
+
+      def check_vserver
+        @log.debug('Checking VServer')
+        Facter::Resolvers::VirtWhat.resolve(:vserver)
+      end
+
       def check_xen
+        @log.debug('Checking XEN')
         Facter::Resolvers::Xen.resolve(:vm)
       end
 
-      def check_product_name
+      def check_other_facts
+        @log.debug('Checking others')
         product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
+        bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+        return 'aws' if bios_vendor&.include?('Amazon EC2')
         return unless product_name
 
-        _, value = Facter::FactsUtils::HYPERVISORS_HASH.find { |key, _value| product_name.include?(key) }
-        value
-      end
+        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
 
-      def check_bios_vendor
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'kvm' if bios_vendor&.include?('Amazon EC2')
+        nil
       end
 
       def check_lspci
+        @log.debug('Checking lspci')
         Facter::Resolvers::Lspci.resolve(:vm)
       end
     end

--- a/lib/facter/facts/linux/ec2_userdata.rb
+++ b/lib/facter/facts/linux/ec2_userdata.rb
@@ -6,7 +6,6 @@ module Facts
       FACT_NAME = 'ec2_userdata'
 
       def initialize
-        @log = Facter::Log.new(self)
         @virtual = Facter::VirtualDetector.new
       end
 

--- a/lib/facter/facts/linux/is_virtual.rb
+++ b/lib/facter/facts/linux/is_virtual.rb
@@ -5,59 +5,20 @@ module Facts
     class IsVirtual
       FACT_NAME = 'is_virtual'
 
-      def call_the_resolver # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        fact_value = check_docker_lxc || check_gce || retrieve_from_virt_what || check_vmware
-        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+      def initialize
+        @virtual = Facter::VirtualDetector.new
+      end
+
+      def call_the_resolver
+        fact_value = @virtual.platform
 
         Facter::ResolvedFact.new(FACT_NAME, check_if_virtual(fact_value))
       end
 
-      def check_gce
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        'gce' if bios_vendor&.include?('Google')
-      end
-
-      def check_docker_lxc
-        Facter::Resolvers::Containers.resolve(:vm)
-      end
-
-      def check_vmware
-        Facter::Resolvers::Vmware.resolve(:vm)
-      end
-
-      def retrieve_from_virt_what
-        Facter::Resolvers::VirtWhat.resolve(:vm)
-      end
-
-      def check_open_vz
-        Facter::Resolvers::OpenVz.resolve(:vm)
-      end
-
-      def check_vserver
-        Facter::Resolvers::VirtWhat.resolve(:vserver)
-      end
-
-      def check_xen
-        Facter::Resolvers::Xen.resolve(:vm)
-      end
-
-      def check_other_facts
-        product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'kvm' if bios_vendor&.include?('Amazon EC2')
-        return unless product_name
-
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
-
-        nil
-      end
-
-      def check_lspci
-        Facter::Resolvers::Lspci.resolve(:vm)
-      end
+      private
 
       def check_if_virtual(found_vm)
-        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?
+        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?.to_s
       end
     end
   end

--- a/lib/facter/facts/linux/virtual.rb
+++ b/lib/facter/facts/linux/virtual.rb
@@ -7,70 +7,17 @@ module Facts
 
       def initialize
         @log = Facter::Log.new(self)
+        @virtual = Facter::VirtualDetector.new
       end
 
-      def call_the_resolver # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def call_the_resolver
         @log.debug('Linux Virtual Resolver')
 
-        fact_value = check_docker_lxc || check_gce || retrieve_from_virt_what || check_vmware
-        fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+        fact_value = @virtual.platform
 
         @log.debug("Fact value is: #{fact_value}")
 
         Facter::ResolvedFact.new(FACT_NAME, fact_value)
-      end
-
-      def check_gce
-        @log.debug('Checking GCE')
-        bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        'gce' if bios_vendor&.include?('Google')
-      end
-
-      def check_docker_lxc
-        @log.debug('Checking Docker and LXC')
-        Facter::Resolvers::Containers.resolve(:vm)
-      end
-
-      def check_vmware
-        @log.debug('Checking VMware')
-        Facter::Resolvers::Vmware.resolve(:vm)
-      end
-
-      def retrieve_from_virt_what
-        @log.debug('Checking virtual_what')
-        Facter::Resolvers::VirtWhat.resolve(:vm)
-      end
-
-      def check_open_vz
-        @log.debug('Checking OpenVZ')
-        Facter::Resolvers::OpenVz.resolve(:vm)
-      end
-
-      def check_vserver
-        @log.debug('Checking VServer')
-        Facter::Resolvers::VirtWhat.resolve(:vserver)
-      end
-
-      def check_xen
-        @log.debug('Checking XEN')
-        Facter::Resolvers::Xen.resolve(:vm)
-      end
-
-      def check_other_facts
-        @log.debug('Checking others')
-        product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
-        bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
-        return 'kvm' if bios_vendor&.include?('Amazon EC2')
-        return unless product_name
-
-        Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
-
-        nil
-      end
-
-      def check_lspci
-        @log.debug('Checking lspci')
-        Facter::Resolvers::Lspci.resolve(:vm)
       end
     end
   end

--- a/lib/facter/facts/linux/virtual.rb
+++ b/lib/facter/facts/linux/virtual.rb
@@ -12,9 +12,7 @@ module Facts
 
       def call_the_resolver
         @log.debug('Linux Virtual Resolver')
-
         fact_value = @virtual.platform
-
         @log.debug("Fact value is: #{fact_value}")
 
         Facter::ResolvedFact.new(FACT_NAME, fact_value)

--- a/lib/facter/facts_utils/virtual_detector.rb
+++ b/lib/facter/facts_utils/virtual_detector.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Facter
+  class VirtualDetector
+    def initialize
+      @log = Facter::Log.new(self)
+    end
+
+    def platform # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
+      fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+
+      fact_value
+    end
+
+    def check_docker_lxc
+      @log.debug('Checking Docker and LXC')
+      Facter::Resolvers::Containers.resolve(:vm)
+    end
+
+    def check_dmi
+      @log.debug('Checking DMI')
+      vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
+      @log.debug("dmi detected vendor: #{vendor}")
+      return 'aws' if vendor =~ /Amazon/
+
+      'xen' if vendor =~ /Xen/
+    end
+
+    def check_gce
+      @log.debug('Checking GCE')
+      bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+      'gce' if bios_vendor&.include?('Google')
+    end
+
+    def check_vmware
+      @log.debug('Checking VMware')
+      Facter::Resolvers::Vmware.resolve(:vm)
+    end
+
+    def retrieve_from_virt_what
+      @log.debug('Checking virtual_what')
+      Facter::Resolvers::VirtWhat.resolve(:vm)
+    end
+
+    def check_open_vz
+      @log.debug('Checking OpenVZ')
+      Facter::Resolvers::OpenVz.resolve(:vm)
+    end
+
+    def check_vserver
+      @log.debug('Checking VServer')
+      Facter::Resolvers::VirtWhat.resolve(:vserver)
+    end
+
+    def check_xen
+      @log.debug('Checking XEN')
+      Facter::Resolvers::Xen.resolve(:vm)
+    end
+
+    def check_other_facts
+      @log.debug('Checking others')
+      product_name = Facter::Resolvers::Linux::DmiBios.resolve(:product_name)
+      bios_vendor =  Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
+      return 'kvm' if bios_vendor&.include?('Amazon EC2')
+      return unless product_name
+
+      Facter::FactsUtils::HYPERVISORS_HASH.each { |key, value| return value if product_name.include?(key) }
+
+      nil
+    end
+
+    def check_lspci
+      @log.debug('Checking lspci')
+      Facter::Resolvers::Lspci.resolve(:vm)
+    end
+  end
+end

--- a/lib/facter/resolvers/dmi_decode.rb
+++ b/lib/facter/resolvers/dmi_decode.rb
@@ -37,6 +37,7 @@ module Facter
           @fact_list[:virtualbox_version] = output.match(/vboxVer_(\S+)/)&.captures&.first
           @fact_list[:virtualbox_revision] = output.match(/vboxRev_(\S+)/)&.captures&.first
           @fact_list[:vmware_version] = extract_vmware_version(output)
+          @fact_list[:vendor] = output.match(/Vendor: (\S+)/)&.captures&.first
 
           @fact_list[fact_name]
         end

--- a/spec/facter/facts/linux/ec2_metadata_spec.rb
+++ b/spec/facter/facts/linux/ec2_metadata_spec.rb
@@ -29,13 +29,15 @@ describe Facts::Linux::Ec2Metadata do
       end
     end
 
-    shared_examples 'call ec2 and check resolved fact' do
+    shared_examples 'check ec2 resolver called with metadata' do
       it 'calls ec2 resolver' do
         fact.call_the_resolver
 
         expect(Facter::Resolvers::Ec2).to have_received(:resolve).with(:metadata)
       end
+    end
 
+    shared_examples 'check resolved fact value' do
       it 'returns ec2 metadata fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'ec2_metadata', value: value)
@@ -49,7 +51,8 @@ describe Facts::Linux::Ec2Metadata do
         allow(virtual_detector_double).to receive(:platform).and_return('kvm')
       end
 
-      it_behaves_like 'call ec2 and check resolved fact'
+      it_behaves_like 'check ec2 resolver called with metadata'
+      it_behaves_like 'check resolved fact value'
     end
 
     context 'when platform is xen' do
@@ -59,7 +62,8 @@ describe Facts::Linux::Ec2Metadata do
         allow(virtual_detector_double).to receive(:platform).and_return('xen')
       end
 
-      it_behaves_like 'call ec2 and check resolved fact'
+      it_behaves_like 'check ec2 resolver called with metadata'
+      it_behaves_like 'check resolved fact value'
     end
 
     context 'when platform is aws' do
@@ -69,7 +73,8 @@ describe Facts::Linux::Ec2Metadata do
         allow(virtual_detector_double).to receive(:platform).and_return('aws')
       end
 
-      it_behaves_like 'call ec2 and check resolved fact'
+      it_behaves_like 'check ec2 resolver called with metadata'
+      it_behaves_like 'check resolved fact value'
     end
   end
 end

--- a/spec/facter/facts/linux/ec2_metadata_spec.rb
+++ b/spec/facter/facts/linux/ec2_metadata_spec.rb
@@ -4,103 +4,72 @@ describe Facts::Linux::Ec2Metadata do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::Ec2Metadata.new }
 
+    let(:virtual_detector_double) { instance_spy(Facter::VirtualDetector) }
+
     before do
+      allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
       allow(Facter::Resolvers::Ec2).to receive(:resolve).with(:metadata).and_return(value)
-      allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(hypervisor)
-      allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
-      allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
-      allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
-      allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
     end
 
     context 'when physical machine with no hypervisor' do
-      let(:hypervisor) { nil }
       let(:value) { nil }
 
       before do
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('MS-7A71')
+        allow(virtual_detector_double).to receive(:platform).and_return(nil)
       end
 
       it 'returns ec2 metadata fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'ec2_metadata', value: nil)
-      end
-
-      it "doesn't call Ec2 resolver" do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Ec2).not_to have_received(:resolve).with(:metadata)
-      end
-    end
-
-    context 'when hypervisor is not kvm or xen' do
-      let(:hypervisor) { nil }
-      let(:value) { nil }
-
-      it 'returns ec2 metadata fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'ec2_metadata', value: nil)
-      end
-
-      it "doesn't call Ec2 resolver" do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Ec2).not_to have_received(:resolve).with(:metadata)
-      end
-    end
-
-    context 'when hypervisor is xen' do
-      let(:hypervisor) { 'xenhvm' }
-
-      context 'when resolver returns a value' do
-        let(:value) { { 'info' => 'value' } }
-
-        it 'calls Facter::Resolvers::Ec2' do
-          fact.call_the_resolver
-          expect(Facter::Resolvers::Ec2).to have_received(:resolve).with(:metadata)
-        end
-
-        it 'returns ec2 userdata fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'ec2_metadata', value: value)
-        end
-      end
-
-      context 'when resolver returns empty hash' do
-        let(:value) { {} }
-
-        it 'returns ec2 metadata fact as nil' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'ec2_metadata', value: nil)
-        end
-      end
-
-      context 'when resolver returns nil' do
-        let(:value) { nil }
-
-        it 'returns ec2 metadata fact as nil' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'ec2_metadata', value: nil)
-        end
-      end
-    end
-
-    context 'when hypervisor is aws' do
-      let(:hypervisor) { 'aws' }
-      let(:value) { { 'info' => 'value' } }
-
-      it 'calls Facter::Resolvers::VirtWhat' do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::VirtWhat).to have_received(:resolve).with(:vm)
-      end
-
-      it 'calls Facter::Resolvers::Ec2' do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Ec2).to have_received(:resolve).with(:metadata)
-      end
-
-      it 'returns ec2 userdata fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'ec2_metadata', value: value)
       end
+
+      it "doesn't call Ec2 resolver" do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Ec2).not_to have_received(:resolve).with(:metadata)
+      end
+    end
+
+    shared_examples 'call ec2 and check resolved fact' do
+      it 'calls ec2 resolver' do
+        fact.call_the_resolver
+
+        expect(Facter::Resolvers::Ec2).to have_received(:resolve).with(:metadata)
+      end
+
+      it 'returns ec2 metadata fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'ec2_metadata', value: value)
+      end
+    end
+
+    context 'when platform is kvm' do
+      let(:value) { { 'info' => 'value' } }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('kvm')
+      end
+
+      it_behaves_like 'call ec2 and check resolved fact'
+    end
+
+    context 'when platform is xen' do
+      let(:value) { { 'info' => 'value' } }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('xen')
+      end
+
+      it_behaves_like 'call ec2 and check resolved fact'
+    end
+
+    context 'when platform is aws' do
+      let(:value) { { 'info' => 'value' } }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('aws')
+      end
+
+      it_behaves_like 'call ec2 and check resolved fact'
     end
   end
 end

--- a/spec/facter/facts/linux/is_virtual_spec.rb
+++ b/spec/facter/facts/linux/is_virtual_spec.rb
@@ -4,172 +4,30 @@ describe Facts::Linux::IsVirtual do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::IsVirtual.new }
 
-    let(:vm) { 'docker' }
-    let(:value) { true }
+    let(:virtual_detector_double) { instance_spy(Facter::VirtualDetector) }
 
     before do
-      allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(vm)
+      allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(virtual_detector_double).to receive(:platform).and_return(virtual_value)
     end
 
-    it 'calls Facter::Resolvers::Containers' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Containers).to have_received(:resolve).with(:vm)
-    end
+    context 'when not in a virtual environment' do
+      let(:virtual_value) { 'physical' }
 
-    it 'returns virtual fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-        have_attributes(name: 'is_virtual', value: value)
-    end
-
-    context 'when is gce' do
-      let(:vm) { nil }
-      let(:value) { true }
-
-      before do
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('Google Engine')
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'is_virtual', value: 'false')
       end
     end
 
-    context 'when is vmware' do
-      let(:vm) { nil }
-      let(:vmware_value) { 'vmware_fusion' }
-      let(:value) { true }
+    context 'when in a virtual environment' do
+      let(:virtual_value) { 'aws' }
 
-      before do
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(vmware_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is xen-hvm' do
-      let(:vm) { nil }
-      let(:virtwhat_value) { 'xenhvm' }
-      let(:value) { true }
-
-      before do
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(virtwhat_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is openVz' do
-      let(:vm) { nil }
-      let(:openvz_value) { 'openvzve' }
-      let(:value) { true }
-
-      before do
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(openvz_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is vserver' do
-      let(:vm) { nil }
-      let(:virtwhat_value) { 'vserver_host' }
-      let(:value) { false }
-
-      before do
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(virtwhat_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is xen priviledged' do
-      let(:vm) { nil }
-      let(:xen_value) { 'xen0' }
-      let(:value) { false }
-
-      before do
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(xen_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is bochs discovered with dmi product_name' do
-      let(:vm) { nil }
-      let(:value) { true }
-
-      before do
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('Bochs Machine')
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when is hyper-v discovered with lspci' do
-      let(:vm) { nil }
-      let(:lspci_value) { 'hyperv' }
-      let(:value) { true }
-
-      before do
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(lspci_value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: value)
-      end
-    end
-
-    context 'when resolvers return nil ' do
-      let(:vm) { false }
-
-      before do
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
-      end
-
-      it 'returns virtual fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: vm)
-      end
-    end
-
-    context 'when product name is not found in the HYPERVISORS_HASH' do
-      let(:vm) { false }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('unknown')
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
-      end
-
-      it 'returns virtual fact as physical' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'is_virtual', value: vm)
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'is_virtual', value: 'true')
       end
     end
   end

--- a/spec/facter/facts/linux/virtual_spec.rb
+++ b/spec/facter/facts/linux/virtual_spec.rb
@@ -10,7 +10,6 @@ describe Facts::Linux::Virtual do
     before do
       allow(Facter::Log).to receive(:new).and_return(log_spy)
       allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
-      allow(Facter::Resolvers::Ec2).to receive(:resolve).with(:metadata).and_return(value)
       allow(virtual_detector_double).to receive(:platform).and_return(value)
     end
 
@@ -23,7 +22,7 @@ describe Facts::Linux::Virtual do
     end
 
     context 'when not in a virtual environment' do
-      let(:value) { nil }
+      let(:value) { 'physical' }
 
       it_behaves_like 'check resolved fact value'
     end

--- a/spec/facter/facts/linux/virtual_spec.rb
+++ b/spec/facter/facts/linux/virtual_spec.rb
@@ -4,204 +4,34 @@ describe Facts::Linux::Virtual do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::Virtual.new }
 
-    context 'when is docker' do
-      let(:vm) { 'docker' }
+    let(:virtual_detector_double) { instance_spy(Facter::VirtualDetector) }
+    let(:log_spy) { instance_spy(Facter::Log) }
 
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(vm)
-      end
+    before do
+      allow(Facter::Log).to receive(:new).and_return(log_spy)
+      allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(Facter::Resolvers::Ec2).to receive(:resolve).with(:metadata).and_return(value)
+      allow(virtual_detector_double).to receive(:platform).and_return(value)
+    end
 
-      it 'calls Facter::Resolvers::Containers' do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Containers).to have_received(:resolve).with(:vm)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: vm)
+    shared_examples 'check resolved fact value' do
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'virtual', value: value)
       end
     end
 
-    context 'when is gce' do
-      let(:value) { 'gce' }
+    context 'when not in a virtual environment' do
+      let(:value) { nil }
 
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('Google Engine')
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
+      it_behaves_like 'check resolved fact value'
     end
 
-    context 'when is xen-hvm' do
-      let(:value) { 'xenhvm' }
+    context 'when in a virtual environment' do
+      let(:value) { 'aws' }
 
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is vmware' do
-      let(:value) { 'vmware_fusion' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is openVz' do
-      let(:value) { 'openvzve' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is vserver' do
-      let(:value) { 'vserver_host' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is xen priviledged' do
-      let(:value) { 'xen0' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is bochs discovered with dmi product_name' do
-      let(:value) { 'bochs' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('Bochs Machine')
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when is hyper-v discovered with lspci' do
-      let(:value) { 'hyperv' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(value)
-      end
-
-      it 'returns virtual fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: value)
-      end
-    end
-
-    context 'when resolvers return nil ' do
-      let(:vm) { 'physical' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
-      end
-
-      it 'returns virtual fact as nil' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: vm)
-      end
-    end
-
-    context 'when product name is not found in the HYPERVISORS_HASH' do
-      let(:vm) { 'physical' }
-
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('unknown')
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
-      end
-
-      it 'returns virtual fact as physical' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'virtual', value: vm)
-      end
+      it_behaves_like 'check resolved fact value'
     end
   end
 end


### PR DESCRIPTION
`ec2_metadata` fact tries to determine on what hypervisor or on what cloud provider it is running on. If it detecters aws, it will call the `ec2` fact.

Problem:
- `ec2_metadata` fact calls the `ec2` resolver when it detects `kvm` hypervisor, but there are other providers that use `kvm`, one example is `gce`. 

Solution:
- improve the detection of hypervisor or cloud provider by adding the logic from virtual and dmi decoder