### PR TITLE
(FACT-2895) add networking.primary6 fact for Linux

### DIFF
--- a/lib/facter/facts/linux/networking/primary6.rb
+++ b/lib/facter/facts/linux/networking/primary6.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    module Networking
+      class Primary6
+        FACT_NAME = 'networking.primary6'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::Linux::Networking.resolve(:primary6_interface)
+
+          Facter::ResolvedFact.new(FACT_NAME, fact_value)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/linux/networking.rb
+++ b/lib/facter/resolvers/linux/networking.rb
@@ -19,6 +19,7 @@ module Facter
             add_info_from_socket_reader
             add_info_from_routing_table
             retrieve_primary_interface
+            retrieve_primary6_interface
             Facter::Util::Resolvers::Networking.expand_main_bindings(@fact_list)
             add_flags
             @fact_list[fact_name]

--- a/lib/facter/util/resolvers/networking/primary_interface.rb
+++ b/lib/facter/util/resolvers/networking/primary_interface.rb
@@ -56,6 +56,16 @@ module Facter
               primary_interface
             end
 
+            def read_from_ip6_route
+              return if Facter::Core::Execution.which('ip').nil?
+
+              ip_command_output = Facter::Core::Execution.execute('ip -json -6 route show default', logger: @log)
+              return if ip_command_output.nil? || ip_command_output.empty?
+
+              require 'json'
+              JSON.parse(ip_command_output).first['dev']
+            end
+
             def find_in_interfaces(interfaces)
               interfaces.each do |iface_name, interface|
                 interface[:bindings]&.each do |binding|

--- a/spec/facter/facts/linux/networking/primary6_spec.rb
+++ b/spec/facter/facts/linux/networking/primary6_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::Networking::Primary6 do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::Networking::Primary6.new }
+
+    let(:value) { 'ens160' }
+
+    before do
+      allow(Facter::Resolvers::Linux::Networking).to receive(:resolve).with(:primary6_interface).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Linux::Networking' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Linux::Networking).to have_received(:resolve).with(:primary6_interface)
+    end
+
+    it 'returns networking.primary6 fact' do
+      expect(fact.call_the_resolver)
+        .to be_an_instance_of(Facter::ResolvedFact)
+        .and have_attributes(name: 'networking.primary6', value: value)
+    end
+
+    context 'when primary6 interface can not be retrieved' do
+      let(:value) { nil }
+
+      it 'returns nil' do
+        expect(fact.call_the_resolver)
+          .to be_an_instance_of(Facter::ResolvedFact).and have_attributes(name: 'networking.primary6', value: value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/linux/networking/primary_spec.rb
+++ b/spec/facter/facts/linux/networking/primary_spec.rb
@@ -10,7 +10,7 @@ describe Facts::Linux::Networking::Primary do
       allow(Facter::Resolvers::Linux::Networking).to receive(:resolve).with(:primary_interface).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::NetworkingLinux' do
+    it 'calls Facter::Resolvers::Linux::Networking' do
       fact.call_the_resolver
       expect(Facter::Resolvers::Linux::Networking).to have_received(:resolve).with(:primary_interface)
     end

--- a/spec/facter/util/resolvers/networking/primary_interface_spec.rb
+++ b/spec/facter/util/resolvers/networking/primary_interface_spec.rb
@@ -70,6 +70,23 @@ describe Facter::Util::Resolvers::Networking::PrimaryInterface do
     end
   end
 
+  describe '#read_from_ip6_route' do
+    before do
+      allow(Facter::Core::Execution).to receive(:execute)
+        .and_return(load_fixture('ip_-json_-6_route_show_default').read)
+    end
+
+    it 'parses output from `ip -json -6 route show default`' do
+      allow(Facter::Core::Execution).to receive(:which).with('ip').and_return('/some/path')
+      expect(primary_interface.read_from_ip6_route).to eq('ens3')
+    end
+
+    it 'returns nil if route command does not exist' do
+      allow(Facter::Core::Execution).to receive(:which).with('ip').and_return(nil)
+      expect(primary_interface.read_from_ip6_route).to be_nil
+    end
+  end
+
   describe '#find_in_interfaces' do
     let(:interfaces) do
       { 'lo' =>

--- a/spec/fixtures/ip_-json_-6_route_show_default
+++ b/spec/fixtures/ip_-json_-6_route_show_default
@@ -1,0 +1,1 @@
+[{"dst":"default","gateway":"fe80::fc00:2ff:fedb:a0d4","dev":"ens3","protocol":"ra","metric":1024,"flags":[],"expires":1634,"metrics":[{"mtu":1500}],"pref":"medium"}]


### PR DESCRIPTION
Returns the egress interface name for the IPv6 default route, analogous to the `networking.primary` fact for IPv4.