### PR TITLE
(FACT-2878) AIX networking resolver rewrite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,8 @@ Metrics/MethodLength:
     - 'lib/facter/resolvers/bsd/ffi/ffi_helper.rb'
     - 'install.rb'
     - 'scripts/generate_changelog.rb'
+    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
+
 
 Metrics/ModuleLength:
   Max: 100
@@ -38,6 +40,7 @@ Metrics/ModuleLength:
     - 'lib/facter.rb'
     - 'agent/lib/facter-ng.rb'
     - 'lib/facter/config.rb'
+    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
 
 Metrics/BlockLength:
   Exclude:
@@ -62,6 +65,7 @@ Metrics/AbcSize:
     - 'lib/facter/resolvers/bsd/ffi/ffi_helper.rb'
     - 'install.rb'
     - 'scripts/generate_changelog.rb'
+    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
@@ -70,6 +74,7 @@ Metrics/PerceivedComplexity:
     - 'lib/facter/custom_facts/core/execution/windows.rb'
     - 'lib/facter/custom_facts/core/execution/posix.rb'
     - 'install.rb'
+    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -80,6 +85,7 @@ Metrics/CyclomaticComplexity:
     - 'lib/facter/framework/detector/os_detector.rb'
     - 'install.rb'
     - 'scripts/generate_changelog.rb'
+    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
 
 Metrics/ClassLength:
   Exclude:
@@ -94,7 +100,6 @@ Metrics/ClassLength:
     - 'install.rb'
     - 'scripts/generate_changelog.rb'
     - 'lib/facter/resolvers/solaris/networking.rb'
-
 
 Naming/AccessorMethodName:
   Exclude:

--- a/lib/facter/resolvers/aix/ffi/ffi.rb
+++ b/lib/facter/resolvers/aix/ffi/ffi.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Aix
+      module FFI
+        RTM_IFINFO = 0xe
+        RTM_NEWADDR = 0xc
+
+        RTAX_DST = 0
+        RTAX_GATEWAY = 1
+        RTAX_NETMASK = 2
+        RTAX_GENMASK = 3
+        RTAX_IFP = 4
+        RTAX_IFA = 5
+        RTAX_AUTHOR = 6
+        RTAX_BRD = 7
+        RTAX_MAX = 8
+
+        RTA_DST = 0x1
+        RTA_GATEWAY = 0x2
+        RTA_NETMASK = 0x4
+        RTA_GENMASK = 0x8
+        RTA_IFP = 0x10
+        RTA_IFA = 0x20
+        RTA_AUTHOR = 0x40
+        RTA_BRD = 0x80
+        RTA_DOWNSTREAM = 0x100
+
+        AF_UNSPEC = 0
+        AF_INET = 2
+        AF_INET6 = 24
+        AF_MAX = 30
+
+        INET_ADDRSTRLEN = 16
+        INET6_ADDRSTRLEN = 46
+
+        RTAX_LIST = [
+          RTAX_DST,
+          RTAX_GATEWAY,
+          RTAX_NETMASK,
+          RTAX_GENMASK,
+          RTAX_IFP,
+          RTAX_IFA,
+          RTAX_AUTHOR,
+          RTAX_BRD
+        ].freeze
+
+        RTA_LIST = [
+          RTA_DST,
+          RTA_GATEWAY,
+          RTA_NETMASK,
+          RTA_GENMASK,
+          RTA_IFP,
+          RTA_IFA,
+          RTA_AUTHOR,
+          RTA_BRD,
+          RTA_DOWNSTREAM
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/aix/ffi/ffi_helper.rb
+++ b/lib/facter/resolvers/aix/ffi/ffi_helper.rb
@@ -1,34 +1,160 @@
 # frozen_string_literal: true
 
 require 'ffi'
-
+require_relative 'structs'
+require_relative 'ffi'
 module Facter
-  module Aix
-    module FfiHelper
-      KINFO_GET_AVENRUN = 1
-      KINFO_READ        = 8 << 8
+  module Resolvers
+    module Aix
+      module FfiHelper
+        KINFO_GET_AVENRUN = 1
+        KINFO_READ        = 8 << 8
+        KINFO_RT          = 1 << 8
+        KINFO_RT_IFLIST   = KINFO_RT | 3
 
-      module Libc
-        extend FFI::Library
+        module Libc
+          extend ::FFI::Library
 
-        RTLD_LAZY   = 0x00000004
-        RTLD_GLOBAL = 0x00010000
-        RTLD_MEMBER = 0x00040000
+          RTLD_LAZY   = 0x00000004
+          RTLD_GLOBAL = 0x00010000
+          RTLD_MEMBER = 0x00040000
 
-        @ffi_lib_flags = RTLD_LAZY | RTLD_GLOBAL | RTLD_MEMBER
-        ffi_lib 'libc.a(shr.o)'
+          @ffi_lib_flags = RTLD_LAZY | RTLD_GLOBAL | RTLD_MEMBER
+          ffi_lib 'libc.a(shr.o)'
 
-        attach_function :getkerninfo, %i[int pointer pointer int], :int
-      end
+          attach_function :getkerninfo, %i[int pointer pointer int], :int
+          attach_function :inet_ntop, %i[int pointer pointer uint], :string
+        end
 
-      def self.read_load_averages
-        averages = FFI::MemoryPointer.new(:long_long, 3)
-        averages_size = FFI::MemoryPointer.new(:int, 1)
-        averages_size.write_int(averages.size)
+        def self.read_load_averages
+          averages = ::FFI::MemoryPointer.new(:long_long, 3)
+          averages_size = ::FFI::MemoryPointer.new(:int, 1)
+          averages_size.write_int(averages.size)
 
-        return if Libc.getkerninfo(KINFO_READ | KINFO_GET_AVENRUN, averages, averages_size, 0).negative?
+          return if Libc.getkerninfo(KINFO_READ | KINFO_GET_AVENRUN, averages, averages_size, 0).negative?
 
-        averages.read_array_of_long_long(3).map { |x| (x / 65_536.0).round(5) }
+          averages.read_array_of_long_long(3).map { |x| (x / 65_536.0).round(5) }
+        end
+
+        def self.read_interfaces
+          ksize = Libc.getkerninfo(KINFO_RT_IFLIST, nil, nil, 0)
+
+          log.debug('getkerninfo call was unsuccessful') if ksize.zero?
+
+          ksize_ptr = ::FFI::MemoryPointer.new(:int, ksize.size)
+          ksize_ptr.write_int(ksize)
+
+          result_ptr = ::FFI::MemoryPointer.new(:char, ksize)
+
+          res = Libc.getkerninfo(KINFO_RT_IFLIST, result_ptr, ksize_ptr, 0)
+          log.debug('getkerninfo call was unsuccessful') if res == -1
+
+          cursor = 0
+
+          interfaces = {}
+          while cursor < ksize_ptr.read_int
+            hdr = FFI::IfMsghdr.new(result_ptr + cursor)
+
+            case hdr[:ifm_type]
+            when FFI::RTM_IFINFO
+              link_addr = FFI::SockaddrDl.new(hdr.to_ptr + hdr.size)
+
+              interface_name = link_addr[:sdl_data].to_s[0, link_addr[:sdl_nlen]]
+              interfaces[interface_name] ||= {}
+
+            when FFI::RTM_NEWADDR
+              addresses = {}
+              addr_cursor = cursor + hdr.size
+              FFI::RTAX_LIST.each do |key|
+                xand = hdr[:ifm_addrs] & FFI::RTA_LIST[key]
+                next unless xand != 0
+
+                sockaddr = FFI::Sockaddr.new(result_ptr + addr_cursor)
+                addresses[key] = sockaddr
+                roundup_nr = roundup(sockaddr)
+                addr_cursor += roundup_nr
+              end
+
+              family = FFI::AF_UNSPEC
+
+              addresses.each do |_k, addr|
+                if family != FFI::AF_UNSPEC &&
+                   addr[:sa_family] != FFI::AF_UNSPEC &&
+                   family != addr[:sa_family]
+                  family = FFI::AF_MAX
+                  break
+                end
+                family = addr[:sa_family]
+              end
+
+              if addresses[FFI::RTAX_NETMASK][:sa_len]
+                addresses[FFI::RTAX_NETMASK][:sa_family] = family
+                netmask = address_to_string(addresses[FFI::RTAX_NETMASK])
+              end
+
+              address = address_to_string(addresses[FFI::RTAX_IFA]) if addresses[FFI::RTAX_IFA][:sa_len]
+
+              if addresses[FFI::RTAX_NETMASK][:sa_len] && addresses[FFI::RTAX_IFA][:sa_len]
+                network = address_to_string(addresses[FFI::RTAX_IFA], addresses[FFI::RTAX_NETMASK])
+              end
+
+              bindings = family == FFI::AF_INET ? :bindings : :bindings6
+              interfaces[interface_name][bindings] ||= []
+              interfaces[interface_name][bindings] << {
+                netmask: netmask.read_string,
+                address: address.read_string,
+                network: network.read_string
+              }
+            else
+              log.debug("got an unknown RT_IFLIST message: #{hdr[:ifm_type]}")
+            end
+
+            cursor += hdr[:ifm_msglen]
+          end
+
+          interfaces
+        end
+
+        def self.roundup(sockaddr)
+          if sockaddr[:sa_len].positive?
+            1 + ((sockaddr[:sa_len] - 1) | (1.size - 1))
+          else
+            1.size
+          end
+        end
+
+        def self.address_to_string(sockaddr, mask = nil)
+          if sockaddr[:sa_family] == FFI::AF_INET
+            in_addr_ip = FFI::SockaddrIn.new(sockaddr.to_ptr)
+
+            if mask && sockaddr[:sa_family] == mask[:sa_family]
+              in_addr_mask = FFI::SockaddrIn.new(mask.to_ptr)
+              in_addr_ip[:sin_addr][:s_addr] &= in_addr_mask[:sin_addr][:s_addr]
+            end
+
+            buffer = ::FFI::MemoryPointer.new(:char, FFI::INET_ADDRSTRLEN)
+            Libc.inet_ntop(FFI::AF_INET, in_addr_ip[:sin_addr].to_ptr, buffer, 16)
+
+            buffer
+          elsif sockaddr[:sa_family] == FFI::AF_INET6
+            in_addr_ip = FFI::SockaddrIn6.new(sockaddr.to_ptr)
+            if mask && sockaddr[:sa_family] == mask[:sa_family]
+              in_addr_mask = FFI::SockaddrIn6.new(sockaddr.to_ptr)
+              16.times do |i|
+                in_addr_ip[:sin6_addr][:u6_addr8][i] &= in_addr_mask[:sin6_addr][:u6_addr8][i]
+              end
+            end
+
+            buffer = ::FFI::MemoryPointer.new(:char, FFI::INET6_ADDRSTRLEN)
+            Libc.inet_ntop(FFI::AF_INET6, in_addr_ip[:sin6_addr].to_ptr, buffer, 16)
+
+            buffer
+          end
+        end
+
+        def self.log
+          @log ||= Log.new(self)
+        end
       end
     end
   end

--- a/lib/facter/resolvers/aix/ffi/structs.rb
+++ b/lib/facter/resolvers/aix/ffi/structs.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Aix
+      module FFI
+        class SockaddrDl < ::FFI::Struct
+          layout :sdl_len, :uchar,
+                 :sdl_family, :uchar,
+                 :sdl_index, :ushort,
+                 :sdl_type, :uchar,
+                 :sdl_nlen, :uchar,
+                 :sdl_alen, :uchar,
+                 :sdl_slen, :uchar,
+                 :sdl_data, [:char, 120]
+        end
+
+        class IfMsghdr < ::FFI::Struct
+          layout :ifm_msglen, :ushort,
+                 :ifm_version, :uchar,
+                 :ifm_type, :uchar,
+                 :ifm_addrs, :int,
+                 :ifm_flags, :int,
+                 :ifm_index, :ushort,
+                 :ifm_addrlen, :uchar
+        end
+
+        class Sockaddr < ::FFI::Struct
+          layout :sa_len, :uchar,
+                 :sa_family, :uchar,
+                 :sa_data, [:char, 14]
+        end
+
+        class InAddr < ::FFI::Struct
+          layout :s_addr, :uint
+        end
+
+        class In6Addr < ::FFI::Struct
+          layout :u6_addr8, [:uchar, 16]
+        end
+
+        class SockaddrIn < ::FFI::Struct
+          layout :sin_len, :uchar,
+                 :sin_family, :uchar,
+                 :sin_port, :ushort,
+                 :sin_addr, InAddr,
+                 :sin_zero, [:uchar, 8]
+        end
+
+        class SockaddrIn6 < ::FFI::Struct
+          layout :sin6_len, :uchar,
+                 :sin6_family, :uchar,
+                 :sin6_port, :ushort,
+                 :sin6_flowinfo, :uint,
+                 :sin6_addr, In6Addr,
+                 :sin6_scope_id, :uint
+        end
+
+        class SockaddrStorage < ::FFI::Struct
+          layout :ss_len, :uchar,
+                 :ss_family, :uchar,
+                 :ss_pad, [:char, 6],
+                 :ss_align, :long_long,
+                 :ss_pad2, [:char, 1264]
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/aix/load_averages.rb
+++ b/lib/facter/resolvers/aix/load_averages.rb
@@ -16,7 +16,7 @@ module Facter
           def read_load_averages(fact_name)
             require_relative 'ffi/ffi_helper'
             @fact_list[:load_averages] = {}.tap do |h|
-              h['1m'], h['5m'], h['15m'] = Facter::Aix::FfiHelper.read_load_averages
+              h['1m'], h['5m'], h['15m'] = FfiHelper.read_load_averages
             end
 
             @fact_list[fact_name]

--- a/lib/facter/resolvers/windows/ffi/network_utils.rb
+++ b/lib/facter/resolvers/windows/ffi/network_utils.rb
@@ -31,8 +31,7 @@ class NetworkUtils
 
     def find_mac_address(adapter)
       adapter[:PhysicalAddress].first(adapter[:PhysicalAddressLength])
-                               .map { |e| format('%<mac_address>02x', mac_address: e.to_i) }
-                               .join(':').upcase
+                               .map { |e| format('%<mac_address>02x', mac_address: e.to_i) }.join(':').upcase
     end
   end
 end

--- a/spec/facter/resolvers/aix/ffi_helper_spec.rb
+++ b/spec/facter/resolvers/aix/ffi_helper_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-describe Facter::Aix::FfiHelper do
+describe Facter::Resolvers::Aix::FfiHelper do
   let(:averages) { double('FFI::MemoryPointer', size: 24) }
   let(:averages_size) { double('FFI::MemoryPointer', write_int: 24) }
 
   before do
-    allow(FFI::MemoryPointer).to receive(:new).with(:long_long, 3).and_return(averages)
-    allow(FFI::MemoryPointer).to receive(:new).with(:int, 1).and_return(averages_size)
+    allow(::FFI::MemoryPointer).to receive(:new).with(:long_long, 3).and_return(averages)
+    allow(::FFI::MemoryPointer).to receive(:new).with(:int, 1).and_return(averages_size)
   end
 
   after do
@@ -14,14 +14,14 @@ describe Facter::Aix::FfiHelper do
   end
 
   it 'returns load average' do
-    allow(Facter::Aix::FfiHelper::Libc).to receive(:getkerninfo).and_return(0)
+    allow(Facter::Resolvers::Aix::FfiHelper::Libc).to receive(:getkerninfo).and_return(0)
     allow(averages).to receive(:read_array_of_long_long).with(3).and_return([655.36, 1310.72, 1966.08])
 
-    expect(Facter::Aix::FfiHelper.read_load_averages).to eq([0.01, 0.02, 0.03])
+    expect(Facter::Resolvers::Aix::FfiHelper.read_load_averages).to eq([0.01, 0.02, 0.03])
   end
 
   it 'does not return load average' do
-    allow(Facter::Aix::FfiHelper::Libc).to receive(:getkerninfo).and_return(-1)
-    expect(Facter::Aix::FfiHelper.read_load_averages).to be_nil
+    allow(Facter::Resolvers::Aix::FfiHelper::Libc).to receive(:getkerninfo).and_return(-1)
+    expect(Facter::Resolvers::Aix::FfiHelper.read_load_averages).to be_nil
   end
 end

--- a/spec/facter/resolvers/aix/load_averages_spec.rb
+++ b/spec/facter/resolvers/aix/load_averages_spec.rb
@@ -4,7 +4,7 @@ describe Facter::Resolvers::Aix::LoadAverages do
   let(:load_averages) { [0.01, 0.02, 0.03] }
 
   before do
-    allow(Facter::Aix::FfiHelper).to receive(:read_load_averages)
+    allow(Facter::Resolvers::Aix::FfiHelper).to receive(:read_load_averages)
       .and_return(load_averages)
   end
 

--- a/spec/mocks/ffi.rb
+++ b/spec/mocks/ffi.rb
@@ -31,7 +31,9 @@ module FFI
 
     def GetAdaptersAddresses(*); end
 
-    def getkerninfo(*); end
+    def getkerninfo(*)
+      0
+    end
 
     def getloadavg(*); end
 
@@ -62,6 +64,8 @@ module FFI
     def write_uint32(); end
 
     def read_uint32(); end
+
+    def self.size; end
   end
 
   class MemoryPointer
@@ -72,6 +76,12 @@ module FFI
     def to_ptr; end
 
     def [](*); end
+
+    def write_int(*); end
+
+    def read_int; end
+
+    def self.size; end
   end
 
   class Struct


### PR DESCRIPTION
Updated AIX resolver to read interfaces using FFI. 
Vlans and secondary ips were not displayed without FFI.