### PR TITLE
(FACT-2870) Don't split legacy fact names

### DIFF
--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -40,11 +40,16 @@ module Facter
     private
 
     def bury_fact(fact)
-      bury(*fact.name.split('.') + fact.filter_tokens << fact.value)
+      split_fact_name = extract_fact_name(fact)
+      bury(*split_fact_name + fact.filter_tokens << fact.value)
     rescue NoMethodError
       @log.error("#{fact.type.to_s.capitalize} fact `#{fact.name}` cannot be added to collection."\
           ' The format of this fact is incompatible with other'\
           " facts that belong to `#{fact.name.split('.').first}` group")
+    end
+
+    def extract_fact_name(fact)
+      fact.type == :legacy ? [fact.name] : fact.name.split('.')
     end
   end
 end

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -67,6 +67,22 @@ describe Facter::FactCollection do
           expect(fact_collection).to eq(expected_hash)
         end
       end
+
+      context 'when fact type is :legacy' do
+        context 'when fact name contains dots' do
+          let(:fact_name) { 'my.dotted.external.fact.name' }
+          let(:fact_value) { 'legacy_fact_value' }
+          let(:type) { :legacy }
+
+          it 'returns a fact with dot in it`s name' do
+            fact_collection.build_fact_collection!([resolved_fact])
+
+            expected_hash = { 'my.dotted.external.fact.name' => 'legacy_fact_value' }
+
+            expect(fact_collection).to eq(expected_hash)
+          end
+        end
+      end
     end
 
     context 'when fact cannot be added to collection' do


### PR DESCRIPTION
The name of some legacy facts gets composed at runtime. e.g. `network_<network_name>`. The network_name can contain dots (`.`) in it's name.
```
network_ens33
network_ens33.13
network_ens33.14
```

Facter interprets dots as composed facts and will try to create a fact hierarchy but will fail. Because legacy facts are never composed, we should not try to create a fact hierarchy for facts with legacy type.

This PR skips fact hierarchy creation for `legacy` facts and just uses their name as it is, no special treatment is given to dots.


