### PR TITLE
(FACT-2878) Fixed output for IPV6 network address

### DIFF
--- a/lib/facter/resolvers/aix/ffi/ffi_helper.rb
+++ b/lib/facter/resolvers/aix/ffi/ffi_helper.rb
@@ -96,6 +96,7 @@ module Facter
 
               if addresses[FFI::RTAX_NETMASK][:sa_len] && addresses[FFI::RTAX_IFA][:sa_len]
                 network = address_to_string(addresses[FFI::RTAX_IFA], addresses[FFI::RTAX_NETMASK])
+                network = '::' if network == '::1'
               end
 
               bindings = family == FFI::AF_INET ? :bindings : :bindings6


### PR DESCRIPTION
There is a minor difference between Facter 3 and Facter 4 output for the IPv6 network address