### PR TITLE
(FACT-2894) Facter fails to retrieve fqdn

### DIFF
--- a/lib/facter/resolvers/hostname_resolver.rb
+++ b/lib/facter/resolvers/hostname_resolver.rb
@@ -42,7 +42,12 @@ module Facter
         end
 
         def retrieve_with_addrinfo(host)
-          name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+          begin
+            name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+          rescue StandardError => e
+            @log.debug("Socket.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
+            return
+          end
           return if name.nil? || name.empty? || host == name[2]
 
           name[2]

--- a/spec/facter/resolvers/hostname_resolver_spec.rb
+++ b/spec/facter/resolvers/hostname_resolver_spec.rb
@@ -81,5 +81,17 @@ describe Facter::Resolvers::Hostname do
         expect(hostname_resolver.resolve(:domain)).to be(nil)
       end
     end
+
+    context 'when getaddrinfo throws exception' do
+      let(:host) { 'foo' }
+
+      before do
+        allow(Socket).to receive(:getaddrinfo).and_raise('socket exception')
+      end
+
+      it 'detects domain from resolv.conf' do
+        expect(hostname_resolver.resolve(:domain)).to eq('baz')
+      end
+    end
   end
 end


### PR DESCRIPTION
**Description of the problem:** Facter fails when Socket.getaddrinfo is called and it prevents fqdn information to be retrieved. 
**Description of the fix:** Rescue SocketError and continue resolving fqdn. 