### PR TITLE
(maint) fix execution tests on windows

### DIFF
--- a/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
@@ -36,6 +36,8 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
+        load_path_facter_dir = "\"#{load_path_facter_dir}\"" if agent.is_cygwin?
+
         agent.rm_rf(load_path_facter_dir)
         agent.rm_rf(config_dir)
       end

--- a/acceptance/tests/options/custom_facts_load_path.rb
+++ b/acceptance/tests/options/custom_facts_load_path.rb
@@ -30,6 +30,8 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
+        load_path_facter_dir = "\"#{load_path_facter_dir}\"" if agent.is_cygwin?
+
         agent.rm_rf(load_path_facter_dir)
       end
 

--- a/acceptance/tests/options/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/no_custom_facts_and_load_path.rb
@@ -30,6 +30,8 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
+        load_path_facter_dir = "\"#{load_path_facter_dir}\"" if agent.is_cygwin?
+
         agent.rm_rf(load_path_facter_dir)
       end
 


### PR DESCRIPTION
no_custom_facts_and_load_path.rb is executing an
`agent.rm_rf(path)` where path contained spaces.
This is not working on windows because `path` needs
to be wrapped between double quotes.

This was working on GitHub Actions because the localhost
connection is using `del` in `rm_rf` method