### PR TITLE
(maint) Fix external fact cache

### DIFF
--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -56,13 +56,15 @@ module Facter
     private
 
     def resolve_fact(searched_fact)
-      return unless fact_cache_enabled?(searched_fact.name)
+      fact_name = if searched_fact.file
+                    File.basename(searched_fact.file)
+                  else
+                    searched_fact.name
+                  end
 
-      fact = if searched_fact.file
-               @fact_groups.get_fact(File.basename(searched_fact.file))
-             else
-               @fact_groups.get_fact(searched_fact.name)
-             end
+      return unless fact_cache_enabled?(fact_name)
+
+      fact = @fact_groups.get_fact(fact_name)
 
       return unless fact
 
@@ -97,14 +99,17 @@ module Facter
     end
 
     def cache_fact(fact)
-      group_name = if fact.file
-                     File.basename(fact.file)
-                   else
-                     @fact_groups.get_fact_group(fact.name)
-                   end
+      fact_name = if fact.file
+                    File.basename(fact.file)
+                  else
+                    fact.name
+                  end
+
+      group_name = @fact_groups.get_fact_group(fact_name)
+
       return if !group_name || fact.value.nil?
 
-      return unless fact_cache_enabled?(fact.name)
+      return unless fact_cache_enabled?(fact_name)
 
       @groups[group_name] ||= {}
       @groups[group_name][fact.name] = fact.value

--- a/spec/facter/cache_manager_spec.rb
+++ b/spec/facter/cache_manager_spec.rb
@@ -13,7 +13,7 @@ describe Facter::CacheManager do
                                        user_query: '', type: :custom, file: nil)
   end
   let(:searched_external_fact) do
-    instance_spy(Facter::SearchedFact, name: 'ext_file.txt', fact_class: nil, filter_tokens: [],
+    instance_spy(Facter::SearchedFact, name: 'my_external_fact', fact_class: nil, filter_tokens: [],
                                        user_query: '', type: :file, file: '/tmp/ext_file.txt')
   end
   let(:searched_facts) { [searched_core_fact, searched_custom_fact, searched_external_fact] }
@@ -103,7 +103,7 @@ describe Facter::CacheManager do
         sf, _cf = cache_manager.resolve_facts(searched_facts)
         expect(sf).to be_an_instance_of(Array).and contain_exactly(
           an_object_having_attributes(name: 'my_custom_fact', type: :custom),
-          an_object_having_attributes(name: 'ext_file.txt', type: :file)
+          an_object_having_attributes(name: 'my_external_fact', type: :file)
         )
       end
 


### PR DESCRIPTION
External fact cache was working only if the external fact had the same name as the file.