### PR TITLE
(FACT-2883) Log resolved facts

### DIFF
--- a/lib/facter/framework/core/fact_manager.rb
+++ b/lib/facter/framework/core/fact_manager.rb
@@ -17,8 +17,7 @@ module Facter
     end
 
     def resolve_facts(user_query = [])
-      loaded_facts = @fact_loader.load(Options.get)
-      searched_facts = QueryParser.parse(user_query, loaded_facts)
+      searched_facts = parse_user_query(user_query)
 
       cache_manager = Facter::CacheManager.new
       searched_facts, cached_facts = cache_manager.resolve_facts(searched_facts)
@@ -32,6 +31,7 @@ module Facter
 
       FactFilter.new.filter_facts!(resolved_facts)
 
+      log_resolved_facts(resolved_facts)
       resolved_facts
     end
 
@@ -47,6 +47,12 @@ module Facter
 
     private
 
+    def parse_user_query(user_query)
+      loaded_facts = @fact_loader.load(Options.get)
+
+      QueryParser.parse(user_query, loaded_facts)
+    end
+
     def override_core_facts(core_facts, custom_facts)
       return core_facts unless custom_facts
 
@@ -59,6 +65,12 @@ module Facter
 
     def root_fact_name(fact)
       fact.name.split('.').first
+    end
+
+    def log_resolved_facts(resolved_facts)
+      resolved_facts.each do |fact|
+        @log.debug("fact \"#{fact.name}\" has resolved to: #{fact.value}") unless fact.value.nil?
+      end
     end
   end
 end


### PR DESCRIPTION
Log on debug resolved facts values.

e.g.
```
[2020-12-02 16:03:27.230497 ] DEBUG Facter::FactManager - fact "os.release" has resolved to: {"full"=>"20.1.0", "major"=>"20", "minor"=>"1"}
[2020-12-02 16:03:27.230507 ] DEBUG Facter::FactManager - fact "os.macosx.product" has resolved to: macOS
[2020-12-02 16:03:27.230519 ] DEBUG Facter::FactManager - fact "os.macosx.version" has resolved to: {"full"=>"11.0.1", "major"=>"11.0", "minor"=>"1"}
[2020-12-02 16:03:27.230528 ] DEBUG Facter::FactManager - fact "os.macosx.build" has resolved to: 20B29
[2020-12-02 16:03:27.230537 ] DEBUG Facter::FactManager - fact "os.name" has resolved to: Darwin
[2020-12-02 16:03:27.230546 ] DEBUG Facter::FactManager - fact "os.hardware" has resolved to: x86_64
[2020-12-02 16:03:27.230555 ] DEBUG Facter::FactManager - fact "os.architecture" has resolved to: x86_64
[2020-12-02 16:03:27.230566 ] DEBUG Facter::FactManager - fact "os.family" has resolved to: Darwin
[2020-12-02 16:03:27.230574 ] DEBUG Facter::FactManager - fact "kernelversion" has resolved to: 20.1.0
[2020-12-02 16:03:27.230657 ] DEBUG Facter::FactManager - fact "kernelrelease" has resolved to: 20.1.0
[2020-12-02 16:03:27.230677 ] DEBUG Facter::FactManager - fact "processors.isa" has resolved to: i386
[2020-12-02 16:03:27.230690 ] DEBUG Facter::FactManager - fact "processors.physicalcount" has resolved to: 6
[2020-12-02 16:03:27.230700 ] DEBUG Facter::FactManager - fact "processors.speed" has resolved to: 2.20 GHz
```
