### PR TITLE
(FACT-2810) Fix dmi.board_asset_tag and dhcp

### DIFF
--- a/lib/facter/resolvers/dmi_resolver.rb
+++ b/lib/facter/resolvers/dmi_resolver.rb
@@ -36,9 +36,9 @@ module Facter
 
             file_content = Util::FileHelper.safe_read("/sys/class/dmi/id/#{fact_name}", nil)
             if files.include?(fact_name.to_s) && file_content
-              @fact_list[fact_name] = file_content.strip
+              file_content = file_content.strip
+              @fact_list[fact_name] = file_content unless file_content.empty?
               chassis_to_name(@fact_list[fact_name]) if fact_name == :chassis_type
-
             end
             @fact_list[fact_name]
           end

--- a/lib/facter/resolvers/networking_linux_resolver.rb
+++ b/lib/facter/resolvers/networking_linux_resolver.rb
@@ -59,9 +59,14 @@ module Facter
           return if !network_info[interface_name] || network_info[interface_name][:dhcp]
 
           index = tokens[0].delete(':')
-          dhcp = Util::FileHelper.safe_read("/run/systemd/netif/leases/#{index}", nil)
-          network_info[interface_name][:dhcp] = dhcp.match(/SERVER_ADDRESS=(.*)/)[1] if dhcp
-          network_info[interface_name][:dhcp] ||= retrieve_from_other_directories(interface_name)
+          file_content = Util::FileHelper.safe_read("/run/systemd/netif/leases/#{index}", nil)
+          dhcp = file_content.match(/SERVER_ADDRESS=(.*)/) if file_content
+          if dhcp
+            network_info[interface_name][:dhcp] = dhcp[1]
+          else
+            alternate_dhcp = retrieve_from_other_directories(interface_name)
+            network_info[interface_name][:dhcp] = alternate_dhcp if alternate_dhcp
+          end
         end
 
         def retrieve_from_other_directories(interface_name)
@@ -75,7 +80,8 @@ module Facter
               content = Util::FileHelper.safe_read("#{dir}#{file}", nil)
               next unless content =~ /interface.*#{interface_name}/
 
-              return content.match(/dhcp-server-identifier ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/)[1]
+              dhcp = content.match(/dhcp-server-identifier ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/)
+              return dhcp[1] if dhcp
             end
           end
           return unless File.readable?('/var/lib/NetworkManager/')

--- a/spec/facter/resolvers/dmi_resolver_spec.rb
+++ b/spec/facter/resolvers/dmi_resolver_spec.rb
@@ -61,6 +61,15 @@ describe Facter::Resolvers::Linux::DmiBios do
       end
     end
 
+    context 'when board_asset_tag file exists but is empty' do
+      let(:file_content) { "\n" }
+      let(:file) { 'board_asset_tag' }
+
+      it 'returns board_manufacturer' do
+        expect(resolver.resolve(:board_asset_tag)).to be(nil)
+      end
+    end
+
     context 'when board_name file exists' do
       let(:file_content) { '440BX Desktop Reference Platform' }
       let(:file) { 'board_name' }

--- a/spec/facter/resolvers/networking_linux_resolver_spec.rb
+++ b/spec/facter/resolvers/networking_linux_resolver_spec.rb
@@ -172,7 +172,6 @@ describe Facter::Resolvers::NetworkingLinux do
             bindings6: [
               { address: '::1', netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', network: '::1' }
             ],
-            dhcp: nil,
             ip: '127.0.0.1',
             ip6: '::1',
             mtu: 65_536,
@@ -190,7 +189,6 @@ describe Facter::Resolvers::NetworkingLinux do
             bindings6: [
               { address: 'fe80::250:56ff:fe9a:8481', netmask: 'ffff:ffff:ffff:ffff::', network: 'fe80::' }
             ],
-            dhcp: nil,
             ip: '10.16.119.155',
             ip6: 'fe80::250:56ff:fe9a:8481',
             mac: '00:50:56:9a:61:46',


### PR DESCRIPTION
When the dhcp and dmi.board_asset_tag facts aren't found, they are displayed as nil.
After this fix, if those facts are not found, they are not displayed at all.
