### PR TITLE
(FACT-2944)Facter fails retrieving fqdn with jruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,7 +126,7 @@ RSpec/DescribedClass:
   EnforcedStyle: explicit
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 6
 
 Style/Documentation:
   Enabled: false

--- a/lib/facter/facts/linux/networking/domain.rb
+++ b/lib/facter/facts/linux/networking/domain.rb
@@ -8,7 +8,7 @@ module Facts
         ALIASES = 'domain'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Hostname.resolve(:domain)
+          fact_value = Facter::Resolvers::Linux::Hostname.resolve(:domain)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/resolvers/linux/hostname.rb
+++ b/lib/facter/resolvers/linux/hostname.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Linux
+      class Hostname < BaseResolver
+        # :fqdn
+        # :domain
+        # :hostname
+
+        init_resolver
+
+        class << self
+          private
+
+          def post_resolve(fact_name, _options)
+            @fact_list.fetch(fact_name) { retrieve_info(fact_name) }
+          end
+
+          def retrieve_info(fact_name)
+            require 'socket'
+            require 'facter/util/resolvers/ffi/hostname'
+
+            output = retrieving_hostname
+            return nil unless output
+
+            # Check if the gethostname method retrieved fqdn
+            hostname, domain = parse_fqdn(output)
+
+            fqdn = retrieve_fqdn_for_host(hostname) if hostname_and_no_domain?(hostname, domain)
+
+            _, domain = parse_fqdn(fqdn) if exists_and_valid_fqdn?(fqdn, hostname)
+
+            domain = read_domain unless exists_and_not_empty?(domain)
+
+            construct_fact_list(hostname, domain, fqdn)
+            @fact_list[fact_name]
+          end
+
+          def retrieving_hostname
+            output = Socket.gethostname
+            if !output || output.empty? || output['0.0.0.0']
+              output = Facter::Util::Resolvers::Ffi::Hostname.getffihostname
+            end
+
+            log.debug("Tried to retrieve hostname and got: #{output}")
+            output && !output.empty? ? output : nil
+          end
+
+          def parse_fqdn(output)
+            if output =~ /(.*?)\.(.+$)/
+              log.debug("Managed to read hostname: #{Regexp.last_match(1)} and domain: #{Regexp.last_match(2)}")
+              [Regexp.last_match(1), Regexp.last_match(2)]
+            else
+              log.debug("Only managed to read hostname: #{output}, no domain was found.")
+              [output, '']
+            end
+          end
+
+          def retrieve_fqdn_for_host(host)
+            begin
+              name = Socket.getaddrinfo(host, 0, Socket::AF_UNSPEC, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME)[0]
+            rescue StandardError => e
+              log.debug("Socket.getaddrinfo failed to retrieve fqdn for hostname #{host} with: #{e}")
+            end
+
+            return name[2] if !name.nil? && !name.empty? && host != name[2] && name[2] != name[3]
+
+            retrieve_fqdn_for_host_with_ffi(host)
+          end
+
+          def retrieve_fqdn_for_host_with_ffi(host)
+            fqdn = Facter::Util::Resolvers::Ffi::Hostname.getffiaddrinfo(host)
+            log.debug("FFI getaddrinfo was called and it retrieved: #{fqdn}")
+            fqdn
+          end
+
+          def exists_and_valid_fqdn?(fqdn, hostname)
+            exists_and_not_empty?(fqdn) && fqdn.start_with?("#{hostname}.")
+          end
+
+          def hostname_and_no_domain?(hostname, domain)
+            domain.empty? && !hostname.empty?
+          end
+
+          def read_domain
+            file_content = Facter::Util::FileHelper.safe_read('/etc/resolv.conf')
+            if file_content =~ /^domain\s+(\S+)/
+              Regexp.last_match(1)
+            elsif file_content =~ /^search\s+(\S+)/
+              Regexp.last_match(1)
+            end
+          end
+
+          def construct_fqdn(host, domain, fqdn)
+            return fqdn if exists_and_not_empty?(fqdn)
+            return if host.nil? || host.empty?
+
+            exists_and_not_empty?(domain) ? "#{host}.#{domain}" : host
+          end
+
+          def construct_fact_list(hostname, domain, fqdn)
+            @fact_list[:hostname] = hostname
+            @fact_list[:domain] = domain
+            @fact_list[:fqdn] = construct_fqdn(@fact_list[:hostname], @fact_list[:domain], fqdn)
+          end
+
+          def exists_and_not_empty?(variable)
+            variable && !variable.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/util/resolvers/ffi/hostname.rb
+++ b/lib/facter/util/resolvers/ffi/hostname.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'ffi'
+
+module Facter
+  module Util
+    module Resolvers
+      module Ffi
+        class AddrInfo < ::FFI::Struct
+          layout  :ai_flags, :int,
+                  :ai_family, :int,
+                  :ai_socketype, :int,
+                  :ai_protocol, :int,
+                  :ai_addrlen, :uint,
+                  :ai_addr, :pointer,
+                  :ai_canonname, :pointer,
+                  :ai_next, :pointer
+        end
+
+        module Hostname
+          HOST_NAME_MAX = 64
+          EAI_NONAME = 8
+
+          extend ::FFI::Library
+          ffi_lib ::FFI::Library::LIBC
+
+          attach_function :getaddrinfo, %i[pointer pointer pointer pointer], :int
+          attach_function :gethostname, %i[pointer int], :int
+
+          def self.getffihostname
+            raw_hostname = ::FFI::MemoryPointer.new(:char, HOST_NAME_MAX)
+
+            res = Hostname.gethostname(raw_hostname, HOST_NAME_MAX)
+            return unless res.zero?
+
+            raw_hostname.read_string
+          end
+
+          def self.getffiaddrinfo(hostname)
+            hostname_ptr = FFI::MemoryPointer.new(hostname)
+
+            hints = Facter::Util::Resolvers::Ffi::AddrInfo.new
+            hints[:ai_family] = Socket::AF_UNSPEC
+            hints[:ai_socketype] = Socket::SOCK_STREAM
+            hints[:ai_flags] = Socket::AI_CANONNAME
+
+            res = Hostname.getaddrinfo(hostname_ptr, FFI::Pointer::NULL, hints.to_ptr, FFI::Pointer::NULL)
+            return if res != 0 || res != EAI_NONAME
+
+            name_ptr = hints[:ai_canonname]
+            return if hints.to_ptr != FFI::Pointer::NULL || !name_ptr || hostname == name_ptr.read_string
+
+            name_ptr.read_string
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/linux/networking/domain_spec.rb
+++ b/spec/facter/facts/linux/networking/domain_spec.rb
@@ -7,12 +7,12 @@ describe Facts::Linux::Networking::Domain do
     let(:value) { 'domain' }
 
     before do
-      allow(Facter::Resolvers::Hostname).to receive(:resolve).with(:domain).and_return(value)
+      allow(Facter::Resolvers::Linux::Hostname).to receive(:resolve).with(:domain).and_return(value)
     end
 
     it 'calls Facter::Resolvers::Hostname' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::Hostname).to have_received(:resolve).with(:domain)
+      expect(Facter::Resolvers::Linux::Hostname).to have_received(:resolve).with(:domain)
     end
 
     it 'returns domain fact' do

--- a/spec/facter/resolvers/linux/hostname_spec.rb
+++ b/spec/facter/resolvers/linux/hostname_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Linux::Hostname do
+  subject(:hostname_resolver) { Facter::Resolvers::Linux::Hostname }
+
+  let(:log_spy) { instance_spy(Facter::Log) }
+
+  shared_examples 'detects values' do
+    it 'detects hostname' do
+      expect(hostname_resolver.resolve(:hostname)).to eq(hostname)
+    end
+
+    it 'returns networking domain' do
+      expect(hostname_resolver.resolve(:domain)).to eq(domain)
+    end
+
+    it 'returns fqdn' do
+      expect(hostname_resolver.resolve(:fqdn)).to eq(fqdn)
+    end
+  end
+
+  describe '#resolve' do
+    before do
+      hostname_resolver.instance_variable_set(:@log, log_spy)
+      allow(Socket).to receive(:gethostname).and_return(host)
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/etc/resolv.conf')
+        .and_return("nameserver 10.10.0.10\nnameserver 10.10.1.10\nsearch baz\ndomain baz\n")
+    end
+
+    after do
+      hostname_resolver.invalidate_cache
+    end
+
+    context 'when ruby socket hostname works' do
+      let(:hostname) { 'foo' }
+      let(:domain) { 'bar' }
+      let(:fqdn) { "#{hostname}.#{domain}" }
+
+      context 'when it returns fqdn' do
+        let(:host) { "#{hostname}.#{domain}" }
+
+        it_behaves_like 'detects values'
+      end
+
+      context 'when it returns only the hostname and ruby addrinfo works' do
+        let(:host) { hostname }
+        let(:addr_info) { [['', '', "#{hostname}.#{domain}", '']] }
+
+        before do
+          allow(Socket).to receive(:getaddrinfo).and_return(addr_info)
+        end
+
+        it_behaves_like 'detects values'
+      end
+
+      context 'when it returns only the hostname and ruby addrinfo fails' do
+        let(:host) { hostname }
+        let(:output) { fqdn }
+
+        before do
+          allow(Socket).to receive(:getaddrinfo).and_return([])
+          allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffiaddrinfo).and_return(output)
+        end
+
+        it_behaves_like 'detects values'
+
+        context 'when ffi addrinfo fails' do
+          let(:output) { nil }
+          let(:resolv_conf) { "domain #{domain}" }
+
+          before do
+            allow(Facter::Util::FileHelper).to receive(:safe_read).with('/etc/resolv.conf').and_return(resolv_conf)
+          end
+
+          it_behaves_like 'detects values'
+
+          context 'when /etc/resolv.conf is empty' do
+            let(:resolv_conf) { '' }
+            let(:domain) { nil }
+            let(:fqdn) { hostname }
+
+            it_behaves_like 'detects values'
+          end
+        end
+      end
+    end
+
+    context 'when ruby socket hostname fails' do
+      let(:hostname) { 'hostnametest' }
+      let(:domain) { 'domaintest' }
+      let(:fqdn) { "#{hostname}.#{domain}" }
+      let(:host) { '' }
+
+      before do
+        allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffihostname).and_return(ffi_host)
+      end
+
+      context 'when ffi hostname works' do
+        let(:ffi_host) { fqdn }
+
+        it_behaves_like 'detects values'
+      end
+
+      context 'when it returns only the hostname and ruby addrinfo works' do
+        let(:addr_info) { [['', '', "#{hostname}.#{domain}", '']] }
+        let(:ffi_host) { hostname }
+
+        before do
+          allow(Socket).to receive(:getaddrinfo).and_return(addr_info)
+        end
+
+        it_behaves_like 'detects values'
+      end
+
+      context 'when it returns only the hostname and ruby addrinfo fails' do
+        let(:ffi_host) { hostname }
+        let(:output) { fqdn }
+
+        before do
+          allow(Socket).to receive(:getaddrinfo).and_return([])
+          allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffiaddrinfo).and_return(output)
+        end
+
+        it_behaves_like 'detects values'
+
+        context 'when ffi addrinfo fails' do
+          let(:output) { nil }
+          let(:resolv_conf) { "domain #{domain}" }
+
+          before do
+            allow(Facter::Util::FileHelper).to receive(:safe_read).with('/etc/resolv.conf').and_return(resolv_conf)
+          end
+
+          it_behaves_like 'detects values'
+
+          context 'when /etc/resolv.conf is empty' do
+            let(:resolv_conf) { '' }
+            let(:domain) { nil }
+            let(:fqdn) { hostname }
+
+            it_behaves_like 'detects values'
+          end
+        end
+      end
+    end
+
+    context 'when ffi hostname fails to return hostname' do
+      let(:hostname) { nil }
+      let(:domain) { nil }
+      let(:host) { '' }
+      let(:fqdn) { nil }
+
+      before do
+        allow(Facter::Util::Resolvers::Ffi::Hostname).to receive(:getffihostname).and_return('')
+      end
+
+      it_behaves_like 'detects values'
+    end
+  end
+end


### PR DESCRIPTION
**Description of the problem:** Facter fails to retrieve domain on jruby because the `Socket.getaddrinfo` call fails.
**Description of the fix:** On linux if any of the Socket method calls fail, try to retrieve information using FFI as described below:
![image](https://user-images.githubusercontent.com/49147761/109532395-c1955c00-7ac1-11eb-9b24-e14f528306f4.png)
