### PR TITLE
(maint) add license attribute to gemspec

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'New version of Facter'
   spec.description   = 'New version of Facter'
+  spec.license       = 'MIT'
 
   spec.files = Dir['bin/facter'] +
                Dir['lib/**/*.rb'] +


### PR DESCRIPTION
Will make license show up in https://rubygems.org/gems/facter and allow it to be found by license audit tools like https://github.com/pivotal/LicenseFinder

