### PR TITLE
(maint) Update regex for os.macosx.build

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -350,7 +350,7 @@ module Facter
             'os.family'                => 'Darwin',
             'os.hardware'              => 'x86_64',
             'os.name'                  => 'Darwin',
-            'os.macosx.build'          => /\d+[A-Z]\d{2,4}\w?/,
+            'os.macosx.build'          => /\d+[A-Z]\d{1,4}\w?/,
             'os.macosx.product'        => 'Mac OS X',
             'os.macosx.version.full'   => /#{os_version}\.\d+/,
             'os.macosx.version.major'  => os_version,


### PR DESCRIPTION
The versioning for macOS has changed from e.g.`19G2021 ` to `19H2 `. In order to accommodate the version change, we need to change the regex for `os.macosx.build` fact.