### PR TITLE
(FACT-2874) Load external facts in lexicographical order

### DIFF
--- a/acceptance/tests/external_facts/files_containing_external_facts_are_loaded_in_lexicographical_order.rb
+++ b/acceptance/tests/external_facts/files_containing_external_facts_are_loaded_in_lexicographical_order.rb
@@ -1,0 +1,31 @@
+test_name "FACT-2874: file containing external facts are loaded in lexicographical order" do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_name = 'test'
+  # Use a static external fact
+  ext_fact1 = "#{fact_name}: 'EXTERNAL1'"
+  ext_fact2 = "#{fact_name}: 'EXTERNAL2'"
+
+  agents.each do |agent|
+    facts_dir = agent.tmpdir('facts.d')
+    ext_fact_path1 = "#{facts_dir}/a_test.yaml"
+    ext_fact_path2 = "#{facts_dir}/b_test.yaml"
+    create_remote_file(agent, ext_fact_path1, ext_fact1)
+    create_remote_file(agent, ext_fact_path2, ext_fact2)
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    step "Agent #{agent}: resolve external fact with the last value it resolves to" do
+      on(agent, facter("--external-dir \"#{facts_dir}\" #{fact_name}")) do |facter_output|
+        assert_equal("EXTERNAL2", facter_output.stdout.chomp)
+      end
+    end
+  end
+end
+
+

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -109,7 +109,7 @@ module LegacyFacter
 
       def entries
         dirs = @directories.select { |directory| File.directory?(directory) }.map do |directory|
-          Dir.entries(directory).map { |directory_entry| File.join(directory, directory_entry) }
+          Dir.entries(directory).map { |directory_entry| File.join(directory, directory_entry) }.sort.reverse!
         end
         dirs.flatten.select { |f| should_parse?(f) }
       rescue Errno::ENOENT

--- a/lib/facter/custom_facts/util/fact.rb
+++ b/lib/facter/custom_facts/util/fact.rb
@@ -173,7 +173,16 @@ module Facter
       end
 
       def sort_by_weight(resolutions)
-        resolutions.sort { |a, b| b <=> a }
+        # sort resolutions:
+        # - descending by weight
+        # - multiple facts have the same weight but different types, the :external fact take precedence
+        # - multiple facts with the same weight and type, the order is preserved.
+        # note: sort_by is  slower than .sort
+        # we cannot use .sort because it is not stable: https://bugs.ruby-lang.org/issues/1089
+
+        # solution from: https://bugs.ruby-lang.org/issues/1089#note-10
+        idx = 0
+        resolutions.sort_by { |x| [-x.weight, (x.fact_type == :external ? 0 : 1), idx += 1] }
       end
 
       def find_first_real_value(resolutions)


### PR DESCRIPTION
**Description of the problem:** When one external fact is defined in 2 or more files, Facter resolves it to the first file it loads.
**Description of the fix:** Load files in lexicographical order to ensure a priority.