### PR TITLE
(maint) Fix puppet facts acceptance tests

### DIFF
--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -6,8 +6,6 @@ test_name "C100036: when run from puppet facts, facts can be blocked via a list 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
-  confine :to, :platform => /skip/
-
   agents.each do |agent|
     step "facts should be blocked when Facter is run from Puppet with a configured blocklist" do
       # default facter.conf

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -5,8 +5,6 @@ test_name "C100039: ttls configured cached facts run from puppet facts return ca
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
-  confine :to, :platform => /skip/
-
   # This fact must be resolvable on ALL platforms
   # Do NOT use the 'kernel' fact as it is used to configure the tests
   cached_factname = 'uptime'

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -339,13 +339,15 @@ module Facter
     # @param options [Hash] parameters for the fact - attributes
     #   of {Facter::Util::Fact} and {Facter::Util::Resolution} can be
     #   supplied here
-    # @param user_queries [String] the fact names
+    # @param user_queries [Array] the fact names
     #
     # @return [FactCollection] hash with fact names and values
     #
     # @api public
     def values(options, user_queries)
       init_cli_options(options, user_queries)
+      Options[:show_legacy] = true
+      log_blocked_facts
       resolved_facts = Facter::FactManager.instance.resolve_facts(user_queries)
 
       if user_queries.count.zero?

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -300,6 +300,20 @@ describe Facter do
       it 'returns hash with os.name fact' do
         expect(Facter.values({}, ['os.name'])).to eq(result)
       end
+
+      it 'sets show_legacy to true' do
+        Facter.values({}, [])
+
+        expect(Facter::Options[:show_legacy]).to be true
+      end
+
+      it 'logs blocked facts' do
+        allow(Facter::Options).to receive(:[]).with(:block_list).and_return(['os'])
+
+        Facter.values({}, [])
+
+        expect(logger).to have_received(:debug).with('blocking collection of os facts')
+      end
     end
 
     context 'when no user query' do


### PR DESCRIPTION
Fixed two small issues when running puppet facts. 
1. Legacy facts were not shown by default
2. Blocked facts debug message was not printed.