### PR TITLE
(maint) Revert facter -p until we upgrade modules that use facter -p.

### DIFF
--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -79,6 +79,11 @@ module Facter
                  type: :boolean,
                  desc: 'Show legacy facts when querying all facts.'
 
+    class_option :puppet,
+                 type: :boolean,
+                 aliases: '-p',
+                 desc: 'Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.'
+
     class_option :yaml,
                  aliases: '-y',
                  type: :boolean,
@@ -150,12 +155,6 @@ module Facter
       cache_groups.gsub!(/:\s*\n/, "\n")
 
       puts cache_groups
-    end
-
-    desc '--puppet, -p', '(NOT SUPPORTED)Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.'
-    map ['--puppet', '-p'] => :puppet
-    def puppet(*_args)
-      puts '`facter --puppet` and `facter -p` are no longer supported, use `puppet facts show` instead'
     end
 
     desc 'help', 'Help for all arguments'


### PR DESCRIPTION
There are still modules that depend on `facter -p` e.g https://github.com/puppetlabs/puppetlabs-facts/blob/master/tasks/ruby.rb . We should change these modules to use `puppet facts show` and only after we upgrade them, remove `-p` from facter.