### PR TITLE
(FACT-2921) Fix os.release fact on Linux

### DIFF
--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -7,10 +7,13 @@ module Facter
         {
           'Linux' => [
             {
-              'Debian' => %w[
-                Elementary
-                Ubuntu
-                Raspbian
+              'Debian' => [
+                'Elementary',
+                { 'Ubuntu' => [
+                  'Linuxmint'
+                ] },
+                'Raspbian',
+                'Devuan'
               ]
             },
             {
@@ -20,13 +23,23 @@ module Facter
                 Centos
                 Ol
                 Scientific
+                Meego
+                Oel
+                Ovs
               ]
             },
             {
-              'Sles' => [
-                'Opensuse'
+              'Sles' => %w[
+                Opensuse
+                Sled
               ]
-            }
+            },
+            'Gentoo',
+            'Alpine',
+            'Photon',
+            'Slackware',
+            'Mageia',
+            'Openwrt'
           ]
         },
         {

--- a/lib/facter/facts/alpine/os/release.rb
+++ b/lib/facter/facts/alpine/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Alpine
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release, release_file: '/etc/alpine-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/os/release.rb
+++ b/lib/facter/facts/amzn/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/devuan/os/distro/release.rb
+++ b/lib/facter/facts/devuan/os/distro/release.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Facts
+  module Devuan
+    module Os
+      module Distro
+        class Release
+          FACT_NAME = 'os.distro.release'
+          ALIASES = %w[lsbdistrelease lsbmajdistrelease lsbminordistrelease].freeze
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::LsbRelease.resolve(:release)
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
+
+            release = construct_release(fact_value)
+
+            [Facter::ResolvedFact.new(FACT_NAME, release),
+             Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
+             Facter::ResolvedFact.new(ALIASES[1], release['major'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[2], release['minor'], :legacy)]
+          end
+
+          def construct_release(version)
+            versions = version.split('.')
+
+            {}.tap do |release|
+              release['full'] = version
+              release['major'] = versions[0]
+              release['minor'] = versions[1] if versions[1]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/devuan/os/release.rb
+++ b/lib/facter/facts/devuan/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Devuan
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release, release_file: '/etc/devuan_version')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/gentoo/os/release.rb
+++ b/lib/facter/facts/gentoo/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Gentoo
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/gentoo-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linuxmint/os/name.rb
+++ b/lib/facter/facts/linuxmint/os/name.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linuxmint
+    module Os
+      class Name
+        FACT_NAME = 'os.name'
+        ALIASES = 'operatingsystem'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::OsRelease.resolve(:id)&.capitalize
+
+          [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/linuxmint/os/release.rb
+++ b/lib/facter/facts/linuxmint/os/release.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linuxmint
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/linuxmint/info',
+                                                                     regex: /^RELEASE=(\d+)/ })
+          Facter::Util::Facts.release_hash_from_matchdata(version)
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/mageia/os/release.rb
+++ b/lib/facter/facts/mageia/os/release.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Facts
+  module Mageia
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/mageia-release',
+                                                                     regex: /Mageia release ([0-9.]+)/ })
+
+          Facter::Util::Facts.release_hash_from_matchdata(version)
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/meego/os/release.rb
+++ b/lib/facter/facts/meego/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Meego
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/meego-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/oel/os/release.rb
+++ b/lib/facter/facts/oel/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Oel
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/enterprise-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/ol/os/release.rb
+++ b/lib/facter/facts/ol/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ol
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/oracle-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/openwrt/os/release.rb
+++ b/lib/facter/facts/openwrt/os/release.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Facts
+  module Openwrt
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/openwrt_version',
+                                                                     regex: /^(\d+.\d+.*)/ })
+          Facter::Util::Facts.release_hash_from_matchdata(version)
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/ovs/os/release.rb
+++ b/lib/facter/facts/ovs/os/release.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ovs
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/ovs-release')
+          version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/photon/os/release.rb
+++ b/lib/facter/facts/photon/os/release.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Facts
+  module Photon
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/lsb-release',
+                                                                     regex: /DISTRIB_RELEASE="(\d+)\.(\d+)/ })
+          return if version.nil? || version[1].nil? || version[2].nil?
+
+          major = version[1].to_s
+          minor = version[2].to_s
+          version_data = major + '.' + minor
+
+          {
+            'full' => version_data,
+            'major' => major,
+            'minor' => minor
+          }
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/rhel/os/release.rb
+++ b/lib/facter/facts/rhel/os/release.rb
@@ -21,14 +21,7 @@ module Facts
           version = Facter::Resolvers::RedHatRelease.resolve(:version)
           version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
 
-          return unless version
-
-          versions = version.split('.')
-          fact_value = {}
-          fact_value['full'] = version
-          fact_value['major'] = versions[0]
-          fact_value['minor'] = versions[1] if versions[1]
-          fact_value
+          Facter::Util::Facts.release_hash_from_string(version)
         end
       end
     end

--- a/lib/facter/facts/slackware/os/release.rb
+++ b/lib/facter/facts/slackware/os/release.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Facts
+  module Slackware
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/slackware-version',
+                                                                     regex: /Slackware ([0-9.]+)/ })
+          Facter::Util::Facts.release_hash_from_matchdata(version)
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/detector/os_detector.rb
+++ b/lib/facter/framework/detector/os_detector.rb
@@ -64,7 +64,14 @@ class OsDetector
     Facter::Resolvers::OsRelease.resolve(:id_like)
   end
 
+  def detect_based_on_release_file
+    @identifier = :devuan if File.readable?('/etc/devuan_version')
+  end
+
   def detect_distro
+    detect_based_on_release_file
+    return @identifier if @identifier
+
     [Facter::Resolvers::OsRelease,
      Facter::Resolvers::RedHatRelease,
      Facter::Resolvers::SuseRelease].each do |resolver|

--- a/lib/facter/resolvers/aio_agent_version.rb
+++ b/lib/facter/resolvers/aio_agent_version.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_agent_version }
         end
 

--- a/lib/facter/resolvers/aix/architecture.rb
+++ b/lib/facter/resolvers/aix/architecture.rb
@@ -9,7 +9,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_architecture(fact_name) }
         end
 

--- a/lib/facter/resolvers/aix/disks.rb
+++ b/lib/facter/resolvers/aix/disks.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { execute_lspv(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/filesystem.rb
+++ b/lib/facter/resolvers/aix/filesystem.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_vtf_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/hardware.rb
+++ b/lib/facter/resolvers/aix/hardware.rb
@@ -9,7 +9,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_hardware(fact_name) }
         end
 

--- a/lib/facter/resolvers/aix/load_averages.rb
+++ b/lib/facter/resolvers/aix/load_averages.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_load_averages(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/memory.rb
+++ b/lib/facter/resolvers/aix/memory.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { execute_svmon(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/mountpoints.rb
+++ b/lib/facter/resolvers/aix/mountpoints.rb
@@ -11,7 +11,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_mount(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/networking.rb
+++ b/lib/facter/resolvers/aix/networking.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_netstat(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/nim.rb
+++ b/lib/facter/resolvers/aix/nim.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_niminfo(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/os_level.rb
+++ b/lib/facter/resolvers/aix/os_level.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_oslevel(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/partitions.rb
+++ b/lib/facter/resolvers/aix/partitions.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { query_cudv(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/processors.rb
+++ b/lib/facter/resolvers/aix/processors.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { query_pddv(fact_name) }
           end
 

--- a/lib/facter/resolvers/aix/serialnumber.rb
+++ b/lib/facter/resolvers/aix/serialnumber.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_serialnumber(fact_name) }
           end
 

--- a/lib/facter/resolvers/augeas.rb
+++ b/lib/facter/resolvers/augeas.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_augeas_version(fact_name) }
         end
 

--- a/lib/facter/resolvers/base_resolver.rb
+++ b/lib/facter/resolvers/base_resolver.rb
@@ -20,10 +20,10 @@ module Facter
         Facter::SessionCache.subscribe(self)
       end
 
-      def self.resolve(fact_name)
+      def self.resolve(fact_name, options = {})
         @semaphore.synchronize do
           subscribe_to_manager
-          post_resolve(fact_name)
+          post_resolve(fact_name, options)
 
           cache_nil_for_unresolved_facts(fact_name)
         end
@@ -40,8 +40,8 @@ module Facter
         @fact_list[fact_name]
       end
 
-      def self.post_resolve(_fact_name)
-        raise NotImplementedError, "You must implement post_resolve(fact_name) method in #{name}"
+      def self.post_resolve(_fact_name, _options)
+        raise NotImplementedError, "You must implement post_resolve(fact_name, options) method in #{name}"
       end
     end
   end

--- a/lib/facter/resolvers/bsd/processors.rb
+++ b/lib/facter/resolvers/bsd/processors.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { collect_processors_info(fact_name) }
           end
 

--- a/lib/facter/resolvers/cloud.rb
+++ b/lib/facter/resolvers/cloud.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { detect_azure(fact_name) }
         end
 

--- a/lib/facter/resolvers/containers.rb
+++ b/lib/facter/resolvers/containers.rb
@@ -13,7 +13,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_cgroup(fact_name) }
         end
 

--- a/lib/facter/resolvers/debian_version.rb
+++ b/lib/facter/resolvers/debian_version.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_debian_version(fact_name) }
         end
 

--- a/lib/facter/resolvers/disk.rb
+++ b/lib/facter/resolvers/disk.rb
@@ -14,7 +14,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/dmi.rb
+++ b/lib/facter/resolvers/dmi.rb
@@ -25,7 +25,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/dmi_decode.rb
+++ b/lib/facter/resolvers/dmi_decode.rb
@@ -27,7 +27,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { run_dmidecode(fact_name) }
         end
 

--- a/lib/facter/resolvers/ec2.rb
+++ b/lib/facter/resolvers/ec2.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           log.debug('Querying Ec2 metadata')
           @fact_list.fetch(fact_name) { read_facts(fact_name) }
         end

--- a/lib/facter/resolvers/eos_release.rb
+++ b/lib/facter/resolvers/eos_release.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_eos_release(fact_name) }
         end
 

--- a/lib/facter/resolvers/facterversion.rb
+++ b/lib/facter/resolvers/facterversion.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_version_file }
         end
 

--- a/lib/facter/resolvers/filesystems.rb
+++ b/lib/facter/resolvers/filesystems.rb
@@ -13,7 +13,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_filesystems(fact_name) }
           end
 

--- a/lib/facter/resolvers/fips_enabled.rb
+++ b/lib/facter/resolvers/fips_enabled.rb
@@ -13,7 +13,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_fips_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/dmi.rb
+++ b/lib/facter/resolvers/freebsd/dmi.rb
@@ -11,7 +11,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/freebsd_version.rb
+++ b/lib/facter/resolvers/freebsd/freebsd_version.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { freebsd_version_system_call(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/geom.rb
+++ b/lib/facter/resolvers/freebsd/geom.rb
@@ -12,7 +12,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/processors.rb
+++ b/lib/facter/resolvers/freebsd/processors.rb
@@ -12,7 +12,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { collect_processors_info(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/swap_memory.rb
+++ b/lib/facter/resolvers/freebsd/swap_memory.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_swap_memory(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/system_memory.rb
+++ b/lib/facter/resolvers/freebsd/system_memory.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { calculate_system_memory(fact_name) }
           end
 

--- a/lib/facter/resolvers/freebsd/virtual.rb
+++ b/lib/facter/resolvers/freebsd/virtual.rb
@@ -19,7 +19,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/gce.rb
+++ b/lib/facter/resolvers/gce.rb
@@ -11,7 +11,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           log.debug('reading Gce metadata')
           @fact_list.fetch(fact_name) { read_facts(fact_name) }
         end

--- a/lib/facter/resolvers/hostname.rb
+++ b/lib/facter/resolvers/hostname.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_info(fact_name) }
         end
 

--- a/lib/facter/resolvers/identity.rb
+++ b/lib/facter/resolvers/identity.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_identity(fact_name) }
         end
 

--- a/lib/facter/resolvers/linux/docker_uptime.rb
+++ b/lib/facter/resolvers/linux/docker_uptime.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { detect_uptime(fact_name) }
           end
 

--- a/lib/facter/resolvers/linux/load_averages.rb
+++ b/lib/facter/resolvers/linux/load_averages.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_load_averages_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/load_averages.rb
+++ b/lib/facter/resolvers/load_averages.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_load_averages(fact_name) }
         end
 

--- a/lib/facter/resolvers/lpar.rb
+++ b/lib/facter/resolvers/lpar.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_lpar(fact_name) }
         end
 

--- a/lib/facter/resolvers/lsb_release.rb
+++ b/lib/facter/resolvers/lsb_release.rb
@@ -14,7 +14,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_facts(fact_name) }
         end
 

--- a/lib/facter/resolvers/lspci.rb
+++ b/lib/facter/resolvers/lspci.rb
@@ -13,7 +13,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { lspci_command(fact_name) }
         end
 

--- a/lib/facter/resolvers/macosx/dmi.rb
+++ b/lib/facter/resolvers/macosx/dmi.rb
@@ -11,7 +11,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts }
           end
 

--- a/lib/facter/resolvers/macosx/filesystems.rb
+++ b/lib/facter/resolvers/macosx/filesystems.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_filesystems(fact_name) }
           end
 

--- a/lib/facter/resolvers/macosx/load_averages.rb
+++ b/lib/facter/resolvers/macosx/load_averages.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_load_averages_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/macosx/mountpoints.rb
+++ b/lib/facter/resolvers/macosx/mountpoints.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_mounts }
           end
 

--- a/lib/facter/resolvers/macosx/processor.rb
+++ b/lib/facter/resolvers/macosx/processor.rb
@@ -18,7 +18,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_processor_data(fact_name) }
           end
 

--- a/lib/facter/resolvers/macosx/swap_memory.rb
+++ b/lib/facter/resolvers/macosx/swap_memory.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_swap_memory(fact_name) }
           end
 

--- a/lib/facter/resolvers/macosx/system_memory.rb
+++ b/lib/facter/resolvers/macosx/system_memory.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { calculate_system_memory(fact_name) }
           end
 

--- a/lib/facter/resolvers/macosx/system_profiler.rb
+++ b/lib/facter/resolvers/macosx/system_profiler.rb
@@ -20,7 +20,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { retrieve_system_profiler(fact_name) }
           end
 

--- a/lib/facter/resolvers/memory.rb
+++ b/lib/facter/resolvers/memory.rb
@@ -11,7 +11,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_meminfo_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/mountpoints.rb
+++ b/lib/facter/resolvers/mountpoints.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_mounts(fact_name) }
         end
 

--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_facts(fact_name) }
         end
 

--- a/lib/facter/resolvers/networking_linux.rb
+++ b/lib/facter/resolvers/networking_linux.rb
@@ -19,7 +19,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_network_info(fact_name) }
 
           @fact_list[fact_name]

--- a/lib/facter/resolvers/open_vz.rb
+++ b/lib/facter/resolvers/open_vz.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { check_proc_vz(fact_name) }
         end
 

--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -19,7 +19,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_os_release_file(fact_name) }
         end
 

--- a/lib/facter/resolvers/partitions.rb
+++ b/lib/facter/resolvers/partitions.rb
@@ -11,7 +11,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_partitions(fact_name) }
         end
 

--- a/lib/facter/resolvers/path.rb
+++ b/lib/facter/resolvers/path.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_path_from_env }
         end
 

--- a/lib/facter/resolvers/processors.rb
+++ b/lib/facter/resolvers/processors.rb
@@ -18,7 +18,7 @@ module Facter
 
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_cpuinfo(fact_name) }
           end
 

--- a/lib/facter/resolvers/redhat_release.rb
+++ b/lib/facter/resolvers/redhat_release.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_redhat_release(fact_name) }
         end
 

--- a/lib/facter/resolvers/release_from_first_line.rb
+++ b/lib/facter/resolvers/release_from_first_line.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    class ReleaseFromFirstLine < BaseResolver
+      # :release
+
+      init_resolver
+
+      class << self
+        private
+
+        def post_resolve(fact_name, options)
+          @fact_list.fetch(fact_name) { read_release_file(fact_name, options) }
+        end
+
+        def read_release_file(fact_name, options)
+          release_file = options[:release_file]
+          return unless release_file
+
+          output = Facter::Util::FileHelper.safe_read(release_file, nil)
+          return @fact_list[fact_name] = nil if output.nil?
+
+          @fact_list[:release] = retrieve_version(output)
+
+          @fact_list[fact_name]
+        end
+
+        def retrieve_version(output)
+          if output[/(Rawhide)$/]
+            'Rawhide'
+          elsif output['release']
+            output.strip =~ /release (\d[\d.]*)/ ? Regexp.last_match(1) : nil
+          else
+            output.strip =~ /Amazon Linux (\d+)/ ? Regexp.last_match(1) : nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/ruby.rb
+++ b/lib/facter/resolvers/ruby.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_ruby_information(fact_name) }
         end
 

--- a/lib/facter/resolvers/selinux.rb
+++ b/lib/facter/resolvers/selinux.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_facts(fact_name) }
         end
 

--- a/lib/facter/resolvers/solaris/disks.rb
+++ b/lib/facter/resolvers/solaris/disks.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_disks_info(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/dmi.rb
+++ b/lib/facter/resolvers/solaris/dmi.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/dmi_sparc.rb
+++ b/lib/facter/resolvers/solaris/dmi_sparc.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/filesystems.rb
+++ b/lib/facter/resolvers/solaris/filesystems.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_sysdef_file(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/ipaddress.rb
+++ b/lib/facter/resolvers/solaris/ipaddress.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_ipaddress(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/ldom.rb
+++ b/lib/facter/resolvers/solaris/ldom.rb
@@ -31,7 +31,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { call_virtinfo(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/memory.rb
+++ b/lib/facter/resolvers/solaris/memory.rb
@@ -12,7 +12,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { calculate_memory(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/mountpoints.rb
+++ b/lib/facter/resolvers/solaris/mountpoints.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_mounts(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/networking.rb
+++ b/lib/facter/resolvers/solaris/networking.rb
@@ -11,7 +11,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/os_release.rb
+++ b/lib/facter/resolvers/solaris/os_release.rb
@@ -12,7 +12,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { build_release_facts(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/processors.rb
+++ b/lib/facter/resolvers/solaris/processors.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { collect_kstat_info(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/zone.rb
+++ b/lib/facter/resolvers/solaris/zone.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { build_zone_fact(fact_name) }
           end
 

--- a/lib/facter/resolvers/solaris/zone_name.rb
+++ b/lib/facter/resolvers/solaris/zone_name.rb
@@ -9,7 +9,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { build_current_zone_name_fact(fact_name) }
           end
 

--- a/lib/facter/resolvers/specific_release_file.rb
+++ b/lib/facter/resolvers/specific_release_file.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    class SpecificReleaseFile < BaseResolver
+      # :release
+
+      init_resolver
+
+      class << self
+        private
+
+        def post_resolve(fact_name, options)
+          @fact_list.fetch(fact_name) { read_release_file(fact_name, options) }
+        end
+
+        def read_release_file(fact_name, options)
+          release_file = options[:release_file]
+          return unless release_file
+
+          output = Facter::Util::FileHelper.safe_read(release_file, nil)
+          return @fact_list[fact_name] = nil if output.nil?
+
+          if options[:regex]
+            @fact_list[:release] = output.strip =~ /#{options[:regex]}/ ? Regexp.last_match : nil
+            return @fact_list[fact_name]
+          end
+
+          @fact_list[:release] = output.strip
+          @fact_list[fact_name]
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/ssh.rb
+++ b/lib/facter/resolvers/ssh.rb
@@ -13,7 +13,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_info(fact_name) }
         end
 

--- a/lib/facter/resolvers/suse_release.rb
+++ b/lib/facter/resolvers/suse_release.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_suse_release(fact_name) }
         end
 

--- a/lib/facter/resolvers/sw_vers.rb
+++ b/lib/facter/resolvers/sw_vers.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { software_version_system_call(fact_name) }
         end
 

--- a/lib/facter/resolvers/timezone.rb
+++ b/lib/facter/resolvers/timezone.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { determine_timezone }
         end
 

--- a/lib/facter/resolvers/uname.rb
+++ b/lib/facter/resolvers/uname.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { uname_system_call(fact_name) }
         end
 

--- a/lib/facter/resolvers/uptime.rb
+++ b/lib/facter/resolvers/uptime.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { uptime_system_call(fact_name) }
         end
 

--- a/lib/facter/resolvers/virt_what.rb
+++ b/lib/facter/resolvers/virt_what.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_from_virt_what(fact_name) }
         end
 

--- a/lib/facter/resolvers/vmware.rb
+++ b/lib/facter/resolvers/vmware.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { vmware_command(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/aio_agent_version.rb
+++ b/lib/facter/resolvers/windows/aio_agent_version.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_version(fact_name) }
           end
 

--- a/lib/facter/resolvers/windows/dmi_bios.rb
+++ b/lib/facter/resolvers/windows/dmi_bios.rb
@@ -12,7 +12,7 @@ module Facter
 
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_bios(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/dmi_computersystem.rb
+++ b/lib/facter/resolvers/windows/dmi_computersystem.rb
@@ -12,7 +12,7 @@ module Facter
 
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_computer_system(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/fips.rb
+++ b/lib/facter/resolvers/windows/fips.rb
@@ -12,7 +12,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_fact_from_registry(fact_name) }
           end
 

--- a/lib/facter/resolvers/windows/hardware_architecture.rb
+++ b/lib/facter/resolvers/windows/hardware_architecture.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_hardware_information(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/identity.rb
+++ b/lib/facter/resolvers/windows/identity.rb
@@ -11,7 +11,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_facts(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/kernel.rb
+++ b/lib/facter/resolvers/windows/kernel.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_os_version_information(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/memory.rb
+++ b/lib/facter/resolvers/windows/memory.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { validate_info(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/netkvm.rb
+++ b/lib/facter/resolvers/windows/netkvm.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_registry(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/networking.rb
+++ b/lib/facter/resolvers/windows/networking.rb
@@ -10,7 +10,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { read_network_information(fact_name) }
           end
 

--- a/lib/facter/resolvers/windows/processors.rb
+++ b/lib/facter/resolvers/windows/processors.rb
@@ -13,7 +13,7 @@ module Facter
 
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_win32_processor(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/product_release.rb
+++ b/lib/facter/resolvers/windows/product_release.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_registry(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/ssh.rb
+++ b/lib/facter/resolvers/windows/ssh.rb
@@ -13,7 +13,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { retrieve_info(fact_name) }
           end
 

--- a/lib/facter/resolvers/windows/system32.rb
+++ b/lib/facter/resolvers/windows/system32.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { retrieve_windows_binaries_path }
         end
 

--- a/lib/facter/resolvers/windows/uptime.rb
+++ b/lib/facter/resolvers/windows/uptime.rb
@@ -13,7 +13,7 @@ module Facter
         class << self
           private
 
-          def post_resolve(fact_name)
+          def post_resolve(fact_name, _options)
             @fact_list.fetch(fact_name) { calculate_system_uptime(fact_name) }
           end
 

--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -16,7 +16,7 @@ module Facter
 
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_fact_from_computer_system(fact_name) }
         end
 

--- a/lib/facter/resolvers/windows/win_os_description.rb
+++ b/lib/facter/resolvers/windows/win_os_description.rb
@@ -10,7 +10,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_from_ole(fact_name) }
         end
 

--- a/lib/facter/resolvers/wpar.rb
+++ b/lib/facter/resolvers/wpar.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { read_wpar(fact_name) }
         end
 

--- a/lib/facter/resolvers/xen.rb
+++ b/lib/facter/resolvers/xen.rb
@@ -12,7 +12,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { detect_xen(fact_name) }
         end
 

--- a/lib/facter/resolvers/zfs.rb
+++ b/lib/facter/resolvers/zfs.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { zfs_fact(fact_name) }
         end
 

--- a/lib/facter/resolvers/zpool.rb
+++ b/lib/facter/resolvers/zpool.rb
@@ -8,7 +8,7 @@ module Facter
       class << self
         private
 
-        def post_resolve(fact_name)
+        def post_resolve(fact_name, _options)
           @fact_list.fetch(fact_name) { zpool_fact(fact_name) }
         end
 

--- a/lib/facter/util/facts/facts_utils.rb
+++ b/lib/facter/util/facts/facts_utils.rb
@@ -24,6 +24,23 @@ module Facter
           FAMILY_HASH.each { |key, array_value| return key if array_value.any? { |os_flavour| os =~ /#{os_flavour}/i } }
           os
         end
+
+        def release_hash_from_string(output)
+          return unless output
+
+          versions = output.split('.')
+          {}.tap do |release|
+            release['full'] = output
+            release['major'] = versions[0]
+            release['minor'] = versions[1] if versions[1]
+          end
+        end
+
+        def release_hash_from_matchdata(data)
+          return if data.nil? || data[1].nil?
+
+          release_hash_from_string(data[1].to_s)
+        end
       end
     end
   end

--- a/spec/facter/facts/alpine/os/release_spec.rb
+++ b/spec/facter/facts/alpine/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Alpine::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Alpine::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, release_file: '/etc/alpine-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '3.13.0' }
+      let(:release) { { 'full' => '3.13.0', 'major' => '3', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+          .with(:release, release_file: '/etc/alpine-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '3' }
+      let(:release) { { 'full' => '3', 'major' => '3' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/amzn/os/release_spec.rb
+++ b/spec/facter/facts/amzn/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/system-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/system-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '2' }
+      let(:release) { { 'full' => '2', 'major' => '2' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/devuan/os/distro/release_spec.rb
+++ b/spec/facter/facts/devuan/os/distro/release_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe Facts::Devuan::Os::Distro::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Devuan::Os::Distro::Release.new }
+
+    let(:value) { '7.2.1511' }
+    let(:release) { { 'full' => '7.2.1511', 'major' => '7', 'minor' => '2' } }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+    end
+
+    it 'returns release fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                        an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
+                        an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                    value: release['major'], type: :legacy),
+                        an_object_having_attributes(name: 'lsbminordistrelease',
+                                                    value: release['minor'], type: :legacy))
+    end
+
+    context 'when lsb_release is not installed' do
+      let(:value) { nil }
+
+      before do
+        allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'os.distro.release', value: value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/devuan/os/release_spec.rb
+++ b/spec/facter/facts/devuan/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Devuan::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Devuan::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, release_file: '/etc/devuan_version')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+          .with(:release, release_file: '/etc/devuan_version')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { 'beowulf' }
+      let(:release) { { 'full' => 'beowulf', 'major' => 'beowulf' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/gentoo/os/release_spec.rb
+++ b/spec/facter/facts/gentoo/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Gentoo::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Gentoo::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/gentoo-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2007.0' }
+      let(:release) { { 'full' => '2007.0', 'major' => '2007', 'minor' => '0' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/gentoo-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '2007.0' }
+      let(:release) { { 'full' => '2007.0', 'major' => '2007', 'minor' => '0' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/linuxmint/os/name_spec.rb
+++ b/spec/facter/facts/linuxmint/os/name_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Linuxmint::Os::Name do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linuxmint::Os::Name.new }
+
+    let(:value) { 'linuxmint' }
+
+    before do
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:id).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::OsRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:id)
+    end
+
+    it 'returns operating system name fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.name', value: value.capitalize),
+                        an_object_having_attributes(name: 'operatingsystem', value: value.capitalize, type: :legacy))
+    end
+  end
+end

--- a/spec/facter/facts/linuxmint/os/release_spec.rb
+++ b/spec/facter/facts/linuxmint/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Linuxmint::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linuxmint::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/linuxmint/info',
+                          regex: /^RELEASE=(\d+)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /^RELEASE=(\d+)/.match('RELEASE=19.4') }
+      let(:release) { { 'full' => '19', 'major' => '19' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/linuxmint/info',
+                            regex: /^RELEASE=(\d+)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '19.4' }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/mageia/os/release_spec.rb
+++ b/spec/facter/facts/mageia/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Mageia::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Mageia::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/mageia-release',
+                          regex: /Mageia release ([0-9.]+)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /Mageia release ([0-9.]+)/.match('Mageia release 19.4') }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/mageia-release',
+                            regex: /Mageia release ([0-9.]+)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '19.4' }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/meego/os/release_spec.rb
+++ b/spec/facter/facts/meego/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Meego::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Meego::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/meego-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/meego-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { 'beowulf' }
+      let(:release) { { 'full' => 'beowulf', 'major' => 'beowulf' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/oel/os/release_spec.rb
+++ b/spec/facter/facts/oel/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Oel::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Oel::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/enterprise-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/enterprise-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { 'beowulf' }
+      let(:release) { { 'full' => 'beowulf', 'major' => 'beowulf' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ol/os/release_spec.rb
+++ b/spec/facter/facts/ol/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Ol::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Ol::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/oracle-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/oracle-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { 'beowulf' }
+      let(:release) { { 'full' => 'beowulf', 'major' => 'beowulf' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/openwrt/os/release_spec.rb
+++ b/spec/facter/facts/openwrt/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Openwrt::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Openwrt::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/openwrt_version',
+                          regex: /^(\d+.\d+.*)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /^(\d+.\d+.*)/.match('19.4') }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/openwrt_version',
+                            regex: /^(\d+.\d+.*)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '19.4' }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ovs/os/release_spec.rb
+++ b/spec/facter/facts/ovs/os/release_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe Facts::Ovs::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Ovs::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/ovs-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/ovs-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { 'beowulf' }
+      let(:release) { { 'full' => 'beowulf', 'major' => 'beowulf' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/photon/os/release_spec.rb
+++ b/spec/facter/facts/photon/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Photon::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Photon::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/lsb-release',
+                          regex: /DISTRIB_RELEASE="(\d+)\.(\d+)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /DISTRIB_RELEASE="(\d+)\.(\d+)/.match('DISTRIB_RELEASE="19.4') }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/lsb-release',
+                            regex: /DISTRIB_RELEASE="(\d+)\.(\d+)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '19.4' }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/slackware/os/release_spec.rb
+++ b/spec/facter/facts/slackware/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Slackware::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Slackware::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/slackware-version',
+                          regex: /Slackware ([0-9.]+)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /Slackware ([0-9.]+)/.match('Slackware 19.4') }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/slackware-version',
+                            regex: /Slackware ([0-9.]+)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '19.4' }
+      let(:release) { { 'full' => '19.4', 'major' => '19', 'minor' => '4' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/resolvers/base_resolver_spec.rb
+++ b/spec/facter/resolvers/base_resolver_spec.rb
@@ -6,7 +6,7 @@ describe Facter::Resolvers::BaseResolver do
     Class.new(Facter::Resolvers::BaseResolver) do
       init_resolver
 
-      def self.post_resolve(fact_name)
+      def self.post_resolve(fact_name, _options)
         @fact_list[fact_name] = 'value'
         @fact_list
       end
@@ -70,7 +70,7 @@ describe Facter::Resolvers::BaseResolver do
       it 'calls the post_resolve method' do
         resolver.resolve(fact)
 
-        expect(resolver).to have_received(:post_resolve).with(fact)
+        expect(resolver).to have_received(:post_resolve).with(fact, {})
       end
     end
 
@@ -106,7 +106,7 @@ describe Facter::Resolvers::BaseResolver do
       resolver.resolve('my_fact')
       resolver.cache_nil_for_unresolved_facts('my_fact')
 
-      expect(resolver.post_resolve('my_fact')).to eq({ 'my_fact' => 'value' })
+      expect(resolver.post_resolve('my_fact', {})).to eq({ 'my_fact' => 'value' })
     end
   end
 
@@ -114,9 +114,9 @@ describe Facter::Resolvers::BaseResolver do
     let(:resolver) { Class.new(Facter::Resolvers::BaseResolver) }
 
     it 'raises NotImplementedError error' do
-      expect { resolver.post_resolve(fact) }.to \
+      expect { resolver.post_resolve(fact, {}) }.to \
         raise_error(NotImplementedError,
-                    'You must implement post_resolve(fact_name) method in ')
+                    'You must implement post_resolve(fact_name, options) method in ')
     end
   end
 end

--- a/spec/facter/resolvers/release_from_first_line_spec.rb
+++ b/spec/facter/resolvers/release_from_first_line_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::ReleaseFromFirstLine do
+  subject(:release_from_first_line_resolver) { Facter::Resolvers::ReleaseFromFirstLine }
+
+  after do
+    release_from_first_line_resolver.invalidate_cache
+  end
+
+  context 'when release file name is not given' do
+    it 'returns nil' do
+      result = release_from_first_line_resolver.resolve(:release, release_folder: 'folder')
+
+      expect(result).to be_nil
+    end
+  end
+
+  context 'when release file is present' do
+    before do
+      allow(Facter::Util::FileHelper).to receive(:safe_read).with(file_name, nil).and_return(result)
+    end
+
+    context 'when release file can not be read' do
+      let(:file_name) { '/etc/ovs-release' }
+      let(:result) { nil }
+
+      it 'returns nil' do
+        result = release_from_first_line_resolver.resolve(:release, release_file: file_name)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when release file is readable' do
+      let(:file_name) { '/etc/oracle-release' }
+      let(:result) { 'Oracle Linux release 10.5 (something)' }
+
+      it 'returns release value' do
+        result = release_from_first_line_resolver.resolve(:release, release_file: file_name)
+
+        expect(result).to eq('10.5')
+      end
+    end
+
+    context 'when os-release file contains Rawhide' do
+      let(:file_name) { '/etc/os-release' }
+      let(:result) { 'a bunch of data and there is Rawhide' }
+
+      it 'returns nil' do
+        result = release_from_first_line_resolver.resolve(:release, release_file: file_name)
+
+        expect(result).to eq('Rawhide')
+      end
+    end
+
+    context 'when os-release file contains Amazon Linux' do
+      let(:file_name) { '/etc/os-release' }
+      let(:result) { 'some other data and Amazon Linux 15 and that\'s it' }
+
+      it 'returns nil' do
+        result = release_from_first_line_resolver.resolve(:release, release_file: file_name)
+
+        expect(result).to eq('15')
+      end
+    end
+
+    context 'when requesting invalid data' do
+      let(:file_name) { '/etc/oracle-release' }
+      let(:result) { nil }
+
+      it 'returns nil' do
+        result = release_from_first_line_resolver.resolve(:something, release_file: file_name)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/facter/resolvers/specific_release_file_spec.rb
+++ b/spec/facter/resolvers/specific_release_file_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::SpecificReleaseFile do
+  subject(:specific_release_file_resolver) { Facter::Resolvers::SpecificReleaseFile }
+
+  after do
+    specific_release_file_resolver.invalidate_cache
+  end
+
+  context 'when release file name is not given' do
+    it 'returns nil' do
+      expect(specific_release_file_resolver.resolve(:release, {})).to be_nil
+    end
+  end
+
+  context 'when release file is present' do
+    let(:result) { nil }
+
+    before do
+      allow(Facter::Util::FileHelper).to receive(:safe_read).with(options[:release_file], nil).and_return(result)
+    end
+
+    context 'when release file can not be read' do
+      let(:options) { { release_file: '/etc/alpine-release' } }
+      let(:result) { nil }
+
+      it 'returns nil' do
+        result = specific_release_file_resolver.resolve(:release, options)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when release file is readable' do
+      let(:options) { { release_file: '/etc/devuan_version' } }
+      let(:result) { load_fixture('os_release_devuan').read }
+
+      it 'returns release value' do
+        result = specific_release_file_resolver.resolve(:release, options)
+
+        expect(result).to eq('beowulf')
+      end
+    end
+
+    context 'when requesting invalid data' do
+      let(:options) { { release_file: '/etc/alpine-release' } }
+      let(:result) { nil }
+
+      it 'returns nil' do
+        result = specific_release_file_resolver.resolve(:something, options)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when release file name is not given' do
+      let(:options) do
+        {
+          release_folder: 'folder',
+          no_regex: /regex/
+        }
+      end
+
+      it 'returns nil' do
+        result = specific_release_file_resolver.resolve(:release, options)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when regex is not given' do
+      let(:options) do
+        {
+          release_file: 'folder',
+          no_regex: /regex/
+        }
+      end
+
+      it 'returns nil' do
+        result = specific_release_file_resolver.resolve(:release, options)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when release file and regex are present' do
+      let(:options) do
+        {
+          release_file: '/etc/ovs-release',
+          regex: /^RELEASE=(\d+)/
+        }
+      end
+
+      before do
+        allow(Facter::Util::FileHelper).to receive(:safe_read).with(options[:release_file], nil).and_return(result)
+      end
+
+      context 'when release file can not be read' do
+        let(:result) { nil }
+
+        it 'returns nil' do
+          result = specific_release_file_resolver.resolve(:release, options)
+
+          expect(result).to be_nil
+        end
+      end
+
+      context 'when release file is readable' do
+        let(:result) { load_fixture('os_release_mint').read }
+
+        it 'returns release value' do
+          result = specific_release_file_resolver.resolve(:release, options)[1]
+
+          expect(result).to eq('19')
+        end
+      end
+
+      context 'when requesting invalid data' do
+        let(:result) { load_fixture('os_release_mint').read }
+
+        it 'returns nil' do
+          result = specific_release_file_resolver.resolve(:something, options)
+
+          expect(result).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/util/facts/facts_utils_spec.rb
+++ b/spec/facter/util/facts/facts_utils_spec.rb
@@ -44,4 +44,60 @@ describe Facter::Util::Facts do
       expect(facts_util.discover_family('Mandriva')).to eq('Mandrake')
     end
   end
+
+  describe '#release_hash_from_string' do
+    it 'returns full release' do
+      expect(facts_util.release_hash_from_string('6.2')['full']).to eq('6.2')
+    end
+
+    it 'returns major release' do
+      expect(facts_util.release_hash_from_string('6.2')['major']).to eq('6')
+    end
+
+    it 'returns valid minor release' do
+      expect(facts_util.release_hash_from_string('6.2.1')['minor']).to eq('2')
+    end
+
+    it 'returns minor release as nil' do
+      expect(facts_util.release_hash_from_string('6')['minor']).to be_nil
+    end
+
+    it 'returns nil if data is nil' do
+      expect(facts_util.release_hash_from_string(nil)).to be_nil
+    end
+  end
+
+  describe '#release_hash_from_matchdata' do
+    let(:match_data) do
+      'RELEASE=4.3' =~ /^RELEASE=(\d+.\d+.*)/
+      Regexp.last_match
+    end
+
+    it 'returns full release' do
+      expect(facts_util.release_hash_from_matchdata(match_data)['full']).to eq('4.3')
+    end
+
+    it 'returns major release' do
+      expect(facts_util.release_hash_from_matchdata(match_data)['major']).to eq('4')
+    end
+
+    it 'returns valid minor release' do
+      expect(facts_util.release_hash_from_matchdata(match_data)['minor']).to eq('3')
+    end
+
+    it 'returns nil if data is nil' do
+      expect(facts_util.release_hash_from_matchdata(nil)).to be_nil
+    end
+
+    context 'when minor version is unavailable' do
+      let(:match_data) do
+        'RELEASE=4' =~ /^RELEASE=(\d+)/
+        Regexp.last_match
+      end
+
+      it 'returns minor release as nil' do
+        expect(facts_util.release_hash_from_matchdata(match_data)['minor']).to be_nil
+      end
+    end
+  end
 end

--- a/spec/fixtures/os_release_devuan
+++ b/spec/fixtures/os_release_devuan
@@ -1,0 +1,1 @@
+beowulf

--- a/spec/fixtures/os_release_mint
+++ b/spec/fixtures/os_release_mint
@@ -1,0 +1,2 @@
+DISTR_NAME="Linuxmint"
+RELEASE=19.3


### PR DESCRIPTION
**Description of the problem:** Os.release fact is retrieved from the `/etc/os-release` file but Facter 3 reads other release files based on OS.
**Description of the fix** Retrieve os.release from the specific release file for every os.