### PR TITLE
(maint) Skip ssh-key types we don't support

### DIFF
--- a/lib/facter/resolvers/ssh_resolver.rb
+++ b/lib/facter/resolvers/ssh_resolver.rb
@@ -27,7 +27,8 @@ module Facter
               next unless file_content
 
               key_type, key = file_content.split(' ')
-              ssh_list << Facter::Util::Resolvers::SshHelper.create_ssh(key_type, key)
+              ssh = Facter::Util::Resolvers::SshHelper.create_ssh(key_type, key)
+              ssh_list << ssh if ssh
             end
           end
           @fact_list[:ssh] = ssh_list

--- a/lib/facter/util/resolvers/ssh_helper.rb
+++ b/lib/facter/util/resolvers/ssh_helper.rb
@@ -14,6 +14,8 @@ module Facter
 
           def create_ssh(key_type, key)
             key_name = SSH_NAME[key_type]
+            return unless key_name
+
             decoded_key = Base64.decode64(key)
             ssh_fp = SSH_FINGERPRINT[key_name]
             sha1 = "SSHFP #{ssh_fp} 1 #{Digest::SHA1.new.update(decoded_key)}"


### PR DESCRIPTION
If we read a ssh key that we do not support, the key will be created with `name=nil` and this will raise an exception in the ssh fact.