### PR TITLE
(maint) Provide virtual and is_virtual facts on FreeBSD

### DIFF
--- a/lib/facter/facts/freebsd/is_virtual.rb
+++ b/lib/facter/facts/freebsd/is_virtual.rb
@@ -18,7 +18,7 @@ module Facts
       private
 
       def check_if_virtual(found_vm)
-        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?.to_s
+        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?
       end
     end
   end

--- a/lib/facter/facts/freebsd/is_virtual.rb
+++ b/lib/facter/facts/freebsd/is_virtual.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    class IsVirtual
+      FACT_NAME = 'is_virtual'
+
+      def initialize
+        @virtual = Facter::VirtualDetector.new
+      end
+
+      def call_the_resolver
+        fact_value = @virtual.platform
+
+        Facter::ResolvedFact.new(FACT_NAME, check_if_virtual(fact_value))
+      end
+
+      private
+
+      def check_if_virtual(found_vm)
+        Facter::FactsUtils::PHYSICAL_HYPERVISORS.count(found_vm).zero?.to_s
+      end
+    end
+  end
+end

--- a/lib/facter/facts/freebsd/virtual.rb
+++ b/lib/facter/facts/freebsd/virtual.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    class Virtual
+      FACT_NAME = 'virtual'
+
+      def initialize
+        @log = Facter::Log.new(self)
+        @virtual = Facter::VirtualDetector.new
+      end
+
+      def call_the_resolver
+        @log.debug('FreeBSD Virtual Resolver')
+        fact_value = @virtual.platform
+        @log.debug("Fact value is: #{fact_value}")
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facter/facts_utils/virtual_detector.rb
+++ b/lib/facter/facts_utils/virtual_detector.rb
@@ -7,8 +7,9 @@ module Facter
     end
 
     def platform # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      fact_value = check_docker_lxc || check_dmi || check_gce || retrieve_from_virt_what || check_vmware
-      fact_value ||= check_open_vz || check_vserver || check_xen || check_other_facts || check_lspci || 'physical'
+      fact_value = check_docker_lxc || check_dmi || check_freebsd || check_gce || retrieve_from_virt_what
+      fact_value ||= check_vmware || check_open_vz || check_vserver || check_xen || check_other_facts
+      fact_value ||= check_lspci || 'physical'
 
       fact_value
     end
@@ -56,6 +57,13 @@ module Facter
     def check_xen
       @log.debug('Checking XEN')
       Facter::Resolvers::Xen.resolve(:vm)
+    end
+
+    def check_freebsd
+      return unless Object.const_defined?('Facter::Resolvers::Freebsd::Virtual')
+
+      @log.debug('Checking if jailed')
+      Facter::Resolvers::Freebsd::Virtual.resolve(:vm)
     end
 
     def check_other_facts

--- a/lib/facter/resolvers/freebsd/virtual_resolver.rb
+++ b/lib/facter/resolvers/freebsd/virtual_resolver.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class Virtual < BaseResolver
+        init_resolver
+
+        class << self
+          #:model
+
+          VM_GUEST_SYSCTL_NAMES = {
+            'hv' => 'hyperv',
+            'microsoft' => 'hyperv',
+            'oracle' => 'virtualbox',
+            'xen' => 'xenu',
+            'none' => nil
+          }.freeze
+
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { read_facts(fact_name) }
+          end
+
+          def read_facts(fact_name)
+            require_relative 'ffi/ffi_helper'
+
+            if Facter::Freebsd::FfiHelper.sysctl_by_name(:long, 'security.jail.jailed').zero?
+              vm = Facter::Freebsd::FfiHelper.sysctl_by_name(:string, 'kern.vm_guest')
+
+              vm = VM_GUEST_SYSCTL_NAMES[vm] if VM_GUEST_SYSCTL_NAMES.key?(vm)
+
+              @fact_list[:vm] = vm
+            else
+              @fact_list[:vm] = 'jail'
+            end
+
+            @fact_list[fact_name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/is_virtual_spec.rb
+++ b/spec/facter/facts/freebsd/is_virtual_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::IsVirtual do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::IsVirtual.new }
+
+    let(:virtual_detector_double) { instance_spy(Facter::VirtualDetector) }
+
+    before do
+      allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(virtual_detector_double).to receive(:platform).and_return(virtual_value)
+    end
+
+    context 'when not in a virtual environment' do
+      let(:virtual_value) { 'physical' }
+
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'is_virtual', value: 'false')
+      end
+    end
+
+    context 'when in a virtual environment' do
+      let(:virtual_value) { 'aws' }
+
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'is_virtual', value: 'true')
+      end
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/is_virtual_spec.rb
+++ b/spec/facter/facts/freebsd/is_virtual_spec.rb
@@ -17,7 +17,7 @@ describe Facts::Freebsd::IsVirtual do
       it 'return resolved fact with nil value' do
         expect(fact.call_the_resolver)
           .to be_an_instance_of(Facter::ResolvedFact)
-          .and have_attributes(name: 'is_virtual', value: 'false')
+          .and have_attributes(name: 'is_virtual', value: false)
       end
     end
 
@@ -27,7 +27,7 @@ describe Facts::Freebsd::IsVirtual do
       it 'return resolved fact with nil value' do
         expect(fact.call_the_resolver)
           .to be_an_instance_of(Facter::ResolvedFact)
-          .and have_attributes(name: 'is_virtual', value: 'true')
+          .and have_attributes(name: 'is_virtual', value: true)
       end
     end
   end

--- a/spec/facter/facts/freebsd/virtual_spec.rb
+++ b/spec/facter/facts/freebsd/virtual_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Virtual do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Virtual.new }
+
+    let(:virtual_detector_double) { instance_spy(Facter::VirtualDetector) }
+    let(:log_spy) { instance_spy(Facter::Log) }
+
+    before do
+      allow(Facter::Log).to receive(:new).and_return(log_spy)
+      allow(Facter::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(virtual_detector_double).to receive(:platform).and_return(value)
+    end
+
+    shared_examples 'check resolved fact value' do
+      it 'return resolved fact with nil value' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'virtual', value: value)
+      end
+    end
+
+    context 'when not in a virtual environment' do
+      let(:value) { 'physical' }
+
+      it_behaves_like 'check resolved fact value'
+    end
+
+    context 'when in a virtual environment' do
+      let(:value) { 'jail' }
+
+      it_behaves_like 'check resolved fact value'
+    end
+  end
+end

--- a/spec/facter/facts_utils/virtual_detector_spec.rb
+++ b/spec/facter/facts_utils/virtual_detector_spec.rb
@@ -69,12 +69,33 @@ describe Facter::VirtualDetector do
       end
     end
 
+    context 'when is FreeBSD' do
+      let(:value) { 'jail' }
+
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return('jail')
+      end
+
+      it 'calls Facter::Resolvers::Freebsd::Virtual' do
+        detector.platform
+
+        expect(Facter::Resolvers::Freebsd::Virtual).to have_received(:resolve).with(:vm)
+      end
+
+      it 'returns jail' do
+        expect(detector.platform).to eq(value)
+      end
+    end
+
     context 'when is gce' do
       let(:value) { 'gce' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('Google Engine')
       end
 
@@ -95,6 +116,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(value)
       end
@@ -116,6 +138,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(value)
@@ -138,6 +161,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -161,6 +185,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -185,6 +210,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -210,6 +236,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
@@ -242,6 +269,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
@@ -269,6 +297,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
@@ -290,6 +319,7 @@ describe Facter::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)

--- a/spec/facter/resolvers/freebsd/virtual_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/virtual_resolver_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::Virtual do
+  subject(:jail_resolver) { Facter::Resolvers::Freebsd::Virtual }
+
+  after do
+    jail_resolver.invalidate_cache
+  end
+
+  before do
+    allow(Facter::Freebsd::FfiHelper).to receive(:sysctl_by_name).with(:long, 'security.jail.jailed').and_return(jailed)
+    allow(Facter::Freebsd::FfiHelper).to receive(:sysctl_by_name).with(:string, 'kern.vm_guest').and_return(vm)
+  end
+
+  let(:jailed) { 0 }
+  let(:vm) { nil }
+
+  context 'when not jailed' do
+    context 'when running on bare metal' do
+      it 'returns nil' do
+        expect(jail_resolver.resolve(:vm)).to be_nil
+      end
+    end
+
+    context 'when running in a vm' do
+      let(:vm) { 'xen' }
+
+      it 'returns xen' do
+        expect(jail_resolver.resolve(:vm)).to eq('xenu')
+      end
+    end
+  end
+
+  context 'when jailed' do
+    let(:jailed) { 1 }
+
+    context 'when running on bare metal' do
+      it 'returns jail' do
+        expect(jail_resolver.resolve(:vm)).to eq('jail')
+      end
+    end
+
+    context 'when running in a vm' do
+      let(:vm) { 'xen' }
+
+      it 'returns jail' do
+        expect(jail_resolver.resolve(:vm)).to eq('jail')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR add the `virtual` and `is_virtual` facts on FreeBSD which seems to have disappeared at some point in Facter 4.

I was able to check the correct behavior on real systems:
* `physical` on bare metal laptop;
* `kvm` at a cloud service provider;
* `jail` in a jail on my laptop.

Overall progress:

* [x] Replace the pciconf provider with one rely on on the `kern.vm_guest` sysctl as spoted by @igalic bellow;
* [x] Ensure the FreeBSD-specific code is only run on FreeBSD.