### PR TITLE
(FACT-2898) resolve facts sequential by default

### DIFF
--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -26,7 +26,7 @@ module Facter
     @config_file_external_dir = []
     @default_external_dir = []
     @fact_groups = {}
-    @sequential = false
+    @sequential = true
     @ttls = []
     @block_list = []
     @color = true
@@ -192,7 +192,7 @@ module Facter
         @fact_groups = {}
         @block_list = {}
         @color = true
-        @sequential = false
+        @sequential = true
         @ttls = []
         @trace = false
         @timing = false

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -36,7 +36,7 @@ describe Facter::OptionStore do
         config_file_external_dir: [],
         default_external_dir: [],
         fact_groups: {},
-        sequential: false,
+        sequential: true,
         block_list: {},
         color: true,
         trace: false,


### PR DESCRIPTION
Spawning one thread for each fact might cause facter to take all the file descriptors and thrown the following error:
```
Error: Could not retrieve local facts: can't create Thread: Resource
temporarily unavailable
```
This PR sets sequential to true, making fact resolution sequential.