### PR TITLE
(FACT-2891) Fix OpenVz detection

### DIFF
--- a/lib/facter/resolvers/open_vz.rb
+++ b/lib/facter/resolvers/open_vz.rb
@@ -15,9 +15,7 @@ module Facter
         end
 
         def check_proc_vz(fact_name)
-          if !Dir.exist?('/proc/vz') || !File.executable?('/proc/lve/list') || Dir.entries('/proc/vz').count.equal?(2)
-            return
-          end
+          return if !Dir.exist?('/proc/vz') || File.file?('/proc/lve/list') || Dir.entries('/proc/vz').count.equal?(2)
 
           @fact_list[:vm] = read_proc_status
           @fact_list[fact_name]

--- a/spec/facter/resolvers/open_vz_spec.rb
+++ b/spec/facter/resolvers/open_vz_spec.rb
@@ -4,7 +4,7 @@ describe Facter::Resolvers::OpenVz do
   subject(:openvz_resolver) { Facter::Resolvers::OpenVz }
 
   let(:vz_dir) { true }
-  let(:list_executable) { true }
+  let(:list_executable) { false }
 
   after do
     openvz_resolver.invalidate_cache
@@ -12,7 +12,7 @@ describe Facter::Resolvers::OpenVz do
 
   before do
     allow(Dir).to receive(:exist?).with('/proc/vz').and_return(vz_dir)
-    allow(File).to receive(:executable?).with('/proc/lve/list').and_return(list_executable)
+    allow(File).to receive(:file?).with('/proc/lve/list').and_return(list_executable)
     allow(Dir).to receive(:entries).with('/proc/vz').and_return(vz_dir_entries)
   end
 


### PR DESCRIPTION
**Description of the problem:** Facter fails to detect that it is on virtual environment when it's run on OpenVZ.
**Description of the fix:** Check if `/proc/lve/list` file is a regular file instead of checking  if it's executable.