### PR TITLE
(maint) spec/fixtures/ip_route_show_default: correct output

### DIFF
--- a/spec/fixtures/ip_route_show_default
+++ b/spec/fixtures/ip_route_show_default
@@ -1,2 +1,1 @@
-10.16.112.0/20 dev ens160 proto kernel scope link src 10.16.124.1
 default via 10.16.112.1 dev ens160


### PR DESCRIPTION
`ip route show default` would only output one line, the default route. So remove the other line.