### PR TITLE
(FACT-2950) return root fact if defined

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,7 @@ Metrics/AbcSize:
     - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
     - 'lib/facter/custom_facts/core/execution/popen3.rb'
     - 'lib/facter.rb'
+    - 'lib/facter/framework/parsers/query_parser.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -69,12 +69,19 @@ module Facter
         resolvable_fact_list = []
 
         loaded_fact_hash.each do |loaded_fact|
-          query_fact = query_tokens[query_token_range].join('.')
+          # return the fact if toplevel namespace is found in the first query token
+          # eg. query: 'os.name' and loaded_fact_hash contains a fact with 'os' name
+          # it will construt and return the 'os' fact
+          if loaded_fact.name == query_tokens[0]
+            resolvable_fact_list = [construct_loaded_fact(query_tokens, query_token_range, loaded_fact)]
+          else
+            query_fact = query_tokens[query_token_range].join('.')
 
-          next unless found_fact?(loaded_fact.name, query_fact)
+            next unless found_fact?(loaded_fact.name, query_fact)
 
-          searched_fact = construct_loaded_fact(query_tokens, query_token_range, loaded_fact)
-          resolvable_fact_list << searched_fact
+            searched_fact = construct_loaded_fact(query_tokens, query_token_range, loaded_fact)
+            resolvable_fact_list << searched_fact
+          end
         end
 
         @log.debug "List of resolvable facts: #{resolvable_fact_list.inspect}"

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -103,5 +103,25 @@ describe Facter::QueryParser do
         )
       end
     end
+
+    context 'when root structured fact is overwritten' do
+      let(:query_list) { ['os.name'] }
+      let(:loaded_facts) do
+        [
+          instance_double(
+            Facter::LoadedFact, name: 'os.name', klass: 'Facter::Ubuntu::Os::Name', type: :core, file: nil
+          ),
+          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil)
+        ]
+      end
+
+      it 'returns the toplevel fact' do
+        matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
+
+        expect(matched_facts).to be_an_instance_of(Array).and \
+          contain_exactly(an_instance_of(Facter::SearchedFact)
+          .and(having_attributes(name: 'os', fact_class: nil, type: :custom)))
+      end
+    end
   end
 end


### PR DESCRIPTION
Because the toplevel fact does not exists, root of
structured core facts cannot be overriden by a
custom fact. This PR updates the QueryParser logic
to return the root fact, if that is found in the
loaded facts list.

eg: the list contains both `os.name` and `os` facts,
the result will be the `os` fact.

This new functionality allows completely redefinition
of core facts. Eg:

```
❯ cat custom_facts/my_custom_fact.rb

Facter.add(:os) do
  has_weight(999)
  setcode do
    {"architecture"=>"x64"}
  end
end

❯ bx facter os
{
  architecture => "x64"
}

❯ bx facter os.name

❯ bx facter os.architecture
x64
```