### PR TITLE
(FACT-2952) Align the lsbmajdistrelease fact with Facter 3

### DIFF
--- a/lib/facter/facts/ubuntu/lsbdistrelease.rb
+++ b/lib/facter/facts/ubuntu/lsbdistrelease.rb
@@ -15,8 +15,8 @@ module Facts
         version = fact_value.split('.')
 
         [Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy),
-         Facter::ResolvedFact.new(ALIASES[0], version[0], :legacy),
-         Facter::ResolvedFact.new(ALIASES[1], version[1], :legacy)]
+         Facter::ResolvedFact.new(ALIASES[0], "#{version[0]}.#{version[1]}", :legacy),
+         Facter::ResolvedFact.new(ALIASES[1], version[2], :legacy)]
       end
     end
   end

--- a/spec/facter/facts/linux/lsbdistrelease_spec.rb
+++ b/spec/facter/facts/linux/lsbdistrelease_spec.rb
@@ -10,40 +10,42 @@ describe Facts::Linux::Lsbdistrelease do
       end
 
       context 'when version_id is retrieved successful' do
-        let(:value) { '18.04' }
-        let(:value_final) { { 'full' => '18.04', 'major' => '18', 'minor' => '04' } }
+        context 'when version consists of only major' do
+          let(:value) { '10' }
+          let(:value_final) { { 'full' => '10', 'major' => '10', 'minor' => nil } }
 
-        it 'calls Facter::Resolvers::LsbRelease with :name' do
-          fact.call_the_resolver
-          expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+          it 'calls Facter::Resolvers::LsbRelease with :name' do
+            fact.call_the_resolver
+            expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+          end
+
+          it 'returns release fact' do
+            expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+              contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
+                              an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                          value: value_final['major'], type: :legacy),
+                              an_object_having_attributes(name: 'lsbminordistrelease',
+                                                          value: value_final['minor'], type: :legacy))
+          end
         end
 
-        it 'returns release fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                            an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                        value: value_final['major'], type: :legacy),
-                            an_object_having_attributes(name: 'lsbminordistrelease',
-                                                        value: value_final['minor'], type: :legacy))
-        end
-      end
+        context 'when versin consists of both major and minor' do
+          let(:value) { '10.08' }
+          let(:value_final) { { 'full' => '10.08', 'major' => '10', 'minor' => '08' } }
 
-      context 'when Debian 10' do
-        let(:value) { '10' }
-        let(:value_final) { { 'full' => '10', 'major' => '10', 'minor' => nil } }
+          it 'calls Facter::Resolvers::LsbRelease with :name' do
+            fact.call_the_resolver
+            expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+          end
 
-        it 'calls Facter::Resolvers::LsbRelease with :name' do
-          fact.call_the_resolver
-          expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
-        end
-
-        it 'returns release fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                            an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                        value: value_final['major'], type: :legacy),
-                            an_object_having_attributes(name: 'lsbminordistrelease',
-                                                        value: value_final['minor'], type: :legacy))
+          it 'returns release fact' do
+            expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+              contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
+                              an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                          value: value_final['major'], type: :legacy),
+                              an_object_having_attributes(name: 'lsbminordistrelease',
+                                                          value: value_final['minor'], type: :legacy))
+          end
         end
       end
 

--- a/spec/facter/facts/ubuntu/lsbdistrelease_spec.rb
+++ b/spec/facter/facts/ubuntu/lsbdistrelease_spec.rb
@@ -11,26 +11,7 @@ describe Facts::Ubuntu::Lsbdistrelease do
 
       context 'when version_id is retrieved successful' do
         let(:value) { '18.04' }
-        let(:value_final) { { 'full' => '18.04', 'major' => '18', 'minor' => '04' } }
-
-        it 'calls Facter::Resolvers::LsbRelease with :name' do
-          fact.call_the_resolver
-          expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
-        end
-
-        it 'returns release fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                            an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                        value: value_final['major'], type: :legacy),
-                            an_object_having_attributes(name: 'lsbminordistrelease',
-                                                        value: value_final['minor'], type: :legacy))
-        end
-      end
-
-      context 'when Debian 10' do
-        let(:value) { '10' }
-        let(:value_final) { { 'full' => '10', 'major' => '10', 'minor' => nil } }
+        let(:value_final) { { 'full' => '18.04', 'major' => '18.04', 'minor' => nil } }
 
         it 'calls Facter::Resolvers::LsbRelease with :name' do
           fact.call_the_resolver


### PR DESCRIPTION
The `lsbmajdistrelease` fact in Facter 4 was not showing the correct value on Ubuntu due to their unique approach on versioning.

Example:
In version `20.04.2`, they consider as follows:
 - `20.04` = major version
 - `2`     = minor version

Most of the other Linux operating systems respect the generic semantic versioning rules (`major.minor.patch`). This commit aligns the fact's output with Facter 3 accordingly.

Also removed and cleaned up some tests (Debian will use the Linux resolver so the case shouldn't be covered under Ubuntu).