### PR TITLE
(maint) fix presuite.rb exitstatus

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -118,7 +118,7 @@ def run(command, dir = './', env = {})
       puts line
       output += line
     end
-    exit_status = wait_thr.value
+    exit_status = wait_thr.value.exitstatus
     exit(exit_status) if exit_status != 0
   end
   output


### PR DESCRIPTION
Open3.popen2e returns a Process::Status object.
We need to take the exit status from that object.