### PR TITLE
(maint) bump rtc to 0.3.1

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
     name: RuboCop TODO
     steps:
       - uses: actions/checkout@v1
-      - uses: gimmyxd/rtc-action@0.2.1
+      - uses: gimmyxd/rtc-action@0.3.1
         env:
           RTC_TOKEN: ${{ secrets.RTC_TOKEN }}
           UPDATE_PR: false


### PR DESCRIPTION
rtc 0.3 skips checks on the files that are `AllCops` excluded: https://github.com/gimmyxd/rtc-action/compare/0.2.1...0.3.1

```
❯ git diff --name-only --diff-filter=M HEAD HEAD~1
acceptance/lib/facter/acceptance/user_fact_utils.rb
acceptance/tests/facts/os_processors_and_kernel.rb
lib/facter/facts/rhel/os/distro/id.rb


# generates in the Action

Inspecting:
- lib/facter/facts/rhel/os/distro/id.rb
```

