### PR TITLE
(FACT-2827) Reset ttls settings on OptionStore reset

### DIFF
--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -22,6 +22,7 @@ module Facter
     @user_query = []
     @block_list = {}
     @fact_groups = {}
+    @ttls = []
     @color = true
     @timing = false
 
@@ -177,6 +178,7 @@ module Facter
         @blocked_facts = []
         @fact_groups = {}
         @block_list = {}
+        @ttls = []
         @timing = false
       end
 

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -36,7 +36,8 @@ describe Facter::OptionStore do
         cache: true,
         color: true,
         trace: false,
-        timing: false
+        timing: false,
+        ttls: []
       )
     end
   end


### PR DESCRIPTION
Unit tests were failing when facter.conf contained ttls settings.