### PR TITLE
(FACT-2927) Fix computation of metrics prefix

### DIFF
--- a/lib/facter/util/facts/unit_converter.rb
+++ b/lib/facter/util/facts/unit_converter.rb
@@ -17,10 +17,11 @@ module Facter
             speed = speed.to_i
             return if !speed || speed.zero?
 
-            prefix = { 3 => 'k', 6 => 'M', 9 => 'G', 12 => 'T' }
+            prefix = { 0 => '', 3 => 'k', 6 => 'M', 9 => 'G', 12 => 'T' }
             power = Math.log10(speed).floor
-            validated_speed = power.zero? ? speed.to_f : speed.fdiv(10**power)
-            format('%<displayed_speed>.2f', displayed_speed: validated_speed).to_s + ' ' + prefix[power] + 'Hz'
+            display_power = power - power % 3
+            validated_speed = power.zero? ? speed.to_f : speed.fdiv(10**display_power)
+            format('%<displayed_speed>.2f', displayed_speed: validated_speed).to_s + ' ' + prefix[display_power] + 'Hz'
           end
 
           def bytes_to_human_readable(bytes)

--- a/lib/facter/util/facts/unit_converter.rb
+++ b/lib/facter/util/facts/unit_converter.rb
@@ -17,11 +17,9 @@ module Facter
             speed = speed.to_i
             return if !speed || speed.zero?
 
-            prefix = { 0 => '', 3 => 'k', 6 => 'M', 9 => 'G', 12 => 'T' }
-            power = Math.log10(speed).floor
-            display_power = power - power % 3
-            validated_speed = power.zero? ? speed.to_f : speed.fdiv(10**display_power)
-            format('%<displayed_speed>.2f', displayed_speed: validated_speed).to_s + ' ' + prefix[display_power] + 'Hz'
+            validated_speed, metric_prefix = determine_metric_prefix(speed)
+
+            format('%<displayed_speed>.2f', displayed_speed: validated_speed).to_s + ' ' + metric_prefix + 'Hz'
           end
 
           def bytes_to_human_readable(bytes)
@@ -54,6 +52,14 @@ module Facter
 
             converted_number = bytes if multiple == 'bytes'
             [converted_number, multiple]
+          end
+
+          def determine_metric_prefix(num)
+            metric_prefix = { 0 => '', 3 => 'k', 6 => 'M', 9 => 'G', 12 => 'T' }
+            power = Math.log10(num).floor
+            display_exponent = power - power % 3
+            coefficient = power.zero? ? num.to_f : num.fdiv(10**display_exponent)
+            [coefficient, metric_prefix[display_exponent]]
           end
         end
       end

--- a/spec/facter/util/facts/unit_converter_spec.rb
+++ b/spec/facter/util/facts/unit_converter_spec.rb
@@ -34,6 +34,14 @@ describe Facter::Util::Facts::UnitConverter do
       expect(converter.hertz_to_human_readable(2_300_000_000)).to eql('2.30 GHz')
     end
 
+    it 'converts to MHz' do
+      expect(converter.hertz_to_human_readable(800_000_000)).to eql('800.00 MHz')
+    end
+
+    it 'handles small-ish number correctly' do
+      expect(converter.hertz_to_human_readable(42)).to eql('42.00 Hz')
+    end
+
     it 'converts to Hz even if argument is string' do
       expect(converter.hertz_to_human_readable('2400')).to eql('2.40 kHz')
     end


### PR DESCRIPTION
For speed values whose log10 is not in (3, 6, 9, 12), the old code lead
to an error when trying to stringify prefix[power] (which was nil).

The error surfaced when a linux system reported a cpu speed of less
than 1 GHz:

```
puts Math.log10(999_999_999).floor
8
```

Not really relevant for processor speed, but the hash 'prefix' now
also handles the case of no metrics prefix at all (just ```Hz```).