### PR TITLE
(maint) Avoid deadlock of Facter::Core::Execution.execute

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -17,6 +17,7 @@ jobs:
         os: [windows-2016, windows-2019, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
     runs-on: ${{ matrix.os }}
     env:
+      BEAKER_debug: true
       FACTER_ROOT: facter
       SHA: latest
       RELEASE_STREAM: puppet7

--- a/acceptance/tests/custom_facts/long_stderr_with_time_limit.rb
+++ b/acceptance/tests/custom_facts/long_stderr_with_time_limit.rb
@@ -1,0 +1,34 @@
+test_name "Facter::Core::Execution doesn't kill process with long stderr message" do
+  tag 'risk:high'
+
+  confine :except, :platform => /windows/
+
+  long_output = "This is a very long error message. " * 4096
+  file_content = <<-EOM
+   #!/bin/sh
+   echo 'newfact=value_of_fact'
+   1>&2 echo #{long_output}
+   exit 1
+  EOM
+
+
+  agents.each do |agent|
+
+    external_dir = agent.tmpdir('external_dir')
+    fact_file = File.join(external_dir, 'test.sh')
+    create_remote_file(agent, fact_file, file_content)
+    agent.chmod('+x', fact_file)
+
+    teardown do
+      agent.rm_rf(external_dir)
+    end
+
+    step "Facter: should resolve the external fact and print as warning script's stderr message" do
+      on agent, facter('--external-dir', external_dir, 'newfact') do |facter_output|
+        assert_match(/value_of_fact/, facter_output.stdout.chomp)
+        assert_match(/WARN test.sh .*test.sh resulted with the following stderr message: This is a very long error message./, facter_output.stderr.chomp)
+      end
+    end
+  end
+end
+

--- a/lib/facter/resolvers/aix/os_level.rb
+++ b/lib/facter/resolvers/aix/os_level.rb
@@ -14,7 +14,7 @@ module Facter
           end
 
           def read_oslevel(fact_name)
-            output = Facter::Core::Execution.execute('/usr/bin/oslevel -s', { limit: 2, logger: log })
+            output = Facter::Core::Execution.execute('/usr/bin/oslevel -s', logger: log)
             @fact_list[:build] = output unless output.empty?
             @fact_list[:kernel] = 'AIX'
 

--- a/spec/facter/resolvers/aix/os_level_spec.rb
+++ b/spec/facter/resolvers/aix/os_level_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Aix::OsLevel do
   before do
     os_level.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/oslevel -s', { limit: 2, logger: log_spy })
+      .with('/usr/bin/oslevel -s', { logger: log_spy })
       .and_return(output)
   end
 


### PR DESCRIPTION
**Description of the problem:** If stdout/stderr are N bytes, and the child process writes N+1 bytes to stderr, but nothing to stdout, then facter will block waiting to read from stdout, hit the timeout, and never read from stderr.
**Description of the fix** Facter will create two reader threads to avoid the deadlock