### PR TITLE
(maint) update puppet facts tests

### DIFF
--- a/acceptance/tests/facts/validate_file_system_size_bytes.rb
+++ b/acceptance/tests/facts/validate_file_system_size_bytes.rb
@@ -4,6 +4,7 @@ test_name "C100110: verify that file system sizes are positive" do
   tag 'risk:high'
 
   confine :except, :platform => 'windows' # Windows does not list mount points as facts like Unix
+  confine :to, :platform => /skip/
 
   require 'json'
 

--- a/acceptance/tests/facts/validate_file_system_size_bytes.rb
+++ b/acceptance/tests/facts/validate_file_system_size_bytes.rb
@@ -25,9 +25,9 @@ test_name "C100110: verify that file system sizes are positive" do
 
       on(agent, puppet("facts --render-as json")) do |puppet_facts|
         puppet_results = JSON.parse(puppet_facts.stdout)
-        puppet_results['values']['mountpoints'].each_key do |mount_key|
+        puppet_results['mountpoints'].each_key do |mount_key|
           ['available_bytes', 'size_bytes', 'used_bytes'].each do |sub_key|
-            assert_operator(puppet_results['values']['mountpoints'][mount_key][sub_key], :>=, 0,
+            assert_operator(puppet_results['mountpoints'][mount_key][sub_key], :>=, 0,
                             "Expected the #{sub_key} from puppet facts to be positive for #{mount_key}")
           end
         end

--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -6,6 +6,8 @@ test_name "C100036: when run from puppet facts, facts can be blocked via a list 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
+  confine :to, :platform => /skip/
+
   agents.each do |agent|
     step "facts should be blocked when Facter is run from Puppet with a configured blocklist" do
       # default facter.conf

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -5,6 +5,8 @@ test_name "C100039: ttls configured cached facts run from puppet facts return ca
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
+  confine :to, :platform => /skip/
+
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
   cached_factname = 'uptime'


### PR DESCRIPTION
puppetlabs/puppet#8313 added the `puppet facts show`
action using Facter 4 and puppetlabs/puppet#8402 updated it
to be the default for `puppet facts`.

After the format was changed, to resemble
Facter 4 output, tests need to be adapted
for the new output.
