### PR TITLE
(FACT-2918) External facts not overwritten by env facts

### DIFF
--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -477,16 +477,16 @@ namespace facter { namespace ruby {
         if (_collection.empty()) {
             bool include_ruby_facts = true;
             _collection.add_default_facts(include_ruby_facts);
+            if (_load_external && !_external_facts_loaded) {
+                _collection.add_external_facts(_external_search_paths);
+                _external_facts_loaded = true;
+            }
             auto const& ruby = api::instance();
             _collection.add_environment_facts([&](string const& name) {
                 // Create a fact and explicitly set the value
                 // We honor environment variables above custom fact resolutions
                 ruby.to_native<fact>(create_fact(ruby.utf8_value(name)))->value(to_ruby(_collection[name]));
             });
-        }
-        if (_load_external && !_external_facts_loaded) {
-                _collection.add_external_facts(_external_search_paths);
-                _external_facts_loaded = true;
         }
         return _collection;
     }


### PR DESCRIPTION
When running puppet facts, environment facts were overwritten
by external facts.
Now the flow was set to default facts -> external facts(external facts
can still be skipped with skip_external_facts metod from puppet) ->
environment facts

PLEASE LABEL YOUR PULL REQUEST ACCORDINGLY!

Choose only one of the following:

"backwards-incompatible" - use this label for PRs that breaks some old functionality

"feature" - use this label for new added functionality

"bugfix" - use this label for PRs that contain fixes

"maintenance" - use this label for PRs that contain trivial changes (eg. changes in unit tests)

Also please add "community" additional label if you're part of puppet community (special attention will be provided for those PRs).
