### PR TITLE
(FACT-2813) Run all acceptance tests with --trace option

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,3 +1,4 @@
 {
-  :type => 'aio',
+  type: 'aio',
+  trace: '--trace'
 }

--- a/acceptance/tests/custom_facts/block_custom_fact.rb
+++ b/acceptance/tests/custom_facts/block_custom_fact.rb
@@ -26,7 +26,8 @@ test_name 'custom facts included in blocklist will not be displayed' do
     fact_dir = agent.tmpdir('custom_facts')
     fact_file = File.join(fact_dir, custom_fact_file)
 
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     agent.mkdir_p(config_dir)
@@ -39,7 +40,7 @@ test_name 'custom facts included in blocklist will not be displayed' do
     end
 
     step "Facter: Verify that the blocked custom fact is not displayed" do
-      on(agent, facter("--custom-dir=#{fact_dir} my_custom_fact")) do |facter_output|
+      on(agent, facter("--custom-dir=#{fact_dir} my_custom_fact #{@options[:trace]}")) do |facter_output|
         assert_equal("", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/custom_facts/cached_custom_fact.rb
+++ b/acceptance/tests/custom_facts/cached_custom_fact.rb
@@ -35,11 +35,13 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
   FACTER_CONF
 
   agents.each do |agent|
-    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    cache_folder = get_cached_facts_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     fact_dir = agent.tmpdir('facter')
     env = { 'FACTERLIB' => fact_dir }
 
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     step "Agent #{agent}: create config file" do
@@ -56,7 +58,7 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
     end
 
     step "should log that it creates cache file and it caches custom facts found in facter.conf" do
-      on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
+      on(agent, facter("#{custom_fact_name} --debug #{@options[:trace]}", environment: env)) do |facter_result|
         assert_equal(custom_fact_value, facter_result.stdout.chomp, "#{custom_fact_name} value changed")
         assert_match(/facts cache file expired, missing or is corrupt/, facter_result.stderr,
                      'Expected debug message to state that custom facts cache file is missing or expired')
@@ -73,7 +75,7 @@ test_name 'ttls configured custom facts files creates cache file and reads cache
     end
 
     step 'should read from the cached file for a custom fact that has been cached' do
-      on(agent, facter("#{custom_fact_name} --debug", environment: env)) do |facter_result|
+      on(agent, facter("#{custom_fact_name} --debug #{@options[:trace]}", environment: env)) do |facter_result|
         assert_match(/Loading cached custom facts from file ".+"|loading cached values for random_custom_fact facts/, facter_result.stderr,
                      'Expected debug message to state that cached custom facts are read from file')
       end

--- a/acceptance/tests/custom_facts/conflicts_with_builtin_fact.rb
+++ b/acceptance/tests/custom_facts/conflicts_with_builtin_fact.rb
@@ -28,7 +28,7 @@ CUSTOM_FACT
     end
 
     fact_name = 'timezone'
-    builtin_value = on(agent, facter('timezone')).stdout.chomp
+    builtin_value = on(agent, facter("timezone #{@options[:trace]}")).stdout.chomp
 
     step "Verify that Facter uses the custom fact's value when its weight is > 0" do
       custom_fact_value = "custom_timezone"
@@ -41,7 +41,7 @@ CUSTOM_FACT
         value: "'#{custom_fact_value}'"
       )
 
-      on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone")) do |result|
+      on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone #{@options[:trace]}")) do |result|
         assert_match(/#{custom_fact_value}/, result.stdout.chomp, "Facter does not use the custom fact's value when its weight is > 0")
       end
     end
@@ -58,7 +58,7 @@ CUSTOM_FACT
         )
       end
 
-      on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone")) do |result|
+      on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone #{@options[:trace]}")) do |result|
         assert_match(/#{builtin_value}/, result.stdout.chomp, "Facter does not use the builtin fact's value when all conflicting custom facts fail to resolve")
       end
     end
@@ -77,7 +77,7 @@ CUSTOM_FACT
           )
         end
 
-        on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone")) do |result|
+        on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone #{@options[:trace]}")) do |result|
           assert_match(/#{builtin_value}/, result.stdout.chomp, "Facter does not give precedence to the builtin fact when all custom facts have zero weight")
         end
       end
@@ -97,7 +97,7 @@ CUSTOM_FACT
           )
         end
 
-        on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone")) do |result|
+        on(agent, facter("--custom-dir \"#{custom_fact_dir}\" timezone #{@options[:trace]}")) do |result|
           assert_match(/#{builtin_value}/, result.stdout.chomp, "Facter does not give precedence to the builtin fact when only some custom facts have zero weight")
         end
       end

--- a/acceptance/tests/custom_facts/custom_fact_with_10001_weight_overrides_external_fact.rb
+++ b/acceptance/tests/custom_facts/custom_fact_with_10001_weight_overrides_external_fact.rb
@@ -21,7 +21,9 @@ test_name "C100153: custom fact with weight of >= 10001 overrides an external fa
 
     # Custom fact with weight >= 10001 should override an external fact
     step "Agent #{agent}: resolve a custom fact with weight of 10001 overriding the external fact" do
-      on(agent, facter("--external-dir \"#{facts_dir}\" --custom-dir=#{facts_dir} test")) do |facter_output|
+      facter_command = "--external-dir \"#{facts_dir}\" --custom-dir=#{facts_dir} test #{@options[:trace]}"
+
+      on(agent, facter(facter_command)) do |facter_output|
         assert_equal("CUSTOM", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
@@ -40,6 +40,7 @@ test_name 'Facter api works when there is an error inside a custom fact file' do
   def create_api_call_file(test_vars, facter_querry)
     file_content = <<-EOM
       require 'facter'
+      #{'Facter.trace(true)' if @options[:trace]}
       Facter.search(\'#{test_vars[:facts_dir]}\')
       #{facter_querry}
     EOM
@@ -91,7 +92,7 @@ test_name 'Facter api works when there is an error inside a custom fact file' do
     end
 
     step "Agent #{agent}: Verify that a core fact is still available" do
-      os_name = on(agent, facter('os.name')).stdout.chomp
+      os_name = on(agent, facter("os.name #{@options[:trace]}")).stdout.chomp
       create_api_call_file(test_vars, "puts Facter.value('os.name')")
       on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
         assert_match(/#{os_name}/, ruby_result.stdout)

--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_cli.rb
@@ -40,7 +40,7 @@ test_name 'Facter cli works when there is an error inside a custom fact file' do
   agents.each do |agent|
     custom_facts = agent.tmpdir('custom_facts_dir')
 
-    os_name = on(agent, facter('os.name')).stdout.chomp
+    os_name = on(agent, facter("os.name #{@options[:trace]}")).stdout.chomp
 
     create_custom_fact_file('file1.rb', first_file_content, custom_facts, agent)
     create_custom_fact_file('file2.rb', second_file_content, custom_facts, agent)
@@ -51,44 +51,49 @@ test_name 'Facter cli works when there is an error inside a custom fact file' do
     end
 
     step "Agent #{agent}: Verify that custom fact 1 is available" do
-      on(agent, facter('custom_fact_1', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("custom_fact_1 #{@options[:trace]}", environment: env),
+         acceptable_exit_codes: [1]) do |facter_output|
         assert_equal('custom_fact_1_value', facter_output.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that custom fact 2 is not available" do
-      on(agent, facter('custom_fact_2', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("custom_fact_2 #{@options[:trace]}", environment: env),
+         acceptable_exit_codes: [1]) do |facter_output|
         assert_equal('', facter_output.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that custom fact 3 is not available" do
-      on(agent, facter('custom_fact_3', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("custom_fact_3 #{@options[:trace]}", environment: env),
+         acceptable_exit_codes: [1]) do |facter_output|
         assert_equal('', facter_output.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that custom fact 4 is available" do
-      on(agent, facter('custom_fact_4', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("custom_fact_4 #{@options[:trace]}", environment: env),
+         acceptable_exit_codes: [1]) do |facter_output|
         assert_equal('custom_fact_4_value', facter_output.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that a core fact is still available" do
-      on(agent, facter('os.name', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("os.name #{@options[:trace]}", environment: env), acceptable_exit_codes: [1]) do |facter_output|
         assert_equal(os_name, facter_output.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that an error is outputted when custom fact file has an error" do
-      on(agent, facter('custom_fact_4', environment: env), acceptable_exit_codes: [1]) do |facter_output|
+      on(agent, facter("custom_fact_4 #{@options[:trace]}", environment: env),
+         acceptable_exit_codes: [1]) do |facter_output|
         assert_match(/ERROR Facter.*error while resolving custom facts in .*file1.rb undefined local variable or method `nill'/,
           facter_output.stderr.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that most core facts are available" do
-      on(agent, facter('--json')) do |facter_output|
+      on(agent, facter("--json #{@options[:trace]}")) do |facter_output|
         expected_keys = %w[identity memory os ruby networking system_uptime processors]
         actual_keys = JSON.parse(facter_output.stdout).keys
 

--- a/acceptance/tests/custom_facts/expand_command.rb
+++ b/acceptance/tests/custom_facts/expand_command.rb
@@ -22,7 +22,7 @@ test_name 'FACT-2054: Custom facts that execute a shell command should expand it
     end
 
     step "Agent: Verify that command is expanded" do
-      on(agent, facter('foo', :environment => env)) do |facter_result|
+      on(agent, facter("foo #{@options[:trace]}", :environment => env)) do |facter_result|
         refute_equal('/opt/puppetlabs', facter_result.stdout.chomp, 'command was not expanded')
       end
     end

--- a/acceptance/tests/custom_facts/having_multiple_facts_in_one_file.rb
+++ b/acceptance/tests/custom_facts/having_multiple_facts_in_one_file.rb
@@ -26,13 +26,13 @@ test_name 'C14893: Facter should handle multiple facts in a single file' do
     end
 
     step "Agent: Verify test_fact1 from #{fact_file}" do
-      on(agent, facter('test_fact1', :environment => env)) do |facter_result|
+      on(agent, facter("test_fact1 #{@options[:trace]}", :environment => env)) do |facter_result|
         assert_equal('test fact 1', facter_result.stdout.chomp, 'test_fact1 is not the correct value')
       end
     end
 
     step "Agent: Verify test_fact2 from #{fact_file}" do
-      on(agent, facter('test_fact2', :environment => env)) do |facter_result|
+      on(agent, facter("test_fact2 #{@options[:trace]}", :environment => env)) do |facter_result|
         assert_equal('test fact 2', facter_result.stdout.chomp, 'test_fact2 is not the correct value')
       end
     end

--- a/acceptance/tests/custom_facts/load_custom_fact_from_lib_facter.rb
+++ b/acceptance/tests/custom_facts/load_custom_fact_from_lib_facter.rb
@@ -14,6 +14,8 @@ end
 
 require 'facter'
 
+#{'Facter.trace(true)' if @options[:trace]}
+
 file_name = 'custom_fact.rb'
 
 path = ARGV[0]

--- a/acceptance/tests/custom_facts/long_stderr_with_time_limit.rb
+++ b/acceptance/tests/custom_facts/long_stderr_with_time_limit.rb
@@ -24,7 +24,7 @@ test_name "Facter::Core::Execution doesn't kill process with long stderr message
     end
 
     step "Facter: should resolve the external fact and print as warning script's stderr message" do
-      on agent, facter('--external-dir', external_dir, 'newfact') do |facter_output|
+      on agent, facter("--external-dir #{external_dir} newfact #{@options[:trace]}") do |facter_output|
         assert_match(/value_of_fact/, facter_output.stdout.chomp)
         assert_match(/WARN test.sh .*test.sh completed with the following stderr message: This is a very long error message./, facter_output.stderr.chomp)
       end

--- a/acceptance/tests/custom_facts/not_expand_command.rb
+++ b/acceptance/tests/custom_facts/not_expand_command.rb
@@ -22,7 +22,7 @@ confine :to, :platform => /el-7/
     end
 
     step "Agent: Verify that command is not expanded" do
-      on(agent, facter('foo', :environment => env)) do |facter_result|
+      on(agent, facter("foo #{@options[:trace]}", :environment => env)) do |facter_result|
         assert_equal('/opt/puppetlabs', facter_result.stdout.chomp, 'command was expanded')
       end
     end

--- a/acceptance/tests/custom_facts/resolution_timeout_option.rb
+++ b/acceptance/tests/custom_facts/resolution_timeout_option.rb
@@ -21,7 +21,7 @@ test_name "Facter::Util::Resolution accepts timeout option" do
     end
 
     step "Facter: Errors that the custom fact reached the timeout" do
-      on(agent, facter('--custom-dir', custom_dir, 'foo'), acceptable_exit_codes: 1) do |output|
+      on(agent, facter("--custom-dir #{custom_dir} foo #{@options[:trace]}"), acceptable_exit_codes: 1) do |output|
         assert_match(/ERROR .*Timed out after 0.2 seconds while resolving fact='foo', resolution=.*/,
                      output.stderr.chomp)
       end

--- a/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
+++ b/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
@@ -31,14 +31,15 @@ test_name 'Facter::Core::Execution accepts and correctly sets a time limit optio
     end
 
     step "Facter: Logs that command of the first custom fact had timeout after setted time limit" do
-      on agent, facter('--custom-dir', custom_dir, 'foo --debug') do |output|
+      on agent, facter('--custom-dir', custom_dir, "foo --debug #{@options[:trace]}") do |output|
         assert_match(/DEBUG Facter::Core::Execution.*Timeout encounter after 2s, killing process with pid:/,
                      output.stderr.chomp)
       end
     end
 
     step "Facter: Logs an error stating that the command of the second custom fact had timeout" do
-      on(agent, facter('--custom-dir', custom_dir, 'custom_fact --debug'), acceptable_exit_codes: 1) do |output|
+      on(agent, facter('--custom-dir', custom_dir, "custom_fact --debug #{@options[:trace]}"),
+         acceptable_exit_codes: 1) do |output|
         assert_match(/ERROR\s+.*Failed while executing '.*sleep.*2': Timeout encounter after 1s, killing process/,
                      output.stderr.chomp)
       end

--- a/acceptance/tests/custom_facts/using_win32ole_should_not_hang.rb
+++ b/acceptance/tests/custom_facts/using_win32ole_should_not_hang.rb
@@ -25,7 +25,7 @@ test_name 'C92060: Custom facts should not hang Facter when using win32ole' do
 
     # Test is assumed to have hung if it takes longer than 5 seconds.
     Timeout::timeout(5) do
-      on agent, facter('--custom-dir', custom_dir, 'custom_fact_ole') do |facter_result|
+      on agent, facter("--custom-dir #{custom_dir} custom_fact_ole #{@options[:trace]}") do |facter_result|
         assert_match(/#<WIN32OLE:0x[0-9a-f]+>/, facter_result.stdout.chomp, 'Custom fact output does not match expected output')
       end
     end

--- a/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
+++ b/acceptance/tests/custom_facts/weighted_cached_custom_facts.rb
@@ -48,10 +48,12 @@ test_name 'ttls configured weighted custom facts files creates cache file and re
   FACTER_CONF
 
   agents.each do |agent|
-    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    cache_folder = get_cached_facts_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     fact_dir = agent.tmpdir('facter')
     env = { 'FACTERLIB' => fact_dir }
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     step "Agent #{agent}: create config file" do
@@ -68,7 +70,8 @@ test_name 'ttls configured weighted custom facts files creates cache file and re
     end
 
     step "should log that it creates cache file and it caches custom facts found in facter.conf with the highest weight" do
-      on(agent, facter("#{duplicate_custom_fact_name} --debug", environment: env)) do |facter_result|
+      facter_command = "#{duplicate_custom_fact_name} --debug #{@options[:trace]}"
+      on(agent, facter(facter_command, environment: env)) do |facter_result|
         assert_equal(custom_fact_value + " 110", facter_result.stdout.chomp, "#{duplicate_custom_fact_name} value changed")
         assert_match(/facts cache file expired, missing or is corrupt/, facter_result.stderr,
                      'Expected debug message to state that custom facts cache file is missing or expired')
@@ -85,7 +88,8 @@ test_name 'ttls configured weighted custom facts files creates cache file and re
     end
 
     step 'should read from the cached file for a custom fact that has been cached' do
-      on(agent, facter("#{duplicate_custom_fact_name} --debug", environment: env)) do |facter_result|
+      facter_command = "#{duplicate_custom_fact_name} --debug #{@options[:trace]}"
+      on(agent, facter(facter_command, environment: env)) do |facter_result|
         assert_match(/Loading cached custom facts from file ".+"|loading cached values for random_custom_fact facts/, facter_result.stderr,
                      'Expected debug message to state that cached custom facts are read from file')
       end

--- a/acceptance/tests/custom_facts/windows_not_expand_command.rb
+++ b/acceptance/tests/custom_facts/windows_not_expand_command.rb
@@ -22,7 +22,7 @@ test_name 'FACT-2054: Execute on Windows with expand => false should raise an er
     end
 
     step "Agent: Verify that exception is raised" do
-      on(agent, facter('foo', :environment => env), :acceptable_exit_codes => [0, 1]) do |output|
+      on(agent, facter("foo #{@options[:trace]}", :environment => env), :acceptable_exit_codes => [0, 1]) do |output|
         assert_match(/Unsupported argument on Windows/, output.stderr, '{:expand => false} on Windows should raise error')
       end
     end

--- a/acceptance/tests/external_facts/block_external_facts.rb
+++ b/acceptance/tests/external_facts/block_external_facts.rb
@@ -28,7 +28,8 @@ test_name 'custom facts included in blocklist will not be displayed' do
     end
 
     step "agent #{agent}: resolve the external fact" do
-      on(agent, facter("--debug --external-dir \"#{facts_dir}\" --config \"#{config_file}\"")) do |facter_output|
+      facter_command = "--debug --external-dir \"#{facts_dir}\" --config \"#{config_file}\" #{@options[:trace]}"
+      on(agent, facter(facter_command)) do |facter_output|
         assert_match(/External fact file external_fact_1#{ext} blocked./, facter_output.stderr.chomp, 'Expected to block the external_fact')
         assert_no_match(/external_fact => external_value/, stdout, 'Expected fact not to match fact')
       end

--- a/acceptance/tests/external_facts/env_var_overrides_external_fact.rb
+++ b/acceptance/tests/external_facts/env_var_overrides_external_fact.rb
@@ -25,7 +25,7 @@ test_name 'C100537: FACTER_ env var should override external fact' do
     end
 
     step "Agent: #{agent}: ensure external fact resolves correctly" do
-      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name}")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name} #{@options[:trace]}")) do |facter_output|
         assert_equal(fact_value,
                      facter_output.stdout.chomp,
                      'Expected external fact to resolve as defined in script')
@@ -33,7 +33,7 @@ test_name 'C100537: FACTER_ env var should override external fact' do
     end
 
     step "Agent #{agent}: the fact value from FACTER_ env var should override the external fact value" do
-      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name}",
+      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name} #{@options[:trace]}",
                        :environment => { "FACTER_#{fact_name}" => override_value })) do |facter_output|
         assert_equal(override_value,
                      facter_output.stdout.chomp,

--- a/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
+++ b/acceptance/tests/external_facts/external_dir_overrides_default_external_fact.rb
@@ -5,7 +5,7 @@ test_name "C100154: --external-dir fact overrides fact in default facts.d direct
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    os_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     ext = get_external_fact_script_extension(agent['platform'])
     factsd = get_factsd_dir(agent['platform'], os_version)
     external_dir = agent.tmpdir('facts.d')
@@ -28,7 +28,7 @@ test_name "C100154: --external-dir fact overrides fact in default facts.d direct
     end
 
     step "Agent #{agent}: the fact value from the custom external dir should override that of facts.d" do
-      on(agent, facter("--external-dir \"#{external_dir}\" external_fact")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" external_fact #{@options[:trace]}")) do |facter_output|
         assert_equal('OVERRIDE_value', facter_output.stdout.chomp, 'Expected to resolve override version of the external_fact')
       end
     end

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact.rb
@@ -20,7 +20,8 @@ test_name "C100150: external fact overrides custom fact without a weight" do
     end
 
     step "Agent #{agent}: resolve an external fact over a custom fact" do
-      on(agent, facter("--external-dir \"#{facts_dir}\" --custom-dir=#{facts_dir} #{fact_name}")) do |facter_output|
+      facter_command = "--external-dir \"#{facts_dir}\" --custom-dir=#{facts_dir} #{fact_name} #{@options[:trace]}"
+      on(agent, facter(facter_command)) do |facter_output|
         assert_equal("EXTERNAL", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_10000_weight_or_less.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_10000_weight_or_less.rb
@@ -21,7 +21,8 @@ test_name "C100151: external fact overrides a custom fact of weight 10000 or les
 
     # Custom fact with weight <= 10000 should give precedence to the EXTERNAL fact
     step "Agent #{agent}: resolve an external fact over the custom fact with a weight of 10000" do
-      on(agent, facter("--external-dir \"#{facts_dir}\" --custom-dir \"#{facts_dir}\" #{fact_name}")) do |facter_output|
+      facter_command = "--external-dir \"#{facts_dir}\" --custom-dir \"#{facts_dir}\" #{fact_name} #{@options[:trace]}"
+      on(agent, facter(facter_command)) do |facter_output|
         assert_equal("EXTERNAL", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_confine.rb
+++ b/acceptance/tests/external_facts/external_fact_overrides_custom_fact_with_confine.rb
@@ -15,7 +15,7 @@ test_name "C100152: external fact overrides a custom fact with a confine" do
     cust_fact_path = "#{facts_dir}/test.rb"
     create_remote_file(agent, ext_fact_path, ext_fact)
 
-    agent_kernel = on(agent, facter('kernel')).stdout.chomp
+    agent_kernel = on(agent, facter("kernel #{@options[:trace]}")).stdout.chomp
     create_remote_file(agent, cust_fact_path,
                        custom_fact_content(fact_name, 'CUSTOM', "confine :kernel=>'#{agent_kernel}'"))
 
@@ -26,7 +26,8 @@ test_name "C100152: external fact overrides a custom fact with a confine" do
     # External fact should take precedence over a custom fact with a confine
     # (from FACT-1413)
     step "Agent #{agent}: resolve external fact over a custom fact with a confine" do
-      on(agent, facter("--external-dir \"#{facts_dir}\" --custom-dir \"#{facts_dir}\" test")) do |facter_output|
+      facter_command = "--external-dir \"#{facts_dir}\" --custom-dir \"#{facts_dir}\" test #{@options[:trace]}"
+      on(agent, facter(facter_command)) do |facter_output|
         assert_equal("EXTERNAL", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/external_facts/external_fact_stderr_messages_output_to_stderr.rb
+++ b/acceptance/tests/external_facts/external_fact_stderr_messages_output_to_stderr.rb
@@ -5,7 +5,8 @@ test_name "C64315: external facts that print messages to stderr should be seen o
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    factsd = get_factsd_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    factsd = get_factsd_dir(agent['platform'],
+                            on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     ext = get_external_fact_script_extension(agent['platform'])
     ext_fact = File.join(factsd, "external_fact#{ext}")
 
@@ -33,7 +34,7 @@ EOM
     end
 
     step "Agent #{agent}: external fact stderr messages should appear on stderr from facter" do
-      on(agent, facter) do |facter_output|
+      on(agent, facter((@options[:trace]).to_s)) do |facter_output|
         assert_match(/WARN.*SCRIPT STDERR/, facter_output.stderr,
                      "Expected facter to output a warning message with the stderr string from the external fact")
       end

--- a/acceptance/tests/external_facts/external_facts_only_run_once.rb
+++ b/acceptance/tests/external_facts/external_facts_only_run_once.rb
@@ -5,7 +5,8 @@ test_name "C14892: external facts should only be run once" do
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    factsd = get_factsd_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    factsd = get_factsd_dir(agent['platform'],
+                            on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     ext = get_external_fact_script_extension(agent['platform'])
     ext_fact = File.join(factsd, "external_fact#{ext}")
 
@@ -33,7 +34,7 @@ EOM
     end
 
     step "Agent #{agent}: ensure the fact is only executed once" do
-      on(agent, facter) do |facter_output|
+      on(agent, facter((@options[:trace]).to_s)) do |facter_output|
         lines = facter_output.stderr.split('\n')
         times = lines.count { |line| line =~ /SCRIPT CALLED/ }
         assert_equal(1, times, "External fact should only execute once: #{facter_output.stderr}")

--- a/acceptance/tests/external_facts/fact_directory_precedence.rb
+++ b/acceptance/tests/external_facts/fact_directory_precedence.rb
@@ -19,7 +19,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
 
   agents.each do |agent|
     # The directories that facter processes facts
-    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    os_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     factsd_dir = get_factsd_dir(agent['platform'], os_version)
     etc_factsd_dir = get_etc_factsd_dir(agent['platform'])
     etc_puppetlabs_factsd_dir = get_etc_puppetlabs_factsd_dir(agent['platform'])
@@ -42,7 +42,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     # A fact in the etc_puppetlabs_factsd_dir directory should resolve to the fact
     step "Agent #{agent}: create and resolve a custom fact in #{etc_puppetlabs_factsd_dir}" do
       create_remote_file(agent, etc_puppetlabs_factsd_path, ext_fact('etc_puppetlabs_path'))
-      on(agent, facter("test")) do |facter_output|
+      on(agent, facter("test #{@options[:trace]}")) do |facter_output|
         assert_match(/etc_puppetlabs_path/, facter_output.stdout, "Fact from #{etc_puppetlabs_factsd_dir} did not resolve correctly")
       end
     end
@@ -61,7 +61,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     # A fact in the etc_factsd_dir directory should resolve to the fact
     step "Agent #{agent}: create and resolve a custom fact in #{etc_factsd_dir}" do
       create_remote_file(agent, etc_factsd_path, ext_fact('etc_path'))
-      on(agent, facter("test")) do |facter_output|
+      on(agent, facter("test #{@options[:trace]}")) do |facter_output|
         assert_match(/etc_path/, facter_output.stdout, "Fact from #{etc_factsd_dir} did not resolve correctly")
       end
     end
@@ -80,7 +80,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     # A fact in the factsd_dir directory should resolve to the fact
     step "Agent #{agent}: create and resolve a custom fact in #{factsd_dir}" do
       create_remote_file(agent, factsd_path, ext_fact('default_factsd'))
-      on(agent, facter("test")) do |facter_output|
+      on(agent, facter("test #{@options[:trace]}")) do |facter_output|
         assert_match(/default_factsd/, facter_output.stdout, "Fact from #{factsd_dir} did not resolve correctly")
       end
     end
@@ -94,7 +94,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     step "Agent #{agent}: create and resolve 2 facts of the same name between #{factsd_dir} and #{etc_factsd_dir}" do
       create_remote_file(agent, factsd_path, ext_fact('BASE'))
       create_remote_file(agent, etc_factsd_path, ext_fact('ETC_FACTS'))
-      on(agent, facter("test")) do |facter_output|
+      on(agent, facter("test #{@options[:trace]}")) do |facter_output|
         assert_match(/ETC_FACTS/, facter_output.stdout, "Fact from #{etc_factsd_dir} should take precedence over #{factsd_dir}")
       end
     end
@@ -103,7 +103,7 @@ test_name "C59201: Fact directory precedence and resolution order for facts" do
     step "Agent #{agent}: create and resolve 2 facts of the same name between #{etc_factsd_dir} and #{etc_puppetlabs_factsd_dir}" do
       create_remote_file(agent, etc_factsd_path, ext_fact('ETC_FACTS'))
       create_remote_file(agent, etc_puppetlabs_factsd_path, ext_fact('ETC_PUPPETLABS_FACTS'))
-      on(agent, facter("test")) do |facter_output|
+      on(agent, facter("test #{@options[:trace]}")) do |facter_output|
         assert_match(/ETC_PUPPETLABS_FACTS/, facter_output.stdout, "Fact from #{etc_puppetlabs_factsd_dir} should take precedence over #{etc_factsd_dir}")
       end
     end

--- a/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
+++ b/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
@@ -23,7 +23,8 @@ test_name 'Should handle same filename in two external directories only if ttl i
     create_remote_file(agent, external_fact_file1, "#{fact1}: #{fact1_value}")
     create_remote_file(agent, external_fact_file2, "#{fact2}: #{fact2_value}")
 
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     teardown do
@@ -33,7 +34,10 @@ test_name 'Should handle same filename in two external directories only if ttl i
     end
 
     step 'works if ttl is not enabled' do
-      on(agent, facter("--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" --debug #{fact1} #{fact2}")) do |facter_output|
+      facter_command = "--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" "\
+"--debug #{fact1} #{fact2} #{@options[:trace]}"
+
+      on(agent, facter(facter_command)) do |facter_output|
         assert_match(/#{fact1} => #{fact1_value}/, stdout, 'Expected fact to match first fact')
         assert_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact to match second fact')
       end
@@ -49,7 +53,10 @@ facts : {
 EOM
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
-      on(agent, facter("--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" --debug #{fact1} #{fact2}"), :acceptable_exit_codes => 1) do |facter_output|
+      facter_command = "--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" "\
+"--debug #{fact1} #{fact2} #{@options[:trace]}"
+
+      on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/ERROR.*Caching is enabled for group "#{external_filename}" while there are at least two external facts files with the same filename/, stderr, 'Expected error message')
         assert_match(/#{fact1} => #{fact1_value}/, stdout, 'Expected fact to match first fact')
         assert_not_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact not to match second fact')

--- a/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
+++ b/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
@@ -95,7 +95,7 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and make sure we get the fact" do
-      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test"]) do |facter_result|
+      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test #{@options[:trace]}"]) do |facter_result|
         assert_match(/USER_TEST_FACTER/, facter_result.stdout, "Fact from #{user_facts_dir} did not resolve correctly")
       end
     end
@@ -119,7 +119,7 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and make sure we get the fact" do
-      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test"]) do |facter_result|
+      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test #{@options[:trace]}"]) do |facter_result|
         assert_match(/USER_TEST_PUPPETLABS/, facter_result.stdout, "Fact from #{user_puppetlabs_facts_dir} did not resolve correctly")
       end
     end
@@ -137,7 +137,7 @@ test_name "C64580: Non-root default user external facts directory is searched fo
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and .facter will take precedence over .puppetlabs" do
-      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test"]) do |facter_result|
+      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' test #{@options[:trace]}"]) do |facter_result|
         assert_match(/USER_PRECEDENCE_FACTER/, facter_result.stdout, "Fact from #{user_puppetlabs_facts_dir} did not resolve correctly")
       end
     end

--- a/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
+++ b/acceptance/tests/external_facts/root_uses_default_external_fact_dir.rb
@@ -9,7 +9,7 @@ test_name "C87571: facter resolves facts in the default facts.d directory" do
   extend Facter::Acceptance::UserFactUtils
 
   agents.each do |agent|
-    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    os_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     ext = get_external_fact_script_extension(agent['platform'])
     factsd = get_factsd_dir(agent['platform'], os_version)
     fact_file = File.join(factsd, "external_fact_1#{ext}")
@@ -26,7 +26,7 @@ test_name "C87571: facter resolves facts in the default facts.d directory" do
     end
 
     step "agent #{agent}: resolve the external fact" do
-      on(agent, facter('external_fact')) do |facter_output|
+      on(agent, facter("external_fact #{@options[:trace]}")) do |facter_output|
         assert_equal('external_value', facter_output.stdout.chomp, 'Expected to resolve the external_fact')
       end
     end

--- a/acceptance/tests/external_facts/structured_executable_facts.rb
+++ b/acceptance/tests/external_facts/structured_executable_facts.rb
@@ -64,7 +64,7 @@ EOM
   kv_output = 'one'
 
   agents.each do |agent|
-    os_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    os_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     factsd = get_factsd_dir(agent['platform'], os_version)
     ext = get_external_fact_script_extension(agent['platform'])
 
@@ -94,7 +94,7 @@ EOM
       agent.chmod('+x', yaml_fact)
 
       step "YAML output should produce a structured fact" do
-        on(agent, facter("yaml_fact")) do
+        on(agent, facter("yaml_fact #{@options[:trace]}")) do
           assert_match(/#{yaml_structured_output}/, stdout, "Expected properly structured fact")
         end
       end
@@ -106,7 +106,7 @@ EOM
       agent.chmod('+x', json_fact)
 
       step "JSON output should produce a structured fact" do
-        on(agent, facter("json_fact")) do
+        on(agent, facter("json_fact #{@options[:trace]}")) do
           assert_match(/#{json_structured_output}/, stdout, "Expected properly structured fact")
         end
       end
@@ -118,7 +118,7 @@ EOM
       agent.chmod('+x', kv_fact)
 
       step "output that is neither yaml nor json should not produce a structured fact" do
-        on(agent, facter("kv_fact")) do
+        on(agent, facter("kv_fact #{@options[:trace]}")) do
           assert_match(/#{kv_output}/, stdout, "Expected a simple key-value fact")
         end
       end
@@ -130,7 +130,7 @@ EOM
       agent.chmod('+x', bad_fact)
 
       step "should error when output is not in a supported format" do
-        on(agent, facter("bad_fact --debug")) do
+        on(agent, facter("bad_fact --debug #{@options[:trace]}")) do
           assert_match(/Could not parse executable fact/, stderr, "Expected parsing the malformed fact to fail")
         end
       end

--- a/acceptance/tests/facter_flush.rb
+++ b/acceptance/tests/facter_flush.rb
@@ -4,6 +4,8 @@ test_name 'facter should flush fact values' do
   fact_content1 = <<-EOM
     require 'facter'
 
+    #{'Facter.trace(true)' if @options[:trace]}
+
     Facter.add(:fact1) do
       'this should be flushed'
     end
@@ -15,6 +17,8 @@ test_name 'facter should flush fact values' do
 
   fact_content2 = <<-EOM
     require 'facter'
+
+    #{'Facter.trace(true)' if @options[:trace]}
 
     Facter.add(:fact2) do
       on_flush do

--- a/acceptance/tests/facter_returns_success_on_non_existent_fact.rb
+++ b/acceptance/tests/facter_returns_success_on_non_existent_fact.rb
@@ -3,7 +3,7 @@ test_name 'C100160: facter exits with success when asked for a non-existent fact
 
   agents.each do |agent|
     step 'facter should return exit code 0 for querying non-existing-fact without --strict flag' do
-      on(agent, facter('non-existing-fact'), :acceptable_exit_codes => 0)
+      on(agent, facter("non-existing-fact #{@options[:trace]}"), :acceptable_exit_codes => 0)
     end
   end
 end

--- a/acceptance/tests/facts/dmi.rb
+++ b/acceptance/tests/facts/dmi.rb
@@ -39,7 +39,7 @@ test_name "C96148: verify dmi facts" do
     end
 
     step("verify that dmi structured fact contains facts") do
-      on(agent, facter("--json dmi")) do |facter_results|
+      on(agent, facter("--json dmi #{@options[:trace]}")) do |facter_results|
         json_facts = JSON.parse(facter_results.stdout)
         expected_facts.each do |fact, value|
           actual_fact = json_result_fact_by_key_path(json_facts, fact)

--- a/acceptance/tests/facts/facterversion.rb
+++ b/acceptance/tests/facts/facterversion.rb
@@ -3,7 +3,7 @@ test_name "C15286: verify facterversion fact" do
 
   agents.each do |agent|
     step("verify that fact facterversion is a version string") do
-      on(agent, facter("facterversion")) do |facter_result|
+      on(agent, facter("facterversion #{@options[:trace]}")) do |facter_result|
         assert_match(/\d+\.\d+\.\d+/, facter_result.stdout.chomp, "Expected 'facterversion' fact to be a version string")
       end
     end

--- a/acceptance/tests/facts/identity.rb
+++ b/acceptance/tests/facts/identity.rb
@@ -41,7 +41,7 @@ test_name 'C100202: Facter identity facts resolve on all platforms' do
         }
       end
 
-      on(agent, facter('--json')) do |facter_result|
+      on(agent, facter("--json #{@options[:trace]}")) do |facter_result|
         results = JSON.parse(facter_result.stdout)
         expected_identity.each do |fact, value|
           assert_match(value, results['identity'][fact].to_s, "Incorrect fact value for identity.#{fact}")

--- a/acceptance/tests/facts/mountpoints_fact.rb
+++ b/acceptance/tests/facts/mountpoints_fact.rb
@@ -4,7 +4,7 @@ test_name '(FACT-1964) Facter mountpoints does not show rootfs as type for root 
 
   agents.each do |agent|
     step 'Ensure that mountpoints does not contain rootfs as type for root directory' do
-      on(agent, facter("mountpoints")) do |facter_result|
+      on(agent, facter("mountpoints #{@options[:trace]}")) do |facter_result|
         assert_no_match(/rootfs/, facter_result.stdout.chomp, "Expected mountpoint with rootfs type to not be present")
       end
     end

--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -78,13 +78,13 @@ test_name 'C59029: networking facts should be fully populated' do
   agents.each do |agent|
     if agent['platform'] =~ /windows/
       step("verify that ipaddress6 is retrieved correctly") do
-        on(agent, facter("ipaddress6")) do |facter_result|
+        on(agent, facter("ipaddress6 #{@options[:trace]}")) do |facter_result|
           assert_match(/^[a-fA-F0-9:]+$/, facter_result.stdout.chomp)
         end
       end
 
       step("verify that network6 is retrieved correctly") do
-        on(agent, facter("network6")) do |facter_result|
+        on(agent, facter("network6 #{@options[:trace]}")) do |facter_result|
           assert_match(/([a-fA-F0-9:]+)?:([a-fA-F0-9:]+)?$/, facter_result.stdout.chomp)
         end
       end

--- a/acceptance/tests/facts/nim_type.rb
+++ b/acceptance/tests/facts/nim_type.rb
@@ -4,7 +4,7 @@ test_name "Test nim_type fact" do
 
   agents.each do |agent|
     step("verify that nim_type is retrieved correctly") do
-      on(agent, facter("nim_type")) do |facter_result|
+      on(agent, facter("nim_type #{@options[:trace]}")) do |facter_result|
         assert_equal("standalone", facter_result.stdout.chomp)
       end
     end

--- a/acceptance/tests/facts/non_root_users_without_errors.rb
+++ b/acceptance/tests/facts/non_root_users_without_errors.rb
@@ -24,7 +24,7 @@ test_name "C59196: running facter as a non-root user should not produce permissi
     end
 
     step "Agent #{agent}: run facter as #{non_root_user} and get no errors" do
-      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}'"]) do |facter_results|
+      on(agent, %Q[su #{non_root_user} -c "'#{facter_path}' #{@options[:trace]}"]) do |facter_results|
         assert_empty(facter_results.stderr.chomp, "Expected no errors from facter when run as user #{non_root_user}")
       end
     end

--- a/acceptance/tests/facts/operatingsystem_detection_after_clear_on_ubuntu.rb
+++ b/acceptance/tests/facts/operatingsystem_detection_after_clear_on_ubuntu.rb
@@ -3,10 +3,11 @@ test_name 'C14891: Facter should properly detect operatingsystem on Ubuntu after
 
   confine :to, :platform => /ubuntu/
 
-  require "puppet/acceptance/common_utils"
-
   script_contents = <<-OS_DETECT
   require 'facter'
+
+  #{'Facter.trace(true)' if @options[:trace]}
+
   Facter['operatingsystem'].value
   Facter.clear
   exit Facter['operatingsystem'].value == 'Ubuntu'
@@ -21,6 +22,6 @@ test_name 'C14891: Facter should properly detect operatingsystem on Ubuntu after
       agent.rm_rf(script_dir)
     end
 
-    on(agent, "#{Puppet::Acceptance::CommandUtils.ruby_command(agent)} #{script_name}", :acceptable_exit_codes => 0)
+    on(agent, "#{ruby_command(agent)} #{script_name}", :acceptable_exit_codes => 0)
   end
 end

--- a/acceptance/tests/facts/os_processors_and_kernel.rb
+++ b/acceptance/tests/facts/os_processors_and_kernel.rb
@@ -8,7 +8,7 @@ test_name 'C100193: Facter os, processors, and kernel facts resolve on all platf
   agents.each do |agent|
     step 'Ensure the os, processors, and kernel fact resolves as expected' do
       expected_facts = os_processors_and_kernel_expected_facts(agent)
-      on(agent, facter('--json')) do |facter_result|
+      on(agent, facter("--json #{@options[:trace]}")) do |facter_result|
         results = JSON.parse(facter_result.stdout)
         expected_facts.each do |fact, value|
           actual_fact = json_result_fact_by_key_path(results, fact)

--- a/acceptance/tests/facts/osx_numeric_hostname.rb
+++ b/acceptance/tests/facts/osx_numeric_hostname.rb
@@ -17,7 +17,7 @@ test_name 'Querying the fqdn with a numeric hostname should not fail' do
     end
 
     step 'Verify fqdn fact does not fail' do
-      on(agent, facter('fqdn'))
+      on(agent, facter("fqdn #{@options[:trace]}"))
     end
   end
 end

--- a/acceptance/tests/facts/partitions.rb
+++ b/acceptance/tests/facts/partitions.rb
@@ -19,7 +19,7 @@ test_name "C96148: verify partitions facts" do
 
   agents.each do |agent|
     step("verify that partitions contain facts") do
-      on(agent, facter("--json partitions")) do |facter_output|
+      on(agent, facter("--json partitions #{@options[:trace]}")) do |facter_output|
         facter_results = JSON.parse(facter_output.stdout)
         facter_results['partitions'].each_key do |partition_name|
           partition_facts = facter_results['partitions'][partition_name]

--- a/acceptance/tests/facts/productname.rb
+++ b/acceptance/tests/facts/productname.rb
@@ -7,7 +7,7 @@ test_name "C89604: verify productname fact" do
 
   agents.each do |agent|
     step("verify the fact productname") do
-      on(agent, facter("productname")) do |facter_result|
+      on(agent, facter("productname #{@options[:trace]}")) do |facter_result|
         assert_match(/\w+/, facter_result.stdout.chomp, "Expected fact 'productname' to be set")
       end
     end

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -46,7 +46,7 @@ test_name "C100305: The Ruby fact should resolve as expected in AIO" do
       }
 
       step("verify that ruby structured fact contains facts") do
-        on(agent, facter("--json ruby")) do |facter_results|
+        on(agent, facter("--json ruby #{@options[:trace]}")) do |facter_results|
           json_facts = JSON.parse(facter_results.stdout)
           expected_facts.each do |fact, value|
             actual_fact = json_result_fact_by_key_path(json_facts, fact)

--- a/acceptance/tests/facts/ssh_key.rb
+++ b/acceptance/tests/facts/ssh_key.rb
@@ -36,14 +36,14 @@ test_name 'SSH publick key' do
 
     step 'SSH publick key with comment is printed' do
       on(agent, "echo '#{rsa_pub_host_key_with_comment}' > #{ssh_host_rsa_key_file}")
-      on(agent, facter('ssh.rsa.key')) do |facter_output|
+      on(agent, facter("ssh.rsa.key #{@options[:trace]}")) do |facter_output|
         assert_equal(key, facter_output.stdout.chomp, 'Expected debug to contain key only')
       end
     end
 
     step 'SSH publick key without comment is printed' do
       on(agent, "echo '#{rsa_pub_host_key_without_comment}' > #{ssh_host_rsa_key_file}")
-      on(agent, facter('ssh.rsa.key')) do |facter_output|
+      on(agent, facter("ssh.rsa.key #{@options[:trace]}")) do |facter_output|
         assert_equal(key, facter_output.stdout.chomp, 'Expected debug to contain key only')
       end
     end

--- a/acceptance/tests/facts/validate_file_system_size_bytes.rb
+++ b/acceptance/tests/facts/validate_file_system_size_bytes.rb
@@ -4,14 +4,13 @@ test_name "C100110: verify that file system sizes are positive" do
   tag 'risk:high'
 
   confine :except, :platform => 'windows' # Windows does not list mount points as facts like Unix
-  confine :to, :platform => /skip/
 
   require 'json'
 
   agents.each do |agent|
     step("verify that facter returns positive numbers for the mount points byte fields") do
 
-      on(agent, facter("--json")) do |facter_output|
+      on(agent, facter("--json #{@options[:trace]}")) do |facter_output|
         facter_results = JSON.parse(facter_output.stdout)
         facter_results['mountpoints'].each_key do |mount_key|
           ['available_bytes', 'size_bytes', 'used_bytes'].each do |sub_key|

--- a/acceptance/tests/facts/verify_tmpfs_file_system.rb
+++ b/acceptance/tests/facts/verify_tmpfs_file_system.rb
@@ -45,7 +45,7 @@ test_name 'C98163: mountpoints fact should show mounts on tmpfs' do
     end
 
     step 'verify tmpfs mount point seen by facter' do
-      on(agent, facter("mountpoints.#{mount_point}")) do |facter_output|
+      on(agent, facter("mountpoints.#{mount_point} #{@options[:trace]}")) do |facter_output|
         assert_match(/filesystem\s+=>\s+\"tmpfs\"/, facter_output.stdout, 'filesystem is the wrong type')
         assert_match(/device\s+=>\s+\"tmpfs\"/, facter_output.stdout, 'device is not a tmpfs')
         assert_match(/noexec/, facter_output.stdout, 'expected to see noexec option')

--- a/acceptance/tests/facts/windows_os.rb
+++ b/acceptance/tests/facts/windows_os.rb
@@ -34,7 +34,7 @@ test_name "Test facter os reports correct os.windows.system32" do
 
     step "Install Windows remote desktop feature" do
       if os_type == "Server"
-        on(agent, powershell("facter os.windows.system32")) do |facter_before_output|
+        on(agent, powershell("facter os.windows.system32 #{@options[:trace]}")) do |facter_before_output|
           assert_equal("C:\\Windows\\system32", facter_before_output.stdout.chomp, 'Before windows feature installation, should be C:\\Windows\\system32')
         end
         on(agent, powershell("Add-WindowsFeature –Name RDS-RD-Server –IncludeAllSubFeature"))
@@ -55,7 +55,7 @@ test_name "Test facter os reports correct os.windows.system32" do
     end
 
     step "Verify facter os reports correct system32 variable" do
-      on(agent, powershell("facter os.windows.system32")) do |facter_output|
+      on(agent, powershell("facter os.windows.system32 #{@options[:trace]}")) do |facter_output|
         assert_equal("C:\\Windows\\system32", facter_output.stdout.chomp, 'Result should be C:\\Windows\\system32')
       end
     end

--- a/acceptance/tests/load_libfacter.rb
+++ b/acceptance/tests/load_libfacter.rb
@@ -2,9 +2,6 @@
 test_name 'C100161: Ruby can load libfacter without raising an error' do
   tag 'risk:high'
 
-  require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
-
   def puppet_ruby_path_to_puppet_install_dir(puppet_ruby_path)
     # find the "puppet" directory which should be the root of the install
     puppet_dir = puppet_ruby_path
@@ -23,6 +20,9 @@ test_name 'C100161: Ruby can load libfacter without raising an error' do
     # create a ruby program that will add a fact through Facter
     fact_content = <<-EOM
     require 'facter'
+
+    #{'Facter.trace(true)' if @options[:trace]}
+
     Facter.add('facter_loaded') do
       setcode do
         'FACTER_LOADED'

--- a/acceptance/tests/no_errors_on_stderr.rb
+++ b/acceptance/tests/no_errors_on_stderr.rb
@@ -2,7 +2,7 @@ test_name 'C14514: Running facter should not output anything to stderr' do
   tag 'risk:high'
 
   agents.each do |agent|
-    on(agent, facter) do |facter_output|
+    on(agent, facter(@options[:trace])) do |facter_output|
       assert_match(/hostname\s*=>\s*\S*/, facter_output.stdout, 'Hostname fact is missing')
       assert_empty(facter_output.stderr, 'Facter should not have written to stderr')
     end

--- a/acceptance/tests/options/blocklist_no_regex.rb
+++ b/acceptance/tests/options/blocklist_no_regex.rb
@@ -26,7 +26,8 @@ test_name 'blocking os fact does not block oss fact' do
     fact_dir = agent.tmpdir('custom_facts')
     fact_file = File.join(fact_dir, custom_fact_file)
 
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     agent.mkdir_p(config_dir)
@@ -39,13 +40,13 @@ test_name 'blocking os fact does not block oss fact' do
     end
 
     step "Facter: Verify that the blocked fact is not displayed" do
-      on(agent, facter("os")) do |facter_output|
+      on(agent, facter("os #{@options[:trace]}")) do |facter_output|
         assert_equal("", facter_output.stdout.chomp)
       end
     end
 
     step "Facter: Verify that the custom fact is displayed" do
-      on(agent, facter("--custom-dir=#{fact_dir} oss")) do |facter_output|
+      on(agent, facter("--custom-dir=#{fact_dir} oss #{@options[:trace]}")) do |facter_output|
         assert_match(/#{custom_fact_value}/, facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/options/blocklist_with_regex.rb
+++ b/acceptance/tests/options/blocklist_with_regex.rb
@@ -26,7 +26,8 @@ test_name 'blocking facts using regex' do
     fact_dir = agent.tmpdir('custom_facts')
     fact_file = File.join(fact_dir, custom_fact_file)
 
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, 'facter.conf')
 
     agent.mkdir_p(config_dir)
@@ -39,13 +40,13 @@ test_name 'blocking facts using regex' do
     end
 
     step "Facter: Verify that the blocked fact is not displayed" do
-      on(agent, facter("os")) do |facter_output|
+      on(agent, facter("os #{@options[:trace]}")) do |facter_output|
         assert_equal("", facter_output.stdout.chomp)
       end
     end
 
     step "Facter: Verify that the blocked custom fact is not displayed" do
-      on(agent, facter("--custom-dir=#{fact_dir} oss")) do |facter_output|
+      on(agent, facter("--custom-dir=#{fact_dir} oss #{@options[:trace]}")) do |facter_output|
         assert_equal("", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/options/color.rb
+++ b/acceptance/tests/options/color.rb
@@ -7,7 +7,8 @@ test_name "C86545: --debug and --color command-line options should print DEBUG m
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using --debug and --color option" do
       # set the TERM type to be a color xterm to help ensure we emit the escape sequence to change the color
-      on(agent, facter('--debug --color'), :environment => { 'TERM' => 'xterm-256color' }) do |facter_output|
+      on(agent, facter("--debug --color #{@options[:trace]}"),
+         :environment => { 'TERM' => 'xterm-256color' }) do |facter_output|
         assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
         assert_match(
           /\e\[(\d{2,3})?;?(\d{1})?;?(\d{2,3})?m/,

--- a/acceptance/tests/options/config.rb
+++ b/acceptance/tests/options/config.rb
@@ -18,7 +18,7 @@ test_name "C100014: --config command-line option designates the location of the 
       end
 
       step "setting --config should cause the config file to be loaded from the specified location" do
-        on(agent, facter("--config \"#{config_file}\"")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" #{@options[:trace]}")) do |facter_output|
           assert_match(/DEBUG/, facter_output.stderr, "Expected debug output on stderr")
         end
       end

--- a/acceptance/tests/options/config_file/blocklist.rb
+++ b/acceptance/tests/options/config_file/blocklist.rb
@@ -20,7 +20,7 @@ test_name "C99972: facts can be blocked via a blocklist in the config file" do
       end
 
       step "blocked facts should not be resolved" do
-        on(agent, facter("--config \"#{config_file}\"")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" #{@options[:trace]}")) do |facter_output|
           # every platform attempts to resolve at least EC2 facts
           assert_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected stderr to contain statement about blocking fact collection")
 

--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -9,7 +9,8 @@ test_name "C100036: when run from puppet facts, facts can be blocked via a list 
   agents.each do |agent|
     step "facts should be blocked when Facter is run from Puppet with a configured blocklist" do
       # default facter.conf
-      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
       teardown do

--- a/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
+++ b/acceptance/tests/options/config_file/custom_dir_overridden_by_cli_custom_dir.rb
@@ -49,7 +49,8 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from the command line custom-dir and not the config file" do
-        on(agent, facter("--config \"#{config_file}\" --custom-dir \"#{custom_cli_dir}\" --json")) do |facter_output|
+        facter_command = "--config \"#{config_file}\" --custom-dir \"#{custom_cli_dir}\" --json #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("cli_value", results['cli_fact'], "Incorrect custom fact value for cli_fact")
           assert_nil(results['config_fact'], "Config fact should not resolve and be nil")

--- a/acceptance/tests/options/config_file/custom_facts.rb
+++ b/acceptance/tests/options/config_file/custom_facts.rb
@@ -35,7 +35,7 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from the configured custom-dir path" do
-        on(agent, facter("--config \"#{config_file}\" config_fact")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" config_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("config_value", facter_output.stdout.chomp, "Incorrect custom fact value")
         end
       end

--- a/acceptance/tests/options/config_file/custom_facts_list.rb
+++ b/acceptance/tests/options/config_file/custom_facts_list.rb
@@ -48,7 +48,7 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from each configured custom-dir path" do
-        on(agent, facter("--config \"#{config_file}\" --json")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" --json #{@options[:trace]}")) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("config_value_1", results['config_fact_1'], "Incorrect custom fact value for config_fact_1")
           assert_equal("config_value_2", results['config_fact_2'], "Incorrect custom fact value for config_fact_2")

--- a/acceptance/tests/options/config_file/debug.rb
+++ b/acceptance/tests/options/config_file/debug.rb
@@ -14,7 +14,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -24,7 +25,7 @@ EOM
       end
 
       step "debug output should print when config file is loaded" do
-        on(agent, facter("")) do |facter_output|
+        on(agent, facter((@options[:trace]).to_s)) do |facter_output|
           assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
         end
       end

--- a/acceptance/tests/options/config_file/debug_override_config_file.rb
+++ b/acceptance/tests/options/config_file/debug_override_config_file.rb
@@ -13,7 +13,8 @@ cli : {
 EOM
 
   agents.each do |agent|
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, "facter.conf")
 
     teardown do
@@ -26,7 +27,7 @@ EOM
     end
 
     step "--debug flag should override debug=false in config file" do
-      on(agent, facter("--debug")) do |facter_output|
+      on(agent, facter("--debug #{@options[:trace]}")) do |facter_output|
         assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
       end
     end

--- a/acceptance/tests/options/config_file/default_file_location.rb
+++ b/acceptance/tests/options/config_file/default_file_location.rb
@@ -30,7 +30,7 @@ EOM
       end
 
       step "config file should be loaded automatically and turn DEBUG output on" do
-        on(agent, facter("")) do |facter_output|
+        on(agent, facter((@options[:trace]).to_s)) do |facter_output|
           assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
         end
       end

--- a/acceptance/tests/options/config_file/external_dir_conflicts_with_cli_no_external_facts.rb
+++ b/acceptance/tests/options/config_file/external_dir_conflicts_with_cli_no_external_facts.rb
@@ -16,7 +16,8 @@ cli : {
 EOM
 
   agents.each do |agent|
-    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_dir = get_default_fact_dir(agent['platform'],
+                                      on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     config_file = File.join(config_dir, "facter.conf")
 
     teardown do
@@ -29,7 +30,7 @@ EOM
     end
 
     step "conflict logic applies across settings sources" do
-      on(agent, facter("--no-external-facts"), :acceptable_exit_codes => [1]) do |facter_output|
+      on(agent, facter("--no-external-facts #{@options[:trace]}"), :acceptable_exit_codes => [1]) do |facter_output|
         assert_match(/no-external-facts and external-dir options conflict/, facter_output.stderr, "Facter should have warned about conflicting settings")
       end
     end

--- a/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
+++ b/acceptance/tests/options/config_file/external_dir_overridden_by_cli_external_dir.rb
@@ -32,7 +32,8 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from the command line external-dir and not the config file" do
-        on(agent, facter("--config \"#{config_file}\" --external-dir \"#{external_cli_dir}\" --json")) do |facter_output|
+        facter_command = "--config \"#{config_file}\" --external-dir \"#{external_cli_dir}\" --json #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("cli_value", results['cli_fact'], "Incorrect custom fact value for cli_fact")
           assert_nil(results['config_fact'], "Config fact should not resolve and be nil")

--- a/acceptance/tests/options/config_file/external_facts.rb
+++ b/acceptance/tests/options/config_file/external_facts.rb
@@ -30,7 +30,7 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact in the external-dir in the configuration file" do
-        on(agent, facter("--config \"#{config_file}\" single_fact")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" single_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("external_value", facter_output.stdout.chomp, "Incorrect external fact value")
         end
       end

--- a/acceptance/tests/options/config_file/external_facts_list.rb
+++ b/acceptance/tests/options/config_file/external_facts_list.rb
@@ -36,7 +36,7 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from each configured external-dir path" do
-        on(agent, facter("--config \"#{config_file}\" --json")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" --json #{@options[:trace]}")) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("external_value_1", results['external_fact_1'], "Incorrect external fact value for external_fact_1")
           assert_equal("external_value_2", results['external_fact_2'], "Incorrect external fact value for external_fact_2")

--- a/acceptance/tests/options/config_file/load_from_ruby.rb
+++ b/acceptance/tests/options/config_file/load_from_ruby.rb
@@ -15,7 +15,8 @@ test_name "C98141: config file is loaded when Facter is run from Puppet" do
     # create paths for default facter.conf, external-dir, and custom-dir
 
     # default facter.conf
-    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                   on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
     # external-dir
@@ -45,6 +46,13 @@ test_name "C98141: config file is loaded when Facter is run from Puppet" do
         global : {
           external-dir : ["#{ext_fact_dir1}", "#{ext_fact_dir2}"],
           custom-dir : ["#{cust_fact_dir}"]
+      }
+      #{
+        if @options[:trace]
+          '  cli : {
+          trace : true
+        }'
+        end
       }
       FILE
 

--- a/acceptance/tests/options/config_file/log_level.rb
+++ b/acceptance/tests/options/config_file/log_level.rb
@@ -15,7 +15,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -25,7 +26,7 @@ EOM
       end
 
       step "log-level set to debug should print DEBUG output to stderr" do
-        on(agent, facter("")) do |facter_output|
+        on(agent, facter((@options[:trace]).to_s)) do |facter_output|
           assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
         end
       end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
@@ -36,7 +36,8 @@ EOM
       end
 
       step "Agent #{agent}: config option no-custom-facts : true and custom-dir should result in an options conflict error" do
-        on(agent, facter("--config \"#{config_file}\""), :acceptable_exit_codes => 1) do |facter_output|
+        facter_command = "--config \"#{config_file}\" #{@options[:trace]}"
+        on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
           assert_match(/options conflict/, facter_output.stderr, "Output does not contain error string")
         end
       end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
@@ -35,7 +35,8 @@ EOM
       end
 
       step "Agent #{agent}: no-custom-facts should ignore the FACTERLIB environment variable" do
-        on(agent, facter("--config \"#{config_file}\" custom_fact", :environment => {'FACTERLIB' => facterlib_dir})) do |facter_output|
+        facter_command = "--config \"#{config_file}\" custom_fact #{@options[:trace]}"
+        on(agent, facter(facter_command, :environment => {'FACTERLIB' => facterlib_dir})) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Custom fact in FACTERLIB should not have resolved")
         end
       end

--- a/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
@@ -4,9 +4,6 @@ test_name "C100004: config file option no-custom-facts : true does not load $LOA
   confine :except, :platform => 'cisco_nexus' # see BKR-749
   tag 'risk:high'
 
-  require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
-
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
@@ -41,7 +38,7 @@ EOM
       end
 
       step("Agent #{agent}: using config no-custom-facts : true should not resolve facts in facter directories on the $LOAD_PATH") do
-        on(agent, facter("--config \"#{config_file}\" custom_fact")) do |facter_output|
+        on(agent, facter("--config \"#{config_file}\" custom_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Custom fact in $LOAD_PATH/facter should not have resolved")
         end
       end

--- a/acceptance/tests/options/config_file/no_external_facts.rb
+++ b/acceptance/tests/options/config_file/no_external_facts.rb
@@ -29,7 +29,7 @@ EOM
       end
 
       step "Agent #{agent}: --no-external-facts option should not load external facts" do
-        on(agent, facter("--no-external-facts external_fact")) do |facter_output|
+        on(agent, facter("--no-external-facts external_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "External fact should not have resolved")
         end
       end

--- a/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/config_file/no_external_facts_and_external_dir.rb
@@ -27,7 +27,8 @@ EOM
       end
 
       step "Agent #{agent}: config option no-external-facts : true and external-dir should result in an options conflict error" do
-        on(agent, facter("--config \"#{config_file}\""), :acceptable_exit_codes => 1) do |facter_output|
+        facter_command = "--config \"#{config_file}\" #{@options[:trace]}"
+        on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
           assert_match(/options conflict/, facter_output.stderr, "Output does not contain error string")
         end
       end

--- a/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
+++ b/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
@@ -22,7 +22,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -33,7 +34,8 @@ EOM
 
       step "no-ruby option should disable custom facts" do
         step "Agent #{agent}: create custom fact directory and custom fact" do
-          custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+          custom_dir = get_user_fact_dir(agent['platform'],
+                                         on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
           agent.mkdir_p(custom_dir)
           custom_fact = File.join(custom_dir, 'custom_fact.rb')
           create_remote_file(agent, custom_fact, custom_fact_content)
@@ -42,7 +44,8 @@ EOM
             agent.rm_rf(custom_dir)
           end
 
-          on(agent, facter("custom_fact", :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|
+          facter_command = "custom_fact #{@options[:trace]}"
+          on(agent, facter(facter_command, :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|
             assert_equal("", facter_output.stdout.chomp, "Expected custom fact to be disabled when no-ruby is true")
           end
         end

--- a/acceptance/tests/options/config_file/no_ruby_disables_ruby_facts.rb
+++ b/acceptance/tests/options/config_file/no_ruby_disables_ruby_facts.rb
@@ -14,7 +14,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -24,7 +25,7 @@ EOM
       end
 
       step "no-ruby option should disable Ruby and facts requiring Ruby" do
-        on(agent, facter("ruby")) do |facter_output|
+        on(agent, facter("ruby #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Expected Ruby and Ruby fact to be disabled")
           assert_equal("", facter_output.stderr.chomp, "Expected no warnings about Ruby on stderr")
         end

--- a/acceptance/tests/options/config_file/trace.rb
+++ b/acceptance/tests/options/config_file/trace.rb
@@ -22,13 +22,15 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and executable custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      custom_dir = get_user_fact_dir(agent['platform'],
+                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, "custom_fact.rb")
       create_remote_file(agent, custom_fact, erroring_custom_fact)
       agent.chmod('+x', custom_fact)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -39,7 +41,8 @@ EOM
       end
 
       step "trace setting should provide a backtrace for a custom fact with errors" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" custom_fact_with_trace"), :acceptable_exit_codes => [1]) do |facter_output|
+        facter_command = "--custom-dir \"#{custom_dir}\" custom_fact_with_trace #{@options[:trace]}"
+        on(agent, facter(facter_command), :acceptable_exit_codes => [1]) do |facter_output|
           assert_match(/backtrace:\s+#{custom_fact}/, facter_output.stderr, "Expected a backtrace for erroneous custom fact")
         end
       end

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
@@ -38,9 +38,11 @@ EOM
       create_remote_file(agent, external_fact, external_fact_content)
       agent.chmod('+x', external_fact)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -70,7 +72,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -79,11 +82,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
@@ -21,9 +21,11 @@ test_name "ttls configured cached external execution resolver with text output c
       create_remote_file(agent, external_fact, external_fact_content(agent['platform'], cached_fact_name, initial_fact_value))
       agent.chmod('+x', external_fact)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -53,7 +55,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -62,11 +65,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
@@ -36,9 +36,11 @@ EOM
       create_remote_file(agent, external_fact, external_fact_content)
       agent.chmod('+x', external_fact)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -68,7 +70,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -77,11 +80,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
@@ -27,9 +27,11 @@ test_name "ttls configured cached external json resolver creates and read json c
 EOM
       create_remote_file(agent, external_fact, external_fact_content)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -58,7 +60,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -67,11 +70,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
@@ -25,9 +25,11 @@ EOM
 
       create_remote_file(agent, external_fact, external_fact_content)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -57,7 +59,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -66,11 +69,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
@@ -25,9 +25,11 @@ EOM
 
       create_remote_file(agent, external_fact, external_fact_content)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, "#{external_cachegroup}#{ext}")
 
@@ -57,7 +59,8 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -66,11 +69,12 @@ EOM
 
       step "should read from a cached JSON file for a fact that has been cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"))
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"))
 
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_fact_in_multiple_groups.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_fact_in_multiple_groups.rb
@@ -26,9 +26,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create cache file with individual fact" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       first_cached_fact_file = File.join(cached_facts_dir, first_fact_group)
       second_cached_fact_file = File.join(cached_facts_dir, second_fact_group)
@@ -44,7 +46,7 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--debug")) do |facter_output|
+        on(agent, facter("--debug #{@options[:trace]}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         first_cat_output = agent.cat(first_cached_fact_file)

--- a/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_creates_json_cache_file.rb
@@ -19,9 +19,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -36,7 +38,7 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--debug")) do |facter_output|
+        on(agent, facter("--debug #{@options[:trace]}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
@@ -26,9 +26,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -44,12 +46,12 @@ EOM
       step "should not read from a cached JSON file for a fact that has been cached but the TTL expired" do
         # Setup a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter("#{@options[:trace]}"))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
         # Change the modified date to sometime in the far distant past
         agent.modified_at(cached_fact_file, '198001010000')
 
-        on(agent, facter("#{cached_factname}")) do |facter_output|
+        on(agent, facter("#{cached_factname} #{@options[:trace]}")) do |facter_output|
           assert_not_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to not match the cached fact file")
         end
       end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
@@ -26,9 +26,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -44,12 +46,12 @@ EOM
       step "should refresh an expired cached fact" do
         # Setup a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter("#{@options[:trace]}"))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
         # Change the modified date to sometime in the far distant past
         agent.modified_at(cached_fact_file, '198001010000')
         # Force facter to recache
-        on(agent, facter("#{cached_factname}"))
+        on(agent, facter("#{cached_factname} #{@options[:trace]}"))
 
         # Read cached fact file content
         cat_output = agent.cat(cached_fact_file)

--- a/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
@@ -27,9 +27,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -45,10 +47,10 @@ EOM
       step "should read from a cached JSON file for a fact that has been cached" do
         # Setup a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter((@options[:trace]).to_s))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("#{cached_factname} --debug")) do
+        on(agent, facter("#{cached_factname} --debug #{@options[:trace]}")) do
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_resolved_by_empty_ttls_cache_list.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_resolved_by_empty_ttls_cache_list.rb
@@ -31,9 +31,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
@@ -49,7 +51,7 @@ EOM
       step "Agent #{agent}: create config file with no cached facts" do
         # Set up a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter(@options[:trace].to_s))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
       end
 
@@ -58,7 +60,7 @@ EOM
         no_cache_config_file = File.join(config_dir, "no-cache.conf")
         create_remote_file(agent, no_cache_config_file, config_no_cache)
 
-        on(agent, facter("--config \"#{no_cache_config_file}\"")) do |facter_output|
+        on(agent, facter("--config \"#{no_cache_config_file}\" #{@options[:trace]}")) do |facter_output|
           assert_match(/#{cached_fact_name}/, facter_output.stdout, "Expected to see the fact in output")
           assert_no_match(/#{cached_fact_value}/, facter_output.stdout, "Expected to not see the cached fact value")
         end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
@@ -19,9 +19,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -37,11 +39,11 @@ EOM
       step "should refresh a cached fact if cache file is corrupt" do
         # Setup a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter("#{@options[:trace]}"))
         # Corrupt the cached fact file
         create_remote_file(agent, cached_fact_file, 'ThisIsNotvalidJSON')
 
-        on(agent, facter("#{cached_factname}")) do
+        on(agent, facter("#{cached_factname} #{@options[:trace]}")) do
           assert_match(/.+/, stdout, "Expected fact to be resolved")
         end
         cat_output = agent.cat(cached_fact_file)

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb
@@ -25,9 +25,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
@@ -43,10 +45,10 @@ EOM
       step "should return an empty string for an empty JSON document" do
         # Setup a known cached fact
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter(""))
+        on(agent, facter("#{@options[:trace]}"))
         create_remote_file(agent, cached_fact_file, empty_cached_fact_content)
 
-        on(agent, facter("#{cached_factname}")) do |facter_output|
+        on(agent, facter("#{cached_factname} #{@options[:trace]}")) do |facter_output|
           assert_empty(facter_output.stdout.chomp, "Expected fact to be empty")
         end
       end

--- a/acceptance/tests/options/config_file/ttls_cached_individual_fact_name.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_individual_fact_name.rb
@@ -26,9 +26,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create cache file with individual fact" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
 
       cached_fact_file = File.join(cached_facts_dir, cached_fact_name)
 
@@ -43,7 +45,7 @@ EOM
 
       step "should create a JSON file for a fact that is to be cached" do
         agent.rm_rf(cached_facts_dir)
-        on(agent, facter("--debug")) do |facter_output|
+        on(agent, facter("--debug #{@options[:trace]}")) do |facter_output|
           assert_match(/caching values for .+ facts/, facter_output.stderr, "Expected debug message to state that values will be cached")
         end
         cat_output = agent.cat(cached_fact_file)
@@ -54,7 +56,7 @@ EOM
         agent.mkdir_p(cached_facts_dir)
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("#{cached_fact_name} --debug")) do
+        on(agent, facter("#{cached_fact_name} --debug #{@options[:trace]}")) do
           assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
           assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
         end

--- a/acceptance/tests/options/config_file/ttls_external_facts_in_custom_groups.rb
+++ b/acceptance/tests/options/config_file/ttls_external_facts_in_custom_groups.rb
@@ -24,7 +24,8 @@ EOM
 
       create_remote_file(agent, external_fact, external_fact_content)
 
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
 
       # Setup facter conf
@@ -50,7 +51,8 @@ EOM
       end
 
       step "should print error and not cache anything" do
-        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}"), acceptable_exit_codes: [1]) do |facter_output|
+        on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name} #{@options[:trace]}"),
+           acceptable_exit_codes: [1]) do |facter_output|
           assert_match(/Caching custom group is not supported for external facts/, facter_output.stderr, "Expected error message to state that external facts cannot be grouped")
         end
       end

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_creates_json_for_cached_facts.rb
@@ -15,13 +15,20 @@ facts : {
         { "#{cached_factname}" : 30 days }
     ]
 }
+#{if @options[:trace]
+    '  cli : {
+       trace : true
+    }'
+  end}
 EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       agent.mkdir_p(facter_conf_default_dir)

--- a/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_puppet_facts_honors_cached_facts.rb
@@ -14,6 +14,11 @@ facts : {
         { "#{cached_factname}" : 30 days }
     ]
 }
+#{if @options[:trace]
+    'cli : {
+      trace : true
+}'
+  end}
 EOM
 
   cached_value = "CACHED_FACT_VALUE"
@@ -26,9 +31,11 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
-      cached_facts_dir = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      cached_facts_dir = get_cached_facts_dir(agent['platform'],
+                                              on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       cached_fact_file = File.join(cached_facts_dir, cached_factname)
 
       agent.mkdir_p(facter_conf_default_dir)

--- a/acceptance/tests/options/config_file/verbose.rb
+++ b/acceptance/tests/options/config_file/verbose.rb
@@ -14,7 +14,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create config file" do
-      config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      config_dir = get_default_fact_dir(agent['platform'],
+                                        on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       config_file = File.join(config_dir, "facter.conf")
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
@@ -24,7 +25,7 @@ EOM
       end
 
       step "debug output should print when config file is loaded" do
-        on(agent, facter("")) do |facter_output|
+        on(agent, facter((@options[:trace]).to_s)) do |facter_output|
           assert_match(/INFO/, facter_output.stderr, "Expected stderr to contain verbose (INFO) statements")
         end
       end

--- a/acceptance/tests/options/custom_facts.rb
+++ b/acceptance/tests/options/custom_facts.rb
@@ -25,7 +25,7 @@ EOM
       end
 
       step "Agent #{agent}: --custom-dir option should resolve custom facts from the specific directory" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" single_custom_fact")) do |facter_output|
+        on(agent, facter("--custom-dir \"#{custom_dir}\" single_custom_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("single_fact", facter_output.stdout.chomp, "Incorrect custom fact value")
         end
       end

--- a/acceptance/tests/options/custom_facts_facterlib.rb
+++ b/acceptance/tests/options/custom_facts_facterlib.rb
@@ -25,7 +25,8 @@ EOM
       end
 
       step "Agent #{agent}: facter should resolve a fact from the directory specified by the environment variable FACTERLIB" do
-        on(agent, facter('custom_fact_facterlib', :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|
+        on(agent, facter("custom_fact_facterlib #{@options[:trace]}",
+                         :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|
           assert_equal("facterlib", facter_output.stdout.chomp, "Incorrect custom fact value for fact in FACTERLIB")
         end
       end

--- a/acceptance/tests/options/custom_facts_list.rb
+++ b/acceptance/tests/options/custom_facts_list.rb
@@ -38,7 +38,8 @@ EOM
       end
 
       step "Agent #{agent}: resolve a fact from each specified --custom-dir option" do
-        on(agent, facter("--custom-dir \"#{custom_dir_1}\" --custom-dir \"#{custom_dir_2}\" --json")) do |facter_output|
+        facter_command = "--custom-dir \"#{custom_dir_1}\" --custom-dir \"#{custom_dir_2}\" --json #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("testvalue_1", results['custom_fact_1'], "Incorrect custom fact value for custom_fact_1")
           assert_equal("testvalue_2", results['custom_fact_2'], "Incorrect custom fact value for custom_fact_2")

--- a/acceptance/tests/options/custom_facts_load_path.rb
+++ b/acceptance/tests/options/custom_facts_load_path.rb
@@ -7,9 +7,6 @@ test_name "C14777: custom facts loaded from facter subdirectory found in $LOAD_P
 
   tag 'risk:high'
 
-  require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
-
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
@@ -34,7 +31,7 @@ EOM
       end
 
       step("Agent #{agent}: resolve the custom fact that is in a facter directory on the $LOAD_PATH")
-      on(agent, facter("custom_fact")) do |facter_output|
+      on(agent, facter("custom_fact #{@options[:trace]}")) do |facter_output|
         assert_equal("load_path", facter_output.stdout.chomp, "Incorrect custom fact value for fact in $LOAD_PATH/facter")
       end
     end

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -4,7 +4,7 @@ test_name "C63191: --debug command-line option prints debugging information to s
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using --debug option" do
-      on(agent, facter('--debug')) do
+      on(agent, facter("--debug #{@options[:trace]}")) do
         assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
       end
     end

--- a/acceptance/tests/options/empty_string_in_blocklist.rb
+++ b/acceptance/tests/options/empty_string_in_blocklist.rb
@@ -7,7 +7,8 @@ test_name "empty string in blocklist does not block facts" do
 
   agents.each do |agent|
     # default facter.conf
-    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                   on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
     teardown do
@@ -25,7 +26,7 @@ test_name "empty string in blocklist does not block facts" do
     end
 
     step "no facts should be blocked is specified" do
-      on(agent, facter) do |facter_output|
+      on(agent, facter(@options[:trace].to_s)) do |facter_output|
         assert_no_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
       end
     end

--- a/acceptance/tests/options/external_facts.rb
+++ b/acceptance/tests/options/external_facts.rb
@@ -19,7 +19,7 @@ test_name "C99974: external fact commandline options --external-dir resolves an 
       end
 
       step "Agent #{agent}: resolve a fact from each specified --external_dir option" do
-        on(agent, facter("--external-dir \"#{external_dir}\" single_fact")) do |facter_output|
+        on(agent, facter("--external-dir \"#{external_dir}\" single_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("external_value", facter_output.stdout.chomp, "Incorrect external fact value")
         end
       end

--- a/acceptance/tests/options/external_facts_list.rb
+++ b/acceptance/tests/options/external_facts_list.rb
@@ -26,7 +26,8 @@ test_name "C99998: external fact commandline option --external-dir can be specif
       end
 
       step "Agent #{agent}: resolve a fact from each specified --external_dir option" do
-        on(agent, facter("--external-dir \"#{external_dir_1}\" --external-dir \"#{external_dir_2}\" --json")) do |facter_output|
+        facter_command = "--external-dir \"#{external_dir_1}\" --external-dir \"#{external_dir_2}\" --json #{@options[:trace]}"
+        on(agent, facter(facter_command)) do |facter_output|
           results = JSON.parse(facter_output.stdout)
           assert_equal("external_value_1", results['external_fact_1'], "Incorrect external fact value for external_fact_1")
           assert_equal("external_value_2", results['external_fact_2'], "Incorrect external fact value for external_fact_2")

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -5,7 +5,7 @@ test_name 'C99984: --help command-line option prints usage information to stdout
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve usage info from stdout using --help option" do
-      on(agent, facter('--help')) do
+      on(agent, facter("--help #{@options[:trace]}")) do
         assert_match(/(facter|facter-ng) \[options\] \[query\] \[query\] \[...\]/, stdout, 'Expected stdout to contain usage information')
       end
     end
@@ -25,7 +25,7 @@ test_name 'C99984: --help command-line option prints usage information to stdout
         --list-block-groups
         --list-cache-groups
       ]
-      on(agent, facter('--help')) do
+      on(agent, facter("--help #{@options[:trace]}")) do
         options.each do |option|
           assert_match(/#{option}/, stdout, "Key: #{option} not found in help description")
         end

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -18,7 +18,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create a structured custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      custom_dir = get_user_fact_dir(agent['platform'],
+                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       agent.mkdir_p(custom_dir)
       create_remote_file(agent, custom_fact, content)
@@ -29,7 +30,7 @@ EOM
       end
 
       step "Agent #{agent}: retrieve output using the --json option" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" --json structured_fact")) do
+        on(agent, facter("--custom-dir \"#{custom_dir}\" --json structured_fact #{@options[:trace]}")) do
           begin
             expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3", "true" => true, "false" => false}}
             assert_equal(expected, JSON.parse(stdout.chomp), "JSON output does not match expected output")

--- a/acceptance/tests/options/list_block_groups.rb
+++ b/acceptance/tests/options/list_block_groups.rb
@@ -6,7 +6,7 @@ test_name "C99969: the `--list-block-groups` command line flag prints available 
 
   agents.each do |agent|
     step "the EC2 blockgroup should be listed" do
-      on(agent, facter("--list-block-groups")) do |facter_output|
+      on(agent, facter("--list-block-groups #{@options[:trace]}")) do |facter_output|
         assert_match(/EC2/, facter_output.stdout, "Expected the EC2 group to be listed")
         assert_match(/ec2_metadata/, facter_output.stdout, "Expected the EC2 group's facts to be listed")
       end

--- a/acceptance/tests/options/list_cache_groups.rb
+++ b/acceptance/tests/options/list_cache_groups.rb
@@ -18,7 +18,7 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
     end
 
     step "the various cache groups should be listed" do
-      on(agent, facter("--list-cache-groups")) do |facter_output|
+      on(agent, facter("--list-cache-groups #{@options[:trace]}")) do |facter_output|
         assert_match(/EC2/, facter_output.stdout, "EC2 group should be listed as cacheable")
         assert_match(/ec2_metadata/, facter_output.stdout, "EC2 group's facts should be listed")
         assert_match(/kernel/, facter_output.stdout, "kernel group should be listed as cacheable")
@@ -42,7 +42,7 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
       external_fact_script_yaml = File.join(external_dir, "#{external_filename}.yaml")
       create_remote_file(agent, external_fact_script_yaml, '')
 
-      on(agent, facter("--external-dir \"#{external_dir}\" --list-cache-groups")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" --list-cache-groups #{@options[:trace]}")) do |facter_output|
         assert_match(/#{external_filename}#{ext}/, facter_output.stdout, "external facts script files should be listed as cacheable")
         assert_match(/#{external_filename}.txt/, facter_output.stdout, "external facts txt files should be listed as cacheable")
         assert_match(/#{external_filename}.json/, facter_output.stdout, "external facts json files should be listed as cacheable")
@@ -54,10 +54,10 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
     step "external facts groups should be listed only without --no-external-facts" do
       agent.mkdir_p(etc_factsd_dir)
       create_remote_file(agent, etc_factsd_path, 'test_fact: test_value')
-      on(agent, facter("--list-cache-groups")) do |facter_output|
+      on(agent, facter("--list-cache-groups #{@options[:trace]}")) do |facter_output|
         assert_match(/#{filename}/, facter_output.stdout, "external facts script files should be listed as cacheable")
       end
-      on(agent, facter("--list-cache-groups --no-external-facts")) do |facter_output|
+      on(agent, facter("--list-cache-groups --no-external-facts #{@options[:trace]}")) do |facter_output|
         assert_no_match(/#{filename}/, facter_output.stdout, "external facts script files should now be listed as cacheable when --no-external-facts is used")
       end
       agent.rm_rf(etc_factsd_path)

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -5,7 +5,7 @@ test_name "C99985: --log-level command-line option can be used to specify loggin
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option" do
-      on(agent, facter('--log-level debug')) do
+      on(agent, facter("--log-level debug #{@options[:trace]}")) do
         assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
       end
     end

--- a/acceptance/tests/options/no_block.rb
+++ b/acceptance/tests/options/no_block.rb
@@ -8,7 +8,8 @@ test_name "C99971: the `--no-block` command line flag prevents facts from being 
 
   agents.each do |agent|
     # default facter.conf
-    facter_conf_default_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    facter_conf_default_dir = get_default_fact_dir(agent['platform'],
+                                                   on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
     facter_conf_default_path = File.join(facter_conf_default_dir, "facter.conf")
 
     teardown do
@@ -26,7 +27,7 @@ test_name "C99971: the `--no-block` command line flag prevents facts from being 
     end
 
     step "no facts should be blocked when `--no-block` is specified" do
-      on(agent, facter("--no-block")) do |facter_output|
+      on(agent, facter("--no-block #{@options[:trace]}")) do |facter_output|
         assert_no_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
       end
     end

--- a/acceptance/tests/options/no_cache_should_not_cache_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_cache_facts.rb
@@ -15,7 +15,7 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
   FILE
 
   agents.each do |agent|
-    kernel_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    kernel_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     config_dir = get_default_fact_dir(agent['platform'], kernel_version)
     config_file = File.join(config_dir, "facter.conf")
 
@@ -35,7 +35,7 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
     end
 
     step "facter should not cache facts when --no-cache is specified" do
-      on(agent, facter("--no-cache")) do |facter_output|
+      on(agent, facter("--no-cache #{@options[:trace]}")) do |facter_output|
         assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to cache any facts")
       end
     end

--- a/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
@@ -23,7 +23,7 @@ EOM
   FILE
 
   agents.each do |agent|
-    kernel_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    kernel_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     config_dir = get_default_fact_dir(agent['platform'], kernel_version)
     config_file = File.join(config_dir, "facter.conf")
 
@@ -45,11 +45,11 @@ EOM
       agent.rm_rf(cached_facts_dir)
 
       # run once to cache the uptime fact
-      on(agent, facter(""))
+      on(agent, facter((@options[:trace]).to_s))
       # override cached content
       create_remote_file(agent, cached_fact_file, bad_cached_content)
 
-      on(agent, facter("--no-cache #{cached_fact_name}")) do |facter_output|
+      on(agent, facter("--no-cache #{cached_fact_name} #{@options[:trace]}")) do |facter_output|
         assert_no_match(/loading cached values for .+ fact/, facter_output.stderr, "facter should not have tried to load any cached facts")
         assert_no_match(/#{bad_cached_fact_value}/, facter_output.stdout, "facter should not have loaded the cached value")
       end

--- a/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
@@ -22,7 +22,7 @@ facts : { ttls : [ { "#{cached_fact_name}" : 30 minutes } ] }
 FILE
 
   agents.each do |agent|
-    kernel_version = on(agent, facter('kernelmajversion')).stdout.chomp.to_f
+    kernel_version = on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f
     config_dir = get_default_fact_dir(agent['platform'], kernel_version)
     config_file = File.join(config_dir, "facter.conf")
 
@@ -44,14 +44,14 @@ FILE
       agent.rm_rf(cached_facts_dir)
 
       # run once to cache the uptime fact
-      on(agent, facter(""))
+      on(agent, facter((@options[:trace]).to_s))
 
       # override cached content
       create_remote_file(agent, cached_fact_file, bad_cached_content)
       # update the modify time on the new cached fact to prompt a refresh
       agent.modified_at(cached_fact_file, '198001010000')
 
-      on(agent, facter("--no-cache")) do |facter_output|
+      on(agent, facter("--no-cache #{@options[:trace]}")) do |facter_output|
         assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to refresh the cache")
       end
 

--- a/acceptance/tests/options/no_color.rb
+++ b/acceptance/tests/options/no_color.rb
@@ -7,7 +7,7 @@ test_name "C99975: --debug and --no-color command-line options should print DEBU
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using --debug anod --no-color options" do
-      on(agent, facter('--debug --no-color')) do |facter_output|
+      on(agent, facter("--debug --no-color #{@options[:trace]}")) do |facter_output|
         assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
         refute_match(/\e\[0;/, facter_output.stderr, "Expected to output to not contain an escape sequence")
       end

--- a/acceptance/tests/options/no_custom_facts.rb
+++ b/acceptance/tests/options/no_custom_facts.rb
@@ -15,7 +15,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      custom_dir = get_user_fact_dir(agent['platform'],
+                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)
@@ -25,7 +26,7 @@ EOM
       end
 
       step "Agent #{agent}: --no-custom-facts option should not load custom facts" do
-        on(agent, facter("--no-custom-facts custom_fact")) do |facter_output|
+        on(agent, facter("--no-custom-facts custom_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Custom fact should not have resolved")
         end
       end

--- a/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/no_custom_facts_and_custom_dir.rb
@@ -11,7 +11,8 @@ test_name "C100001: custom fact commandline options --no-custom-facts together w
     end
 
     step "Agent #{agent}: --no-custom-facts and --custom-dir options should result in a error" do
-      on(agent, facter("--no-custom-facts --custom-dir '#{custom_dir}'"), :acceptable_exit_codes => 1) do |facter_output|
+      facter_command = "--no-custom-facts --custom-dir '#{custom_dir}' #{@options[:trace]}"
+      on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/options conflict/, facter_output.stderr.chomp, "Output does not contain error string")
       end
     end

--- a/acceptance/tests/options/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/no_custom_facts_and_facterlib.rb
@@ -25,7 +25,8 @@ EOM
       end
 
       step "Agent #{agent}: --no-custom-facts should ignore the FACTERLIB environment variable" do
-        on(agent, facter('--no-custom-facts custom_fact', :environment => { 'FACTERLIB' => facterlib_dir })) do |facter_output|
+        facter_command = "--no-custom-facts custom_fact #{@options[:trace]}"
+        on(agent, facter(facter_command, :environment => { 'FACTERLIB' => facterlib_dir })) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Custom fact in FACTERLIB should not have resolved")
         end
       end

--- a/acceptance/tests/options/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/no_custom_facts_and_load_path.rb
@@ -7,9 +7,6 @@ test_name "C100003: custom fact commandline options --no-custom-facts does not l
   confine :except, :platform => 'cisco_nexus' # see BKR-749
   tag 'risk:high'
 
-  require 'puppet/acceptance/common_utils'
-  extend Puppet::Acceptance::CommandUtils
-
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 
@@ -34,7 +31,7 @@ EOM
       end
 
       step("Agent #{agent}: using --no-custom-facts should not resolve facts on the $LOAD_PATH") do
-        on(agent, facter("--no-custom-facts custom_fact")) do |facter_output|
+        on(agent, facter("--no-custom-facts custom_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "Custom fact in $LOAD_PATH/facter should not have resolved")
         end
       end

--- a/acceptance/tests/options/no_external_facts.rb
+++ b/acceptance/tests/options/no_external_facts.rb
@@ -19,7 +19,7 @@ test_name "C99961: external fact command line option --no-external-facts does no
       end
 
       step "Agent #{agent}: --no-external-facts option should not load external facts" do
-        on(agent, facter("--no-external-facts external_fact")) do |facter_output|
+        on(agent, facter("--no-external-facts external_fact #{@options[:trace]}")) do |facter_output|
           assert_equal("", facter_output.stdout.chomp, "External fact should not have resolved")
         end
       end

--- a/acceptance/tests/options/no_external_facts_and_external_dir.rb
+++ b/acceptance/tests/options/no_external_facts_and_external_dir.rb
@@ -11,7 +11,8 @@ test_name "C100002: external fact commandline options --no-external-facts togeth
     end
 
     step "Agent #{agent}: --no-external-facts and --external-dir options should result in a error" do
-      on(agent, facter("--no-external-facts --external-dir '#{external_dir}'"), :acceptable_exit_codes => 1) do |facter_output|
+      facter_command = "--no-external-facts --external-dir '#{external_dir}' #{@options[:trace]}"
+      on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/options conflict/, facter_output.stderr.chomp, "Output does not contain error string")
       end
     end

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -18,7 +18,7 @@ EOM
 
   agents.each do |agent|
     step "--no-ruby option should disable Ruby and facts requiring ruby from being loaded" do
-      on(agent, facter("--no-ruby ruby")) do
+      on(agent, facter("--no-ruby ruby #{@options[:trace]}")) do
         assert_equal("", stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{stdout.chomp}")
         assert_equal("", stderr.chomp, "Expected no warnings about Ruby on stderr, but got output: #{stderr.chomp}")
       end
@@ -26,7 +26,8 @@ EOM
 
     step "--no-ruby option should disable custom facts" do
       step "Agent #{agent}: create custom fact directory and custom fact" do
-        custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+        custom_dir = get_user_fact_dir(agent['platform'],
+                                       on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
         agent.mkdir_p(custom_dir)
         custom_fact = File.join(custom_dir, 'custom_fact.rb')
         create_remote_file(agent, custom_fact, content)
@@ -35,7 +36,7 @@ EOM
           agent.rm_rf(custom_fact)
         end
 
-        on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do
+        on(agent, facter("--no-ruby custom_fact #{@options[:trace]}", :environment => { 'FACTERLIB' => custom_dir })) do
           assert_equal("", stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{stdout.chomp}")
         end
       end

--- a/acceptance/tests/options/puppet_facts.rb
+++ b/acceptance/tests/options/puppet_facts.rb
@@ -26,11 +26,11 @@ test_name "C14783: facter -p loads facts from puppet" do
     end
 
     step "Agent #{agent}: verify facts" do
-      on(agent, facter("-p external")) do |facter_output|
+      on(agent, facter("-p external #{@options[:trace]}")) do |facter_output|
         assert_equal("external", facter_output.stdout.chomp)
       end
 
-      on(agent, facter("-p custom")) do |facter_output|
+      on(agent, facter("-p custom #{@options[:trace]}")) do |facter_output|
         assert_equal("custom", facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/options/sequential.rb
+++ b/acceptance/tests/options/sequential.rb
@@ -3,7 +3,7 @@ test_name "--sequential argument does not generate any errors" do
 
   agents.each do |agent|
     step "--sequential should generate no errors" do
-      on(agent, facter("--sequential --debug"), :acceptable_exit_codes => 0) do |facter_output|
+      on(agent, facter("--sequential --debug  #{@options[:trace]}"), :acceptable_exit_codes => 0) do |facter_output|
         assert_match(/Resolving facts sequentially/, facter_output.stderr, "Resolving facts sequentially")
       end
     end

--- a/acceptance/tests/options/show_legacy.rb
+++ b/acceptance/tests/options/show_legacy.rb
@@ -4,13 +4,13 @@ test_name "C87580: --show-legacy command-line option results in output with lega
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve legacy output using a hash" do
-      on(agent, facter("--show-legacy")) do
+      on(agent, facter("--show-legacy #{@options[:trace]}")) do
         assert_match(/^rubyversion => [0-9]+\.[0-9]+\.[0-9]+$/, stdout.chomp, 'hash legacy output does not contain legacy fact rubyversion')
       end
     end
 
     step "Agent #{agent}: retrieve legacy output using the --json option" do
-      on(agent, facter("--show-legacy --json")) do
+      on(agent, facter("--show-legacy --json #{@options[:trace]}")) do
         assert_match(/^  "rubyversion": "[0-9]+\.[0-9]+\.[0-9]+",$/, stdout.chomp, 'json legacy output does not contain legacy fact rubyversion')
       end
     end

--- a/acceptance/tests/options/strict.rb
+++ b/acceptance/tests/options/strict.rb
@@ -3,7 +3,8 @@ test_name 'C98098: --strict flag returns errors on non-existent facts' do
 
   agents.each do |agent|
     step 'facter should return exit code 1 for querying non-existing-fact with --strict flag' do
-      on(agent, facter('non-existing-fact --strict'), :acceptable_exit_codes => 1) do |facter_output|
+      facter_command = "non-existing-fact --strict #{@options[:trace]}"
+      on(agent, facter(facter_command), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/ERROR\s+.* - .*fact "non-existing-fact" does not exist/, facter_output.stderr, 'Unexpected error was detected!')
       end
     end

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -16,7 +16,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create custom fact directory and executable custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      custom_dir = get_user_fact_dir(agent['platform'],
+                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       agent.mkdir_p(custom_dir)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       create_remote_file(agent, custom_fact, content)

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -4,7 +4,7 @@ test_name "C99986: --verbose command-line option prints verbose information to s
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve verbose info from stderr using --verbose option" do
-      on(agent, facter('--verbose')) do
+      on(agent, facter("--verbose #{@options[:trace]}")) do
         assert_match(/INFO .*executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
       end
     end

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -4,7 +4,7 @@ test_name "C99983: --version command-line option returns the version string" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve version info using the --version option" do
-      on(agent, facter('--version')) do
+      on(agent, facter("--version #{@options[:trace]}")) do
         assert_match(/\d+\.\d+\.\d+/, stdout, "Output #{stdout} is not a recognized version string")
       end
     end

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -18,7 +18,8 @@ EOM
 
   agents.each do |agent|
     step "Agent #{agent}: create a structured custom fact" do
-      custom_dir = get_user_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+      custom_dir = get_user_fact_dir(agent['platform'],
+                                     on(agent, facter("kernelmajversion #{@options[:trace]}")).stdout.chomp.to_f)
       custom_fact = File.join(custom_dir, 'custom_fact.rb')
       agent.mkdir_p(custom_dir)
       create_remote_file(agent, custom_fact, content)
@@ -29,7 +30,7 @@ EOM
       end
 
       step "Agent #{agent}: retrieve output using the --yaml option" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" --yaml structured_fact")) do
+        on(agent, facter("--custom-dir \"#{custom_dir}\" --yaml structured_fact #{@options[:trace]}")) do
           begin
             expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}
             assert_equal(expected, YAML.load(stdout), "YAML output does not match expected output")

--- a/acceptance/tests/session_cached_is_not_refershed_in_session.rb
+++ b/acceptance/tests/session_cached_is_not_refershed_in_session.rb
@@ -3,7 +3,9 @@ test_name 'facter should not update it`s session cache in same session' do
 
   fact_content = <<-EOM
     require 'facter'
-    
+
+    #{'Facter.trace(true)' if @options[:trace]}
+
     seconds_before = Facter.value('system_uptime.seconds')
     sleep(3)
     seconds_after = Facter.value('system_uptime.seconds')

--- a/acceptance/tests/ticket_1238_hostname_fqdn.rb
+++ b/acceptance/tests/ticket_1238_hostname_fqdn.rb
@@ -30,7 +30,7 @@ test_name 'C93827: facter fqdn should return the hostname when its a fully quali
     end
 
     step 'validate facter uses hostname as the fqdn if its a fully qualified domain name' do
-      on(agent, 'facter fqdn') do |facter_output|
+      on(agent, "facter fqdn #{@options[:trace]}") do |facter_output|
         assert_equal(fqdn, facter_output.stdout.chomp, 'facter did not return the hostname set by the test')
       end
     end
@@ -50,7 +50,7 @@ test_name 'C93827: facter fqdn should return the hostname when its a fully quali
   end
 
   step 'validate facter uses hostname as the LONG fqdn if its a fully qualified domain name' do
-    on(agent, 'facter fqdn') do |facter_output|
+    on(agent, "facter fqdn #{@options[:trace]}") do |facter_output|
       assert_equal(fqdn_long, facter_output.stdout.chomp, 'facter did not return the hostname set by the test')
     end
   end

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -239,8 +239,8 @@ module Facter
       nil
     end
 
-    # Flushes cached values for all facts. This does not cause code to be
-    # reloaded; it only clears the cached results.
+    # Flushes cached values for all core and custom facts (external facts are not cleared).
+    # This does not cause code to be reloaded; it only clears the cached results.
     #
     # @return [void]
     #


### PR DESCRIPTION
In the beaker config, we added the trace option which is passed to all facter calls in all acceptance
tests. 