### PR TITLE
(FACT-1383) Add Azure instance metadata fact

### DIFF
--- a/acceptance/tests/options/no_cache_should_not_cache_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_cache_facts.rb
@@ -36,7 +36,7 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
 
     step "facter should not cache facts when --no-cache is specified" do
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to cache any facts")
+        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to cache any facts")
       end
     end
   end

--- a/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
@@ -52,7 +52,7 @@ FILE
       agent.modified_at(cached_fact_file, '198001010000')
 
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to refresh the cache")
+        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to refresh the cache")
       end
 
       cat_output = agent.cat(cached_fact_file)

--- a/lib/facter/facts/linux/az_metadata.rb
+++ b/lib/facter/facts/linux/az_metadata.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    class AzMetadata
+      FACT_NAME = 'az_metadata'
+
+      def initialize
+        @virtual = Facter::Util::Facts::VirtualDetector.new
+      end
+
+      def call_the_resolver
+        return Facter::ResolvedFact.new(FACT_NAME, nil) unless azure_hypervisor?
+
+        fact_value = Facter::Resolvers::Az.resolve(:metadata)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value&.empty? ? nil : fact_value)
+      end
+
+      private
+
+      def azure_hypervisor?
+        @virtual.platform == 'hyperv'
+      end
+    end
+  end
+end

--- a/lib/facter/facts/windows/az_metadata.rb
+++ b/lib/facter/facts/windows/az_metadata.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Facts
+  module Windows
+    class AzMetadata
+      FACT_NAME = 'az_metadata'
+
+      def initialize
+        @virtual = Facter::Util::Facts::VirtualDetector.new
+      end
+
+      def call_the_resolver
+        return Facter::ResolvedFact.new(FACT_NAME, nil) unless azure_hypervisor?
+
+        fact_value = Facter::Resolvers::Az.resolve(:metadata)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value&.empty? ? nil : fact_value)
+      end
+
+      private
+
+      def azure_hypervisor?
+        @virtual.platform == 'hyperv'
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/az.rb
+++ b/lib/facter/resolvers/az.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    class Az < BaseResolver
+      init_resolver
+
+      AZ_METADATA_URL = 'http://169.254.169.254/metadata/instance?api-version=2020-09-01'
+      AZ_SESSION_TIMEOUT = 5
+
+      class << self
+        private
+
+        def post_resolve(fact_name, _options)
+          log.debug('Querying Az metadata')
+          @fact_list.fetch(fact_name) { read_facts(fact_name) }
+        end
+
+        def read_facts(fact_name)
+          @fact_list[:metadata] = {}
+          data = get_data_from(AZ_METADATA_URL)
+          @fact_list[:metadata] = JSON.parse(data) unless data.empty?
+
+          @fact_list[fact_name]
+        end
+
+        def get_data_from(url)
+          headers = { Metadata: 'true' }
+          Facter::Util::Resolvers::Http.get_request(url, headers, { session: determine_session_timeout })
+        end
+
+        def determine_session_timeout
+          session_env = ENV['AZ_SESSION_TIMEOUT']
+          session_env ? session_env.to_i : AZ_SESSION_TIMEOUT
+        end
+      end
+    end
+  end
+end

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -55,6 +55,17 @@ augeasversion:
     resolution: |
         All platforms: query augparse for the augeas version.
 
+az_metadata:
+    type: map
+    description: |
+        Return the Microsoft Azure instance metadata.
+        Please see the [Microsoft Azure instance metadata documentation](http://https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service) for the contents of this fact.
+    resolution: |
+        Azure: query the Azure metadata endpoint and parse the response.
+    caveats: |
+        All platforms: `libfacter` must be built with `libcurl` support.
+    validate: false
+
 blockdevices:
     type: string
     hidden: true

--- a/spec/facter/facts/linux/az_metadata_spec.rb
+++ b/spec/facter/facts/linux/az_metadata_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe Facts::Linux::AzMetadata do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Linux::AzMetadata.new }
+
+    let(:virtual_detector_double) { instance_spy(Facter::Util::Facts::VirtualDetector) }
+
+    before do
+      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+    end
+
+    context 'when physical machine with no hypervisor' do
+      let(:value) { nil }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return(nil)
+      end
+
+      it 'returns az metadata fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'az_metadata', value: value)
+      end
+
+      it "doesn't call az resolver" do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Az).not_to have_received(:resolve).with(:metadata)
+      end
+    end
+
+    context 'when platform is hyperv' do
+      let(:value) { { 'info' => 'value' } }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('hyperv')
+      end
+
+      context 'when on Azure' do
+        it 'calls the az resolver' do
+          fact.call_the_resolver
+
+          expect(Facter::Resolvers::Az).to have_received(:resolve).with(:metadata)
+        end
+
+        it 'returns az_metadata fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'az_metadata', value: value)
+        end
+      end
+
+      context 'when not on Azure' do
+        let(:value) { nil }
+
+        it 'returns az_metadata fact as nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'az_metadata', value: value)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/windows/az_metadata_spec.rb
+++ b/spec/facter/facts/windows/az_metadata_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe Facts::Windows::AzMetadata do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Windows::AzMetadata.new }
+
+    let(:virtual_detector_double) { instance_spy(Facter::Util::Facts::VirtualDetector) }
+
+    before do
+      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+      allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+    end
+
+    context 'when physical machine with no hypervisor' do
+      let(:value) { nil }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return(nil)
+      end
+
+      it 'returns az metadata fact as nil' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'az_metadata', value: value)
+      end
+
+      it "doesn't call az resolver" do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Az).not_to have_received(:resolve).with(:metadata)
+      end
+    end
+
+    context 'when platform is hyperv' do
+      let(:value) { { 'info' => 'value' } }
+
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('hyperv')
+      end
+
+      context 'when on Azure' do
+        it 'calls the az resolver' do
+          fact.call_the_resolver
+
+          expect(Facter::Resolvers::Az).to have_received(:resolve).with(:metadata)
+        end
+
+        it 'returns az_metadata fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'az_metadata', value: value)
+        end
+      end
+
+      context 'when not on Azure' do
+        let(:value) { nil }
+
+        it 'returns az_metadata fact as nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'az_metadata', value: value)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/resolvers/az_spec.rb
+++ b/spec/facter/resolvers/az_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Az do
+  subject(:az) { Facter::Resolvers::Az }
+
+  let(:uri) { 'http://169.254.169.254/metadata/instance?api-version=2020-09-01' }
+  let(:log_spy) { instance_spy(Facter::Log) }
+
+  before do
+    allow(Facter::Util::Resolvers::Http).to receive(:get_request)
+      .with(uri, { Metadata: 'true' }, { session: 5 }).and_return(output)
+    az.instance_variable_set(:@log, log_spy)
+  end
+
+  after do
+    az.invalidate_cache
+  end
+
+  context 'when no exception is thrown' do
+    let(:output) { '{"azEnvironment":"AzurePublicCloud"}' }
+
+    it 'returns az metadata' do
+      expect(az.resolve(:metadata)).to eq({ 'azEnvironment' => 'AzurePublicCloud' })
+    end
+  end
+
+  context 'when an exception is thrown' do
+    let(:output) { '' }
+
+    it 'returns empty az metadata' do
+      expect(az.resolve(:metadata)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the `az_metadata` fact that contains all available metadata information of the Microsoft Azure instance on which facter is being run. Support added for Linux and Windows.