### PR TITLE
(FACT-2856) Facter fails when interface name is not UTF-8

### DIFF
--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -35,6 +35,7 @@ require 'facter/framework/config/fact_groups'
 load_dir(['config'])
 
 load_dir(%w[resolvers utils])
+load_dir(%w[resolvers utils networking])
 load_dir(['resolvers'])
 load_dir(['facts_utils'])
 load_dir(%w[framework core])

--- a/lib/facter/resolvers/utils/networking/dhcp.rb
+++ b/lib/facter/resolvers/utils/networking/dhcp.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Utils
+      module Networking
+        module Dhcp
+          class << self
+            def get(interface_name, log = nil)
+              dhcpinfo_command = Facter::Core::Execution.which('dhcpinfo') || '/sbin/dhcpinfo'
+              result = Facter::Core::Execution.execute("#{dhcpinfo_command} -i #{interface_name} ServerID", logger: log)
+
+              result.chomp
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/utils/networking/networking.rb
+++ b/lib/facter/resolvers/utils/networking/networking.rb
@@ -58,6 +58,12 @@ module Resolvers
           addr.empty? || addr.start_with?('127.', '169.254.') || addr.start_with?('fe80') || addr.eql?('::1')
         end
 
+        def calculate_mask_length(netmask)
+          ipaddr = IPAddr.new(netmask)
+
+          ipaddr.to_i.to_s(2).count('1')
+        end
+
         private
 
         def expand_interfaces(interfaces)

--- a/lib/facter/resolvers/utils/networking/primary_interface.rb
+++ b/lib/facter/resolvers/utils/networking/primary_interface.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Utils
+      module Networking
+        module PrimaryInterface
+          class << self
+            def get(log = nil)
+              result = Facter::Core::Execution.execute('route -n get default', logger: log)
+
+              result.match(/interface: (.+)/)&.captures&.first
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/windows/memory_resolver.rb
+++ b/lib/facter/resolvers/windows/memory_resolver.rb
@@ -23,6 +23,10 @@ module Facter
             return
           end
 
+          # we need to enlarge the scope of this pointer so that Ruby GC will not free the memory.
+          # If the pointer if freed, Lifreq structures will contain garbage from memory.
+          @long_living_pointer = state_ptr
+
           PerformanceInformation.new(state_ptr)
         end
 

--- a/spec/facter/resolvers/utils/networking/networking_spec.rb
+++ b/spec/facter/resolvers/utils/networking/networking_spec.rb
@@ -262,4 +262,26 @@ describe Resolvers::Utils::Networking do
       end
     end
   end
+
+  describe '#calculate_mask_length' do
+    context 'when ip v4' do
+      let(:netmask) { '255.0.0.0' }
+
+      it 'returns 8 as mask length' do
+        mask_length = Resolvers::Utils::Networking.calculate_mask_length(netmask)
+
+        expect(mask_length).to be(8)
+      end
+    end
+
+    context 'when ip v6' do
+      let(:netmask) { '::ffff:ffff:ffff:ffff:ffff:ffff' }
+
+      it 'returns 10 as mask length' do
+        mask_length = Resolvers::Utils::Networking.calculate_mask_length(netmask)
+
+        expect(mask_length).to be(96)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Problem:** facter will fail to read networking interfaces randomly. Instead of useful data, garbage from memory was read and the formatter was not able to transform it in the user desired format.

The problem was caused by a pointer that has method scope and was deallocated by the GC to early. The pointer was pointing to a buffer over which structures were mapped. Because the memory was freed by the GC to early, the memory was overridden and the structures became corrupt.

**Solution:** increase the scope of the pointer, so that the memory is not deallocated to early.