### PR TITLE
(TBD) Shell out to puppet facts show to retrieve puppet facts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ Metrics/AbcSize:
     - 'lib/facter/custom_facts/core/execution/windows.rb'
     - 'lib/facter/custom_facts/core/execution/base.rb'
     - 'lib/facter/custom_facts/core/resolvable.rb'
+    - 'lib/facter/framework/cli/cli.rb'
     - 'lib/facter/resolvers/bsd/ffi/ffi_helper.rb'
     - 'install.rb'
     - 'scripts/generate_changelog.rb'

--- a/lib/facter/framework/formatters/formatter_factory.rb
+++ b/lib/facter/framework/formatters/formatter_factory.rb
@@ -2,7 +2,7 @@
 
 module Facter
   class FormatterFactory
-    def self.build(options)
+    def self.build(options = {})
       return JsonFactFormatter.new if options[:json]
       return YamlFactFormatter.new if options[:yaml]
       return HoconFactFormatter.new if options[:hocon]

--- a/lib/facter/framework/formatters/legacy_fact_formatter.rb
+++ b/lib/facter/framework/formatters/legacy_fact_formatter.rb
@@ -18,6 +18,14 @@ module Facter
       format_for_single_user_query(user_queries.first, resolved_facts)
     end
 
+    def format_raw_hash(fact_collection)
+      pretty_json = hash_to_facter_format(fact_collection)
+
+      pretty_json = remove_enclosing_accolades(pretty_json)
+      pretty_json = remove_comma_and_quotation(pretty_json)
+      handle_newlines(pretty_json)
+    end
+
     private
 
     def format_for_no_query(resolved_facts)


### PR DESCRIPTION
Implement `facter -p` by shelling out to `puppet facts show` and parsing the
JSON results using the legacy formatter. This will collect facts in places that
only puppet knows about, such as `clientversion` and custom & external facts in
the agent's libdir.

This shows `facter -p` retrieving osfamily (core fact), puppetversion (defined [programmatically by puppet](https://github.com/puppetlabs/puppet/blob/e68bf5794e213597af93df558d4a16216ec94078/lib/puppet.rb#L196-L198)) and `puppet_environmentpath` (a [pluginsynced custom fact](https://github.com/puppetlabs/puppetlabs-stdlib/blob/13eb80c918a4b51429b4d707385c6c941b3bef17/lib/facter/puppet_settings.rb#L29-L35) from stdlib):

```
$ bx facter -p osfamily puppetversion puppet_environmentpath
osfamily => Darwin
puppet_environmentpath => /Users/josh/.puppetlabs/etc/code/environments
puppetversion => 7.3.0
```

It also preserves the behavior of emitting a single value:

```
$ bx facter -p puppetversion
7.3.0
```