### PR TITLE
(FACT-2917) Blocking `legacy` facts slows down facter

### DIFF
--- a/lib/facter/framework/config/fact_groups.rb
+++ b/lib/facter/framework/config/fact_groups.rb
@@ -24,6 +24,9 @@ module Facter
       fact_list = []
 
       @block_list.each do |group_name|
+        # legacy is a special group and does not need to be broken into facts
+        next if group_name == 'legacy'
+
         facts_for_block = @groups[group_name]
 
         fact_list += facts_for_block || [group_name]

--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -83,6 +83,8 @@ module Facter
     def block_facts(facts, options)
       blocked_facts = options[:blocked_facts] || []
 
+      facts.reject! { |fact| fact.type == :legacy } if options[:block_list]&.include?('legacy')
+
       reject_list_core, reject_list_legacy = construct_reject_lists(blocked_facts, facts)
 
       facts = facts.reject do |fact|

--- a/spec/framework/config/fact_groups_spec.rb
+++ b/spec/framework/config/fact_groups_spec.rb
@@ -54,6 +54,20 @@ describe Facter::FactGroups do
       end
     end
 
+    context 'with blocked `legacy` group' do
+      before do
+        stub_const('Facter::Config::FACT_GROUPS', 'legacy' => %w[legacy_fact1 legacy_fact2])
+        allow(config_reader).to receive(:block_list).and_return(%w[legacy])
+      end
+
+      # legacy facts are excluded because they are blocked by another mechanism that takes into account the fact's type
+      it 'excludes legacy facts' do
+        blk_list = fact_groups.new
+
+        expect(blk_list.blocked_facts).to be_empty
+      end
+    end
+
     context 'without block_list' do
       before do
         allow(config_reader).to receive(:block_list).and_return([])

--- a/spec/framework/core/fact_loaders/fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/fact_loader_spec.rb
@@ -127,7 +127,7 @@ describe Facter::FactLoader do
       expect(loaded_facts1).to eq(loaded_facts2)
     end
 
-    it 'env facts ovveride core facts' do
+    it 'env facts override core facts' do
       options = { external_facts: true }
 
       allow(internal_fact_loader_double).to receive(:core_facts).and_return([loaded_fact_os_name])
@@ -138,6 +138,24 @@ describe Facter::FactLoader do
       expect(loaded_facts).to be_an_instance_of(Array).and contain_exactly(
         loaded_env_custom_fact
       )
+    end
+
+    context 'when blocking legacy group' do
+      before do
+        facts_to_load = [loaded_fact_os_name_legacy]
+
+        allow(internal_fact_loader_double).to receive(:core_facts).and_return(facts_to_load)
+        allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
+        allow(external_fact_loader_double).to receive(:external_facts).and_return([])
+      end
+
+      let(:options) { { block_list: 'legacy' } }
+
+      it 'blocks legacy facts' do
+        loaded_facts = Facter::FactLoader.instance.load(options)
+
+        expect(loaded_facts).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
In order to exclude legacy facts we are using a mechanism that compares the name of all facts to all facts from [legacy group](https://github.com/puppetlabs/facter/blob/5f00e96aaff19bfa5af85d195624bb873463233f/lib/facter/config.rb#L244). The comparison is done using [regex](https://github.com/puppetlabs/facter/blob/5f00e96aaff19bfa5af85d195624bb873463233f/lib/facter/framework/core/fact_loaders/fact_loader.rb#L103) and for large numbers of facts it is slow. 

The fix: instead of using the regex comparison, we can use the fact type to block legacy facts.