### PR TITLE
(FACT-2817) Only invalidate session cache on clear and reset.

### DIFF
--- a/acceptance/tests/session_cached_is_not_refershed_in_session.rb
+++ b/acceptance/tests/session_cached_is_not_refershed_in_session.rb
@@ -1,0 +1,27 @@
+test_name 'facter should not update it`s session cache in same session' do
+  tag 'risk:high'
+
+  fact_content = <<-EOM
+    require 'facter'
+    
+    seconds_before = Facter.value('system_uptime.seconds')
+    sleep(3)
+    seconds_after = Facter.value('system_uptime.seconds')
+    
+    puts seconds_before == seconds_after
+  EOM
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('test_scripts')
+    script_path = File.join(fact_dir, 'session_test.rb')
+    create_remote_file(agent, script_path, fact_content)
+
+    teardown do
+      agent.rm_rf(script_path)
+    end
+
+    on(agent, "#{ruby_command(agent)} #{script_path}") do |ruby_result|
+      assert_equal('true', ruby_result.stdout.chomp, 'Expect the session cache is not reset in same session')
+    end
+  end
+end

--- a/custom_facts/my_custom_fact.rb
+++ b/custom_facts/my_custom_fact.rb
@@ -3,7 +3,6 @@
 Facter.add(:my_custom_fact) do
   has_weight(10_000)
   setcode do
-    # 'my_custom_fact'
     Facter.value('os')
   end
 end

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -83,6 +83,7 @@ module Facter
       Options[:custom_dir] = []
       LegacyFacter.collection.invalidate_custom_facts
       LegacyFacter.collection.reload_custom_facts
+      SessionCache.invalidate_all_caches
     end
 
     def core_value(user_query)
@@ -170,7 +171,6 @@ module Facter
     def each
       log_blocked_facts
       resolved_facts = Facter::FactManager.instance.resolve_facts
-      SessionCache.invalidate_all_caches
 
       resolved_facts.each do |fact|
         yield(fact.name, fact.value)
@@ -206,6 +206,7 @@ module Facter
       LegacyFacter.reset
       Options[:custom_dir] = []
       Options[:external_dir] = []
+      SessionCache.invalidate_all_caches
       nil
     end
 
@@ -270,7 +271,6 @@ module Facter
       log_blocked_facts
 
       resolved_facts = Facter::FactManager.instance.resolve_facts
-      Facter::SessionCache.invalidate_all_caches
       Facter::FactCollection.new.build_fact_collection!(resolved_facts)
     end
 
@@ -308,7 +308,6 @@ module Facter
     def values(options, user_queries)
       init_cli_options(options, user_queries)
       resolved_facts = Facter::FactManager.instance.resolve_facts(user_queries)
-      Facter::SessionCache.invalidate_all_caches
 
       if user_queries.count.zero?
         Facter::FactCollection.new.build_fact_collection!(resolved_facts)
@@ -336,7 +335,6 @@ module Facter
       logger.info("executed with command line: #{ARGV.drop(1).join(' ')}")
       log_blocked_facts
       resolved_facts = Facter::FactManager.instance.resolve_facts(args)
-      SessionCache.invalidate_all_caches
       fact_formatter = Facter::FormatterFactory.build(Facter::Options.get)
 
       status = error_check(resolved_facts)
@@ -426,7 +424,6 @@ module Facter
     def resolve_fact(user_query)
       user_query = user_query.to_s
       resolved_facts = Facter::FactManager.instance.resolve_facts([user_query])
-      SessionCache.invalidate_all_caches
       # we must make a distinction between custom facts that return nil and nil facts
       # Nil facts should not be packaged as ResolvedFacts! (add_fact_to_searched_facts packages facts)
       resolved_facts = resolved_facts.reject { |fact| fact.type == :nil }


### PR DESCRIPTION
The `SessionCache` is used internal to store resolver values. If a resolver is called multiple times, we only resolve once the data and all subsequent request to that resolver, will hit the cache. 

## Problem
The current implementation invalidates this session cache after each request (to_hash, value, []), but Facter 3 invalidates this cache only on `reset` and `clear`. 

## Solution
Invalidate the session cache only on `reset` and `clear`