### PR TITLE
(FACT-1383) Add Azure instance metadata fact

### DIFF
--- a/acceptance/tests/options/no_cache_should_not_cache_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_cache_facts.rb
@@ -36,7 +36,7 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
 
     step "facter should not cache facts when --no-cache is specified" do
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to cache any facts")
+        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to cache any facts")
       end
     end
   end

--- a/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
@@ -52,7 +52,7 @@ FILE
       agent.modified_at(cached_fact_file, '198001010000')
 
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching/, facter_output.stderr, "facter should not have tried to refresh the cache")
+        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to refresh the cache")
       end
 
       cat_output = agent.cat(cached_fact_file)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ set(LIBFACTER_COMMON_SOURCES
     "src/facts/map_value.cc"
     "src/facts/resolver.cc"
     "src/facts/resolvers/augeas_resolver.cc"
+    "src/facts/resolvers/az_resolver.cc"
     "src/facts/resolvers/disk_resolver.cc"
     "src/facts/resolvers/dmi_resolver.cc"
     "src/facts/resolvers/ec2_resolver.cc"

--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -616,6 +616,11 @@ namespace facter { namespace facts {
         constexpr static char const* solaris_zones = "solaris_zones";
 
         /**
+         * The fact for Azure metadata.
+         */
+        constexpr static char const* az_metadata = "az_metadata";
+
+        /**
          * The fact for EC2 metadata.
          */
         constexpr static char const* ec2_metadata = "ec2_metadata";

--- a/lib/inc/internal/facts/resolvers/az_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/az_resolver.hpp
@@ -1,0 +1,30 @@
+/**
+* @file
+* Declares the base AZ fact resolver.
+*/
+#pragma once
+
+#include <facter/facts/resolver.hpp>
+
+namespace facter { namespace facts { namespace resolvers {
+
+    /**
+    * Responsible for resolving AZ facts.
+    */
+    struct az_resolver : resolver
+    {
+        /**
+         * Constructs the az_resolver.
+         */
+        az_resolver();
+
+        /**
+         * Called to resolve all facts the resolver is responsible for.
+         * @param facts The fact collection that is resolving facts.
+         */
+        virtual void resolve(collection& facts) override;
+
+        bool is_blockable() const override;
+    };
+
+}}}  // namespace facter::facts::resolvers

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -320,6 +320,17 @@ domain:
         POSIX platforms: use the `getaddrinfo` function to retrieve the network domain.
         Windows: query the registry to retrieve the network domain; falls back to the primary interface's domain if not set in the registry.
 
+az_metadata:
+    type: map
+    description: |
+        Return the Microsoft Azure instance metadata.
+        Please see the [Microsoft Azure instance metadata documentation](http://https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service) for the contents of this fact.
+    resolution: |
+        Azure: query the Azure metadata endpoint and parse the response.
+    caveats: |
+        All platforms: `libfacter` must be built with `libcurl` support.
+    validate: false
+
 ec2_metadata:
     type: map
     description: |

--- a/lib/src/facts/collection.cc
+++ b/lib/src/facts/collection.cc
@@ -11,6 +11,7 @@
 #include <internal/facts/resolvers/hypervisors_resolver.hpp>
 #include <internal/facts/resolvers/ruby_resolver.hpp>
 #include <internal/facts/resolvers/path_resolver.hpp>
+#include <internal/facts/resolvers/az_resolver.hpp>
 #include <internal/facts/resolvers/ec2_resolver.hpp>
 #include <internal/facts/resolvers/gce_resolver.hpp>
 #include <internal/facts/resolvers/augeas_resolver.hpp>
@@ -693,6 +694,7 @@ namespace facter { namespace facts {
             add(make_shared<resolvers::ruby_resolver>());
         }
         add(make_shared<resolvers::path_resolver>());
+        add(make_shared<resolvers::az_resolver>());
         add(make_shared<resolvers::ec2_resolver>());
         add(make_shared<resolvers::gce_resolver>());
         add(make_shared<resolvers::augeas_resolver>());

--- a/lib/src/facts/resolvers/az_resolver.cc
+++ b/lib/src/facts/resolvers/az_resolver.cc
@@ -1,0 +1,261 @@
+#include <internal/facts/resolvers/az_resolver.hpp>
+#include <facter/facts/collection.hpp>
+#include <facter/facts/fact.hpp>
+#include <facter/facts/scalar_value.hpp>
+#include <facter/facts/array_value.hpp>
+#include <facter/facts/map_value.hpp>
+#include <facter/facts/vm.hpp>
+#include <leatherman/logging/logging.hpp>
+#include <leatherman/locale/locale.hpp>
+#include <leatherman/util/environment.hpp>
+#include <boost/algorithm/string.hpp>
+#include <rapidjson/reader.h>
+#include <rapidjson/error/en.h>
+#include <stack>
+#include <tuple>
+#include <stdexcept>
+
+#ifdef USE_CURL
+#include <leatherman/curl/client.hpp>
+#include <leatherman/curl/request.hpp>
+#include <leatherman/curl/response.hpp>
+namespace lth_curl = leatherman::curl;
+#endif
+
+using namespace std;
+using namespace rapidjson;
+using namespace leatherman::util;
+
+namespace facter { namespace facts { namespace resolvers {
+
+   az_resolver::az_resolver() :
+        resolver(
+            "AZ",
+            {
+                fact::az_metadata
+            })
+    {
+    }
+
+#ifdef USE_CURL
+    static const char* AZ_METADATA_URL = "http://169.254.169.254/metadata/instance?api-version=2020-09-01";
+    static const unsigned int AZ_CONNECTION_TIMEOUT = 600;
+    #ifdef HAS_LTH_GET_INT
+        static const unsigned int AZ_SESSION_TIMEOUT = environment::get_int("AZ_SESSION_TIMEOUT", 5000);
+    #else
+        static const unsigned int AZ_SESSION_TIMEOUT = 5000;
+    #endif
+#endif
+
+    struct json_event_handler
+    {
+        explicit json_event_handler(map_value& root) :
+            _initialized(false),
+            _root(root)
+        {
+        }
+
+        bool Null()
+        {
+            check_initialized();
+            _key.clear();
+            return true;
+        }
+
+        bool Bool(bool b)
+        {
+            add_value(make_value<boolean_value>(b));
+            return true;
+        }
+
+        bool Int(int i)
+        {
+            Uint64(static_cast<uint64_t>(i));
+            return true;
+        }
+
+        bool Uint(unsigned int i)
+        {
+            Uint64(static_cast<uint64_t>(i));
+            return true;
+        }
+
+        bool Int64(int64_t i)
+        {
+            Uint64(static_cast<uint64_t>(i));
+            return true;
+        }
+
+        bool Uint64(uint64_t i)
+        {
+            add_value(make_value<integer_value>(i));
+            return true;
+        }
+
+        bool Double(double d)
+        {
+            add_value(make_value<double_value>(d));
+            return true;
+        }
+
+        bool String(char const* s, SizeType len, bool copy)
+        {
+            add_value(make_value<string_value>(s));
+            return true;
+        }
+
+        bool Key(const char* str, SizeType length, bool copy)
+        {
+            check_initialized();
+            _key = string(str, length);
+            return true;
+        }
+
+        bool StartObject()
+        {
+            if (!_initialized) {
+                _initialized = true;
+                return true;
+            }
+
+            // Push a map onto the stack
+            _stack.emplace(make_tuple(move(_key), make_value<map_value>()));
+            return true;
+        }
+
+        bool EndObject(SizeType count)
+        {
+            // Check to see if the stack is empty since we don't push for the top-level object
+            if (_stack.empty()) {
+                return true;
+            }
+
+            // Pop the data off the stack
+            auto top = move(_stack.top());
+            _stack.pop();
+
+            // Restore the key and add the value
+            _key = move(get<0>(top));
+            add_value(move(get<1>(top)));
+            return true;
+        }
+
+        bool StartArray()
+        {
+            check_initialized();
+
+            // Push an array onto the stack
+            _stack.emplace(make_tuple(move(_key), make_value<array_value>()));
+            return true;
+        }
+
+        bool EndArray(SizeType count)
+        {
+            // Pop the data off the stack
+            auto top = move(_stack.top());
+            _stack.pop();
+
+            // Restore the key and add the value
+            _key = move(get<0>(top));
+            add_value(move(get<1>(top)));
+            return true;
+        }
+
+    private:
+        template <typename T> void add_value(unique_ptr<T>&& val)
+        {
+            check_initialized();
+
+            value* current = nullptr;
+
+            if (_stack.empty()) {
+                current = &_root;
+            } else {
+                current = get<1>(_stack.top()).get();
+            }
+
+            auto map = dynamic_cast<map_value*>(current);
+            if (map) {
+                if (_key.empty()) {
+                    throw external::external_fact_exception("expected non-empty key in object.");
+                }
+                map->add(move(_key), move(val));
+                return;
+            }
+            auto array = dynamic_cast<array_value*>(current);
+            if (array) {
+                array->add(move(val));
+                return;
+            }
+        }
+
+        void check_initialized() const
+        {
+            if (!_initialized) {
+                throw external::external_fact_exception("expected document to contain an object.");
+            }
+        }
+
+        bool _initialized;
+        map_value& _root;
+        string _key;
+        stack<tuple<string, unique_ptr<value>>> _stack;
+    };
+
+    void az_resolver::resolve(collection& facts)
+    {
+        auto virtualization = facts.get<string_value>(fact::virtualization);
+        if (!virtualization || virtualization->value() != vm::hyperv) {
+            LOG_DEBUG("not running under a Azure instance.");
+            return;
+        }
+
+#ifndef USE_CURL
+        LOG_INFO("Azure instance metadata fact is unavailable: facter was built without libcurl support.");
+        return;
+#else
+        LOG_DEBUG("querying Azure metadata.");
+
+        try
+        {
+            lth_curl::request req(AZ_METADATA_URL);
+            req.add_header("Metadata", "true");
+            req.connection_timeout(AZ_CONNECTION_TIMEOUT);
+            req.timeout(AZ_SESSION_TIMEOUT);
+
+            lth_curl::client cli;
+            auto response = cli.get(req);
+            if (response.status_code() != 200) {
+                LOG_DEBUG("request for {1} returned a status code of {2}.", req.url(), response.status_code());
+                return;
+            }
+
+            auto data = make_value<map_value>();
+
+            Reader reader;
+            StringStream ss(response.body().c_str());
+            json_event_handler handler(*data);
+            auto result = reader.Parse(ss, handler);
+            if (!result) {
+                LOG_ERROR("failed to parse Azure metadata: {1}.", GetParseError_En(result.Code()));
+                return;
+            }
+
+            if (!data->empty()) {
+                facts.add(fact::az_metadata, move(data));
+            }
+        } catch (lth_curl::http_request_exception& ex) {
+            LOG_DEBUG("Azure instance metadata fact is unavailable: not running under an Azure instance or Azure is not responding in a timely manner.");
+            LOG_TRACE("EC2 metadata request failed: {1}", ex.what());
+            return;
+        } catch (runtime_error& ex) {
+            LOG_ERROR("Azure metadata request failed: {1}", ex.what());
+        }
+#endif
+    }
+
+    bool az_resolver::is_blockable() const {
+        return true;
+    }
+}}}  // namespace facter::facts::resolvers
+

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -13,6 +13,7 @@
 
 // Include all base resolvers here
 #include <internal/facts/resolvers/augeas_resolver.hpp>
+#include <internal/facts/resolvers/az_resolver.hpp>
 #include <internal/facts/resolvers/disk_resolver.hpp>
 #include <internal/facts/resolvers/dmi_resolver.hpp>
 #include <internal/facts/resolvers/ec2_resolver.hpp>
@@ -495,6 +496,7 @@ void add_all_facts(collection& facts)
     facts.add("facterversion", make_value<string_value>("version"));
     facts.add("aio_agent_version", make_value<string_value>(""));
     facts.add(make_shared<augeas_resolver>());
+    facts.add(fact::az_metadata, make_value<map_value>());
     facts.add(make_shared<disk_resolver>());
     facts.add(make_shared<dmi_resolver>());
     facts.add(make_shared<filesystem_resolver>());


### PR DESCRIPTION
This commit adds the `az_metadata` fact that contains all available metadata information of the Microsoft Azure instance on which facter is being run. Support added for Linux and Windows.