### PR TITLE
(FACT-2811)part 1. Fixed solaris virtual, is_virtual tests, options_store an…

### DIFF
--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -25,6 +25,7 @@ module Facter
     @ttls = []
     @color = true
     @timing = false
+    @strict = false
 
     class << self
       attr_reader :debug, :verbose, :log_level, :show_legacy,
@@ -165,6 +166,7 @@ module Facter
         @cli = nil
         @cache = true
         @trace = false
+        @color = true
         reset_config
       end
 
@@ -173,6 +175,7 @@ module Facter
         @custom_facts = true
         @external_dir = []
         @default_external_dir = []
+        @config_file_custom_dir = []
         @config_file_external_dir = []
         @external_facts = true
         @blocked_facts = []

--- a/lib/facter/resolvers/solaris/dmi.rb
+++ b/lib/facter/resolvers/solaris/dmi.rb
@@ -37,6 +37,8 @@ module Facter
 
             output = exec_smbios(param[0])
             facts = param[1]
+            return unless output
+
             facts.each do |name, regx|
               @fact_list[name] = output.match(/#{regx}/)&.captures&.first
             end

--- a/spec/facter/facts/solaris/is_virtual_spec.rb
+++ b/spec/facter/facts/solaris/is_virtual_spec.rb
@@ -5,6 +5,7 @@ describe Facts::Solaris::IsVirtual do
     subject(:fact) { Facts::Solaris::IsVirtual.new }
 
     let(:processor) { 'i386' }
+    let(:logger_double) { instance_spy(Facter::Log) }
 
     before do
       allow(Facter::Resolvers::Uname).to receive(:resolve).with(:processor).and_return(processor)
@@ -25,16 +26,33 @@ describe Facts::Solaris::IsVirtual do
         allow(Facter::Resolvers::Solaris::Dmi).to receive(:resolve).with(:product_name).and_return('unkown')
         allow(Facter::Resolvers::Solaris::Dmi).to receive(:resolve).with(:bios_vendor).and_return('unkown')
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
       end
 
-      it 'returns is_virtual fact as physical' do
+      it 'returns is_virtual fact as false' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'is_virtual', value: vm)
       end
     end
 
-    context 'when ldom hypervisor is found' do
+    context 'when Ldom role_control is false, ldom hypervisor is found' do
       let(:vm) { true }
+      let(:role_control) { 'false' }
+
+      before do
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_impl).and_return(vm)
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_control).and_return(role_control)
+      end
+
+      it 'returns is_virtual fact as true' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'is_virtual', value: vm)
+      end
+    end
+
+    context 'when Ldom role_control is true' do
+      let(:role_control) { 'true' }
+      let(:vm) { false }
       let(:current_zone_name) { 'global' }
 
       before do
@@ -44,25 +62,14 @@ describe Facts::Solaris::IsVirtual do
           .and_return(current_zone_name)
         allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_impl).and_return(vm)
         allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_control).and_return(role_control)
+        allow(Facter::Resolvers::Solaris::Dmi).to receive(:resolve).with(:product_name).and_return(nil)
+        allow(Facter::Resolvers::Solaris::Dmi).to receive(:resolve).with(:bios_vendor).and_return(nil)
+        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
       end
 
-      context 'when role_control is false' do
-        let(:role_control) { 'false' }
-
-        it 'returns virtual fact as physical' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'is_virtual', value: vm)
-        end
-      end
-
-      context 'when role_control is true' do
-        let(:role_control) { 'true' }
-        let(:vm) { false }
-
-        it 'returns is_virtual fact as physical' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'is_virtual', value: vm)
-        end
+      it 'returns is_virtual fact as false' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'is_virtual', value: vm)
       end
     end
 
@@ -111,6 +118,7 @@ describe Facts::Solaris::IsVirtual do
         allow(Facter::Resolvers::Solaris::ZoneName).to receive(:resolve).with(:current_zone_name).and_return(vm)
         allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_impl).and_return(nil)
         allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_control).and_return(nil)
+        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
       end
 
       context 'when processor is i386' do

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -6,7 +6,7 @@ describe Facter::Resolvers::Partitions do
   let(:sys_block_path) { '/sys/block' }
   let(:sys_block_subdirs) { ['.', '..', 'sda'] }
 
-  after do
+  before do
     Facter::Resolvers::Partitions.invalidate_cache
   end
 
@@ -145,7 +145,7 @@ describe Facter::Resolvers::Partitions do
           { '/dev/sys/block/sda' => { backing_file: 'some_path', size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
-        it 'return partitions fact' do
+        it 'returns partitions fact' do
           expect(resolver.resolve(:partitions)).to eq(partitions)
         end
       end
@@ -155,7 +155,7 @@ describe Facter::Resolvers::Partitions do
           { '/dev/sys/block/sda' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
-        it 'return partitions fact' do
+        it 'returns partitions fact' do
           allow(Facter::Util::FileHelper).to receive(:safe_read)
             .with("#{sys_block_path}/sda/loop/backing_file").and_return('')
 

--- a/spec/facter/resolvers/windows/virtualization_resolver_spec.rb
+++ b/spec/facter/resolvers/windows/virtualization_resolver_spec.rb
@@ -11,13 +11,10 @@ describe Facter::Resolvers::Virtualization do
     allow(win).to receive(:exec_query).with('SELECT Manufacturer,Model,OEMStringArray FROM Win32_ComputerSystem')
                                       .and_return(query_result)
     Facter::Resolvers::Virtualization.instance_variable_set(:@log, logger)
+    Facter::Resolvers::Virtualization.invalidate_cache
   end
 
   describe '#resolve VirtualBox' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -47,10 +44,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve Vmware' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -71,10 +64,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve KVM' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -95,10 +84,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve Openstack VM' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -119,10 +104,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve Microsoft VM' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -143,10 +124,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve Xen VM' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -167,10 +144,6 @@ describe Facter::Resolvers::Virtualization do
   end
 
   describe '#resolve Amazon EC2 VM' do
-    after do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     before do
       allow(win32ole).to receive(:Model).and_return(model)
       allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
@@ -214,19 +187,19 @@ describe Facter::Resolvers::Virtualization do
     let(:query_result) { nil }
 
     it 'detects virtual machine model' do
+      Facter::Resolvers::Virtualization.instance_variable_set(:@fact_list, { virtual: 'physical' })
+
       expect(Facter::Resolvers::Virtualization.resolve(:virtual)).to eql('physical')
     end
 
     it 'detects that is virtual' do
+      Facter::Resolvers::Virtualization.instance_variable_set(:@fact_list, { is_virtual: false })
+
       expect(Facter::Resolvers::Virtualization.resolve(:is_virtual)).to be(false)
     end
   end
 
   describe '#resolve  when WMI query returns nil' do
-    before do
-      Facter::Resolvers::Virtualization.invalidate_cache
-    end
-
     let(:query_result) { nil }
 
     it 'logs that query failed and virtual nil' do
@@ -243,7 +216,6 @@ describe Facter::Resolvers::Virtualization do
 
   describe '#resolve when WMI query returns nil for Model and Manufacturer' do
     before do
-      Facter::Resolvers::Virtualization.invalidate_cache
       allow(win32ole).to receive(:Model).and_return(nil)
       allow(win32ole).to receive(:Manufacturer).and_return(nil)
       allow(win32ole).to receive(:OEMStringArray).and_return('')

--- a/spec/facter/util/file_helper_spec.rb
+++ b/spec/facter/util/file_helper_spec.rb
@@ -9,15 +9,12 @@ describe Facter::Util::FileHelper do
     "Facter::Util::FileHelper - #{Facter::CYAN}File at: /Users/admin/file.txt is not accessible.#{Facter::RESET}"
   end
   let(:array_content) { ['line 1', 'line 2', 'line 3'] }
-  let(:logger_double) { instance_spy(Logger) }
+  let(:logger_double) { instance_spy(Facter::Log) }
 
   before do
     Facter::Log.class_variable_set(:@@logger, logger_double)
     allow(Facter).to receive(:debugging?).and_return(true)
-  end
-
-  after do
-    Facter::Log.class_variable_set(:@@logger, Logger.new(STDOUT))
+    allow(Facter::OptionStore).to receive(:color).and_return(true)
   end
 
   shared_context 'when file is readable' do

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -37,7 +37,8 @@ describe Facter::OptionStore do
         color: true,
         trace: false,
         timing: false,
-        ttls: []
+        ttls: [],
+        strict: false
       )
     end
   end
@@ -255,7 +256,13 @@ describe Facter::OptionStore do
   end
 
   describe '#debug' do
+    before do
+      allow(Facter::Log).to receive(:level=).with(level)
+    end
+
     context 'when true' do
+      let(:level) { :debug }
+
       it 'sets debug to true and log_level to :debug' do
         expect do
           option_store.debug = true
@@ -265,6 +272,8 @@ describe Facter::OptionStore do
     end
 
     context 'when false' do
+      let(:level) { :warn }
+
       it 'sets log_level to default (:warn)' do
         option_store.instance_variable_set(:@log_level, :info)
 
@@ -277,7 +286,13 @@ describe Facter::OptionStore do
   end
 
   describe '#verbose=' do
+    before do
+      allow(Facter::Log).to receive(:level=).with(level)
+    end
+
     context 'when true' do
+      let(:level) { :info }
+
       it 'sets log_level to :info' do
         expect do
           option_store.verbose = true
@@ -287,6 +302,8 @@ describe Facter::OptionStore do
     end
 
     context 'when false' do
+      let(:level) { :warn }
+
       it 'sets log_level to default (:warn)' do
         option_store.instance_variable_set(:@log_level, :debug)
 
@@ -379,6 +396,10 @@ describe Facter::OptionStore do
   end
 
   describe '#reset' do
+    before do
+      allow(Facter::Log).to receive(:level=).with(:debug)
+    end
+
     it 'resets to default' do
       default = option_store.all
 

--- a/spec/framework/detector/os_detector_spec.rb
+++ b/spec/framework/detector/os_detector_spec.rb
@@ -5,12 +5,17 @@ require 'rbconfig'
 describe OsDetector do
   let(:os_hierarchy) { instance_spy(Facter::OsHierarchy) }
   let(:logger) { instance_spy(Facter::Log) }
+  let(:initial_os) { RbConfig::CONFIG['host_os'] }
 
   before do
+    RbConfig::CONFIG['host_os'] = initial_os
     Singleton.__init__(OsDetector)
-
     allow(Facter::Log).to receive(:new).and_return(logger)
     allow(Facter::OsHierarchy).to receive(:new).and_return(os_hierarchy)
+  end
+
+  after do
+    RbConfig::CONFIG['host_os'] = initial_os
   end
 
   describe 'initialize' do


### PR DESCRIPTION
This PR fixes some unit tests that fail when running them with rspec --order random.
 - added config_file_custom_dir and color to reset. Added strict to default options.
- refactored solaris is_virtual and virtual unit tests and added missing mock.
- Fixed test cleanup for windows virtualization and how the session cache is tested.
- Reset RbConfig::CONFIG['host_os'] after each test