### PR TITLE
(FACT-2853) Replace _ with - in help.

### DIFF
--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -1,12 +1,34 @@
 # This test is intended to ensure that the --help command-line option works
 # properly. This option prints usage information and available command-line
 # options.
-test_name "C99984: --help command-line option prints usage information to stdout" do
+test_name 'C99984: --help command-line option prints usage information to stdout' do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve usage info from stdout using --help option" do
       on(agent, facter('--help')) do
-        assert_match(/(facter|facter-ng) \[options\] \[query\] \[query\] \[...\]/, stdout, "Expected stdout to contain usage information")
+        assert_match(/(facter|facter-ng) \[options\] \[query\] \[query\] \[...\]/, stdout, 'Expected stdout to contain usage information')
+      end
+    end
+
+    step 'Facter help should list options with minus sign' do
+      options = %w[
+        --no-color
+        --custom-dir
+        --external-dir
+        --log-level
+        --no-block
+        --no-cache
+        --no-custom-facts
+        --no-external-facts
+        --no-ruby
+        --show-legacy
+        --list-block-groups
+        --list-cache-groups
+      ]
+      on(agent, facter('--help')) do
+        options.each do |option|
+          assert_match(/#{option}/, stdout, "Key: #{option} not found in help description")
+        end
       end
     end
   end

--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -206,6 +206,7 @@ module Facter
       end
 
       def build_option(name, aliases, description)
+        name = name.tr('_', '-')
         help_option = +''
         help_option << aliases.join(',').rjust(10)
         help_option << ' '


### PR DESCRIPTION
The problem: `facter --help` outputs arguments with `_` instead of `-` in their name.
```
           [--color]                      Enable color output.
           [--no_color]                   Disable color output.
        -c [--config]                     The location of the config file.
           [--custom_dir]                 A directory to use for custom facts.
        -d [--debug]                      Enable debug output.
           [--external_dir]               A directory to use for external facts.
           [--hocon]                      Output in Hocon format.
        -j [--json]                       Output in JSON format.
        -l [--log_level]                  Set logging level. Supported levels are: none, trace, debug, info, warn, error, and fatal.
           [--no_block]                   Disable fact blocking.
           [--no_cache]                   Disable loading and refreshing facts from the cache
           [--no_custom_facts]            Disable custom facts.
           [--no_external_facts]          Disable external facts.
           [--no_ruby]                    Disable loading Ruby, facts requiring Ruby, and custom facts.
           [--trace]                      Enable backtraces for custom facts.
           [--verbose]                    Enable verbose (info) output.
           [--show_legacy]                Show legacy facts when querying all facts.
        -p [--puppet]                     Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.
        -y [--yaml]                       Output in YAML format.
           [--strict]                     Enable more aggressive error reporting.
        -t [--timing]                     Show how much time it took to resolve each fact
           [--list_block_groups]          List block groups
           [--list_cache_groups]          List cache groups
           [--help]                       Help for all arguments
```


The fix: All the `_` have been replaced with '-' in `facter --help`
```
           [--color]                      Enable color output.
           [--no-color]                   Disable color output.
        -c [--config]                     The location of the config file.
           [--custom-dir]                 A directory to use for custom facts.
        -d [--debug]                      Enable debug output.
           [--external-dir]               A directory to use for external facts.
           [--hocon]                      Output in Hocon format.
        -j [--json]                       Output in JSON format.
        -l [--log-level]                  Set logging level. Supported levels are: none, trace, debug, info, warn, error, and fatal.
           [--no-block]                   Disable fact blocking.
           [--no-cache]                   Disable loading and refreshing facts from the cache
           [--no-custom-facts]            Disable custom facts.
           [--no-external-facts]          Disable external facts.
           [--no-ruby]                    Disable loading Ruby, facts requiring Ruby, and custom facts.
           [--trace]                      Enable backtraces for custom facts.
           [--verbose]                    Enable verbose (info) output.
           [--show-legacy]                Show legacy facts when querying all facts.
        -y [--yaml]                       Output in YAML format.
           [--strict]                     Enable more aggressive error reporting.
        -t [--timing]                     Show how much time it took to resolve each fact
           [--sequential]                 Resolve facts sequentially
           [--list-block-groups]          List block groups
           [--list-cache-groups]          List cache groups
           [--puppet]                     (NOT SUPPORTED)Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.
           [--help]                       Help for all arguments

```