### PR TITLE
(FACT-2832) Use full path for augparse command 

### DIFF
--- a/lib/facter/resolvers/augeas_resolver.rb
+++ b/lib/facter/resolvers/augeas_resolver.rb
@@ -20,7 +20,13 @@ module Facter
         end
 
         def read_augeas_from_cli
-          output = Facter::Core::Execution.execute('augparse --version 2>&1', logger: log)
+          command = if File.readable?('/opt/puppetlabs/puppet/bin/augparse')
+                      '/opt/puppetlabs/puppet/bin/augparse'
+                    else
+                      'augparse'
+                    end
+
+          output = Facter::Core::Execution.execute("#{command} --version 2>&1", logger: log)
           Regexp.last_match(1) if output =~ /^augparse (\d+\.\d+\.\d+)/
         end
 

--- a/spec/facter/resolvers/augeas_resolver_spec.rb
+++ b/spec/facter/resolvers/augeas_resolver_spec.rb
@@ -4,9 +4,11 @@ describe Facter::Resolvers::Augeas do
   subject(:augeas) { Facter::Resolvers::Augeas }
 
   let(:log_spy) { instance_spy(Facter::Log) }
+  let(:readable) { false }
 
   before do
     augeas.instance_variable_set(:@log, log_spy)
+    allow(File).to receive(:readable?).with('/opt/puppetlabs/puppet/bin/augparse').and_return(readable)
   end
 
   after do
@@ -17,6 +19,20 @@ describe Facter::Resolvers::Augeas do
     before do
       allow(Facter::Core::Execution).to receive(:execute)
         .with('augparse --version 2>&1', logger: log_spy)
+        .and_return('augparse 1.12.0 <http://augeas.net/>')
+    end
+
+    it 'returns build' do
+      expect(augeas.resolve(:augeas_version)).to eq('1.12.0')
+    end
+  end
+
+  context 'when augparse is installed with puppet-agent package on unix based systems' do
+    let(:readable) { true }
+
+    before do
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('/opt/puppetlabs/puppet/bin/augparse --version 2>&1', logger: log_spy)
         .and_return('augparse 1.12.0 <http://augeas.net/>')
     end
 


### PR DESCRIPTION
**Description of the problem:** On unix like systems and linux operating systems, the call: `::Augeas.open` is very time consuming. Also `augparse` command is not found because the puppet directories are not in path.
**Description of the fix:** On unix like and linux systems, call augparse with the full path and avoid calling the method `::Augeas.open`.

**Note:** Augeas is shipped in puppet-agent packages except Windows ones (that's is why this change is not affecting Windows behaviour)