### PR TITLE
(FACT-2829) Fixed partitions and mount points facts

### DIFF
--- a/lib/facter/resolvers/mountpoints_resolver.rb
+++ b/lib/facter/resolvers/mountpoints_resolver.rb
@@ -16,7 +16,21 @@ module Facter
         def root_device
           cmdline = Util::FileHelper.safe_read('/proc/cmdline')
           match = cmdline.match(/root=([^\s]+)/)
-          match&.captures&.first
+          root = match&.captures&.first
+
+          if !root.nil? && root.include?('=')
+            # We are dealing with the PARTUUID of the partition. Need to extract partition path.
+            root_partition_path = convert_partuuid_to_path(root)
+            root = root_partition_path unless root_partition_path.nil?
+          end
+          root
+        end
+
+        def convert_partuuid_to_path(root)
+          blkid_content = Facter::Core::Execution.execute('blkid', logger: log)
+          partuuid = root.split('=').last
+          match = blkid_content.match(/(.+)#{partuuid}/)
+          match&.captures&.first&.split(':')&.first
         end
 
         def compute_device(device)
@@ -26,36 +40,47 @@ module Facter
           device
         end
 
-        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def read_mounts(fact_name)
           mounts = []
-          FilesystemHelper.read_mountpoints.each do |fs|
-            device = compute_device(fs.name)
-            filesystem = fs.mount_type
-            path = fs.mount_point
-            options = fs.options.split(',').map(&:strip)
+          FilesystemHelper.read_mountpoints.each do |file_system|
+            mount = {}
+            get_mount_data(file_system, mount)
 
-            next if path =~ %r{^/(proc|sys)} && filesystem != 'tmpfs' || filesystem == 'autofs'
+            next if mount[:path] =~ %r{^/(proc|sys)} && mount[:filesystem] != 'tmpfs' || mount[:filesystem] == 'autofs'
 
-            stats = FilesystemHelper.read_mountpoint_stats(path)
-            size_bytes = stats.bytes_total.abs
-            available_bytes = stats.bytes_available.abs
-
-            used_bytes = stats.bytes_used.abs
-            total_bytes = used_bytes + available_bytes
-            capacity = FilesystemHelper.compute_capacity(used_bytes, total_bytes)
-
-            size = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(size_bytes)
-            available = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(available_bytes)
-            used = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(used_bytes)
-
-            mounts << Hash[FilesystemHelper::MOUNT_KEYS.zip(FilesystemHelper::MOUNT_KEYS
-              .map { |v| binding.local_variable_get(v) })]
+            get_mount_sizes(mount)
+            mounts << mount
           end
+
           @fact_list[:mountpoints] = mounts
           @fact_list[fact_name]
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+        def get_mount_data(file_system, mount)
+          mount[:device] = compute_device(file_system.name)
+          mount[:filesystem] = file_system.mount_type
+          mount[:path] = file_system.mount_point
+          mount[:options] = file_system.options.split(',').map(&:strip)
+        end
+
+        def get_mount_sizes(mount)
+          stats = FilesystemHelper.read_mountpoint_stats(mount[:path])
+
+          get_bytes_data(mount, stats)
+
+          total_bytes = mount[:used_bytes] + mount[:available_bytes]
+          mount[:capacity] = FilesystemHelper.compute_capacity(mount[:used_bytes], total_bytes)
+
+          mount[:size] = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(mount[:size_bytes])
+          mount[:available] = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(mount[:available_bytes])
+          mount[:used] = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(mount[:used_bytes])
+        end
+
+        def get_bytes_data(mount, stats)
+          mount[:size_bytes] = stats.bytes_total.abs
+          mount[:available_bytes] = stats.bytes_available.abs
+          mount[:used_bytes] = stats.bytes_used.abs
+        end
       end
     end
   end

--- a/lib/facter/resolvers/partitions.rb
+++ b/lib/facter/resolvers/partitions.rb
@@ -26,9 +26,9 @@ module Facter
             if File.directory?("#{block_path}/device")
               extract_from_device(block_path, blkid_and_lsblk)
             elsif File.directory?("#{block_path}/dm")
-              extract_from_dm(block_path, blkid_and_lsblk)
+              extract_from_dm(block_path, block_device, blkid_and_lsblk)
             elsif File.directory?("#{block_path}/loop")
-              extract_from_loop(block_path, blkid_and_lsblk)
+              extract_from_loop(block_path, block_device, blkid_and_lsblk)
             end
           end
 
@@ -43,21 +43,21 @@ module Facter
           end
         end
 
-        def extract_from_dm(block_path, blkid_and_lsblk)
+        def extract_from_dm(block_path, block_device, blkid_and_lsblk)
           map_name = Util::FileHelper.safe_read("#{block_path}/dm/name").chomp
           if map_name.empty?
-            populate_partitions("/dev#{block_path}", block_path, blkid_and_lsblk)
+            populate_partitions("/dev/#{block_device}", block_path, blkid_and_lsblk)
           else
             populate_partitions("/dev/mapper/#{map_name}", block_path, blkid_and_lsblk)
           end
         end
 
-        def extract_from_loop(block_path, blkid_and_lsblk)
+        def extract_from_loop(block_path, block_device, blkid_and_lsblk)
           backing_file = Util::FileHelper.safe_read("#{block_path}/loop/backing_file").chomp
           if backing_file.empty?
-            populate_partitions("/dev#{block_path}", block_path, blkid_and_lsblk)
+            populate_partitions("/dev/#{block_device}", block_path, blkid_and_lsblk)
           else
-            populate_partitions("/dev#{block_path}", block_path, blkid_and_lsblk, backing_file)
+            populate_partitions("/dev/#{block_device}", block_path, blkid_and_lsblk, backing_file)
           end
         end
 

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -126,7 +126,7 @@ describe Facter::Resolvers::Partitions do
 
       context 'when device name file is not readable' do
         let(:partitions) do
-          { '/dev/sys/block/sda' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
+          { '/dev/sda' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
         before do
@@ -154,7 +154,7 @@ describe Facter::Resolvers::Partitions do
 
       context 'when backing_file is readable' do
         let(:partitions) do
-          { '/dev/sys/block/sda' => { backing_file: 'some_path', size: '98.25 MiB', size_bytes: 103_021_056 } }
+          { '/dev/sda' => { backing_file: 'some_path', size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
         it 'returns partitions fact' do
@@ -164,7 +164,7 @@ describe Facter::Resolvers::Partitions do
 
       context 'when backing_file is not readable' do
         let(:partitions) do
-          { '/dev/sys/block/sda' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
+          { '/dev/sda' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
         before do

--- a/spec/fixtures/blkid_output_root_has_partuuid
+++ b/spec/fixtures/blkid_output_root_has_partuuid
@@ -1,0 +1,6 @@
+/dev/xvda1: LABEL="cloudimg-rootfs" UUID="f387d281-b162-4d60-84b5-e7e94687e6b8" TYPE="ext4" PARTUUID="a2f52878-01"
+/dev/loop0: TYPE="squashfs"
+/dev/loop1: TYPE="squashfs"
+/dev/loop2: TYPE="squashfs"
+/dev/loop3: TYPE="squashfs"
+/dev/loop4: TYPE="squashfs"

--- a/spec/fixtures/cmdline_root_device_partuuid
+++ b/spec/fixtures/cmdline_root_device_partuuid
@@ -1,0 +1,1 @@
+BOOT_IMAGE=/boot/vmlinuz-5.4.0-1024-aws root=PARTUUID=a2f52878-01 ro console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 panic=-1


### PR DESCRIPTION
**Problem:** 
On ubuntu 20.04, amazon vm, the partitions paths were detected as '/dev/sys/block/<name>'
instead of '/dev/<name>'.
The root partition was detected by it's PARTUUID instead of it's path.
**Fix:**
'sys/block' is not added to the partitions path if it's data is extracted from '/sys/block/<name>/dm', or
'/sys/block/<name>/loop' folders.
If /proc/cmdline returns the root partition's PARTUUID then, if possible, we make an extra call to blkid to get it's path.
