### PR TITLE
(maint) Add guard agains no user query

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -471,8 +471,9 @@ module Facter
 
     def resolve_facts_for_user_query(user_query)
       resolved_facts = Facter::FactManager.instance.resolve_facts(user_query)
-      user_queries = resolved_facts.uniq(&:user_query).map(&:user_query)
-      resolved_facts.reject! { |fact| fact.type == :custom && fact.value.nil? } if user_queries.first.empty?
+      user_querie = resolved_facts.uniq(&:user_query).map(&:user_query).first
+
+      resolved_facts.reject! { |fact| fact.type == :custom && fact.value.nil? } if user_querie&.empty?
 
       resolved_facts
     end

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -288,6 +288,22 @@ describe Facter do
         expect(json_fact_formatter).to have_received(:format).with([])
       end
     end
+
+    context 'when no facts are returned' do
+      let(:type) { :custom }
+      let(:fact_value) { nil }
+      let(:fact_user_query) { '' }
+      let(:expected_json_output) { {} }
+
+      before do
+        allow(fact_manager_spy).to receive(:resolve_facts).and_return([])
+        allow(json_fact_formatter).to receive(:format).with([]).and_return(expected_json_output)
+      end
+
+      it 'does not raise exceptions' do
+        expect { Facter.to_user_output({}, '') }.not_to raise_error
+      end
+    end
   end
 
   describe '#value' do


### PR DESCRIPTION
In some exceptional cases we can have an empty resolve_facts list. In this case, no user query will be detected as it is read from the resolved facts. 

The PR adds a guard for this exceptional case.