### PR TITLE
(maint) to_hash API method should return a hash

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -334,7 +334,8 @@ module Facter
 
       resolved_facts = Facter::FactManager.instance.resolve_facts
       resolved_facts.reject! { |fact| fact.type == :custom && fact.value.nil? }
-      Facter::FactCollection.new.build_fact_collection!(resolved_facts)
+      collection = Facter::FactCollection.new.build_fact_collection!(resolved_facts)
+      Hash[collection]
     end
 
     # Check whether printing stack trace is enabled

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -190,16 +190,21 @@ describe Facter do
   end
 
   describe '#to_hash' do
+    before do
+      allow(Hash).to receive(:[]).with(fact_collection_spy).and_return({})
+      allow(Hash).to receive(:[]).with(empty_fact_collection).and_return({})
+    end
+
     it 'returns one resolved fact' do
       mock_fact_manager(:resolve_facts, [os_fact])
 
-      expect(Facter.to_hash).to eq(fact_collection_spy)
+      expect(Facter.to_hash).to eq({})
     end
 
     it 'return no resolved facts' do
       mock_fact_manager(:resolve_facts, [])
 
-      expect(Facter.to_hash).to eq(empty_fact_collection)
+      expect(Facter.to_hash).to eq({})
     end
 
     context 'when custom fact with nil value' do


### PR DESCRIPTION
**Description of the problem:** dig on $facts (`'dig($facts, "os", "family")'`) fails with Facter 4. Facter's API method `to_hash` returns a different data type (Facter::FactCollection) than Facter 3.
**Description of the fix:** Ensure that `to_hash` method returns a ruby Hash instance. 