### PR TITLE
(docs) Fix some old references to 'master' branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,12 @@ top of things.
 ## Making Changes
 
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
+  * This is usually the `main` branch.
   * Once merged, your work will be automatically promoted to the other release
     streams when our internal CI passes.
-  * To quickly create a topic branch based on master, run `git checkout -b
-    fix/master/my_contribution master`. Please avoid working directly on the
-    `master` branch.
+  * To quickly create a topic branch based on main, run `git checkout -b
+    fix/main/my_contribution main`. Please avoid working directly on the
+    `main` branch.
 * Make commits of logical units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format. We use the [50/72 rule](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) in commit messages.

--- a/tasks/commits.rake
+++ b/tasks/commits.rake
@@ -6,7 +6,7 @@ task(:commits) do
   # in the branch targeted for a PR. This is accomplished by using the
   # TRAVIS_COMMIT_RANGE environment variable, which is present in travis CI and
   # populated with the range of commits the PR contains. If not available, this
-  # falls back to `master..HEAD` as a next best bet as `master` is unlikely to
+  # falls back to `main..HEAD` as a next best bet as `main` is unlikely to
   # ever be absent.
   commit_range = 'HEAD^..HEAD'
   puts "Checking commits #{commit_range}"


### PR DESCRIPTION
The switch from 'master' to 'main' was done last year. The most relevant
issue is probably https://tickets.puppetlabs.com/browse/PUP-10668.