### PR TITLE
(maint) Improve FreeBSD version detection

### DIFF
--- a/lib/facter/resolvers/freebsd/freebsd_version_resolver.rb
+++ b/lib/facter/resolvers/freebsd/freebsd_version_resolver.rb
@@ -14,10 +14,13 @@ module Facter
           end
 
           def freebsd_version_system_call(fact_name)
-            output = Facter::Core::Execution.execute('/bin/freebsd-version -kru', logger: log)
-            return if output.empty?
+            output = Facter::Core::Execution.execute('/bin/freebsd-version -k', logger: log)
 
-            build_fact_list(output)
+            @fact_list[:installed_kernel] = output.strip unless output.empty?
+
+            output = Facter::Core::Execution.execute('/bin/freebsd-version -ru', logger: log)
+
+            build_fact_list(output) unless output.empty?
 
             @fact_list[fact_name]
           end
@@ -25,9 +28,8 @@ module Facter
           def build_fact_list(output)
             freebsd_version_results = output.split("\n")
 
-            @fact_list[:installed_kernel]   = freebsd_version_results[0].strip
-            @fact_list[:running_kernel]     = freebsd_version_results[1].strip
-            @fact_list[:installed_userland] = freebsd_version_results[2].strip
+            @fact_list[:running_kernel]     = freebsd_version_results[0].strip
+            @fact_list[:installed_userland] = freebsd_version_results[1].strip
           end
         end
       end

--- a/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
@@ -5,10 +5,11 @@ describe Facter::Resolvers::Freebsd::FreebsdVersion do
 
   before do
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/bin/freebsd-version -kru', logger: freebsd_version.log)
-      .and_return('13.0-CURRENT
-        12.1-RELEASE-p3
-        12.0-STABLE')
+      .with('/bin/freebsd-version -k', logger: freebsd_version.log)
+      .and_return("13.0-CURRENT\n")
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('/bin/freebsd-version -ru', logger: freebsd_version.log)
+      .and_return("12.1-RELEASE-p3\n12.0-STABLE\n")
   end
 
   it 'returns installed kernel' do


### PR DESCRIPTION
`freebsd-version -k` returns the installed version of the installed kernel, but jails might have no kernel installed because they are running from the host's kernel.  In such a situation, freebsd-version fails — which is expected — but the other information we are interested in not gathered.

Rework the resolver so that freebsd-version is run twice, so that we can still gather the information of the running kernel and installed userland when no installed kernel is available.