### PR TITLE
Fix domain / fqdn resolution on CentOS / Debian (at least)

### DIFF
--- a/lib/facter/resolvers/hostname_resolver.rb
+++ b/lib/facter/resolvers/hostname_resolver.rb
@@ -31,11 +31,7 @@ module Facter
             domain = Regexp.last_match(1)
           else
             file_content = Facter::Util::FileHelper.safe_read('/etc/resolv.conf')
-            if file_content =~ /^search\s+(\S+)/
-              domain = Regexp.last_match(1)
-            elsif file_content =~ /^domain\s+(\S+)/
-              domain = Regexp.last_match(1)
-            end
+            domain = file_content =~ /^domain\s+(\S+)/ && Regexp.last_match(1)
           end
           domain
         end

--- a/lib/facter/resolvers/hostname_resolver.rb
+++ b/lib/facter/resolvers/hostname_resolver.rb
@@ -13,7 +13,7 @@ module Facter
         end
 
         def retrieve_hostname(fact_name)
-          output = Facter::Core::Execution.execute('hostname', logger: log)
+          output = Facter::Core::Execution.execute('hostname -f', logger: log)
 
           # get domain
           domain = read_domain(output)

--- a/spec/facter/resolvers/hostname_resolver_spec.rb
+++ b/spec/facter/resolvers/hostname_resolver_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Resolvers::Hostname do
       allow(Facter::Core::Execution).to receive(:execute).with('hostname -f', logger: log_spy).and_return(host)
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/etc/resolv.conf')
-        .and_return("nameserver 10.10.0.10\nnameserver 10.10.1.10\nsearch baz\ndomain baz\n")
+        .and_return("nameserver 10.10.0.10\nnameserver 10.10.1.10\nsearch baz\ndomain qux\n")
     end
 
     after do
@@ -39,7 +39,7 @@ describe Facter::Resolvers::Hostname do
 
     context 'when hostname returns host' do
       let(:hostname) { 'foo' }
-      let(:domain) { 'baz' }
+      let(:domain) { 'qux' }
       let(:host) { hostname }
       let(:fqdn) { "#{hostname}.#{domain}" }
 

--- a/spec/facter/resolvers/hostname_resolver_spec.rb
+++ b/spec/facter/resolvers/hostname_resolver_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Hostname do
   describe '#resolve' do
     before do
       hostname_resolver.instance_variable_set(:@log, log_spy)
-      allow(Facter::Core::Execution).to receive(:execute).with('hostname', logger: log_spy).and_return(host)
+      allow(Facter::Core::Execution).to receive(:execute).with('hostname -f', logger: log_spy).and_return(host)
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/etc/resolv.conf')
         .and_return("nameserver 10.10.0.10\nnameserver 10.10.1.10\nsearch baz\ndomain baz\n")


### PR DESCRIPTION
After updating a CentOS node to Puppet 7, I saw that the domain name / fqdn facts have changed:

```sh-session
romain@nsXXXXXX ~ % facter hostname
nsXXXXXX
romain@nsXXXXXX ~ % facter fqdn    
nsXXXXXX.ovh.net
romain@ns565980 ~ % hostname -f
nsXXXXXX.vittoria.pro
```

CentOS seems to use a reverse IP lookup to get the FQDN from the hostname.  But facter reads /etc/resolv.conf which in my case is:

```
nameserver 127.0.0.1
search ovh.net
```

I reverted to the 6.x version of Puppet.

The same problem probably affect at least Debian nodes.