### PR TITLE
(FACT-2882) Fix domain fact on Windows

### DIFF
--- a/lib/facter/facts/windows/networking/fqdn.rb
+++ b/lib/facter/facts/windows/networking/fqdn.rb
@@ -12,7 +12,7 @@ module Facts
           hostname = Facter::Resolvers::Hostname.resolve(:hostname)
           return Facter::ResolvedFact.new(FACT_NAME, nil) if !hostname || hostname.empty?
 
-          fact_value = [hostname, domain].compact.join('.')
+          fact_value = domain && !domain.empty? ? [hostname, domain].compact.join('.') : hostname
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/spec/facter/facts/windows/networking/fqdn_spec.rb
+++ b/spec/facter/facts/windows/networking/fqdn_spec.rb
@@ -54,6 +54,18 @@ describe Facts::Windows::Networking::Fqdn do
       end
     end
 
+    context 'when domain is empty string' do
+      let(:domain_name) { '' }
+      let(:hostname) { 'hostname' }
+      let(:value) { hostname }
+
+      it 'returns hostname as fqdn without a trailing dot' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'networking.fqdn', value: value),
+                          an_object_having_attributes(name: 'fqdn', value: value, type: :legacy))
+      end
+    end
+
     context 'when hostname is empty' do
       let(:domain_name) { 'domain' }
       let(:hostname) { '' }


### PR DESCRIPTION
**Description of the problem:** Facter fails to retrieve `domain` fact when Windows does not expose the host's primary DNS suffix via WMI and it's only present in the registry.
**Description of the fix:** Try to retrieve domain from registry if the domain wasn't retrieved with GetAdaptersAddresses call. Also fixed the trailing dot problem with `fqdn` fact when the domain is missing.