### PR TITLE
(FACT-2839) Added extra check for TTLS keys

### DIFF
--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -10,7 +10,7 @@ module Facter
     end
 
     def resolve_facts(searched_facts)
-      return searched_facts, [] if !File.directory?(@cache_dir) || !Options[:cache]
+      return searched_facts, [] if (!File.directory?(@cache_dir) || !Options[:cache]) && Options[:ttls].any?
 
       facts = []
       searched_facts.delete_if do |fact|
@@ -27,7 +27,7 @@ module Facter
     end
 
     def cache_facts(resolved_facts)
-      return unless Options[:cache]
+      return unless Options[:cache] && Options[:ttls].any?
 
       resolved_facts.each do |fact|
         cache_fact(fact)

--- a/spec/facter/cache_manager_spec.rb
+++ b/spec/facter/cache_manager_spec.rb
@@ -33,6 +33,7 @@ describe Facter::CacheManager do
     allow(Facter::FactGroups).to receive(:new).and_return(fact_groups)
     allow(Facter::Options).to receive(:[]).with(:debug).and_return(false)
     allow(Facter::Options).to receive(:[])
+    allow(Facter::Options).to receive(:[]).with(:ttls).and_return([])
   end
 
   describe '#resolve_facts' do
@@ -40,6 +41,7 @@ describe Facter::CacheManager do
       before do
         allow(File).to receive(:directory?).with(cache_dir).and_return(false)
         allow(Facter::Options).to receive(:[]).with(:cache).and_return(true)
+        allow(Facter::Options).to receive(:[]).with(:ttls).and_return(['fact'])
       end
 
       it 'returns searched facts' do
@@ -57,6 +59,7 @@ describe Facter::CacheManager do
       before do
         allow(File).to receive(:directory?).with(cache_dir).and_return(true)
         allow(Facter::Options).to receive(:[]).with(:cache).and_return(false)
+        allow(Facter::Options).to receive(:[]).with(:ttls).and_return(['fact'])
       end
 
       it 'returns searched facts' do
@@ -192,6 +195,7 @@ describe Facter::CacheManager do
         allow(File).to receive(:readable?).with(cache_file_name).and_return(false)
         allow(File).to receive(:write).with(cache_file_name, cached_core_fact)
         allow(Facter::Options).to receive(:[]).with(:cache).and_return(true)
+        allow(Facter::Options).to receive(:[]).with(:ttls).and_return(['fact'])
       end
 
       it 'caches fact' do


### PR DESCRIPTION
This extra check helps in optimising the cache mechanism in order not to check wether a fact needs to be cached unless facts or groups are defined in facter.conf