### PR TITLE
(FACT-2903) Fix blockdevices facts

### DIFF
--- a/lib/facter/facts/aix/disks.rb
+++ b/lib/facter/facts/aix/disks.rb
@@ -4,7 +4,7 @@ module Facts
   module Aix
     class Disks
       FACT_NAME = 'disks'
-      ALIASES = %w[blockdevices blockdevice_.*_size'].freeze
+      ALIASES = %w[blockdevices blockdevice_.*_size].freeze
 
       def call_the_resolver
         facts = []

--- a/lib/facter/facts/linux/disks.rb
+++ b/lib/facter/facts/linux/disks.rb
@@ -4,7 +4,7 @@ module Facts
   module Linux
     class Disks
       FACT_NAME = 'disks'
-      ALIASES = %w[blockdevices blockdevice_.*_model blockdevice_.*_size blockdevice_.*_vendor'].freeze
+      ALIASES = %w[blockdevices blockdevice_.*_model blockdevice_.*_size blockdevice_.*_vendor].freeze
 
       def call_the_resolver
         facts = []

--- a/lib/facter/facts/solaris/disks.rb
+++ b/lib/facter/facts/solaris/disks.rb
@@ -4,7 +4,7 @@ module Facts
   module Solaris
     class Disks
       FACT_NAME = 'disks'
-      ALIASES = %w[blockdevices blockdevice_.*_size blockdevice_.*_vendor'].freeze
+      ALIASES = %w[blockdevices blockdevice_.*_size blockdevice_.*_vendor].freeze
 
       def call_the_resolver
         facts = []


### PR DESCRIPTION
The alias list for disks has an extra ' at the end which makes some legacy blockdevice facts unresolvable on Linux, Solaris and AIX.

The typos were present for some time but only came to light after 4d5f4a59dd168a02be7e47ed94c9c3452955eee4.

Remove it.