### PR TITLE
(FACT-2851) Log useful error message when fact cannot be added to fact collection

### DIFF
--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -4,6 +4,7 @@ module Facter
   class FactCollection < Hash
     def initialize
       super
+      @log = Log.new(self)
     end
 
     def build_fact_collection!(facts)
@@ -40,6 +41,10 @@ module Facter
 
     def bury_fact(fact)
       bury(*fact.name.split('.') + fact.filter_tokens << fact.value)
+    rescue NoMethodError
+      @log.error("#{fact.type.to_s.capitalize} fact `#{fact.name}` cannot be added to collection."\
+          ' The format of this fact is incompatible with other'\
+          " facts that belong to `#{fact.name.split('.').first}` group")
     end
   end
 end

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -6,10 +6,13 @@ describe Facter::FactCollection do
   describe '#build_fact_collection!' do
     let(:user_query) { 'os' }
     let(:resolved_fact) { Facter::ResolvedFact.new(fact_name, fact_value, type) }
+    let(:logger) { instance_spy(Facter::Log) }
 
     before do
       resolved_fact.filter_tokens = []
       resolved_fact.user_query = user_query
+
+      allow(Facter::Log).to receive(:new).and_return(logger)
     end
 
     context 'when fact has some value' do
@@ -63,6 +66,20 @@ describe Facter::FactCollection do
 
           expect(fact_collection).to eq(expected_hash)
         end
+      end
+    end
+
+    context 'when fact cannot be added to collection' do
+      let(:fact_name) { 'mygroup.fact1' }
+      let(:fact_value) { 'g1_f1_value' }
+      let(:type) { :custom }
+
+      let(:resolved_fact2) { Facter::ResolvedFact.new('mygroup.fact1.subfact1', 'g1_sg1_f1_value', type) }
+
+      it 'logs error' do
+        fact_collection.build_fact_collection!([resolved_fact, resolved_fact2])
+
+        expect(logger).to have_received(:error)
       end
     end
   end


### PR DESCRIPTION
Facter 4 introduces a new way of aggregating fact via the `.` notation. e.g

```
Facter.add(:'my_fact.f1') do
  setcode do
    'f1_value'
  end
end

Facter.add(:'my_fact.f2') do
  setcode do
    'f2_value'
  end
end
```

Facter output:
```
my_fact => {
  f1 => "f1_value",
  f2 => "f2_value"
}
```


Because a tree must be constructed from the custom fact names, but there are some cases where such three cannot be constructed. The current PR logs an error message that help users discover what custom facts names are incompatible.

e.g. of incompatible custom fact names
```
Facter.add(:'my_fact.f1') do
  setcode do
    'f1_value'
  end
end

Facter.add(:'my_fact.f1.l1') do
  setcode do
    'f1_l1_value'
  end
end
```

will generate the fallowing error:
```
[2020-11-18 15:05:24.456348 ] ERROR Facter::FactCollection - Custom fact `my_fact.f1.l1` cannot be added to collection. The format of this fact is incompatible with other facts that belong to `my_fact` group 
```