### PR TITLE
(FACT-2882) Fix fqdn on Linux

### DIFF
--- a/lib/facter/resolvers/hostname_resolver.rb
+++ b/lib/facter/resolvers/hostname_resolver.rb
@@ -3,41 +3,83 @@
 module Facter
   module Resolvers
     class Hostname < BaseResolver
+      # :fqdn
+      # :domain
+      # :hostname
+
       init_resolver
 
       class << self
         private
 
         def post_resolve(fact_name)
-          @fact_list.fetch(fact_name) { retrieve_hostname(fact_name) }
+          @fact_list.fetch(fact_name) { retrieve_info(fact_name) }
         end
 
-        def retrieve_hostname(fact_name)
-          output = Facter::Core::Execution.execute('hostname', logger: log)
+        def retrieve_info(fact_name)
+          require 'socket'
+          output = Socket.gethostname
+          hostname, domain = retrieve_from_fqdn(output)
 
-          # get domain
-          domain = read_domain(output)
+          fqdn = retrieve_with_addrinfo(hostname) if hostname_and_no_domain?(hostname, domain)
 
-          # get hostname
-          hostname = output =~ /(.*?)\./ ? Regexp.last_match(1) : output
-          @fact_list[:hostname] ||= hostname&.strip
-          @fact_list[:domain] ||= domain&.strip
-          @fact_list[:fqdn] ||= "#{@fact_list[:hostname]}.#{@fact_list[:domain]}"
+          _, domain = retrieve_from_fqdn(fqdn) if exists_and_valid_fqdn?(fqdn, hostname)
+
+          domain = read_domain unless exists_and_not_empty?(domain)
+
+          construct_fact_list(hostname, domain, fqdn)
           @fact_list[fact_name]
         end
 
-        def read_domain(output)
-          if output =~ /.*?\.(.+$)/
-            domain = Regexp.last_match(1)
+        def retrieve_from_fqdn(output)
+          if output =~ /(.*?)\.(.+$)/
+            log.debug("Managed to read hostname: #{Regexp.last_match(1)} and domain: #{Regexp.last_match(2)}")
+            [Regexp.last_match(1), Regexp.last_match(2)]
           else
-            file_content = Facter::Util::FileHelper.safe_read('/etc/resolv.conf')
-            if file_content =~ /^search\s+(\S+)/
-              domain = Regexp.last_match(1)
-            elsif file_content =~ /^domain\s+(\S+)/
-              domain = Regexp.last_match(1)
-            end
+            log.debug("Only managed to read hostname: #{output}, no domain was found.")
+            [output, '']
           end
-          domain
+        end
+
+        def retrieve_with_addrinfo(host)
+          name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+          return if name.nil? || name.empty? || host == name[2]
+
+          name[2]
+        end
+
+        def exists_and_valid_fqdn?(fqdn, hostname)
+          exists_and_not_empty?(fqdn) && fqdn.start_with?("#{hostname}.")
+        end
+
+        def hostname_and_no_domain?(hostname, domain)
+          domain.empty? && !hostname.empty?
+        end
+
+        def read_domain
+          file_content = Facter::Util::FileHelper.safe_read('/etc/resolv.conf')
+          if file_content =~ /^domain\s+(\S+)/
+            Regexp.last_match(1)
+          elsif file_content =~ /^search\s+(\S+)/
+            Regexp.last_match(1)
+          end
+        end
+
+        def construct_fqdn(host, domain, fqdn)
+          return fqdn if exists_and_not_empty?(fqdn)
+          return if host.nil? || host.empty?
+
+          exists_and_not_empty?(domain) ? "#{host}.#{domain}" : host
+        end
+
+        def construct_fact_list(hostname, domain, fqdn)
+          @fact_list[:hostname] = hostname
+          @fact_list[:domain] = domain
+          @fact_list[:fqdn] = construct_fqdn(@fact_list[:hostname], @fact_list[:domain], fqdn)
+        end
+
+        def exists_and_not_empty?(variable)
+          variable && !variable.empty?
         end
       end
     end


### PR DESCRIPTION
**Description of the problem:** Domain is not retrieve correctly on Linux based systems and results in a faulty fqdn fact.
**Description of the fix** Use Ruby Socket's methods to retrieve domain correctly.