### PR TITLE
(maint)Enable puppet facts to disable legacy facts

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -381,7 +381,6 @@ module Facter
     # @api public
     def values(options, user_queries)
       init_cli_options(options, user_queries)
-      Options[:show_legacy] = true
       log_blocked_facts
       resolved_facts = Facter::FactManager.instance.resolve_facts(user_queries)
       resolved_facts.reject! { |fact| fact.type == :custom && fact.value.nil? }

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -365,10 +365,10 @@ describe Facter do
         expect(Facter.values({}, ['os.name'])).to eq(result)
       end
 
-      it 'sets show_legacy to true' do
+      it 'show_legacy is false by default' do
         Facter.values({}, [])
 
-        expect(Facter::Options[:show_legacy]).to be true
+        expect(Facter::Options[:show_legacy]).to be false
       end
 
       it 'logs blocked facts' do

--- a/spec_integration/facter_resolve_spec.rb
+++ b/spec_integration/facter_resolve_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'integration_helper'
+
+describe Facter do
+  context 'when calling the ruby API resolve' do
+    it 'returns a hash that includes legacy values' do
+      result = Facter.resolve('--show-legacy')
+
+      expect(result['uptime_hours']).not_to be_nil
+    end
+
+    it "returns a hash that doesn't include legacy values" do
+      result = Facter.resolve('--show-legacy false')
+
+      expect(result['uptime_hours']).to be_nil
+    end
+  end
+end

--- a/spec_integration/facter_values_spec.rb
+++ b/spec_integration/facter_values_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'integration_helper'
+
+describe Facter do
+  context 'when calling the ruby API values' do
+    it 'returns a hash that includes legacy values' do
+      result = Facter.values({ show_legacy: true }, [])
+
+      expect(result['uptime_hours']).not_to be_nil
+    end
+
+    it "returns a hash that doesn't include legacy values" do
+      result = Facter.values({ show_legacy: false }, [])
+
+      expect(result['uptime_hours']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Enable `puppet facts show` application to decide if legacy facts should be displayed.

This PR depends on [this one](https://github.com/puppetlabs/puppet/pull/8475) and fixes: [PUP-10850](https://tickets.puppetlabs.com/browse/PUP-10850) 