### PR TITLE
(maint) Move benchmarking of core facts to CoreFact class.

### DIFF
--- a/lib/facter/framework/core/fact/internal/core_fact.rb
+++ b/lib/facter/framework/core/fact/internal/core_fact.rb
@@ -11,7 +11,12 @@ module Facter
 
       return unless fact_class
 
-      fact_class.new.call_the_resolver
+      fact_value = nil
+      Facter::Framework::Benchmarking::Timer.measure(@searched_fact.name) do
+        fact_value = fact_class.new.call_the_resolver
+      end
+
+      fact_value
     end
   end
 end

--- a/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
+++ b/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
@@ -44,8 +44,7 @@ module Facter
         .each do |searched_fact|
         begin
           fact = CoreFact.new(searched_fact)
-          fact_value = nil
-          Facter::Framework::Benchmarking::Timer.measure(searched_fact.name) { fact_value = fact.create }
+          fact_value = fact.create
           resolved_facts << fact_value unless fact_value.nil?
         rescue StandardError => e
           @@log.log_exception(e)


### PR DESCRIPTION
Timing was not displayed when facts were resolved in parallel. The fix moves fact benchmarking for core facts in CoreFact class.