### PR TITLE
(FACT-2947) On Solaris, don't hardcode libsocket path

### DIFF
--- a/lib/facter/resolvers/solaris/ffi/functions.rb
+++ b/lib/facter/resolvers/solaris/ffi/functions.rb
@@ -6,7 +6,7 @@ module Facter
       module FFI
         module Ioctl
           extend ::FFI::Library
-          ffi_lib ::FFI::Library::LIBC, '/usr/lib/libsocket.so'
+          ffi_lib ::FFI::Library::LIBC, 'socket'
 
           attach_function :ioctl_base, :ioctl, %i[int int pointer], :int
           attach_function :open_socket, :socket, %i[int int int], :int


### PR DESCRIPTION
When I run Facter on a SmartOS (Solaris/Illumos) base64 zone using their `ruby27-puppet-6.18.0` package, Facter tries to load an incompatible (32-bit) `libsocket.so` from a hardcoded path using `ffi`:
```console
$ facter27
/opt/local/lib/ruby/gems/2.7.0/gems/ffi-1.13.1/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library '/usr/lib/libsocket.so': ld.so.1: ruby27: fatal: /usr/lib/libsocket.so: wrong ELF class: ELFCLASS32 (LoadError)
$ file /opt/local/bin/facter27
/opt/local/bin/facter27:        executable /opt/local/bin/ruby27 script
$ file /opt/local/bin/ruby27
/opt/local/bin/ruby27:  ELF 64-bit LSB executable AMD64 Version 1, dynamically linked, not stripped, no debugging information available
$ file /usr/lib/libsocket.so
/usr/lib/libsocket.so:  ELF 32-bit LSB dynamic lib 80386 Version 1, dynamically linked, not stripped, no debugging information available
```

This PR changes the hardcoded absolute path to just the library name.  Now `ffi` uses the system's dynamic library search paths to locate the correct shared library: `/lib/64/libsocket.so.1`.
