### PR TITLE
(FACT-2931) resolve os.distro without lsb

### DIFF
--- a/lib/facter/facts/amzn/lsbdistcodename.rb
+++ b/lib/facter/facts/amzn/lsbdistcodename.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    class Lsbdistcodename
+      FACT_NAME = 'lsbdistcodename'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/lsbdistdescription.rb
+++ b/lib/facter/facts/amzn/lsbdistdescription.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    class Lsbdistdescription
+      FACT_NAME = 'lsbdistdescription'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/lsbdistid.rb
+++ b/lib/facter/facts/amzn/lsbdistid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    class Lsbdistid
+      FACT_NAME = 'lsbdistid'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/os/distro/codename.rb
+++ b/lib/facter/facts/amzn/os/distro/codename.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    module Os
+      module Distro
+        class Codename
+          FACT_NAME = 'os.distro.codename'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::SpecificReleaseFile.resolve(
+              :release, release_file: '/etc/system-release'
+            ).match(/.*release.*(\(.*\)).*/)
+
+            fact_value = fact_value[1].gsub(/\(|\)/, '') if fact_value
+            fact_value ||= 'n/a'
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/os/distro/description.rb
+++ b/lib/facter/facts/amzn/os/distro/description.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    module Os
+      module Distro
+        class Description
+          FACT_NAME = 'os.distro.description'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::SpecificReleaseFile.resolve(
+              :release, release_file: '/etc/system-release'
+            )
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/os/distro/id.rb
+++ b/lib/facter/facts/amzn/os/distro/id.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    module Os
+      module Distro
+        class Id
+          FACT_NAME = 'os.distro.id'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::SpecificReleaseFile.resolve(
+              :release, release_file: '/etc/system-release'
+            ).split('release')[0].split.reject { |el| el.casecmp('linux').zero? }.join
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/amzn/os/distro/release.rb
+++ b/lib/facter/facts/amzn/os/distro/release.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Facts
+  module Amzn
+    module Os
+      module Distro
+        class Release
+          FACT_NAME = 'os.distro.release'
+          ALIASES = %w[lsbdistrelease lsbmajdistrelease lsbminordistrelease].freeze
+
+          def call_the_resolver
+            version = determine_release_version
+
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+            [Facter::ResolvedFact.new(FACT_NAME, version),
+             Facter::ResolvedFact.new(ALIASES[0], version['full'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[1], version['major'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[2], version['minor'], :legacy)]
+          end
+
+          def determine_release_version
+            version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+            version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+            Facter::Util::Facts.release_hash_from_string(version)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/rhel/lsbdistcodename.rb
+++ b/lib/facter/facts/rhel/lsbdistcodename.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Rhel
+    class Lsbdistcodename
+      FACT_NAME = 'lsbdistcodename'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/rhel/lsbdistdescription.rb
+++ b/lib/facter/facts/rhel/lsbdistdescription.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Rhel
+    class Lsbdistdescription
+      FACT_NAME = 'lsbdistdescription'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/rhel/lsbdistid.rb
+++ b/lib/facter/facts/rhel/lsbdistid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Rhel
+    class Lsbdistid
+      FACT_NAME = 'lsbdistid'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/rhel/os/distro/codename.rb
+++ b/lib/facter/facts/rhel/os/distro/codename.rb
@@ -6,13 +6,11 @@ module Facts
       module Distro
         class Codename
           FACT_NAME = 'os.distro.codename'
-          ALIASES = 'lsbdistcodename'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+            fact_value = Facter::Resolvers::RedHatRelease.resolve(:codename)
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/rhel/os/distro/description.rb
+++ b/lib/facter/facts/rhel/os/distro/description.rb
@@ -6,13 +6,11 @@ module Facts
       module Distro
         class Description
           FACT_NAME = 'os.distro.description'
-          ALIASES = 'lsbdistdescription'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+            fact_value = Facter::Resolvers::RedHatRelease.resolve(:description)
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/rhel/os/distro/id.rb
+++ b/lib/facter/facts/rhel/os/distro/id.rb
@@ -6,13 +6,11 @@ module Facts
       module Distro
         class Id
           FACT_NAME = 'os.distro.id'
-          ALIASES = 'lsbdistid'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+            fact_value = Facter::Resolvers::RedHatRelease.resolve(:distributor_id)
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/rhel/os/distro/release.rb
+++ b/lib/facter/facts/rhel/os/distro/release.rb
@@ -9,20 +9,21 @@ module Facts
           ALIASES = %w[lsbdistrelease lsbmajdistrelease lsbminordistrelease].freeze
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:release)
-            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
+            version = determine_release_version
 
-            versions = fact_value.split('.')
-            release = {
-              'full' => fact_value,
-              'major' => versions[0],
-              'minor' => versions[1]
-            }
+            return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
 
-            [Facter::ResolvedFact.new(FACT_NAME, release),
-             Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
-             Facter::ResolvedFact.new(ALIASES[1], versions[0], :legacy),
-             Facter::ResolvedFact.new(ALIASES[2], versions[1], :legacy)]
+            [Facter::ResolvedFact.new(FACT_NAME, version),
+             Facter::ResolvedFact.new(ALIASES[0], version['full'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[1], version['major'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[2], version['minor'], :legacy)]
+          end
+
+          def determine_release_version
+            version = Facter::Resolvers::RedHatRelease.resolve(:version)
+            version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
+
+            Facter::Util::Facts.release_hash_from_string(version)
           end
         end
       end

--- a/lib/facter/facts/sles/lsbdistcodename.rb
+++ b/lib/facter/facts/sles/lsbdistcodename.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Sles
+    class Lsbdistcodename
+      FACT_NAME = 'lsbdistcodename'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/sles/lsbdistdescription.rb
+++ b/lib/facter/facts/sles/lsbdistdescription.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Sles
+    class Lsbdistdescription
+      FACT_NAME = 'lsbdistdescription'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/sles/lsbdistid.rb
+++ b/lib/facter/facts/sles/lsbdistid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Sles
+    class Lsbdistid
+      FACT_NAME = 'lsbdistid'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/sles/os/distro/codename.rb
+++ b/lib/facter/facts/sles/os/distro/codename.rb
@@ -6,13 +6,12 @@ module Facts
       module Distro
         class Codename
           FACT_NAME = 'os.distro.codename'
-          ALIASES = 'lsbdistcodename'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+            fact_value = Facter::Resolvers::OsRelease.resolve(:version_codename)
+            fact_value = 'n/a' if !fact_value || fact_value.empty?
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/sles/os/distro/description.rb
+++ b/lib/facter/facts/sles/os/distro/description.rb
@@ -6,13 +6,10 @@ module Facts
       module Distro
         class Description
           FACT_NAME = 'os.distro.description'
-          ALIASES = 'lsbdistdescription'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
-
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            fact_value = Facter::Resolvers::OsRelease.resolve(:pretty_name)
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/sles/os/distro/id.rb
+++ b/lib/facter/facts/sles/os/distro/id.rb
@@ -6,13 +6,14 @@ module Facts
       module Distro
         class Id
           FACT_NAME = 'os.distro.id'
-          ALIASES = 'lsbdistid'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
-
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            fact_value = if Facter::Resolvers::OsRelease.resolve(:version_id).start_with?('12')
+                           'SUSE LINUX'
+                         else
+                           'SUSE'
+                         end
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facter/facts/sles/os/distro/release.rb
+++ b/lib/facter/facts/sles/os/distro/release.rb
@@ -9,20 +9,25 @@ module Facts
           ALIASES = %w[lsbdistrelease lsbmajdistrelease lsbminordistrelease].freeze
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:release)
-            return Facter::ResolvedFact.new(FACT_NAME, nil) unless fact_value
+            version = Facter::Resolvers::OsRelease.resolve(:version_id)
+            fact_value = build_fact_list(version)
 
-            versions = fact_value.split('.')
-            release = {
-              'full' => fact_value,
-              'major' => versions[0],
-              'minor' => versions[1]
-            }
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
+             Facter::ResolvedFact.new(ALIASES[0], fact_value[:full], :legacy),
+             Facter::ResolvedFact.new(ALIASES[1], fact_value[:major], :legacy),
+             Facter::ResolvedFact.new(ALIASES[2], fact_value[:minor], :legacy)]
+          end
 
-            [Facter::ResolvedFact.new(FACT_NAME, release),
-             Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
-             Facter::ResolvedFact.new(ALIASES[1], versions[0], :legacy),
-             Facter::ResolvedFact.new(ALIASES[2], versions[1], :legacy)]
+          def build_fact_list(version)
+            if version.include?('.')
+              {
+                full: version,
+                major: version.split('.').first,
+                minor: version.split('.').last
+              }
+            else
+              { full: version, major: version, minor: nil }
+            end
           end
         end
       end

--- a/spec/facter/facts/amzn/lsbdistcodename_spec.rb
+++ b/spec/facter/facts/amzn/lsbdistcodename_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Lsbdistcodename do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Lsbdistcodename.new }
+
+    let(:value) { 'amzn' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    end
+
+    it 'returns lsbdistcodename fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistcodename', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/amzn/lsbdistdescription_spec.rb
+++ b/spec/facter/facts/amzn/lsbdistdescription_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Lsbdistdescription do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Lsbdistdescription.new }
+
+    let(:value) { 'amzn' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+    end
+
+    it 'returns lsbdistdescription fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistdescription', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/amzn/lsbdistid_spec.rb
+++ b/spec/facter/facts/amzn/lsbdistid_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Lsbdistid do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Lsbdistid.new }
+
+    let(:value) { 'amzn' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+    end
+
+    it 'returns lsbdistid fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistid', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/amzn/os/distro/codename_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/codename_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Os::Distro::Codename do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Os::Distro::Codename.new }
+
+    context 'when codename is not in system-release' do
+      let(:value) { 'Amazon Linux AMI release 2017.03' }
+      let(:expected_value) { 'n/a' }
+
+      before do
+        allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+          .with(:release, release_file: '/etc/system-release').and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+          .with(:release, release_file: '/etc/system-release')
+      end
+
+      it "returns 'n/a' fact value" do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: expected_value)
+      end
+    end
+
+    context 'when codename is in system-release' do
+      let(:value) { 'Amazon Linux release 2 (2017.12) LTS Release Candidate' }
+      let(:expected_value) { '2017.12' }
+
+      before do
+        allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+          .with(:release, release_file: '/etc/system-release').and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+          .with(:release, release_file: '/etc/system-release')
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: expected_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/amzn/os/distro/description_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/description_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Os::Distro::Description do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Os::Distro::Description.new }
+
+    let(:value) { 'Amazon Linux AMI release 2017.03' }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, release_file: '/etc/system-release').and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::SpecificReleaseFile' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        .with(:release, release_file: '/etc/system-release')
+    end
+
+    it 'returns release fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.description', value: value)
+    end
+  end
+end

--- a/spec/facter/facts/amzn/os/distro/id_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/id_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Os::Distro::Id do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Os::Distro::Id.new }
+
+    let(:value) { 'Amazon Linux AMI release 2017.03' }
+    let(:expected_value) { 'AmazonAMI' }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, release_file: '/etc/system-release').and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::SpecificReleaseFile' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        .with(:release, release_file: '/etc/system-release')
+    end
+
+    it 'returns release fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.id', value: expected_value)
+    end
+  end
+end

--- a/spec/facter/facts/amzn/os/distro/release_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Amzn::Os::Distro::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Amzn::Os::Distro::Release.new }
+
+    before do
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, release_file: '/etc/system-release')
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { '2.13.0' }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+
+      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
+          .with(:release, release_file: '/etc/system-release')
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '2' }
+      let(:release) { { 'full' => '2', 'major' => '2' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.distro.release', value: nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/rhel/lsbdistcodename_spec.rb
+++ b/spec/facter/facts/rhel/lsbdistcodename_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Rhel::Lsbdistcodename do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Rhel::Lsbdistcodename.new }
+
+    let(:value) { 'rhel' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    end
+
+    it 'returns lsbdistcodename fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistcodename', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/rhel/lsbdistdescription_spec.rb
+++ b/spec/facter/facts/rhel/lsbdistdescription_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Rhel::Lsbdistdescription do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Rhel::Lsbdistdescription.new }
+
+    let(:value) { 'rhel' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+    end
+
+    it 'returns lsbdistdescription fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistdescription', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/rhel/lsbdistid_spec.rb
+++ b/spec/facter/facts/rhel/lsbdistid_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Rhel::Lsbdistid do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Rhel::Lsbdistid.new }
+
+    let(:value) { 'rhel' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+    end
+
+    it 'returns lsbdistid fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistid', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/rhel/os/distro/codename_spec.rb
+++ b/spec/facter/facts/rhel/os/distro/codename_spec.rb
@@ -4,21 +4,20 @@ describe Facts::Rhel::Os::Distro::Codename do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Rhel::Os::Distro::Codename.new }
 
-    let(:value) { 'Core' }
+    let(:value) { 'Fedora' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+      allow(Facter::Resolvers::RedHatRelease).to receive(:resolve).with(:codename).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::RedHatRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+      expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:codename)
     end
 
     it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.codename', value: value),
-                        an_object_having_attributes(name: 'lsbdistcodename', value: value, type: :legacy))
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.codename', value: value)
     end
   end
 end

--- a/spec/facter/facts/rhel/os/distro/description_spec.rb
+++ b/spec/facter/facts/rhel/os/distro/description_spec.rb
@@ -7,18 +7,19 @@ describe Facts::Rhel::Os::Distro::Description do
     let(:value) { 'CentOS Linux release 7.2.1511 (Core)' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+      allow(Facter::Resolvers::RedHatRelease).to receive(:resolve)
+        .with(:description).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::RedHatRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+      expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve)
+        .with(:description)
     end
 
     it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.description', value: value),
-                        an_object_having_attributes(name: 'lsbdistdescription', value: value, type: :legacy))
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.description', value: value)
     end
   end
 end

--- a/spec/facter/facts/rhel/os/distro/id_spec.rb
+++ b/spec/facter/facts/rhel/os/distro/id_spec.rb
@@ -4,21 +4,20 @@ describe Facts::Rhel::Os::Distro::Id do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Rhel::Os::Distro::Id.new }
 
-    let(:value) { 'CentOS' }
+    let(:value) { 'RedHatEnterprise' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+      allow(Facter::Resolvers::RedHatRelease).to receive(:resolve).with(:distributor_id).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::RedHatRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+      expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:distributor_id)
     end
 
     it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.id', value: value),
-                        an_object_having_attributes(name: 'lsbdistid', value: value, type: :legacy))
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.id', value: value)
     end
   end
 end

--- a/spec/facter/facts/rhel/os/distro/release_spec.rb
+++ b/spec/facter/facts/rhel/os/distro/release_spec.rb
@@ -4,38 +4,82 @@ describe Facts::Rhel::Os::Distro::Release do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Rhel::Os::Distro::Release.new }
 
-    let(:value) { '7.2.1511' }
-    let(:release) { { 'full' => '7.2.1511', 'major' => '7', 'minor' => '2' } }
-
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+      allow(Facter::Resolvers::RedHatRelease).to receive(:resolve).with(:version).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
-    end
+    context 'when os is RedHat' do
+      context 'when version has only major and minor' do
+        let(:value) { '6.2' }
+        let(:release) { { 'full' => '6.2', 'major' => '6', 'minor' => '2' } }
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
-                        an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                        an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                    value: release['major'], type: :legacy),
-                        an_object_having_attributes(name: 'lsbminordistrelease',
-                                                    value: release['minor'], type: :legacy))
-    end
+        it 'calls Facter::Resolvers::RedHatRelease with version' do
+          fact.call_the_resolver
+          expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:version)
+        end
 
-    context 'when lsb_release is not installed' do
-      let(:value) { nil }
-
-      before do
-        allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+            contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                            an_object_having_attributes(name: 'lsbdistrelease',
+                                                        value: release['full'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                        value: release['major'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbminordistrelease',
+                                                        value: release['minor'], type: :legacy))
+        end
       end
 
-      it 'returns release fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact)
-          .and have_attributes(name: 'os.distro.release', value: value)
+      context 'when version also contains build number' do
+        let(:value) { '7.4.1708' }
+        let(:release) { { 'full' => '7.4.1708', 'major' => '7', 'minor' => '4' } }
+
+        it 'calls Facter::Resolvers::RedHatRelease with version' do
+          fact.call_the_resolver
+          expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:version)
+        end
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+            contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                            an_object_having_attributes(name: 'lsbdistrelease',
+                                                        value: release['full'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                        value: release['major'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbminordistrelease',
+                                                        value: release['minor'], type: :legacy))
+        end
+      end
+    end
+
+    context 'when os is Centos' do
+      let(:value) { nil }
+      let(:red_release) { '6.2' }
+      let(:release) { { 'full' => '6.2', 'major' => '6', 'minor' => '2' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(red_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version_id' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'calls Facter::Resolvers::RedHatRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:version)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
       end
     end
   end

--- a/spec/facter/facts/sles/lsbdistcodename_spec.rb
+++ b/spec/facter/facts/sles/lsbdistcodename_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Sles::Lsbdistcodename do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Sles::Lsbdistcodename.new }
+
+    let(:value) { 'sles' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    end
+
+    it 'returns lsbdistcodename fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistcodename', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/sles/lsbdistdescription_spec.rb
+++ b/spec/facter/facts/sles/lsbdistdescription_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Sles::Lsbdistdescription do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Sles::Lsbdistdescription.new }
+
+    let(:value) { 'sles' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+    end
+
+    it 'returns lsbdistdescription fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistdescription', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/sles/lsbdistid_spec.rb
+++ b/spec/facter/facts/sles/lsbdistid_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Sles::Lsbdistid do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Sles::Lsbdistid.new }
+
+    let(:value) { 'sles' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+    end
+
+    it 'returns lsbdistid fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistid', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/sles/os/distro/codename_spec.rb
+++ b/spec/facter/facts/sles/os/distro/codename_spec.rb
@@ -4,21 +4,67 @@ describe Facts::Sles::Os::Distro::Codename do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Sles::Os::Distro::Codename.new }
 
-    let(:value) { 'Core' }
+    context 'when codename is not in os-release' do
+      let(:value) { nil }
+      let(:expected_value) { 'n/a' }
 
-    before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+          .with(:version_codename).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_codename)
+      end
+
+      it "returns 'n/a' fact value" do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: expected_value)
+      end
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    context 'when codename is empty' do
+      let(:value) { '' }
+      let(:expected_value) { 'n/a' }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+          .with(:version_codename).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_codename)
+      end
+
+      it "returns 'n/a' fact value" do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: expected_value)
+      end
     end
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.codename', value: value),
-                        an_object_having_attributes(name: 'lsbdistcodename', value: value, type: :legacy))
+    context 'when codename is in os-release' do
+      let(:value) { 'SP1' }
+      let(:expected_value) { 'SP1' }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+          .with(:version_codename).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_codename)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: expected_value)
+      end
     end
   end
 end

--- a/spec/facter/facts/sles/os/distro/description_spec.rb
+++ b/spec/facter/facts/sles/os/distro/description_spec.rb
@@ -4,21 +4,22 @@ describe Facts::Sles::Os::Distro::Description do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Sles::Os::Distro::Description.new }
 
-    let(:value) { 'CentOS Linux release 7.2.1511 (Core)' }
+    let(:value) { 'SUSE Linux Enterprise Server 15' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+        .with(:pretty_name).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::OsRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+      expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+        .with(:pretty_name)
     end
 
     it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.description', value: value),
-                        an_object_having_attributes(name: 'lsbdistdescription', value: value, type: :legacy))
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.description', value: value)
     end
   end
 end

--- a/spec/facter/facts/sles/os/distro/id_spec.rb
+++ b/spec/facter/facts/sles/os/distro/id_spec.rb
@@ -4,21 +4,44 @@ describe Facts::Sles::Os::Distro::Id do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Sles::Os::Distro::Id.new }
 
-    let(:value) { 'CentOS' }
+    context 'when sles 12' do
+      let(:expected_value) { 'SUSE LINUX' }
 
-    before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+          .with(:version_id).and_return('12.1')
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_id)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.id', value: expected_value)
+      end
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
-    end
+    context 'when sles 15' do
+      let(:expected_value) { 'SUSE' }
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.id', value: value),
-                        an_object_having_attributes(name: 'lsbdistid', value: value, type: :legacy))
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+          .with(:version_id).and_return('15')
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_id)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.id', value: expected_value)
+      end
     end
   end
 end

--- a/spec/facter/facts/sles/os/distro/release_spec.rb
+++ b/spec/facter/facts/sles/os/distro/release_spec.rb
@@ -4,38 +4,56 @@ describe Facts::Sles::Os::Distro::Release do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Sles::Os::Distro::Release.new }
 
-    let(:value) { '7.2.1511' }
-    let(:release) { { 'full' => '7.2.1511', 'major' => '7', 'minor' => '2' } }
-
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve)
+        .with(:version_id)
+        .and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
-    end
+    context 'when version has .' do
+      let(:value) { '12.1' }
+      let(:release) { { 'full' => '12.1', 'major' => '12', 'minor' => '1' } }
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
-                        an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                        an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                    value: release['major'], type: :legacy),
-                        an_object_having_attributes(name: 'lsbminordistrelease',
-                                                    value: release['minor'], type: :legacy))
-    end
-
-    context 'when lsb_release is not installed' do
-      let(:value) { nil }
-
-      before do
-        allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+      it 'calls Facter::Resolvers::OsRelease with version_id' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve)
+          .with(:version_id)
       end
 
-      it 'returns release fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact)
-          .and have_attributes(name: 'os.distro.release', value: value)
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
+      end
+    end
+
+    context 'when version is simple' do
+      let(:value) { '15' }
+      let(:release) { { 'full' => '15', 'major' => '15', 'minor' => nil } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
       end
     end
   end

--- a/spec/facter/resolvers/redhat_release_spec.rb
+++ b/spec/facter/resolvers/redhat_release_spec.rb
@@ -10,22 +10,68 @@ describe Facter::Resolvers::RedHatRelease do
   end
 
   context 'when redhat-realse has codename' do
-    before do
-      allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/etc/redhat-release', nil)
-        .and_return("Red Hat Enterprise Linux Server release 5.10 (Tikanga)\n")
-    end
+    {
+      fedora: {
+        release_file_content: "Fedora release 32 (Thirty Two)\n",
+        name: 'Fedora',
+        version: '32',
+        codename: 'Thirty Two',
+        description: 'Fedora release 32 (Thirty Two)',
+        distributor_id: 'Fedora'
 
-    it 'returns os NAME' do
-      expect(redhat_release.resolve(:name)).to eq('RedHat')
-    end
+      },
+      el: {
+        release_file_content: "Red Hat Enterprise Linux release 8.0 (Ootpa)\n",
+        name: 'RedHat',
+        version: '8.0',
+        codename: 'Ootpa',
+        description: 'Red Hat Enterprise Linux release 8.0 (Ootpa)',
+        distributor_id: 'RedHatEnterprise'
+      },
+      el_server: {
+        release_file_content: "Red Hat Enterprise Linux Server release 5.10 (Tikanga)\n",
+        name: 'RedHat',
+        version: '5.10',
+        codename: 'Tikanga',
+        description: 'Red Hat Enterprise Linux Server release 5.10 (Tikanga)',
+        distributor_id: 'RedHatEnterpriseServer'
+      },
+      centos: {
+        release_file_content: "CentOS Linux release 7.2.1511 (Core)\n",
+        name: 'CentOS',
+        version: '7.2.1511',
+        codename: 'Core',
+        description: 'CentOS Linux release 7.2.1511 (Core)',
+        distributor_id: 'CentOS'
+      }
+    }.each_pair do |platform, data|
+      context "when #{platform.capitalize}" do
+        before do
+          allow(Facter::Util::FileHelper).to receive(:safe_read)
+            .with('/etc/redhat-release', nil)
+            .and_return(data[:release_file_content])
+        end
 
-    it 'returns os VERSION_ID' do
-      expect(redhat_release.resolve(:version)).to eq('5.10')
-    end
+        it 'returns os NAME' do
+          expect(redhat_release.resolve(:name)).to eq(data[:name])
+        end
 
-    it 'returns os VERSION_CODENAME' do
-      expect(redhat_release.resolve(:codename)).to eq('Tikanga')
+        it 'returns os VERSION_ID' do
+          expect(redhat_release.resolve(:version)).to eq(data[:version])
+        end
+
+        it 'returns os VERSION_CODENAME' do
+          expect(redhat_release.resolve(:codename)).to eq(data[:codename])
+        end
+
+        it 'returns os DESCRIPTION' do
+          expect(redhat_release.resolve(:description)).to eq(data[:description])
+        end
+
+        it 'returns os DISTRIBUTOR_ID' do
+          expect(redhat_release.resolve(:distributor_id)).to eq(data[:distributor_id])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
`os.distro` facts will now work even if lsb release is not installed.
For the legacy lsb facts, lsb_release needs to be installed in order for them to be displayed
This is changing the following platforms
- [x] rhel(el, centos, fedora)
- [x] amazon
- [x] sles

The functionality is extracted from the `lsb_release` packages