### PR TITLE
(maint) Fix virtual_detector

### DIFF
--- a/lib/facter/facts_utils/virtual_detector.rb
+++ b/lib/facter/facts_utils/virtual_detector.rb
@@ -22,7 +22,7 @@ module Facter
       @log.debug('Checking DMI')
       vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
       @log.debug("dmi detected vendor: #{vendor}")
-      return 'aws' if vendor =~ /Amazon/
+      return 'kvm' if vendor =~ /Amazon/
 
       'xen' if vendor =~ /Xen/
     end

--- a/spec/facter/facts_utils/virtual_detector_spec.rb
+++ b/spec/facter/facts_utils/virtual_detector_spec.rb
@@ -46,7 +46,7 @@ describe Facter::VirtualDetector do
         end
 
         it 'returns vendor' do
-          expect(detector.platform).to eq('aws')
+          expect(detector.platform).to eq('kvm')
         end
       end
 


### PR DESCRIPTION
When we detect Amazon as vendor using `dmidecode` we can conclude that the hypervisor is `kvm` because when it is `xen`, the vendor is `Xen`

As the `virtual_detector` is used in virtual fact, we should return the hypervisor instead of the cloud provider.