### PR TITLE
(FACT-2846) Fix networking fact when peer ip

### DIFF
--- a/lib/facter/resolvers/networking_linux_resolver.rb
+++ b/lib/facter/resolvers/networking_linux_resolver.rb
@@ -113,6 +113,8 @@ module Facter
                       "ip4_mask_length = #{ip4_mask_length}")
 
           binding = ::Resolvers::Utils::Networking.build_binding(ip4_address, ip4_mask_length)
+          return unless binding
+
           build_network_info_structure!(network_info, interface_name, :bindings)
 
           network_info[interface_name][:bindings] << binding
@@ -120,7 +122,7 @@ module Facter
 
         def retrieve_name_and_ip_info(tokens)
           interface_name = tokens[1]
-          ip_info = tokens[3].split('/')
+          ip_info = tokens[4] =~ /peer/ ? tokens[5].split('/') : tokens[3].split('/')
           ip_address = ip_info[0]
           ip_mask_length = ip_info[1]
 

--- a/lib/facter/resolvers/utils/networking.rb
+++ b/lib/facter/resolvers/utils/networking.rb
@@ -12,6 +12,8 @@ module Resolvers
         #
         # @return [Hash] Hash containing ip address, netmask and network
         def build_binding(addr, mask_length)
+          return if !addr || !mask_length
+
           ip = IPAddr.new(addr)
           mask_helper = ip.ipv6? ? 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff' : '255.255.255.255'
           mask = IPAddr.new(mask_helper).mask(mask_length)

--- a/spec/facter/resolvers/utils/networking_spec.rb
+++ b/spec/facter/resolvers/utils/networking_spec.rb
@@ -19,6 +19,12 @@ describe Resolvers::Utils::Networking do
       end
     end
 
+    context "when mask's length is nil" do
+      it 'returns nil' do
+        expect(networking_helper.build_binding(ipv4, nil)).to be(nil)
+      end
+    end
+
     context 'when input is ipv6 address' do
       let(:network) do
         IPAddr.new('fe80:0000:0000:0000:0000:0000:0000:0000/ffff:ffff:ffff:ffff:0000:0000:0000:0000').to_s

--- a/spec/fixtures/ip_o_address_with_peer
+++ b/spec/fixtures/ip_o_address_with_peer
@@ -1,0 +1,5 @@
+1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
+1: lo    inet6 ::1/128 scope host \       valid_lft forever preferred_lft forever
+2: ens160    inet 127.0.0.1/8 scope global dynamic ens160\       valid_lft 732sec preferred_lft 732sec
+2: ens160    inet 110.141.0.1 peer 10.141.0.2/32 scope global secondary ens160\       valid_lft forever preferred_lft forever
+2: ens160    inet6 fe80::250:56ff:fe9a:8481/64 scope link \       valid_lft forever preferred_lft forever


### PR DESCRIPTION
**Description of the problem:** When VPN server is installed on the system, facter fails to retrieve networking information.
**Description of the fix:** Facter retrieves mask's length when there is a peer ip address. Also additional nil checks are added when trying to build an interface's binding.