### PR TITLE
(FACT-2932) fix acceptance tests leakage 

### DIFF
--- a/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_custom_dir.rb
@@ -31,7 +31,10 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
-        agent.rm_rf(custom_fact)
+        custom_dir = "\"#{custom_dir}\"" if agent.is_cygwin?
+        agent.rm_rf(custom_dir)
+
+        config_dir = "\"#{config_dir}\"" if agent.is_cygwin?
         agent.rm_rf(config_dir)
       end
 

--- a/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_facterlib.rb
@@ -30,7 +30,10 @@ EOM
       create_remote_file(agent, config_file, config_content)
 
       teardown do
+        facterlib_dir = "\"#{facterlib_dir}\"" if agent.is_cygwin?
         agent.rm_rf(facterlib_dir)
+
+        config_dir = "\"#{config_dir}\"" if agent.is_cygwin?
         agent.rm_rf(config_dir)
       end
 

--- a/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
+++ b/acceptance/tests/options/config_file/no_custom_facts_and_load_path.rb
@@ -37,8 +37,9 @@ EOM
 
       teardown do
         load_path_facter_dir = "\"#{load_path_facter_dir}\"" if agent.is_cygwin?
-
         agent.rm_rf(load_path_facter_dir)
+
+        config_dir = "\"#{config_dir}\"" if agent.is_cygwin?
         agent.rm_rf(config_dir)
       end
 

--- a/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
+++ b/acceptance/tests/options/config_file/no_ruby_disables_custom_facts.rb
@@ -39,6 +39,7 @@ EOM
           create_remote_file(agent, custom_fact, custom_fact_content)
 
           teardown do
+            custom_dir = "\"#{custom_dir}\"" if agent.is_cygwin?
             agent.rm_rf(custom_dir)
           end
 

--- a/acceptance/tests/options/no_custom_facts.rb
+++ b/acceptance/tests/options/no_custom_facts.rb
@@ -21,7 +21,8 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
-        agent.rm_rf(custom_fact)
+        custom_dir = "\"#{custom_dir}\"" if agent.is_cygwin?
+        agent.rm_rf(custom_dir)
       end
 
       step "Agent #{agent}: --no-custom-facts option should not load custom facts" do

--- a/acceptance/tests/options/no_custom_facts_and_facterlib.rb
+++ b/acceptance/tests/options/no_custom_facts_and_facterlib.rb
@@ -21,6 +21,7 @@ EOM
       create_remote_file(agent, custom_fact, content)
 
       teardown do
+        facterlib_dir = "\"#{facterlib_dir}\"" if agent.is_cygwin?
         agent.rm_rf(facterlib_dir)
       end
 

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -32,7 +32,8 @@ EOM
         create_remote_file(agent, custom_fact, content)
 
         teardown do
-          agent.rm_rf(custom_fact)
+          custom_dir = "\"#{custom_dir}\"" if agent.is_cygwin?
+          agent.rm_rf(custom_dir)
         end
 
         on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do


### PR DESCRIPTION
On windows platforms, the directory containing a custom fact is not properly deleted during teardown.
