### PR TITLE
(FACT-2924) Facter fails with invalid config file

### DIFF
--- a/lib/facter/framework/config/config_reader.rb
+++ b/lib/facter/framework/config/config_reader.rb
@@ -33,9 +33,16 @@ module Facter
 
       def refresh_config(config_path)
         @conf = File.readable?(config_path) ? Hocon.load(config_path) : {}
+      rescue StandardError => e
+        log.warn("Facter failed to read config file #{config_path} with the following error: #{e.message}")
+        @conf = {}
       end
 
       private
+
+      def log
+        @log ||= Log.new(self)
+      end
 
       def default_path
         os = OsDetector.instance.identifier

--- a/spec/framework/config/config_reader_spec.rb
+++ b/spec/framework/config/config_reader_spec.rb
@@ -120,6 +120,23 @@ describe Facter::ConfigReader do
       end
     end
 
+    context 'with invalid config file' do
+      let(:config) { 'some corrupt information' }
+      let(:log) { instance_spy(Facter::Log) }
+
+      before do
+        allow(Facter::Log).to receive(:new).and_return(log)
+        allow(Hocon).to receive(:load).and_raise(StandardError)
+        allow(log).to receive(:warn)
+      end
+
+      it 'loggs a warning' do
+        config_reader.init
+
+        expect(log).to have_received(:warn).with(/Facter failed to read config file/)
+      end
+    end
+
     context 'with global section in config file' do
       let(:config) { { 'global' => 'global_config' } }
 


### PR DESCRIPTION
**Description of the problem:** Facter fails when an invalid config file is provided.
**Description of the fix:** Log a warning message stating that the parsing of config file failed and continue retrieving facts with the default options.