### PR TITLE
(maint) Use strings instead of symbols for os names.

### DIFF
--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -5,16 +5,16 @@ module Facter
     unless defined?(OS_HIERARCHY)
       OS_HIERARCHY = [
         {
-          "Linux": [
+          'Linux' => [
             {
-              "Debian": %w[
+              'Debian' => %w[
                 Elementary
                 Ubuntu
                 Raspbian
               ]
             },
             {
-              "Rhel": %w[
+              'Rhel' => %w[
                 Fedora
                 Amzn
                 Centos
@@ -23,14 +23,14 @@ module Facter
               ]
             },
             {
-              "Sles": [
+              'Sles' => [
                 'Opensuse'
               ]
             }
           ]
         },
         {
-          "Bsd": [
+          'Bsd' => [
             'Freebsd'
           ]
         },


### PR DESCRIPTION
If symbols are used for os names, the matching is not done correctly and the os hierarchy cannot be detected.