### PR TITLE
(FACT-2834) Dinamically get AIX proc number

### DIFF
--- a/lib/facter/resolvers/aix/architecture_resolver.rb
+++ b/lib/facter/resolvers/aix/architecture_resolver.rb
@@ -14,9 +14,11 @@ module Facter
 
         def read_architecture(fact_name)
           require_relative 'utils/odm_query'
+
+          proc_number = read_proc
           odmquery = ODMQuery.new
           odmquery
-            .equals('name', 'proc0')
+            .equals('name', proc_number)
             .equals('attribute', 'type')
 
           result = odmquery.execute
@@ -31,6 +33,18 @@ module Facter
           end
 
           @fact_list[fact_name]
+        end
+
+        def read_proc
+          odmquery = ODMQuery.new
+          odmquery
+            .equals('PdDvLn', 'processor/sys/proc_rspc')
+            .equals('status', '1')
+
+          result = odmquery.execute
+          result.each_line do |line|
+            return line.split('=')[1].strip.delete('\"') if line.include?('name')
+          end
         end
       end
     end

--- a/spec/facter/resolvers/aix/architecture_resolver_spec.rb
+++ b/spec/facter/resolvers/aix/architecture_resolver_spec.rb
@@ -3,12 +3,17 @@
 describe Facter::Resolvers::Architecture do
   describe '#resolve' do
     before do
-      odm = double('ODMQuery')
+      odm1 = instance_double(Facter::ODMQuery)
+      odm2 = instance_double(Facter::ODMQuery)
 
-      allow(Facter::ODMQuery).to receive(:new).and_return(odm)
-      allow(odm).to receive(:equals).with('name', 'proc0').and_return(odm)
-      allow(odm).to receive(:equals).with('attribute', 'type')
-      allow(odm).to receive(:execute).and_return(result)
+      allow(Facter::ODMQuery).to receive(:new).and_return(odm1, odm2)
+      allow(odm1).to receive(:equals).with('PdDvLn', 'processor/sys/proc_rspc').and_return(odm1)
+      allow(odm1).to receive(:equals).with('status', '1').and_return(odm1)
+      allow(odm1).to receive(:execute).and_return('proc8')
+
+      allow(odm2).to receive(:equals).with('name', 'proc8').and_return(odm2)
+      allow(odm2).to receive(:equals).with('attribute', 'type').and_return(odm2)
+      allow(odm2).to receive(:execute).and_return(result)
     end
 
     after do


### PR DESCRIPTION
This PR fixes a problem that occurs when proc0 is deleted or not configured because the ODM query to read the architecture was hardcoded to use proc0. The fix was to read the which proc is available first, then query with it. 