### PR TITLE
(FACT-2956) rework Facter.value

### DIFF
--- a/acceptance/lib/facter/acceptance/api_utils.rb
+++ b/acceptance/lib/facter/acceptance/api_utils.rb
@@ -1,0 +1,32 @@
+module Facter
+  module Acceptance
+    module ApiUtils
+      # create a facter_run.rb file that loads facter,
+      # register a teardown that will clear the executable dir
+      # set different config options(debug, custom/external dir)
+      # print the result of Facter.value
+      def facter_value_rb(agent, fact_name, options = {})
+        dir = agent.tmpdir('executables')
+
+        teardown do
+          agent.rm_rf(dir)
+        end
+
+        rb_file = File.join(dir, 'facter_run.rb')
+
+        file_content = <<-RUBY
+          require 'facter'
+
+          Facter.debugging(#{options.fetch(:debug, false)})
+          Facter.search('#{options.fetch(:custom_dir, '')}')
+          Facter.search_external(['#{options.fetch(:external_dir, '')}'])
+
+          puts Facter.value('#{fact_name}')
+        RUBY
+
+        create_remote_file(agent, rb_file, file_content)
+        rb_file
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/core_and_custom.rb
+++ b/acceptance/tests/api/value/core_and_custom.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(core_fact) when custom fact is defined' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    fact_name = 'os.name'
+    core_fact_value = os_processors_and_kernel_expected_facts(agent)[fact_name]
+
+    step 'in different file than fact name' do
+      facts_dir = agent.tmpdir('facts')
+
+      teardown do
+        agent.rm_rf(facts_dir)
+      end
+
+      fact_file = File.join(facts_dir, 'test_fact.rb')
+      fact_content = <<-RUBY
+        Facter.add('#{fact_name}') do
+          has_weight(100)
+          setcode { 'custom_fact' }
+        end
+      RUBY
+
+      create_remote_file(agent, fact_file, fact_content)
+
+      step 'returns core fact value' do
+        facter_rb = facter_value_rb(agent, fact_name, custom_dir: facts_dir)
+        fact_value = on(agent, "#{ruby_command(agent)} #{facter_rb}").stdout&.strip
+
+        assert_match(fact_value, core_fact_value, 'Incorrect fact value for os.name')
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/core_and_custom_overwrite.rb
+++ b/acceptance/tests/api/value/core_and_custom_overwrite.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(core_fact) when custom fact is defined and overwrites core' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    fact_name = 'os.name'
+
+    step 'in the same file as fact name' do
+      facts_dir = agent.tmpdir('facts')
+
+      teardown do
+        agent.rm_rf(facts_dir)
+      end
+
+      fact_file = File.join(facts_dir, 'os.name.rb')
+      fact_content = <<-RUBY
+        Facter.add('#{fact_name}') do
+          has_weight(100)
+          setcode { 'custom_fact' }
+        end
+      RUBY
+
+      create_remote_file(agent, fact_file, fact_content)
+
+      step 'returns custom fact value' do
+        facter_rb = facter_value_rb(agent, fact_name, custom_dir: facts_dir)
+        fact_value = on(agent, "#{ruby_command(agent)} #{facter_rb}").stdout&.strip
+
+        assert_match(fact_value, 'custom_fact', 'Incorrect fact value for os.name')
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/core_fact.rb
+++ b/acceptance/tests/api/value/core_fact.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(core_fact)' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    fact_name = 'os.name'
+    core_fact_value = os_processors_and_kernel_expected_facts(agent)[fact_name]
+
+    step 'returns core fact value' do
+      facter_rb = facter_value_rb(agent, fact_name)
+      fact_value = on(agent, "#{ruby_command(agent)} #{facter_rb}").stdout&.strip
+
+      assert_match(fact_value, core_fact_value, 'Incorrect fact value for os.name')
+    end
+  end
+end

--- a/acceptance/tests/api/value/custom_fact_in_different_file.rb
+++ b/acceptance/tests/api/value/custom_fact_in_different_file.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(custom_fact) in different file' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    facts_dir = agent.tmpdir('facts')
+    fact_name = 'single_custom_fact'
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    fact_file = File.join(facts_dir, 'another_fact.rb')
+    fact_content = <<-RUBY
+        Facter.add('#{fact_name}') do
+          setcode { 'single_custom_fact' }
+        end
+    RUBY
+
+    create_remote_file(agent, fact_file, fact_content)
+
+    step 'returns custom_fact fact value after loading all custom facts' do
+      facter_rb = facter_value_rb(agent, fact_name, custom_dir: facts_dir, debug: true)
+      on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
+        output = result.stdout.strip
+        assert_match(/has resolved to: #{fact_name}/, output, 'Incorrect fact value for custom fact')
+        assert_match(/Searching fact: #{fact_name} in all custom facts/, output, 'Loaded all custom facts')
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/custom_fact_in_same_file_as_fact_name.rb
+++ b/acceptance/tests/api/value/custom_fact_in_same_file_as_fact_name.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(custom_fact) in the same file as fact name' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    facts_dir = agent.tmpdir('facts')
+    fact_name = 'single_custom_fact'
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    fact_file = File.join(facts_dir, "#{fact_name}.rb")
+    fact_content = <<-RUBY
+        Facter.add('#{fact_name}') do
+          setcode { 'single_custom_fact' }
+        end
+    RUBY
+
+    create_remote_file(agent, fact_file, fact_content)
+
+    step 'returns custom_fact fact value without loading all custom facts' do
+      facter_rb = facter_value_rb(agent, fact_name, custom_dir: facts_dir, debug: true)
+      on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
+        output = result.stdout.strip
+        assert_match(/has resolved to: #{fact_name}/, output, 'Incorrect fact value for custom fact')
+        assert_no_match(/Searching fact: #{fact_name} in all custom facts/, output, 'Loaded all custom facts')
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/external_fact.rb
+++ b/acceptance/tests/api/value/external_fact.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(external_fact)' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    facts_dir = agent.tmpdir('facts')
+    fact_name = 'my_external_fact'
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    fact_file = File.join(facts_dir, 'external.txt')
+    fact_content = 'my_external_fact=123'
+
+    create_remote_file(agent, fact_file, fact_content)
+
+    step 'returns external fact without loading custom facts' do
+      facter_rb = facter_value_rb(agent, fact_name, external_dir: facts_dir, debug: true)
+      on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
+        output = result.stdout.strip
+        assert_match(/has resolved to: 123/, output, 'Incorrect fact value for external fact')
+        assert_no_match(/in all custom facts/, output, 'Loaded all custom facts')
+      end
+    end
+  end
+end

--- a/acceptance/tests/api/value/non_existent_fact.rb
+++ b/acceptance/tests/api/value/non_existent_fact.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(not_existent)' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    fact_name = 'non_existent'
+    facts_dir = agent.tmpdir('facts')
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    step 'it loads facts in the correct order' do
+      facter_rb = facter_value_rb(
+        agent, fact_name,
+        external_dir: facts_dir,
+        custom_dir: facts_dir,
+        debug: true
+      )
+
+      on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
+        output = result.stdout.strip
+        assert_no_match(/has resolved to: /, output, 'Fact was found')
+        assert_match(
+          /Searching fact: #{fact_name} in file: #{fact_name}.rb/,
+          output,
+          'Did not load fact name file'
+        )
+        assert_match(
+          /Searching fact: #{fact_name} in core facts and external facts/,
+          output,
+          'Did not load core and external'
+        )
+        assert_match(
+          /Searching fact: #{fact_name} in all custom facts/,
+          output, '
+          Did not load all custom facts'
+        )
+      end
+    end
+  end
+end

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -253,23 +253,6 @@ module Facter
       self
     end
 
-    # Returns a fact object by name.  If you use this, you still have to
-    # call {Facter::Util::Fact#value `value`} on it to retrieve the actual
-    # value.
-    #
-    # @param user_query [String] the name of the fact
-    #
-    # @return [Facter::Util::Fact, nil] The fact object, or nil if no fact
-    #   is found.
-    #
-    # @api public
-    def fact(user_query)
-      user_query = user_query.to_s
-      resolve_fact(user_query)
-
-      @already_searched[user_query]
-    end
-
     # Reset search paths for custom and external facts
     # If config file is set custom and external facts will be reloaded
     #
@@ -411,7 +394,25 @@ module Facter
     def value(user_query)
       user_query = user_query.to_s
       resolve_fact(user_query)
+
       @already_searched[user_query]&.value
+    end
+
+    # Returns a fact object by name.  If you use this, you still have to
+    # call {Facter::Util::Fact#value `value`} on it to retrieve the actual
+    # value.
+    #
+    # @param user_query [String] the name of the fact
+    #
+    # @return [Facter::Util::Fact, nil] The fact object, or nil if no fact
+    #   is found.
+    #
+    # @api public
+    def fact(user_query)
+      user_query = user_query.to_s
+      resolve_fact(user_query)
+
+      @already_searched[user_query]
     end
 
     # Returns Facter version
@@ -545,7 +546,7 @@ module Facter
     # @return [ResolvedFact]
     def resolve_fact(user_query)
       user_query = user_query.to_s
-      resolved_facts = Facter::FactManager.instance.resolve_facts([user_query])
+      resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
       # we must make a distinction between custom facts that return nil and nil facts
       # Nil facts should not be packaged as ResolvedFacts! (add_fact_to_searched_facts packages facts)
       resolved_facts = resolved_facts.reject { |fact| fact.type == :nil }

--- a/lib/facter/custom_facts/util/collection.rb
+++ b/lib/facter/custom_facts/util/collection.rb
@@ -106,6 +106,11 @@ module LegacyFacter
         @loaded = false
       end
 
+      def custom_fact(fact_name)
+        internal_loader.load(fact_name)
+        @custom_facts = @facts.select { |_k, v| v.options[:fact_type] == :custom }
+      end
+
       # Builds a hash of custom facts
       def custom_facts
         return @custom_facts if @valid_custom_facts

--- a/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
@@ -10,20 +10,23 @@ module Facter
       @external_facts = load_external_facts
     end
 
+    def load_fact(fact_name)
+      build_custom_facts(LegacyFacter.collection.custom_fact(fact_name)) || []
+    end
+
     private
 
     def load_custom_facts
-      custom_facts = []
-
       custom_facts_to_load = LegacyFacter.collection.custom_facts
+      build_custom_facts(custom_facts_to_load) || []
+    end
 
-      custom_facts_to_load&.each do |k, v|
+    def build_custom_facts(custom_facts_to_load)
+      custom_facts_to_load&.map do |k, v|
         loaded_fact = LoadedFact.new(k.to_s, nil, :custom)
         loaded_fact.is_env = v.options[:is_env] if v.options[:is_env]
-        custom_facts << loaded_fact
+        loaded_fact
       end
-
-      custom_facts
     end
 
     def load_external_facts

--- a/lib/facter/framework/core/fact_manager.rb
+++ b/lib/facter/framework/core/fact_manager.rb
@@ -8,18 +8,16 @@ module Facter
       @internal_fact_mgr = InternalFactManager.new
       @external_fact_mgr = ExternalFactManager.new
       @fact_loader = FactLoader.instance
+      @options = Options.get
       @log = Log.new(self)
     end
 
-    def searched_facts(user_query = [])
-      loaded_facts = @fact_loader.load(Options.get)
-      QueryParser.parse(user_query, loaded_facts)
-    end
-
     def resolve_facts(user_query = [])
-      searched_facts = parse_user_query(user_query)
-
+      @options[:user_query] = user_query
       cache_manager = Facter::CacheManager.new
+
+      searched_facts = QueryParser.parse(user_query, @fact_loader.load(@options))
+
       searched_facts, cached_facts = cache_manager.resolve_facts(searched_facts)
       internal_facts = @internal_fact_mgr.resolve_facts(searched_facts)
       external_facts = @external_fact_mgr.resolve_facts(searched_facts)
@@ -35,23 +33,94 @@ module Facter
       resolved_facts
     end
 
-    def resolve_core(user_query = [])
-      loaded_facts_hash = @fact_loader.internal_facts
+    # resolve a fact by name, in a similar way that facter 3 does.
+    # search is done in multiple steps, and the next step is executed
+    # only if the previous one was not able to resolve the fact
+    # - load the `fact_name.rb` from the configured custom directories
+    # - load all the core facts, external facts and env facts
+    # - load all custom facts
+    def resolve_fact(user_query)
+      @options[:user_query] = user_query
+      @log.debug("resolving fact with user_query: #{user_query}")
+
+      @cache_manager = Facter::CacheManager.new
+
+      resolved_facts = custom_fact_by_filename ||
+                       core_or_external_fact ||
+                       all_custom_facts
+
+      @cache_manager.cache_facts(resolved_facts)
+
+      log_resolved_facts(resolved_facts)
+      resolved_facts
+    end
+
+    def resolve_core(user_query = [], options = {})
+      @cache_manager = CacheManager.new
+      core_fact(user_query, options)
+    end
+
+    private
+
+    def core_fact(user_query, options)
+      loaded_facts_hash = @fact_loader.load_internal_facts(options)
 
       searched_facts = QueryParser.parse(user_query, loaded_facts_hash)
+      searched_facts, cached_facts = @cache_manager.resolve_facts(searched_facts)
+
       resolved_facts = @internal_fact_mgr.resolve_facts(searched_facts)
+      resolved_facts = resolved_facts.concat(cached_facts)
+
       FactFilter.new.filter_facts!(resolved_facts, user_query)
 
       resolved_facts
     end
 
-    private
+    def custom_fact_by_filename
+      user_query = @options[:user_query]
+      @log.debug("Searching fact: #{user_query} in file: #{user_query}.rb")
 
-    def parse_user_query(user_query)
-      options = Options.get
-      options[:user_query] = user_query
-      loaded_facts = @fact_loader.load(options)
+      custom_fact = @fact_loader.load_custom_fact(@options, user_query)
+      return unless custom_fact.any?
 
+      searched_facts = parse_user_query(custom_fact, @options)
+      searched_facts, cached_facts = @cache_manager.resolve_facts(searched_facts)
+
+      resolved_facts = @external_fact_mgr.resolve_facts(searched_facts)
+      resolved_facts = resolved_facts.concat(cached_facts)
+      resolved_facts if resolved_facts.any?
+    end
+
+    def core_or_external_fact
+      user_query = @options[:user_query]
+      @log.debug("Searching fact: #{user_query} in core facts and external facts")
+
+      core_facts = core_fact([user_query], @options)
+      external_facts = @fact_loader.load_external_facts(@options)
+      searched_facts = parse_user_query(external_facts, @options)
+      searched_facts, cached_facts = @cache_manager.resolve_facts(searched_facts)
+
+      resolved_facts = @external_fact_mgr.resolve_facts(searched_facts)
+      resolved_facts = override_core_facts(core_facts, resolved_facts)
+      resolved_facts = resolved_facts.concat(cached_facts)
+
+      resolved_facts if resolved_facts.map(&:value).any?
+    end
+
+    def all_custom_facts
+      user_query = @options[:user_query]
+      @log.debug("Searching fact: #{user_query} in all custom facts")
+
+      custom_facts = @fact_loader.load_custom_facts(@options)
+      searched_facts = parse_user_query(custom_facts, @options)
+      searched_facts, cached_facts = @cache_manager.resolve_facts(searched_facts)
+
+      resolved_facts = @external_fact_mgr.resolve_facts(searched_facts)
+      resolved_facts.concat(cached_facts)
+    end
+
+    def parse_user_query(loaded_facts, options)
+      user_query = Array(options[:user_query])
       QueryParser.parse(user_query, loaded_facts)
     end
 

--- a/spec/custom_facts/util/collection_spec.rb
+++ b/spec/custom_facts/util/collection_spec.rb
@@ -15,6 +15,7 @@ describe LegacyFacter::Util::Collection do
 
   before do
     Singleton.__init__(Facter::FactManager)
+    Singleton.__init__(Facter::FactLoader)
   end
 
   it 'delegates its load_all method to its loader' do

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -199,14 +199,14 @@ describe Facter do
 
   describe '#value' do
     it 'returns a value' do
-      mock_fact_manager(:resolve_facts, [os_fact])
+      mock_fact_manager(:resolve_fact, [os_fact])
       mock_collection(:value, 'Ubuntu')
 
       expect(Facter.value('os.name')).to eq('Ubuntu')
     end
 
     it 'return no value' do
-      mock_fact_manager(:resolve_facts, [])
+      mock_fact_manager(:resolve_fact, [])
       mock_collection(:value, nil)
 
       expect(Facter.value('os.name')).to be nil
@@ -218,7 +218,7 @@ describe Facter do
       let(:fact_user_query) { '' }
 
       it 'returns the custom fact' do
-        mock_fact_manager(:resolve_facts, [os_fact])
+        mock_fact_manager(:resolve_fact, [os_fact])
         mock_collection(:value, 'Ubuntu')
 
         expect(Facter.value('os.name')).to eq('Ubuntu')
@@ -228,20 +228,20 @@ describe Facter do
 
   describe '#fact' do
     it 'returns a fact' do
-      mock_fact_manager(:resolve_facts, [os_fact])
+      mock_fact_manager(:resolve_fact, [os_fact])
       mock_collection(:value, 'Ubuntu')
 
       expect(Facter.fact('os.name')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: 'Ubuntu')
     end
 
     it 'can be interpolated' do
-      mock_fact_manager(:resolve_facts, [os_fact])
+      mock_fact_manager(:resolve_fact, [os_fact])
       mock_collection(:value, 'Ubuntu')
       expect("#{Facter.fact('os.name')}-test").to eq('Ubuntu-test')
     end
 
     it 'returns no value' do
-      mock_fact_manager(:resolve_facts, [])
+      mock_fact_manager(:resolve_fact, [])
       mock_collection(:value, nil, key_error)
 
       expect(Facter.fact('os.name')).to be_nil
@@ -249,7 +249,7 @@ describe Facter do
 
     context 'when there is a resolved fact with type nil' do
       before do
-        allow(fact_manager_spy).to receive(:resolve_facts).and_return([missing_fact])
+        allow(fact_manager_spy).to receive(:resolve_fact).and_return([missing_fact])
         allow(fact_collection_spy).to receive(:build_fact_collection!).with([]).and_return(empty_fact_collection)
         allow(fact_collection_spy).to receive(:value).and_raise(KeyError)
       end
@@ -271,7 +271,7 @@ describe Facter do
       let(:fact_user_query) { '' }
 
       it 'returns the custom fact' do
-        mock_fact_manager(:resolve_facts, [os_fact])
+        mock_fact_manager(:resolve_fact, [os_fact])
         mock_collection(:value, 'Ubuntu')
 
         expect(Facter.fact('os.name'))
@@ -283,14 +283,14 @@ describe Facter do
 
   describe '#[]' do
     it 'returns a fact' do
-      mock_fact_manager(:resolve_facts, [os_fact])
+      mock_fact_manager(:resolve_fact, [os_fact])
       mock_collection(:value, 'Ubuntu')
 
       expect(Facter['os.name']).to be_instance_of(Facter::ResolvedFact).and(having_attributes(value: 'Ubuntu'))
     end
 
     it 'return no value' do
-      mock_fact_manager(:resolve_facts, [])
+      mock_fact_manager(:resolve_fact, [])
       mock_collection(:value, nil, key_error)
 
       expect(Facter['os.name']).to be_nil
@@ -302,7 +302,7 @@ describe Facter do
       let(:fact_user_query) { '' }
 
       it 'returns the custom fact' do
-        mock_fact_manager(:resolve_facts, [os_fact])
+        mock_fact_manager(:resolve_fact, [os_fact])
         mock_collection(:value, 'Ubuntu')
 
         expect(Facter['os.name'])

--- a/spec/framework/core/fact_loaders/class_discoverer_spec.rb
+++ b/spec/framework/core/fact_loaders/class_discoverer_spec.rb
@@ -4,6 +4,10 @@ describe Facter::ClassDiscoverer do
   describe '#discover_classes' do
     let(:result) { [Facts::Windows::NetworkInterfaces, Facts::Windows::FipsEnabled] }
 
+    before do
+      Singleton.__init__(Facter::ClassDiscoverer)
+    end
+
     it 'loads all classes' do
       allow(Module).to receive(:const_get).with('Facts::Windows').and_return(Facts::Windows)
       allow(Facts::Windows).to receive(:constants).and_return(%i[NetworkInterfaces FipsEnabled])

--- a/spec/framework/core/fact_manager_spec.rb
+++ b/spec/framework/core/fact_manager_spec.rb
@@ -4,90 +4,349 @@ describe Facter::FactManager do
   let(:internal_manager) { instance_spy(Facter::InternalFactManager) }
   let(:external_manager) { instance_spy(Facter::ExternalFactManager) }
   let(:cache_manager) { instance_spy(Facter::CacheManager) }
+  let(:logger) { instance_spy(Facter::Log) }
+
+  def stub_query_parser(withs, returns)
+    allow(Facter::QueryParser).to receive(:parse).with(*withs).and_return(returns)
+  end
+
+  def stub_internal_manager(withs, returns)
+    allow(internal_manager).to receive(:resolve_facts).with(withs).and_return(returns)
+  end
+
+  def stub_external_manager(withs, returns)
+    allow(external_manager).to receive(:resolve_facts).with(withs).and_return(returns)
+  end
+
+  def stub_cache_manager(withs, returns)
+    allow(cache_manager).to receive(:resolve_facts).with(withs).and_return([withs, Array(returns)])
+    allow(cache_manager).to receive(:cache_facts)
+  end
 
   before do
     Singleton.__init__(Facter::FactManager)
+    Singleton.__init__(Facter::FactLoader)
+
+    allow(Facter::Log).to receive(:new).and_return(logger)
     allow(Facter::InternalFactManager).to receive(:new).and_return(internal_manager)
     allow(Facter::ExternalFactManager).to receive(:new).and_return(external_manager)
     allow(Facter::CacheManager).to receive(:new).and_return(cache_manager)
   end
 
   describe '#resolve_facts' do
-    it 'resolved all facts' do
-      ubuntu_os_name = double(Facts::Linux::Os::Name)
-      user_query = []
+    let(:os) { 'os' }
+    let(:os_klass) { instance_double(Facts::Linux::Os::Name) }
+    let(:user_query) { [] }
+    let(:loaded_facts) do
+      [
+        instance_double(Facter::LoadedFact, name: 'os.name', klass: os_klass, type: :core),
+        instance_double(Facter::LoadedFact, name: 'custom_fact', klass: nil, type: :custom)
+      ]
+    end
 
-      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: ubuntu_os_name, type: :core)
-      loaded_fact_custom_fact = double(Facter::LoadedFact, name: 'custom_fact', klass: nil, type: :custom)
-      loaded_facts = [loaded_fact_os_name, loaded_fact_custom_fact]
+    let(:searched_facts) do
+      [
+        instance_double(
+          Facter::SearchedFact,
+          name: os, fact_class: os_klass, filter_tokens: [],
+          user_query: '', type: :core
+        ),
+        instance_double(
+          Facter::SearchedFact,
+          name: 'my_custom_fact', fact_class: nil,
+          filter_tokens: [], user_query: '', type: :custom
+        )
+      ]
+    end
 
+    let(:resolved_fact) { mock_resolved_fact(os, 'Ubuntu', '', []) }
+
+    before do
       allow(Facter::FactLoader.instance).to receive(:load).and_return(loaded_facts)
+      stub_query_parser([user_query, loaded_facts], searched_facts)
+      stub_internal_manager(searched_facts, [resolved_fact])
+      stub_external_manager(searched_facts, nil)
+      stub_cache_manager(searched_facts, [])
+    end
 
-      searched_fact1 = double(Facter::SearchedFact, name: 'os', fact_class: ubuntu_os_name, filter_tokens: [],
-                                                    user_query: '', type: :core)
-      searched_fact2 = double(Facter::SearchedFact, name: 'my_custom_fact', fact_class: nil, filter_tokens: [],
-                                                    user_query: '', type: :custom)
-
-      resolved_fact = mock_resolved_fact('os', 'Ubuntu', '', [])
-
-      seached_facts = [searched_fact1, searched_fact2]
-
-      allow(Facter::QueryParser)
-        .to receive(:parse)
-        .with(user_query, loaded_facts)
-        .and_return(seached_facts)
-
-      allow(internal_manager)
-        .to receive(:resolve_facts)
-        .with(seached_facts)
-        .and_return([resolved_fact])
-
-      allow(external_manager)
-        .to receive(:resolve_facts)
-        .with(seached_facts)
-
-      allow(cache_manager)
-        .to receive(:resolve_facts)
-        .with(seached_facts)
-        .and_return([seached_facts, []])
-
-      allow(cache_manager)
-        .to receive(:cache_facts)
-        .with([resolved_fact])
-
+    it 'resolved all facts' do
       resolved_facts = Facter::FactManager.instance.resolve_facts(user_query)
 
       expect(resolved_facts).to eq([resolved_fact])
     end
   end
 
+  describe '#resolve_fact' do
+    context 'with custom fact' do
+      let(:user_query) { 'custom_fact' }
+      let(:fact_name) { 'custom_fact' }
+      let(:custom_fact) { instance_double(Facter::LoadedFact, name: fact_name, klass: nil, type: :custom) }
+      let(:loaded_facts) { [custom_fact] }
+
+      let(:searched_facts) do
+        [
+          instance_double(
+            Facter::SearchedFact,
+            name: fact_name, fact_class: nil,
+            filter_tokens: [], user_query: '', type: :custom
+          )
+        ]
+      end
+
+      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', '', [], :custom) }
+      let(:cached_fact) { mock_resolved_fact(fact_name, 'cached_custom', '', [], :custom) }
+
+      context 'when is found in custom_dir/fact_name.rb' do
+        before do
+          # mock custom_fact_by_filename to return resolved_fact
+          allow(Facter::FactLoader.instance).to receive(:load_custom_fact).and_return(loaded_facts)
+          stub_query_parser([[user_query], loaded_facts], searched_facts)
+          stub_internal_manager(searched_facts, [resolved_fact])
+          stub_external_manager(searched_facts, [resolved_fact])
+          stub_cache_manager(searched_facts, [])
+        end
+
+        it 'tries to load it from fact_name.rb' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).to have_received(:debug)
+            .with("Searching fact: #{user_query} in file: #{user_query}.rb")
+        end
+
+        it 'does not load core and external facts' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).not_to have_received(:debug)
+            .with("Searching fact: #{user_query} in core facts and external facts")
+        end
+
+        it 'does not load all custom facts' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).not_to have_received(:debug)
+            .with("Searching fact: #{user_query} in all custom facts")
+        end
+
+        it 'resolves fact' do
+          resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(resolved_facts).to eql([resolved_fact])
+        end
+      end
+
+      context 'when is not found in custom_dir/fact_name.rb' do
+        before do
+          # mock custom_fact_by_filename to return nil
+          allow(Facter::FactLoader.instance).to receive(:load_custom_fact).and_return([])
+          stub_query_parser([[user_query], []], [])
+          stub_external_manager(searched_facts, [])
+          stub_cache_manager([], [])
+
+          # mock core_or_external_fact to return nil
+          allow(Facter::FactLoader.instance).to receive(:load_internal_facts).and_return([])
+          stub_query_parser([[user_query], []], [])
+          stub_internal_manager([], [])
+          stub_external_manager([], [])
+          stub_cache_manager([], [])
+
+          # mock all_custom_facts to return resolved_fact
+          allow(Facter::FactLoader.instance).to receive(:load_custom_facts).and_return(loaded_facts)
+          stub_query_parser([[user_query], loaded_facts], searched_facts)
+          stub_external_manager(searched_facts, [resolved_fact])
+          stub_cache_manager(searched_facts, [])
+        end
+
+        it 'tries to load it from fact_name.rb' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).to have_received(:debug)
+            .with("Searching fact: #{user_query} in file: #{user_query}.rb")
+        end
+
+        it 'loads core and external facts' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).to have_received(:debug)
+            .with("Searching fact: #{user_query} in core facts and external facts")
+        end
+
+        it 'loads all custom facts' do
+          Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(logger).to have_received(:debug)
+            .with("Searching fact: #{user_query} in all custom facts")
+        end
+
+        it 'resolves fact' do
+          resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(resolved_facts).to eql([resolved_fact])
+        end
+      end
+
+      context 'when fact is cached' do
+        before do
+          # mock custom_fact_by_filename to return cached_fact
+          allow(Facter::FactLoader.instance).to receive(:load_custom_fact).and_return(loaded_facts)
+          stub_query_parser([[user_query], loaded_facts], searched_facts)
+          stub_internal_manager(searched_facts, [])
+          stub_external_manager(searched_facts, [])
+          stub_cache_manager(searched_facts, cached_fact)
+        end
+
+        it 'returns the cached fact' do
+          resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
+
+          expect(resolved_facts).to eql([cached_fact])
+        end
+      end
+    end
+
+    context 'with core fact' do
+      let(:user_query) { 'os.name' }
+      let(:os) { 'os' }
+      let(:os_klass) { instance_double(Facts::Linux::Os::Name) }
+      let(:core_fact) { instance_double(Facter::LoadedFact, name: 'os.name', klass: os_klass, type: :core) }
+      let(:loaded_facts) { [core_fact] }
+
+      let(:searched_facts) do
+        [
+          instance_double(
+            Facter::SearchedFact,
+            name: os, fact_class: os_klass, filter_tokens: [],
+            user_query: '', type: :core
+          )
+        ]
+      end
+
+      let(:resolved_fact) { mock_resolved_fact('os.name', 'darwin', '', [], :core) }
+
+      before do
+        # mock custom_fact_by_filename to return nil
+        allow(Facter::FactLoader.instance).to receive(:load_custom_fact).and_return([])
+        stub_query_parser([[user_query], []], [])
+        stub_external_manager(searched_facts, [])
+        stub_cache_manager([], [])
+
+        # mock core_or_external_fact to return the core resolved_fact
+        allow(Facter::FactLoader.instance).to receive(:load_internal_facts).and_return(loaded_facts)
+        stub_query_parser([[user_query], loaded_facts], searched_facts)
+        stub_internal_manager(searched_facts, [resolved_fact])
+        stub_external_manager([], [])
+        stub_cache_manager(searched_facts, [])
+      end
+
+      it 'tries to load it from fact_name.rb' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).to have_received(:debug)
+          .with("Searching fact: #{user_query} in file: #{user_query}.rb")
+      end
+
+      it 'loads core and external facts' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).to have_received(:debug)
+          .with("Searching fact: #{user_query} in core facts and external facts")
+      end
+
+      it 'does not load all custom facts' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).not_to have_received(:debug)
+          .with("Searching fact: #{user_query} in all custom facts")
+      end
+
+      it 'resolves fact' do
+        resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(resolved_facts).to eql([resolved_fact])
+      end
+    end
+
+    context 'with non existent fact' do
+      let(:user_query) { 'non_existent' }
+      let(:fact_name) { 'non_existent' }
+      let(:custom_fact) { instance_double(Facter::LoadedFact, name: 'custom_fact', klass: nil, type: :custom) }
+      let(:loaded_facts) { [custom_fact] }
+
+      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', '', [], :custom) }
+
+      before do
+        # mock custom_fact_by_filename to return nil
+        allow(Facter::FactLoader.instance).to receive(:load_custom_fact).and_return([])
+        stub_query_parser([[user_query], []], [])
+        stub_external_manager([], [])
+        stub_cache_manager([], [])
+
+        # mock core_or_external_fact to return nil
+        allow(Facter::FactLoader.instance).to receive(:load_internal_facts).and_return([])
+        stub_query_parser([[user_query], []], [])
+        stub_internal_manager([], [])
+        stub_external_manager([], [])
+        stub_cache_manager([], [])
+
+        # mock all_custom_facts to return nil
+        allow(Facter::FactLoader.instance).to receive(:load_custom_facts).and_return([])
+        stub_query_parser([[user_query], []], [])
+        stub_external_manager([], [])
+        stub_cache_manager([], [])
+      end
+
+      it 'tries to load it from fact_name.rb' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).to have_received(:debug)
+          .with("Searching fact: #{user_query} in file: #{user_query}.rb")
+      end
+
+      it 'loads core and external facts' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).to have_received(:debug)
+          .with("Searching fact: #{user_query} in core facts and external facts")
+      end
+
+      it 'loads all custom facts' do
+        Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(logger).to have_received(:debug)
+          .with("Searching fact: #{user_query} in all custom facts")
+      end
+
+      it 'resolves fact' do
+        resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
+
+        expect(resolved_facts).to eql([])
+      end
+    end
+  end
+
   describe '#resolve_core' do
+    let(:user_query) { [] }
+    let(:ubuntu_os_name) { class_double(Facts::Linux::Os::Name) }
+    let(:loaded_facts) do
+      instance_double(Facter::LoadedFact, name: 'os.name', klass: ubuntu_os_name, type: :core)
+    end
+    let(:searched_fact) do
+      instance_double(
+        Facter::SearchedFact,
+        name: 'os', fact_class: ubuntu_os_name,
+        filter_tokens: [], user_query: '', type: :core
+      )
+    end
+    let(:resolved_fact) { mock_resolved_fact('os', 'Ubuntu', '', []) }
+
     it 'resolves all core facts' do
-      ubuntu_os_name = double(Facts::Linux::Os::Name)
-      user_query = []
-
-      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: ubuntu_os_name, type: :core)
-      loaded_facts = [loaded_fact_os_name]
-
-      allow(Facter::FactLoader.instance).to receive(:load).and_return(loaded_facts)
+      allow(Facter::FactLoader.instance).to receive(:load_internal_facts).and_return(loaded_facts)
       allow(Facter::FactLoader.instance).to receive(:internal_facts).and_return(loaded_facts)
 
-      searched_fact = double(Facter::SearchedFact, name: 'os', fact_class: ubuntu_os_name, filter_tokens: [],
-                                                   user_query: '', type: :core)
-
-      resolved_fact = mock_resolved_fact('os', 'Ubuntu', '', [])
-
-      allow(Facter::QueryParser)
-        .to receive(:parse)
-        .with(user_query, loaded_facts)
-        .and_return([searched_fact])
-
-      allow(internal_manager)
-        .to receive(:resolve_facts)
-        .with([searched_fact])
-        .and_return([resolved_fact])
+      stub_query_parser([user_query, loaded_facts], [searched_fact])
+      stub_internal_manager([searched_fact], [resolved_fact])
+      stub_cache_manager([searched_fact], [])
 
       resolved_facts = Facter::FactManager.instance.resolve_core(user_query)
+
       expect(resolved_facts).to eq([resolved_fact])
     end
   end


### PR DESCRIPTION
Updated Facter.value to resolve the facts in a
similar way to Facter 3:
  - ~~search in the internal collection(not ported to Facter 4)~~
  - load the `fact_name.rb` from the configured custom directories
  - load all the core facts, external facts and env facts
  - load all custom facts

Side note: `Facter.value` becomes considerably faster for core and external facts on systems that have many custom facts because it will not call `Kernel.load` to evaluate all the custom facts files.

Run unit tests:

- [x] puppetlabs-puppet_agent
- [x] puppetlabs-stdlib
- [x] puppet-nginx
- [x] puppetlabs-apt
- [x] puppetlabs-java
- [x] puppetlabs-acl
- [x] puppet-prometheus

```
puppetlabs-stdlib unit tests
  Facter 4(4.0.51):     Took 86 seconds (1:26) 
  Facter 4(FACT-2956):  Took 51 seconds

puppetlabs-apt unit tests
  Facter 4(4.0.51):    Took 27 seconds
  Facter 4(FACT-2956): Took 21 seconds


puppetlabs-acl unit tests
  Facter 4(4.0.51):    Took 26 seconds
  Facter 4(FACT-2956): Took 26 seconds

puppet-prometheus unit tests
   Facter 4(4.0.51):    Took 201 seconds (3:21)
   Facter 4(FACT-2956): Took 155 seconds (2:35)
```

TODO:
- [x] squash commits after review