### PR TITLE
(maint) update maintainability and test coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Modules Status](https://github.com/puppetlabs/facter/workflows/Acceptance%20tests/badge.svg?branch=main)](https://github.com/puppetlabs/facter/actions)
 [![Modules Status](https://github.com/puppetlabs/facter/workflows/Unit%20tests/badge.svg?branch=main)](https://github.com/puppetlabs/facter/actions)
 [![Modules Status](https://github.com/puppetlabs/facter/workflows/Checks/badge.svg?branch=main)](https://github.com/puppetlabs/facter/actions)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/bf43445f767f2d64170a/test_coverage)](https://codeclimate.com/github/puppetlabs/facter/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/bf43445f767f2d64170a/maintainability)](https://codeclimate.com/github/puppetlabs/facter/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/3bd4be86f4b0b49bc0ca/test_coverage)](https://codeclimate.com/github/puppetlabs/facter/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/3bd4be86f4b0b49bc0ca/maintainability)](https://codeclimate.com/github/puppetlabs/facter/maintainability)
 
 
 Facter is a command-line tool that gathers basic facts about nodes (systems) such as hardware details, network settings, OS type and version, and more. These facts are made available as variables in your Puppet manifests and can be used to inform conditional expressions in Puppet.


### PR DESCRIPTION
After moving from facter-ng to facter repo, the code coverage and maintainability badges stopped working.
This PR updates the link to the badges