### PR TITLE
(FACT-2842) Fix ldom facts on Solaris

### DIFF
--- a/lib/facter/facts/solaris/hypervisors/ldom.rb
+++ b/lib/facter/facts/solaris/hypervisors/ldom.rb
@@ -11,6 +11,9 @@ module Facts
         end
 
         def call_the_resolver
+          chassis_serial = Facter::Resolvers::Solaris::Ldom.resolve(:chassis_serial)
+          return Facter::ResolvedFact.new(FACT_NAME, nil) if !chassis_serial || chassis_serial.empty?
+
           fact_value = %i[
             chassis_serial control_domain domain_name
             domain_uuid role_control role_io role_root role_service

--- a/lib/facter/facts/solaris/ldom.rb
+++ b/lib/facter/facts/solaris/ldom.rb
@@ -10,8 +10,11 @@ module Facts
       end
 
       def call_the_resolver
+        chassis_serial = resolve(:chassis_serial)
+        return Facter::ResolvedFact.new(FACT_NAME, nil) if !chassis_serial || chassis_serial.empty?
+
         fact_value = {
-          domainchassis: resolve(:chassis_serial),
+          domainchassis: chassis_serial,
           domaincontrol: resolve(:control_domain),
           domainname: resolve(:domain_name),
           domainrole: {

--- a/lib/facter/resolvers/solaris/ldom.rb
+++ b/lib/facter/resolvers/solaris/ldom.rb
@@ -36,8 +36,6 @@ module Facter
           end
 
           def call_virtinfo(fact_name)
-            # return unless File.executable?('/usr/sbin/virtinfo')
-
             virtinfo_output = Facter::Core::Execution.execute('/usr/sbin/virtinfo  -a  -p', logger: log)
             return if virtinfo_output.empty?
 

--- a/spec/facter/facts/solaris/hypervisors/ldom_spec.rb
+++ b/spec/facter/facts/solaris/hypervisors/ldom_spec.rb
@@ -56,18 +56,30 @@ describe Facts::Solaris::Hypervisors::Ldom do
       end
 
       context 'when role_control is false' do
-        let(:value) do
-          {
-            'chassis_serial' => nil,
-            'control_domain' => nil,
-            'domain_name' => nil,
-            'domain_uuid' => nil,
-            'role_control' => nil,
-            'role_io' => nil,
-            'role_root' => nil,
-            'role_service' => nil
-          }
+        let(:value) { nil }
+
+        it 'returns virtual fact as physical' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'hypervisors.ldom', value: value)
         end
+      end
+    end
+
+    context 'when ldom resolver returns empty string' do
+      before do
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:chassis_serial).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:control_domain).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:domain_name).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_control).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_impl).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_io).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_root).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_service).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:domain_uuid).and_return('')
+      end
+
+      context 'when role_control is false' do
+        let(:value) { nil }
 
         it 'returns virtual fact as physical' do
           expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \

--- a/spec/facter/facts/solaris/ldom_spec.rb
+++ b/spec/facter/facts/solaris/ldom_spec.rb
@@ -61,22 +61,30 @@ describe Facts::Solaris::Ldom do
       end
 
       context 'when role_control is false' do
-        let(:value) do
-          {
-            'domainchassis' => nil,
-            'domaincontrol' => nil,
-            'domainname' => nil,
-            'domainrole' =>
-            {
-              'control' => nil,
-              'impl' => nil,
-              'io' => nil,
-              'root' => nil,
-              'service' => nil
-            },
-            'domainuuid' => nil
-          }
+        let(:value) { nil }
+
+        it 'returns virtual fact as physical' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'ldom', value: value)
         end
+      end
+    end
+
+    context 'when ldom resolver returns empty string' do
+      before do
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:chassis_serial).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:control_domain).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:domain_name).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_control).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_impl).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_io).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_root).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:role_service).and_return('')
+        allow(Facter::Resolvers::Solaris::Ldom).to receive(:resolve).with(:domain_uuid).and_return('')
+      end
+
+      context 'when role_control is false' do
+        let(:value) { nil }
 
         it 'returns virtual fact as physical' do
           expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \


### PR DESCRIPTION
**Description of the problem:** ldom and hypervisors.ldom facts are displayed even if they are empty
**Description of the fix:** A check was added to avoid showing the facts when they are nil.