### PR TITLE
(maint) Fix fact augmenter

### DIFF
--- a/lib/facter/framework/core/fact_augmenter.rb
+++ b/lib/facter/framework/core/fact_augmenter.rb
@@ -16,7 +16,7 @@ module Facter
     private_class_method def self.get_resolved_facts_for_searched_fact(searched_fact, resolved_facts)
       if searched_fact.name.include?('.*')
         resolved_facts
-          .select { |resolved_fact| resolved_fact.name.match(searched_fact.user_query) }
+          .select { |resolved_fact| resolved_fact.name.match(searched_fact.name) }
           .reject(&:user_query)
           .uniq(&:name)
       else


### PR DESCRIPTION
When there was a searched fact with a regex in it's name, the fact augmenter tried to match it to a resolved fact using the user query, which is wrong because when no user query is provided, it will match all facts, an it will wrongfully augment them.