### PR TITLE
gemspec: add homepage metadata

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = '4.0.51'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
+  spec.homepage      = 'https://github.com/puppetlabs/facter'
 
   spec.summary       = 'New version of Facter'
   spec.description   = 'New version of Facter'


### PR DESCRIPTION
this makes it easier to access the sources of the gem
from rubygems.org or from automated tooling

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>

"maintenance" - use this label for PRs that contain trivial changes (eg. changes in unit tests)