### PR TITLE
(FACT-2860) Agent release pipeline updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ group(:release, optional: true) do
   gem 'octokit', '~> 4.18.0'
 end
 
+gem 'packaging', require: false
+
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,12 @@ desc 'Generate changelog'
 task :changelog, [:version] do |_t, args|
   sh "./scripts/generate_changelog.rb #{args[:version]}"
 end
+
+if Rake.application.top_level_tasks.grep(/^(pl:|package:)/).any?
+  begin
+    require 'packaging'
+    Pkg::Util::RakeUtils.load_packaging_tasks
+  rescue LoadError => e
+    puts "Error loading packaging rake tasks: #{e}"
+  end
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,0 +1,3 @@
+---
+build_gem: TRUE
+project: facter

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,0 +1,1 @@
+build_defaults.yaml

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
- add the packaging gem to the Gemfile
- remove '~> 2.0' constraint for bundler dependency (jenkins workers have bundler 1 and 2 can't be easily installed)
- update Rakefile to load packaging rake tasks
- create a file similar to
  https://github.com/puppetlabs/bolt/blob/main/ext/build_defaults.yaml
  so the `pl:jenkins:ship_to_artifactory` task doesn't fail horribly
