### PR TITLE
(FACT-2881) Exclude nil custom facts from Facter API

### DIFF
--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -9,7 +9,7 @@ module Facter
 
     def build_fact_collection!(facts)
       facts.each do |fact|
-        next if %i[custom core legacy].include?(fact.type) && fact.value.nil?
+        next if %i[core legacy].include?(fact.type) && fact.value.nil?
 
         bury_fact(fact)
       end

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -55,19 +55,6 @@ describe Facter::FactCollection do
         end
       end
 
-      context 'when fact type is :custom' do
-        let(:fact_name) { 'operatingsystem' }
-        let(:fact_value) { nil }
-        let(:type) { :custom }
-
-        it 'does not add fact to collection' do
-          fact_collection.build_fact_collection!([resolved_fact])
-          expected_hash = {}
-
-          expect(fact_collection).to eq(expected_hash)
-        end
-      end
-
       context 'when fact type is :legacy' do
         context 'when fact name contains dots' do
           let(:fact_name) { 'my.dotted.external.fact.name' }


### PR DESCRIPTION
Exclude custom fact with nil value from to_user_output, values and to_hash ruby API's.

![facter-apis](https://user-images.githubusercontent.com/3924120/100903868-0dd6fd00-34cf-11eb-99ee-9d2b8a44de46.png)