### PR TITLE
(maint) Resolve fact values when group was previously cached

### DIFF
--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -78,7 +78,7 @@ module Facter
       Facter::Framework::Benchmarking::Timer.measure(searched_fact.name, 'cached') do
         data = read_group_json(fact_group)
       end
-      return unless data
+      return unless data && data[searched_fact.name]
 
       @log.debug("loading cached values for #{searched_fact.name} facts")
 


### PR DESCRIPTION
If a group containing multiple facts was cached, but facter was run with a query for only one of the facts, the other facts would not be written to the cache file. On future runs, those facts would not be resolved at all.