### PR TITLE
(maint) Pass on_fail to execute_command

### DIFF
--- a/lib/facter/custom_facts/util/parser.rb
+++ b/lib/facter/custom_facts/util/parser.rb
@@ -150,7 +150,7 @@ module LegacyFacter
 
       class ScriptParser < Base
         def parse_results
-          stdout, stderr = Facter::Core::Execution.execute_command(quote(filename))
+          stdout, stderr = Facter::Core::Execution.execute_command(quote(filename), nil)
           log_stderr(stderr, filename, filename)
           parse_executable_output(stdout)
         end

--- a/spec/custom_facts/util/parser_spec.rb
+++ b/spec/custom_facts/util/parser_spec.rb
@@ -138,7 +138,7 @@ describe LegacyFacter::Util::Parser do
     let(:logger) { instance_spy(Facter::Log) }
 
     def expects_script_to_return(path, content, result, err = nil)
-      allow(Facter::Core::Execution).to receive(:execute_command).with(path).and_return([content, err])
+      allow(Facter::Core::Execution).to receive(:execute_command).with(path, nil).and_return([content, err])
       allow(File).to receive(:executable?).with(path).and_return(true)
       allow(FileTest).to receive(:file?).with(path).and_return(true)
 
@@ -180,7 +180,7 @@ describe LegacyFacter::Util::Parser do
 
     it 'handles Time correctly' do
       yaml_data = "---\nfirst: 2020-07-15 05:38:12.427678398 +00:00\n"
-      allow(Facter::Core::Execution).to receive(:execute_command).with(cmd).and_return([yaml_data, nil])
+      allow(Facter::Core::Execution).to receive(:execute_command).with(cmd, nil).and_return([yaml_data, nil])
       allow(File).to receive(:executable?).with(cmd).and_return(true)
       allow(FileTest).to receive(:file?).with(cmd).and_return(true)
 
@@ -194,7 +194,8 @@ describe LegacyFacter::Util::Parser do
     it 'quotes scripts with spaces' do
       path = "/h a s s p a c e s#{ext}"
 
-      expect(Facter::Core::Execution).to receive(:execute_command).with("\"#{path}\"").and_return([data_in_txt, nil])
+      expect(Facter::Core::Execution).to receive(:execute_command)
+        .with("\"#{path}\"", nil).and_return([data_in_txt, nil])
       expects_script_to_return(path, data_in_txt, data)
     end
 


### PR DESCRIPTION
Pass on_fail to execute_command, because with the current implementation, an empty hash is returned
when an error occurs.
