### PR TITLE
(FACT-2854) Empty string in blocklist should not block all facts

### DIFF
--- a/acceptance/tests/options/blocklist_no_regex.rb
+++ b/acceptance/tests/options/blocklist_no_regex.rb
@@ -1,0 +1,53 @@
+test_name 'blocking os fact does not block oss fact' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  custom_fact_file = 'custom_facts.rb'
+  custom_fact_name = "oss"
+  custom_fact_value = "custom_fact_value"
+
+  fact_content = <<-CUSTOM_FACT
+  Facter.add(:#{custom_fact_name}) do
+    setcode do
+      "#{custom_fact_value}"
+    end
+  end
+  CUSTOM_FACT
+
+  config_data = <<~FACTER_CONF
+    facts : {
+      blocklist : [ "os" ],
+    }
+  FACTER_CONF
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, custom_fact_file)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, fact_file, fact_content)
+    create_remote_file(agent, config_file, config_data)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step "Facter: Verify that the blocked fact is not displayed" do
+      on(agent, facter("os")) do |facter_output|
+        assert_equal("", facter_output.stdout.chomp)
+      end
+    end
+
+    step "Facter: Verify that the custom fact is displayed" do
+      on(agent, facter("--custom-dir=#{fact_dir} oss")) do |facter_output|
+        assert_match(/#{custom_fact_value}/, facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/blocklist_with_regex.rb
+++ b/acceptance/tests/options/blocklist_with_regex.rb
@@ -1,0 +1,53 @@
+test_name 'blocking facts using regex' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  custom_fact_file = 'custom_facts.rb'
+  custom_fact_name = "oss"
+  custom_fact_value = "custom_fact_value"
+
+  fact_content = <<-CUSTOM_FACT
+  Facter.add(:#{custom_fact_name}) do
+    setcode do
+      "#{custom_fact_value}"
+    end
+  end
+  CUSTOM_FACT
+
+  config_data = <<~FACTER_CONF
+    facts : {
+      blocklist : [ "os.*" ],
+    }
+  FACTER_CONF
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, custom_fact_file)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, fact_file, fact_content)
+    create_remote_file(agent, config_file, config_data)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step "Facter: Verify that the blocked fact is not displayed" do
+      on(agent, facter("os")) do |facter_output|
+        assert_equal("", facter_output.stdout.chomp)
+      end
+    end
+
+    step "Facter: Verify that the blocked custom fact is not displayed" do
+      on(agent, facter("--custom-dir=#{fact_dir} oss")) do |facter_output|
+        assert_equal("", facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/options/empty_string_in_blocklist.rb
+++ b/acceptance/tests/options/empty_string_in_blocklist.rb
@@ -1,0 +1,33 @@
+# This tests is intended to verify that an empty string in blocklist will not block all facts
+test_name "empty string in blocklist does not block facts" do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  agents.each do |agent|
+    # default facter.conf
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
+
+    teardown do
+      agent.rm_rf(facter_conf_default_dir)
+    end
+
+    # create the directories
+    agent.mkdir_p(facter_conf_default_dir)
+
+    step "Agent #{agent}: create config file" do
+      create_remote_file(agent, facter_conf_default_path, <<-FILE)
+      cli : { debug : true }
+      facts : { blocklist : [ "" ] }
+      FILE
+    end
+
+    step "no facts should be blocked is specified" do
+      on(agent, facter) do |facter_output|
+        assert_no_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -84,7 +84,7 @@ module Facter
 
       blocked_facts.each do |blocked|
         facts.each do |fact|
-          next unless fact.name =~ /^#{blocked}/
+          next unless fact.name =~ /^#{blocked}\..*|^#{blocked}$/
 
           if fact.type == :core
             reject_list_core << fact


### PR DESCRIPTION
Adding an empty string in the blocklist, causes all facts to match the regex and be blocked.
