### PR TITLE
(FACT-2902) Correctly detect family for Linux

### DIFF
--- a/lib/facter/facts/linux/os/family.rb
+++ b/lib/facter/facts/linux/os/family.rb
@@ -8,8 +8,10 @@ module Facts
         ALIASES = 'osfamily'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::OsRelease.resolve(:id_like)
-          fact_value ||= Facter::Resolvers::OsRelease.resolve(:id)
+          id = Facter::Resolvers::OsRelease.resolve(:id_like)
+          id ||= Facter::Resolvers::OsRelease.resolve(:id)
+
+          fact_value = Facter::Util::Facts.discover_family(id)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value.capitalize),
            Facter::ResolvedFact.new(ALIASES, fact_value.capitalize, :legacy)]

--- a/lib/facter/framework/detector/os_detector.rb
+++ b/lib/facter/framework/detector/os_detector.rb
@@ -45,6 +45,7 @@ class OsDetector
     if hierarchy.empty?
       @log.debug("Could not detect hierarchy using os identifier: #{identifier} , trying with family")
 
+      # https://www.commandlinux.com/man-page/man5/os-release.5.html
       detect_family.to_s.split.each do |family|
         hierarchy = @os_hierarchy.construct_hierarchy(family)
         return hierarchy unless hierarchy.empty?

--- a/lib/facter/util/facts/facts_utils.rb
+++ b/lib/facter/util/facts/facts_utils.rb
@@ -9,6 +9,22 @@ module Facter
                            'BHYVE' => 'bhyve' }.freeze
 
       PHYSICAL_HYPERVISORS = %w[physical xen0 vmware_server vmware_workstation openvzhn vserver_host].freeze
+      REDHAT_FAMILY = %w[redhat rhel fedora centos scientific ascendos cloudlinux psbm
+                         oraclelinux ovs oel amazon xenserver xcp-ng virtuozzo photon].freeze
+      DEBIAN_FAMILY = %w[debian ubuntu huaweios linuxmint devuan kde].freeze
+      SUSE_FAMILY = %w[sles sled suse].freeze
+      GENTOO_FAMILY = ['gentoo'].freeze
+      ARCH_FAMILY = %w[arch manjaro].freeze
+      MANDRAKE_FAMILY = %w[mandrake mandriva mageia].freeze
+      FAMILY_HASH = { 'RedHat' => REDHAT_FAMILY, 'Debian' => DEBIAN_FAMILY, 'Suse' => SUSE_FAMILY,
+                      'Gentoo' => GENTOO_FAMILY, 'Archlinux' => ARCH_FAMILY, 'Mandrake' => MANDRAKE_FAMILY }.freeze
+
+      class << self
+        def discover_family(os)
+          FAMILY_HASH.each { |key, array_value| return key if array_value.any? { |os_flavour| os =~ /#{os_flavour}/i } }
+          os
+        end
+      end
     end
   end
 end

--- a/spec/facter/util/facts/facts_utils_spec.rb
+++ b/spec/facter/util/facts/facts_utils_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe Facter::Util::Facts do
+  subject(:facts_util) { Facter::Util::Facts }
+
+  describe '#discover_family' do
+    it "discovers Fedora's family" do
+      expect(facts_util.discover_family('rhel fedora')).to eq('RedHat')
+    end
+
+    it "discovers Centos's family" do
+      expect(facts_util.discover_family('rhel fedora centos')).to eq('RedHat')
+    end
+
+    it "discovers PSBM's family" do
+      expect(facts_util.discover_family('PSBM')).to eq('RedHat')
+    end
+
+    it "discovers Virtuozzo's family" do
+      expect(facts_util.discover_family('VirtuozzoLinux')).to eq('RedHat')
+    end
+
+    it "discovers SLED's family" do
+      expect(facts_util.discover_family('SLED')).to eq('Suse')
+    end
+
+    it "discovers KDE's family" do
+      expect(facts_util.discover_family('KDE')).to eq('Debian')
+    end
+
+    it "discovers HuaweiOS's family" do
+      expect(facts_util.discover_family('HuaweiOS')).to eq('Debian')
+    end
+
+    it "discovers Gentoo's family" do
+      expect(facts_util.discover_family('gentoo')).to eq('Gentoo')
+    end
+
+    it "discovers Manjaro's family" do
+      expect(facts_util.discover_family('Manjaro')).to eq('Archlinux')
+    end
+
+    it "discovers Mandriva's family" do
+      expect(facts_util.discover_family('Mandriva')).to eq('Mandrake')
+    end
+  end
+end


### PR DESCRIPTION
**Description of the problem:** For some Linux operating systems, Facter detects family by reading `/etc/os-release` without checking or "translating" the information. Ex: For KDE Neon family is detected as `family => "Ubuntu debian"`.
**Description of the fix:** Translate the id_like field from `/etc/os-release` to CFacter known families.