### PR TITLE
(FACT-2958) Add flat custom fact to fact hierarchy.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,8 @@ Metrics/AbcSize:
     - 'lib/facter/custom_facts/core/execution/popen3.rb'
     - 'lib/facter.rb'
     - 'lib/facter/framework/parsers/query_parser.rb'
+    - 'lib/facter/custom_facts/util/directory_loader.rb'
+    - 'lib/facter/framework/core/fact/external/external_fact_manager.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
@@ -102,6 +104,7 @@ Metrics/ClassLength:
     - 'install.rb'
     - 'scripts/generate_changelog.rb'
     - 'lib/facter/resolvers/solaris/networking.rb'
+    - 'lib/facter/custom_facts/util/directory_loader.rb'
 
 Naming/AccessorMethodName:
   Exclude:

--- a/acceptance/lib/facter/acceptance/api_utils.rb
+++ b/acceptance/lib/facter/acceptance/api_utils.rb
@@ -27,6 +27,29 @@ module Facter
         create_remote_file(agent, rb_file, file_content)
         rb_file
       end
+
+      def facter_to_hash_rb(agent, options = {})
+        dir = agent.tmpdir('executables')
+
+        teardown do
+          agent.rm_rf(dir)
+        end
+
+        rb_file = File.join(dir, 'facter_run.rb')
+
+        file_content = <<-RUBY
+          require 'facter'
+
+          Facter.debugging(#{options.fetch(:debug, false)})
+          Facter.search('#{options.fetch(:custom_dir, '')}')
+          Facter.search_external(['#{options.fetch(:external_dir, '')}'])
+
+          puts Facter.to_hash.to_json
+        RUBY
+
+        create_remote_file(agent, rb_file, file_content)
+        rb_file
+      end
     end
   end
 end

--- a/acceptance/tests/api/to_hash/with_structured_facts.rb
+++ b/acceptance/tests/api/to_hash/with_structured_facts.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+test_name 'to_hash handles custom and external structured facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::UserFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'custom1.key2'
+  fact_2_name = 'custom1.key3'
+  fact_1_value = 'custom1'
+  fact_2_value = 'custom2'
+
+  custom_fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}', type: :structured) do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}', type: :structured) do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  fact_1_name = 'external1.key2'
+  fact_2_name = 'external1.key3'
+  fact_1_value = 'external1'
+  fact_2_value = 'external2'
+  ext_fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  ext_fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  agents.each do |agent|
+    # create custom facts
+    custom_facts_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(custom_facts_dir, fact_file)
+    create_remote_file(agent, fact_file, custom_fact_content)
+
+    # create external facts
+    external_dir = agent.tmpdir('facts.d')
+    facts_dir = File.join(external_dir, 'structured')
+    agent.mkdir_p(facts_dir)
+    create_remote_file(agent, File.join(facts_dir, 'fact_1.txt'), ext_fact_1_content)
+    create_remote_file(agent, File.join(facts_dir, 'fact_2.txt'), ext_fact_2_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(custom_facts_dir)
+    end
+
+    step 'returns custom and external structured facts' do
+      facter_rb = facter_to_hash_rb(agent, custom_dir: custom_facts_dir, external_dir: external_dir)
+      result = JSON.parse(
+        on(agent, "#{ruby_command(agent)} #{facter_rb}").stdout&.strip
+      )
+
+      assert_equal(result['custom1'], { 'key2' => 'custom1', 'key3' => 'custom2' })
+      assert_equal(result['external1'], { 'key2' => 'external1', 'key3' => 'external2' })
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/block_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/block_structured_custom_fact.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+test_name 'strucutured custom facts can be blocked' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}', type: :structured) do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}', type: :structured) do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      blocklist : [ "#{fact_1_name}" ],
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'blocked structured custom fact is not displayed' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2")) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step 'the remaining structured fact is displayed' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3")) do |facter_output|
+        assert_equal(fact_2_value, facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/cached_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/cached_structured_custom_fact.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+test_name 'structured custom facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}', type: :structured) do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}', type: :structured) do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  partial_file_content = <<~RUBY
+    {
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+    }
+    fact-groups : {
+      cached-custom-facts : ["key1"],
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'creates the cache for part of the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        partial_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'creates the cache for full fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value ,
+              'key3' => fact_2_value
+            },
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/define_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/define_structured_custom_fact.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+test_name 'custom facts can be defined structured' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_name = 'key1.key2'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_name}', type: :structured) do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  agents.each do |agent|
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+    end
+
+    step 'access fact with dot' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2")) do |facter_output|
+        assert_equal(fact_value, facter_output.stdout.chomp)
+      end
+
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          { 'key1' => { 'key2' => fact_value } },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/extend_structured_core_fact.rb
+++ b/acceptance/tests/custom_facts/structured/extend_structured_core_fact.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+test_name 'custom structured facts can extend core facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  core_fact = 'os'
+  fact_file = 'custom_fact.rb'
+  fact_name = 'extension'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{core_fact}.#{fact_name}', type: :structured) do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  agents.each do |agent|
+    builtin_value = JSON.parse(on(agent, facter('os  --json')).stdout.chomp)
+    builtin_value['os'][fact_name] = fact_value
+    expected_value = builtin_value
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+    end
+
+    step 'check that core fact is extended' do
+      on(agent, facter("os --custom-dir=#{fact_dir} --json")) do |facter_output|
+        assert_equal(
+          expected_value,
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/override_structured_core_fact.rb
+++ b/acceptance/tests/custom_facts/structured/override_structured_core_fact.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+test_name 'custom structured facts can override parts of core facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  core_fact = 'os'
+  fact_file = 'custom_fact.rb'
+  fact_name = 'name'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{core_fact}.#{fact_name}', weight: 999, type: :structured) do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  agents.each do |agent|
+    builtin_value = JSON.parse(on(agent, facter('os  --json')).stdout.chomp)
+    builtin_value['os'][fact_name] = fact_value
+    expected_value = builtin_value
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+    end
+
+    step 'check that core fact is extended' do
+      on(agent, facter("os --custom-dir=#{fact_dir} --json")) do |facter_output|
+        assert_equal(
+          expected_value,
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+
+      on(agent, facter("os.name --custom-dir=#{fact_dir}")) do |facter_output|
+        assert_equal(
+          fact_value,
+          facter_output.stdout.chomp
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/partial_cached_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/partial_cached_structured_custom_fact.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+test_name 'structured custom facts can be granually cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}', type: :structured) do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}', type: :structured) do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+    }
+    fact-groups : {
+      cached-custom-facts : ["#{fact_1_name}"],
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'does not create cache of part of the fact that is not in ttls' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(false, result)
+    end
+
+    step 'creates a cached-custom-facts cache file that contains fact information' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value ,
+              'key3' => fact_2_value
+            },
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+test_name 'strucutured external facts can be blocked' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  config_data = <<~HOCON
+    facts : {
+      blocklist : [ "#{fact_1_name}" ],
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    facts_dir = File.join(external_dir, 'structured')
+    agent.mkdir_p(facts_dir)
+    create_remote_file(agent, File.join(facts_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(facts_dir, 'fact_2.txt'), fact_2_content)
+
+    teardown do
+      agent.rm_rf(facts_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'blocked structured external fact is not displayed' do
+      on(agent, facter("--external-dir=#{external_dir} key1.key2")) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step 'the remaining structured fact is displayed' do
+      on(agent, facter("--external-dir=#{external_dir} key1.key3")) do |facter_output|
+        assert_equal(fact_2_value, facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
@@ -32,18 +32,18 @@ test_name 'strucutured external facts can be blocked' do
     create_remote_file(agent, File.join(facts_dir, 'fact_2.txt'), fact_2_content)
 
     teardown do
-      agent.rm_rf(facts_dir)
+      agent.rm_rf(external_dir)
       agent.rm_rf(config_dir)
     end
 
     step 'blocked structured external fact is not displayed' do
-      on(agent, facter("--external-dir=#{external_dir} key1.key2")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key2")) do |facter_output|
         assert_equal('', facter_output.stdout.chomp)
       end
     end
 
     step 'the remaining structured fact is displayed' do
-      on(agent, facter("--external-dir=#{external_dir} key1.key3")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key3")) do |facter_output|
         assert_equal(fact_2_value, facter_output.stdout.chomp)
       end
     end

--- a/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# caching breaks structured external facts
+
+test_name 'strucutured external facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  cached_file_1_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  cached_file_2_content = <<~RUBY
+    {
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "fact_1.txt" : 3 days },
+          { "fact_2.txt" : 3 days }
+      ]
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+
+    external_dir = agent.tmpdir('facts.d')
+    facts_dir = File.join(external_dir, 'structured')
+    agent.mkdir_p(facts_dir)
+    create_remote_file(agent, File.join(facts_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(facts_dir, 'fact_2.txt'), fact_2_content)
+
+
+    teardown do
+      agent.rm_rf(facts_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'creates a fact_1.txt and fact_2.txt cache file that contains fact information' do
+      on(agent, facter("--external-dir=#{external_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value ,
+              'key3' => fact_2_value
+            },
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+
+      assert_equal(true, agent.file_exist?("#{cache_folder}/fact_1.txt"))
+      assert_equal(true, agent.file_exist?("#{cache_folder}/fact_2.txt"))
+
+      assert_match(
+        cached_file_1_content.chomp,
+         agent.cat("#{cache_folder}/fact_1.txt").strip,
+        'Expected cached external fact file to contain fact information for fact_1'
+      )
+
+      assert_match(
+        cached_file_2_content.chomp,
+         agent.cat("#{cache_folder}/fact_2.txt").strip,
+        'Expected cached external fact file to contain fact information for fact_2'
+      )
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
@@ -55,13 +55,13 @@ test_name 'strucutured external facts can be cached' do
 
 
     teardown do
-      agent.rm_rf(facts_dir)
+      agent.rm_rf(external_dir)
       agent.rm_rf(config_dir)
       agent.rm_rf(cache_folder)
     end
 
     step 'creates a fact_1.txt and fact_2.txt cache file that contains fact information' do
-      on(agent, facter("--external-dir=#{external_dir} key1 --json")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
         assert_equal(
           {
             'key1' => {

--- a/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
@@ -15,19 +15,19 @@ test_name 'external facts can be defined as structured under facts_dir/structure
     facts_dir = File.join(external_dir, 'structured')
     agent.mkdir_p(facts_dir)
 
-    ext_fact_path = "#{facts_dir}/test.yaml"
+    ext_fact_path = File.join(facts_dir, 'test.yaml')
     create_remote_file(agent, ext_fact_path, ext_fact_content)
 
     teardown do
-      agent.rm_rf(facts_dir)
+      agent.rm_rf(external_dir)
     end
 
     step 'resolve an external structured fact' do
-      on(agent, facter("--external-dir #{facts_dir} #{fact_name}")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name}")) do |facter_output|
         assert_equal(fact_value, facter_output.stdout.chomp)
       end
 
-      on(agent, facter("--external-dir #{external_dir} key1 --json")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
         assert_equal(
           { 'key1' => { 'key2' => fact_value } },
           JSON.parse(facter_output.stdout.chomp)

--- a/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+test_name 'external facts can be defined as structured under facts_dir/structured' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_name = 'key1.key2'
+  fact_value = 'EXTERNAL'
+  ext_fact_content = "#{fact_name}: '#{fact_value}'"
+
+  agents.each do |agent|
+    external_dir = agent.tmpdir('facts.d')
+    facts_dir = File.join(external_dir, 'structured')
+    agent.mkdir_p(facts_dir)
+
+    ext_fact_path = "#{facts_dir}/test.yaml"
+    create_remote_file(agent, ext_fact_path, ext_fact_content)
+
+    teardown do
+      agent.rm_rf(facts_dir)
+    end
+
+    step 'resolve an external structured fact' do
+      on(agent, facter("--external-dir #{facts_dir} #{fact_name}")) do |facter_output|
+        assert_equal(fact_value, facter_output.stdout.chomp)
+      end
+
+      on(agent, facter("--external-dir #{external_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          { 'key1' => { 'key2' => fact_value } },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
@@ -47,18 +47,18 @@ test_name 'strucutured external facts can be cached' do
 
 
     teardown do
-      agent.rm_rf(facts_dir)
+      agent.rm_rf(external_dir)
       agent.rm_rf(config_dir)
       agent.rm_rf(cache_folder)
     end
 
     step 'does not create cache of part of the fact that is not in ttls' do
-      on(agent, facter("--external-dir=#{external_dir} key1.key3"))
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key3"))
       assert_equal(false, agent.file_exist?("#{cache_folder}/fact_2.txt"))
     end
 
     step 'creates a fact_1.txt cache file that contains fact information' do
-      on(agent, facter("--external-dir=#{external_dir} key1.key2"))
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key2"))
 
       result = agent.file_exist?("#{cache_folder}/fact_1.txt")
       assert_equal(true, result)
@@ -72,7 +72,7 @@ test_name 'strucutured external facts can be cached' do
     end
 
     step 'resolves the entire fact' do
-      on(agent, facter("--external-dir #{external_dir} key1 --json")) do |facter_output|
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
         assert_equal(
           {
             'key1' => {

--- a/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# caching breaks structured external facts
+
+test_name 'strucutured external facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "fact_1.txt" : 3 days }
+      ]
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+
+    external_dir = agent.tmpdir('facts.d')
+    facts_dir = File.join(external_dir, 'structured')
+    agent.mkdir_p(facts_dir)
+    create_remote_file(agent, File.join(facts_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(facts_dir, 'fact_2.txt'), fact_2_content)
+
+
+    teardown do
+      agent.rm_rf(facts_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'does not create cache of part of the fact that is not in ttls' do
+      on(agent, facter("--external-dir=#{external_dir} key1.key3"))
+      assert_equal(false, agent.file_exist?("#{cache_folder}/fact_2.txt"))
+    end
+
+    step 'creates a fact_1.txt cache file that contains fact information' do
+      on(agent, facter("--external-dir=#{external_dir} key1.key2"))
+
+      result = agent.file_exist?("#{cache_folder}/fact_1.txt")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/fact_1.txt")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the entire fact' do
+      on(agent, facter("--external-dir #{external_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value ,
+              'key3' => fact_2_value
+            },
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -551,10 +551,9 @@ module Facter
       # Nil facts should not be packaged as ResolvedFacts! (add_fact_to_searched_facts packages facts)
       resolved_facts = resolved_facts.reject { |fact| fact.type == :nil }
       fact_collection = FactCollection.new.build_fact_collection!(resolved_facts)
-      splitted_user_query = Facter::Utils.split_user_query(user_query)
 
       begin
-        value = fact_collection.value(*splitted_user_query)
+        value = fact_collection.value(user_query)
         add_fact_to_searched_facts(user_query, value)
       rescue KeyError
         nil

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -43,7 +43,7 @@ module LegacyFacter
       def load(collection)
         weight = @weight
 
-        searched_facts, cached_facts = load_directory_entries(collection)
+        searched_facts, cached_facts = load_directory_entries
 
         load_cached_facts(collection, cached_facts, weight)
 
@@ -52,7 +52,7 @@ module LegacyFacter
 
       private
 
-      def load_directory_entries(_collection)
+      def load_directory_entries
         cm = Facter::CacheManager.new
         facts = []
         entries.each do |file|
@@ -63,13 +63,22 @@ module LegacyFacter
             Facter.log_exception(Exception.new("Caching is enabled for group \"#{basename}\" while "\
               'there are at least two external facts files with the same filename'))
           else
-            searched_fact = Facter::SearchedFact.new(basename, nil, [], nil, :file)
-            searched_fact.file = file
-            facts << searched_fact
+            facts << build_searched_fact(basename, file)
           end
         end
 
         cm.resolve_facts(facts)
+      end
+
+      def build_searched_fact(basename, file)
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: nil,
+          filter_tokens: [],
+          structured: false
+        )
+        searched_fact = Facter::SearchedFact.new(basename, nil, :file, fact_attributes)
+        searched_fact.file = file
+        searched_fact
       end
 
       def load_cached_facts(collection, cached_facts, weight)

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -143,13 +143,14 @@ module LegacyFacter
 
       def structured_entries
         dirs = @directories.select { |directory| File.directory?(directory) }.map do |directory|
-          structured_dir = Dir.glob("#{directory}/**/*").find { |e| File.directory?(e) && e =~ /structured$/ }
-          next unless structured_dir
+          structured_dir = File.join(directory, 'structured')
+          next unless File.directory?(structured_dir)
 
           Dir.entries(structured_dir).map do |directory_entry|
             File.join(structured_dir, directory_entry)
           end
         end
+
         dirs.flatten.compact.select { |f| should_parse?(f) }
       rescue Errno::ENOENT
         []

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -97,8 +97,10 @@ module LegacyFacter
 
       def load_cached_facts(collection, cached_facts, weight)
         cached_facts.each do |cached_fact|
-          collection.add(cached_fact.name, value: cached_fact.value, fact_type: :external,
-                                           file: cached_fact.file) { has_weight(weight) }
+          collection.add(cached_fact.name,
+                         value: cached_fact.value,
+                         fact_type: :external, file: cached_fact.file,
+                         structured: cached_fact.structured) { has_weight(weight) }
         end
       end
 

--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -64,11 +64,10 @@ module LegacyFacter
         fact_attributes = Facter::FactAttributes.new(
           user_query: nil,
           filter_tokens: [],
-          structured: structured
+          structured: structured,
+          file: file
         )
-        searched_fact = Facter::SearchedFact.new(basename, nil, :file, fact_attributes)
-        searched_fact.file = file
-        searched_fact
+        Facter::SearchedFact.new(basename, nil, :file, fact_attributes)
       end
 
       def resolve_structured_facts(fact_list, cache_manager)

--- a/lib/facter/custom_facts/util/fact.rb
+++ b/lib/facter/custom_facts/util/fact.rb
@@ -246,7 +246,7 @@ module Facter
           end
         else
           case resolution_type
-          when :simple
+          when :simple, :structured
             resolve = Facter::Util::Resolution.new(resolution_name, self)
           when :aggregate
             resolve = Facter::Core::Aggregate.new(resolution_name, self)

--- a/lib/facter/custom_facts/util/resolution.rb
+++ b/lib/facter/custom_facts/util/resolution.rb
@@ -112,7 +112,7 @@ module Facter
       #
       # @api private
       def options(options)
-        accepted_options = %i[name value timeout weight fact_type file is_env]
+        accepted_options = %i[name value timeout weight fact_type file is_env structured]
 
         accepted_options.each do |option_name|
           instance_variable_set("@#{option_name}", options.delete(option_name)) if options.key?(option_name)

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Facter

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -116,28 +116,13 @@ cache_format_version is incorrect!")
       true
     end
 
-    def extract_fact_name(fact)
-      case fact.type
-      when :legacy
-        [fact.name]
-      when :custom
-        fact.options[:type] == :structured ? fact.name.split('.') : [fact.name]
-      when :external
-        Options[:structured_external_facts] == true ? fact.name.split('.') : [fact.name]
-      else
-        fact.name.split('.')
-      end
-    end
-
     def create_facts(searched_fact, data)
       if searched_fact.type == :file
         resolve_external_fact(searched_fact, data)
       else
         return unless data[searched_fact.name]
 
-        # structured
-        name = extract_fact_name(searched_fact)
-        rf = Facter::ResolvedFact.new(searched_fact.name, data.dig(*name), searched_fact.type,
+        rf = Facter::ResolvedFact.new(searched_fact.name, data[searched_fact.name], searched_fact.type,
                                       searched_fact.user_query, searched_fact.filter_tokens)
         rf.options = searched_fact.options
         [rf]
@@ -170,8 +155,8 @@ cache_format_version is incorrect!")
 
       return unless fact_cache_enabled?(fact_name)
 
-      @groups[group_name] ||= FactCollection.new
-      @groups[group_name].bury_fact(fact)
+      @groups[group_name] ||= {}
+      @groups[group_name][fact.name] = fact.value
     end
 
     def write_cache

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 module Facter
@@ -147,7 +148,7 @@ cache_format_version is incorrect!")
         fact_attributes = Facter::FactAttributes.new(
           user_query: searched_fact.user_query,
           filter_tokens: searched_fact.filter_tokens,
-          structured: false,
+          structured: searched_fact.structured,
           file: searched_fact.file
         )
 

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -122,10 +122,19 @@ cache_format_version is incorrect!")
       else
         return unless data[searched_fact.name]
 
-        rf = Facter::ResolvedFact.new(searched_fact.name, data[searched_fact.name], searched_fact.type,
-                                      searched_fact.user_query, searched_fact.filter_tokens)
-        rf.options = searched_fact.options
-        [rf]
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: searched_fact.user_query,
+          filter_tokens: searched_fact.filter_tokens,
+          structured: searched_fact.structured
+        )
+
+        [Facter::ResolvedFact.new(
+          searched_fact.name,
+          data[searched_fact.name],
+          searched_fact.type,
+          fact_attributes
+        )]
+
       end
     end
 
@@ -134,8 +143,18 @@ cache_format_version is incorrect!")
       data.each do |fact_name, fact_value|
         next if fact_name == 'cache_format_version'
 
-        fact = Facter::ResolvedFact.new(fact_name, fact_value, searched_fact.type,
-                                        searched_fact.user_query, searched_fact.filter_tokens)
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: searched_fact.user_query,
+          filter_tokens: searched_fact.filter_tokens,
+          structured: false
+        )
+
+        fact = Facter::ResolvedFact.new(
+          fact_name,
+          fact_value,
+          searched_fact.type,
+          fact_attributes
+        )
         fact.file = searched_fact.file
         facts << fact
       end

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -125,7 +125,8 @@ cache_format_version is incorrect!")
         fact_attributes = Facter::FactAttributes.new(
           user_query: searched_fact.user_query,
           filter_tokens: searched_fact.filter_tokens,
-          structured: searched_fact.structured
+          structured: searched_fact.structured,
+          file: nil
         )
 
         [Facter::ResolvedFact.new(
@@ -146,17 +147,13 @@ cache_format_version is incorrect!")
         fact_attributes = Facter::FactAttributes.new(
           user_query: searched_fact.user_query,
           filter_tokens: searched_fact.filter_tokens,
-          structured: false
+          structured: false,
+          file: searched_fact.file
         )
 
-        fact = Facter::ResolvedFact.new(
-          fact_name,
-          fact_value,
-          searched_fact.type,
-          fact_attributes
+        facts << Facter::ResolvedFact.new(
+          fact_name, fact_value, searched_fact.type, fact_attributes
         )
-        fact.file = searched_fact.file
-        facts << fact
       end
       facts
     end

--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -116,14 +116,31 @@ cache_format_version is incorrect!")
       true
     end
 
+    def extract_fact_name(fact)
+      case fact.type
+      when :legacy
+        [fact.name]
+      when :custom
+        fact.options[:type] == :structured ? fact.name.split('.') : [fact.name]
+      when :external
+        Options[:structured_external_facts] == true ? fact.name.split('.') : [fact.name]
+      else
+        fact.name.split('.')
+      end
+    end
+
     def create_facts(searched_fact, data)
       if searched_fact.type == :file
         resolve_external_fact(searched_fact, data)
       else
         return unless data[searched_fact.name]
 
-        [Facter::ResolvedFact.new(searched_fact.name, data[searched_fact.name], searched_fact.type,
-                                  searched_fact.user_query, searched_fact.filter_tokens)]
+        # structured
+        name = extract_fact_name(searched_fact)
+        rf = Facter::ResolvedFact.new(searched_fact.name, data.dig(*name), searched_fact.type,
+                                      searched_fact.user_query, searched_fact.filter_tokens)
+        rf.options = searched_fact.options
+        [rf]
       end
     end
 
@@ -153,8 +170,8 @@ cache_format_version is incorrect!")
 
       return unless fact_cache_enabled?(fact_name)
 
-      @groups[group_name] ||= {}
-      @groups[group_name][fact.name] = fact.value
+      @groups[group_name] ||= FactCollection.new
+      @groups[group_name].bury_fact(fact)
     end
 
     def write_cache

--- a/lib/facter/framework/core/fact/external/external_fact_manager.rb
+++ b/lib/facter/framework/core/fact/external/external_fact_manager.rb
@@ -18,10 +18,13 @@ module Facter
 
       custom_facts.each do |custom_fact|
         fact = LegacyFacter[custom_fact.name]
-        resolved_fact = ResolvedFact.new(custom_fact.name, fact.value, :custom)
+        type = fact.options[:fact_type] || :custom
+
+        resolved_fact = ResolvedFact.new(custom_fact.name, fact.value, type)
         resolved_fact.filter_tokens = []
         resolved_fact.user_query = custom_fact.user_query
         resolved_fact.file = fact.options[:file]
+        resolved_fact.options = fact.options
 
         resolved_custom_facts << resolved_fact
       end

--- a/lib/facter/framework/core/fact/external/external_fact_manager.rb
+++ b/lib/facter/framework/core/fact/external/external_fact_manager.rb
@@ -25,12 +25,13 @@ module Facter
           structured: custom_fact.structured
         )
 
-        resolved_fact = ResolvedFact.new(
-          custom_fact.name,
-          fact.value,
-          type,
-          fact_attributes
-        )
+        fact_value = if type == :external && custom_fact.structured
+                       fact.options[:value]
+                     else
+                       fact.value
+                     end
+
+        resolved_fact = ResolvedFact.new(custom_fact.name, fact_value, type, fact_attributes)
         resolved_fact.file = fact.options[:file]
 
         resolved_custom_facts << resolved_fact

--- a/lib/facter/framework/core/fact/external/external_fact_manager.rb
+++ b/lib/facter/framework/core/fact/external/external_fact_manager.rb
@@ -19,12 +19,19 @@ module Facter
       custom_facts.each do |custom_fact|
         fact = LegacyFacter[custom_fact.name]
         type = fact.options[:fact_type] || :custom
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: custom_fact.user_query,
+          filter_tokens: [],
+          structured: custom_fact.structured
+        )
 
-        resolved_fact = ResolvedFact.new(custom_fact.name, fact.value, type)
-        resolved_fact.filter_tokens = []
-        resolved_fact.user_query = custom_fact.user_query
+        resolved_fact = ResolvedFact.new(
+          custom_fact.name,
+          fact.value,
+          type,
+          fact_attributes
+        )
         resolved_fact.file = fact.options[:file]
-        resolved_fact.options = fact.options
 
         resolved_custom_facts << resolved_fact
       end

--- a/lib/facter/framework/core/fact/external/external_fact_manager.rb
+++ b/lib/facter/framework/core/fact/external/external_fact_manager.rb
@@ -14,15 +14,14 @@ module Facter
     end
 
     def external_facts(custom_facts)
-      resolved_custom_facts = []
-
-      custom_facts.each do |custom_fact|
+      custom_facts.map do |custom_fact|
         fact = LegacyFacter[custom_fact.name]
         type = fact.options[:fact_type] || :custom
         fact_attributes = Facter::FactAttributes.new(
           user_query: custom_fact.user_query,
           filter_tokens: [],
-          structured: custom_fact.structured
+          structured: custom_fact.structured,
+          file: fact.options[:file]
         )
 
         fact_value = if type == :external && custom_fact.structured
@@ -31,13 +30,8 @@ module Facter
                        fact.value
                      end
 
-        resolved_fact = ResolvedFact.new(custom_fact.name, fact_value, type, fact_attributes)
-        resolved_fact.file = fact.options[:file]
-
-        resolved_custom_facts << resolved_fact
+        ResolvedFact.new(custom_fact.name, fact_value, type, fact_attributes)
       end
-
-      resolved_custom_facts
     end
   end
 end

--- a/lib/facter/framework/core/fact/internal/core_fact.rb
+++ b/lib/facter/framework/core/fact/internal/core_fact.rb
@@ -7,13 +7,13 @@ module Facter
     end
 
     def create
-      fact_class = @searched_fact.fact_class
+      klass = @searched_fact.klass
 
-      return unless fact_class
+      return unless klass
 
       fact_value = nil
       Facter::Framework::Benchmarking::Timer.measure(@searched_fact.name) do
-        fact_value = fact_class.new.call_the_resolver
+        fact_value = klass.new.call_the_resolver
       end
 
       fact_value

--- a/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
+++ b/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
@@ -28,17 +28,14 @@ module Facter
     end
 
     def resolve_nil_facts(searched_facts)
-      resolved_facts = []
-      searched_facts.select { |fact| fact.type == :nil }.each do |fact|
+      searched_facts.select { |fact| fact.type == :nil }.map do |fact|
         fact_attributes = Facter::FactAttributes.new(
           user_query: fact.name,
           filter_tokens: [],
           structured: false
         )
-        resolved_facts << ResolvedFact.new(fact.name, nil, :nil, fact_attributes)
+        ResolvedFact.new(fact.name, nil, :nil, fact_attributes)
       end
-
-      resolved_facts
     end
 
     def resolve_sequentially(searched_facts)

--- a/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
+++ b/lib/facter/framework/core/fact/internal/internal_fact_manager.rb
@@ -30,7 +30,12 @@ module Facter
     def resolve_nil_facts(searched_facts)
       resolved_facts = []
       searched_facts.select { |fact| fact.type == :nil }.each do |fact|
-        resolved_facts << ResolvedFact.new(fact.name, nil, :nil, fact.name)
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: fact.name,
+          filter_tokens: [],
+          structured: false
+        )
+        resolved_facts << ResolvedFact.new(fact.name, nil, :nil, fact_attributes)
       end
 
       resolved_facts
@@ -40,7 +45,7 @@ module Facter
       resolved_facts = []
 
       searched_facts
-        .uniq { |searched_fact| searched_fact.fact_class.name }
+        .uniq { |searched_fact| searched_fact.klass.name }
         .each do |searched_fact|
         begin
           fact = CoreFact.new(searched_fact)
@@ -58,7 +63,7 @@ module Facter
     def start_threads(searched_facts)
       # only resolve a fact once, even if multiple search facts depend on that fact
       searched_facts
-        .uniq { |searched_fact| searched_fact.fact_class.name }
+        .uniq { |searched_fact| searched_fact.klass.name }
         .map do |searched_fact|
         Thread.new do
           resolve_fact(searched_fact)

--- a/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
@@ -41,8 +41,9 @@ module Facter
       external_facts_to_load = LegacyFacter.collection.external_facts
 
       external_facts_to_load&.each do |k, v|
-        loaded_fact = LoadedFact.new(k.to_s, nil, :external)
-        loaded_fact.file = v.options[:file]
+        loaded_fact = LoadedFact.new(
+          k.to_s, nil, :external, v.options[:file], v.options[:structured]
+        )
         loaded_fact.is_env = v.options[:is_env]
         external_facts << loaded_fact
       end

--- a/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
@@ -23,7 +23,13 @@ module Facter
 
     def build_custom_facts(custom_facts_to_load)
       custom_facts_to_load&.map do |k, v|
-        loaded_fact = LoadedFact.new(k.to_s, nil, :custom, nil, v.options)
+        loaded_fact = LoadedFact.new(
+          k.to_s,
+          nil,
+          :custom,
+          nil,
+          v.options[:type]&.to_sym == :structured
+        )
         loaded_fact.is_env = v.options[:is_env] if v.options[:is_env]
         loaded_fact
       end

--- a/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/external_fact_loader.rb
@@ -23,7 +23,7 @@ module Facter
 
     def build_custom_facts(custom_facts_to_load)
       custom_facts_to_load&.map do |k, v|
-        loaded_fact = LoadedFact.new(k.to_s, nil, :custom)
+        loaded_fact = LoadedFact.new(k.to_s, nil, :custom, nil, v.options)
         loaded_fact.is_env = v.options[:is_env] if v.options[:is_env]
         loaded_fact
       end

--- a/lib/facter/framework/core/options/config_file_options.rb
+++ b/lib/facter/framework/core/options/config_file_options.rb
@@ -30,7 +30,6 @@ module Facter
         augment_custom(Facter::ConfigReader.global)
         augment_external(Facter::ConfigReader.global)
         augment_show_legacy(Facter::ConfigReader.global)
-        augment_structured_facts(Facter::ConfigReader.global)
         augment_sequential(Facter::ConfigReader.global)
       end
 
@@ -69,12 +68,6 @@ module Facter
 
         @options[:external_dir] = [global_conf['external-dir']].flatten unless global_conf['external-dir'].nil?
         @options[:config_file_external_dir] = @options[:external_dir] || []
-      end
-
-      def augment_structured_facts(global_conf)
-        return if !global_conf || global_conf['structured-external-facts'].nil?
-
-        @options[:structured_external_facts] = global_conf['structured-external-facts']
       end
 
       def augment_ruby(global_conf)

--- a/lib/facter/framework/core/options/config_file_options.rb
+++ b/lib/facter/framework/core/options/config_file_options.rb
@@ -30,6 +30,7 @@ module Facter
         augment_custom(Facter::ConfigReader.global)
         augment_external(Facter::ConfigReader.global)
         augment_show_legacy(Facter::ConfigReader.global)
+        augment_structured_facts(Facter::ConfigReader.global)
         augment_sequential(Facter::ConfigReader.global)
       end
 
@@ -68,6 +69,12 @@ module Facter
 
         @options[:external_dir] = [global_conf['external-dir']].flatten unless global_conf['external-dir'].nil?
         @options[:config_file_external_dir] = @options[:external_dir] || []
+      end
+
+      def augment_structured_facts(global_conf)
+        return if !global_conf || global_conf['structured-external-facts'].nil?
+
+        @options[:structured_external_facts] = global_conf['structured-external-facts']
       end
 
       def augment_ruby(global_conf)

--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -26,7 +26,6 @@ module Facter
     @default_external_dir = []
     @fact_groups = {}
     @sequential = true
-    @structured_external_facts = false
     @ttls = []
     @block_list = []
     @color = true
@@ -43,7 +42,7 @@ module Facter
 
       attr_accessor :config, :strict, :json,
                     :cache, :yaml, :puppet, :ttls, :block, :cli, :config_file_custom_dir,
-                    :config_file_external_dir, :default_external_dir, :fact_groups, :structured_external_facts,
+                    :config_file_external_dir, :default_external_dir, :fact_groups,
                     :block_list, :color, :trace, :sequential, :timing, :hocon, :allow_external_loggers
 
       attr_writer :external_dir
@@ -203,7 +202,6 @@ module Facter
 
       def reset_facts
         @custom_facts = true
-        @structured_external_facts = false
         @external_dir = []
         @custom_dir = []
       end

--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -26,6 +26,7 @@ module Facter
     @default_external_dir = []
     @fact_groups = {}
     @sequential = true
+    @structured_external_facts = false
     @ttls = []
     @block_list = []
     @color = true
@@ -42,7 +43,7 @@ module Facter
 
       attr_accessor :config, :strict, :json,
                     :cache, :yaml, :puppet, :ttls, :block, :cli, :config_file_custom_dir,
-                    :config_file_external_dir, :default_external_dir, :fact_groups,
+                    :config_file_external_dir, :default_external_dir, :fact_groups, :structured_external_facts,
                     :block_list, :color, :trace, :sequential, :timing, :hocon, :allow_external_loggers
 
       attr_writer :external_dir
@@ -202,6 +203,7 @@ module Facter
 
       def reset_facts
         @custom_facts = true
+        @structured_external_facts = false
         @external_dir = []
         @custom_dir = []
       end

--- a/lib/facter/framework/formatters/formatter_helper.rb
+++ b/lib/facter/framework/formatters/formatter_helper.rb
@@ -9,7 +9,7 @@ module Facter
           fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
 
           splitted_user_query = Utils.split_user_query(user_query)
-          printable_value = fact_collection.dig(*splitted_user_query)
+          printable_value = fact_collection.dig(*splitted_user_query) || fact_collection.dig(user_query)
           facts_to_display.merge!(user_query => printable_value)
         end
 
@@ -25,7 +25,7 @@ module Facter
         fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
         fact_collection = Utils.sort_hash_by_key(fact_collection)
         splitted_user_query = Utils.split_user_query(user_query)
-        fact_collection.dig(*splitted_user_query)
+        fact_collection.dig(*splitted_user_query) || fact_collection.dig(user_query)
       end
 
       private

--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -41,8 +41,17 @@ module Facter
       def no_user_query(loaded_facts)
         searched_facts = []
         loaded_facts.each do |loaded_fact|
-          sf = SearchedFact.new(loaded_fact.name, loaded_fact.klass, [], '', loaded_fact.type)
-          sf.options = loaded_fact.options
+          fact_attributes = Facter::FactAttributes.new(
+            user_query: '',
+            filter_tokens: [],
+            structured: loaded_fact.structured
+          )
+          sf = SearchedFact.new(
+            loaded_fact.name,
+            loaded_fact.klass,
+            loaded_fact.type,
+            fact_attributes
+          )
           searched_facts << sf
         end
         searched_facts
@@ -60,8 +69,14 @@ module Facter
 
           return resolvable_fact_list if resolvable_fact_list.any?
         end
-
-        resolvable_fact_list << SearchedFact.new(query, nil, [], query, :nil) if resolvable_fact_list.empty?
+        if resolvable_fact_list.empty?
+          fact_attributes = Facter::FactAttributes.new(
+            user_query: query,
+            filter_tokens: [],
+            structured: false
+          )
+          resolvable_fact_list << SearchedFact.new(query, nil, :nil, fact_attributes)
+        end
 
         resolvable_fact_list
       end
@@ -107,11 +122,15 @@ module Facter
         user_query = @query_list.any? ? query_tokens.join('.') : ''
         fact_name = loaded_fact.name.to_s
         klass_name = loaded_fact.klass
-        type = loaded_fact.type
-        sf = SearchedFact.new(fact_name, klass_name, filter_tokens, user_query, type)
-        sf.file = loaded_fact.file
-        sf.options = loaded_fact.options
 
+        fact_attributes = Facter::FactAttributes.new(
+          user_query: user_query,
+          filter_tokens: filter_tokens,
+          structured: loaded_fact.structured
+        )
+
+        sf = SearchedFact.new(fact_name, klass_name, loaded_fact.type, fact_attributes)
+        sf.file = loaded_fact.file
         sf
       end
 

--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -41,7 +41,9 @@ module Facter
       def no_user_query(loaded_facts)
         searched_facts = []
         loaded_facts.each do |loaded_fact|
-          searched_facts << SearchedFact.new(loaded_fact.name, loaded_fact.klass, [], '', loaded_fact.type)
+          sf = SearchedFact.new(loaded_fact.name, loaded_fact.klass, [], '', loaded_fact.type)
+          sf.options = loaded_fact.options
+          searched_facts << sf
         end
         searched_facts
       end
@@ -108,6 +110,7 @@ module Facter
         type = loaded_fact.type
         sf = SearchedFact.new(fact_name, klass_name, filter_tokens, user_query, type)
         sf.file = loaded_fact.file
+        sf.options = loaded_fact.options
 
         sf
       end

--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -39,22 +39,16 @@ module Facter
       end
 
       def no_user_query(loaded_facts)
-        searched_facts = []
-        loaded_facts.each do |loaded_fact|
+        loaded_facts.map do |loaded_fact|
           fact_attributes = Facter::FactAttributes.new(
             user_query: '',
             filter_tokens: [],
             structured: loaded_fact.structured
           )
-          sf = SearchedFact.new(
-            loaded_fact.name,
-            loaded_fact.klass,
-            loaded_fact.type,
-            fact_attributes
+          SearchedFact.new(
+            loaded_fact.name, loaded_fact.klass, loaded_fact.type, fact_attributes
           )
-          searched_facts << sf
         end
-        searched_facts
       end
 
       def search_for_facts(query, loaded_fact_hash)
@@ -120,18 +114,15 @@ module Facter
       def construct_loaded_fact(query_tokens, query_token_range, loaded_fact)
         filter_tokens = construct_filter_tokens(query_tokens, query_token_range)
         user_query = @query_list.any? ? query_tokens.join('.') : ''
-        fact_name = loaded_fact.name.to_s
-        klass_name = loaded_fact.klass
 
         fact_attributes = Facter::FactAttributes.new(
           user_query: user_query,
           filter_tokens: filter_tokens,
-          structured: loaded_fact.structured
+          structured: loaded_fact.structured,
+          file: loaded_fact.file
         )
 
-        sf = SearchedFact.new(fact_name, klass_name, loaded_fact.type, fact_attributes)
-        sf.file = loaded_fact.file
-        sf
+        SearchedFact.new(loaded_fact.name.to_s, loaded_fact.klass, loaded_fact.type, fact_attributes)
       end
 
       def construct_filter_tokens(query_tokens, query_token_range)

--- a/lib/facter/models/fact_attributes.rb
+++ b/lib/facter/models/fact_attributes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Facter
+  class FactAttributes
+    attr_accessor :user_query, :filter_tokens, :structured
+
+    def initialize(user_query:, filter_tokens:, structured:)
+      @user_query = user_query
+      @filter_tokens = filter_tokens
+      @structured = structured
+    end
+  end
+end

--- a/lib/facter/models/fact_attributes.rb
+++ b/lib/facter/models/fact_attributes.rb
@@ -2,12 +2,13 @@
 
 module Facter
   class FactAttributes
-    attr_accessor :user_query, :filter_tokens, :structured
+    attr_accessor :user_query, :filter_tokens, :structured, :file
 
-    def initialize(user_query:, filter_tokens:, structured:)
+    def initialize(user_query:, filter_tokens:, structured:, file: nil)
       @user_query = user_query
       @filter_tokens = filter_tokens
       @structured = structured
+      @file = file
     end
   end
 end

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -66,7 +66,7 @@ module Facter
       when :custom
         fact.structured ? fact.name.split('.') : [fact.name]
       when :external
-        Options[:structured_external_facts] == true ? fact.name.split('.') : [fact.name]
+        fact.structured ? fact.name.split('.') : [fact.name]
       else
         fact.name.split('.')
       end

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -64,7 +64,7 @@ module Facter
       when :legacy
         [fact.name]
       when :custom
-        fact.options[:type] == :structured ? fact.name.split('.') : [fact.name]
+        fact.structured ? fact.name.split('.') : [fact.name]
       when :external
         Options[:structured_external_facts] == true ? fact.name.split('.') : [fact.name]
       else

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -40,14 +40,14 @@ module Facter
       self
     end
 
+    private
+
     def bury_fact(fact)
       split_fact_name = extract_fact_name(fact)
       bury(*split_fact_name + fact.filter_tokens << fact.value)
     rescue NoMethodError
       log_exception(fact)
     end
-
-    private
 
     def bury_custom_flat(fact)
       bury(*[fact.name] + fact.filter_tokens << fact.value)

--- a/lib/facter/models/loaded_fact.rb
+++ b/lib/facter/models/loaded_fact.rb
@@ -2,16 +2,16 @@
 
 module Facter
   class LoadedFact
-    attr_reader :name, :klass, :type
+    attr_reader :name, :klass, :type, :structured
     attr_accessor :file, :is_env, :options
 
-    def initialize(name, klass, type = nil, file = nil, options = {})
+    def initialize(name, klass, type = nil, file = nil, structured = false)
       @name = name
       @klass = klass
       @type = type.nil? ? :core : type
       @file = file
       @is_env = false
-      @options = options
+      @structured = structured
     end
   end
 end

--- a/lib/facter/models/loaded_fact.rb
+++ b/lib/facter/models/loaded_fact.rb
@@ -3,14 +3,15 @@
 module Facter
   class LoadedFact
     attr_reader :name, :klass, :type
-    attr_accessor :file, :is_env
+    attr_accessor :file, :is_env, :options
 
-    def initialize(name, klass, type = nil, file = nil)
+    def initialize(name, klass, type = nil, file = nil, options = {})
       @name = name
       @klass = klass
       @type = type.nil? ? :core : type
       @file = file
       @is_env = false
+      @options = options
     end
   end
 end

--- a/lib/facter/models/null_fact_attributes.rb
+++ b/lib/facter/models/null_fact_attributes.rb
@@ -2,12 +2,13 @@
 
 module Facter
   class NullFactAttributes
-    attr_accessor :user_query, :filter_tokens, :structured
+    attr_accessor :user_query, :filter_tokens, :structured, :file
 
     def initialize
       @user_query = nil
       @filter_tokens = []
       @structured = false
+      @file = nil
     end
   end
 end

--- a/lib/facter/models/null_fact_attributes.rb
+++ b/lib/facter/models/null_fact_attributes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Facter
+  class NullFactAttributes
+    attr_accessor :user_query, :filter_tokens, :structured
+
+    def initialize
+      @user_query = nil
+      @filter_tokens = []
+      @structured = false
+    end
+  end
+end

--- a/lib/facter/models/resolved_fact.rb
+++ b/lib/facter/models/resolved_fact.rb
@@ -3,7 +3,7 @@
 module Facter
   class ResolvedFact
     attr_reader :name, :type
-    attr_accessor :user_query, :filter_tokens, :value, :file
+    attr_accessor :user_query, :filter_tokens, :value, :file, :options
 
     def initialize(name, value = '', type = :core, user_query = nil, filter_tokens = [])
       @name = name

--- a/lib/facter/models/resolved_fact.rb
+++ b/lib/facter/models/resolved_fact.rb
@@ -3,11 +3,11 @@
 module Facter
   class ResolvedFact
     extend Forwardable
-    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured
-    def_delegators :@fact_attributes, :user_query=, :filter_tokens=, :structured=
+    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured, :file
+    def_delegators :@fact_attributes, :user_query=, :filter_tokens=
 
     attr_reader :name, :type
-    attr_accessor :value, :file, :options
+    attr_accessor :value
 
     def initialize(name, value, type = :core, fact_attributes = NullFactAttributes.new)
       @name = name

--- a/lib/facter/models/resolved_fact.rb
+++ b/lib/facter/models/resolved_fact.rb
@@ -2,15 +2,18 @@
 
 module Facter
   class ResolvedFact
-    attr_reader :name, :type
-    attr_accessor :user_query, :filter_tokens, :value, :file, :options
+    extend Forwardable
+    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured
+    def_delegators :@fact_attributes, :user_query=, :filter_tokens=, :structured=
 
-    def initialize(name, value = '', type = :core, user_query = nil, filter_tokens = [])
+    attr_reader :name, :type
+    attr_accessor :value, :file, :options
+
+    def initialize(name, value, type = :core, fact_attributes = NullFactAttributes.new)
       @name = name
       @value = Utils.deep_stringify_keys(value)
       @type = type
-      @user_query = user_query
-      @filter_tokens = filter_tokens
+      @fact_attributes = fact_attributes
     end
 
     def legacy?

--- a/lib/facter/models/searched_fact.rb
+++ b/lib/facter/models/searched_fact.rb
@@ -3,7 +3,7 @@
 module Facter
   class SearchedFact
     attr_reader :name, :fact_class, :filter_tokens, :user_query, :type
-    attr_accessor :file
+    attr_accessor :file, :options
 
     def initialize(fact_name, fact_class, filter_tokens, user_query, type)
       @name = fact_name

--- a/lib/facter/models/searched_fact.rb
+++ b/lib/facter/models/searched_fact.rb
@@ -2,15 +2,18 @@
 
 module Facter
   class SearchedFact
-    attr_reader :name, :fact_class, :filter_tokens, :user_query, :type
+    extend Forwardable
+    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured
+    def_delegators :@fact_attributes, :user_query=, :filter_tokens=, :structured=
+
+    attr_reader :name, :klass, :type
     attr_accessor :file, :options
 
-    def initialize(fact_name, fact_class, filter_tokens, user_query, type)
-      @name = fact_name
-      @fact_class = fact_class
-      @filter_tokens = filter_tokens
-      @user_query = user_query
+    def initialize(name, klass, type, fact_attributes)
+      @name = name
+      @klass = klass
       @type = type
+      @fact_attributes = fact_attributes
     end
   end
 end

--- a/lib/facter/models/searched_fact.rb
+++ b/lib/facter/models/searched_fact.rb
@@ -3,11 +3,10 @@
 module Facter
   class SearchedFact
     extend Forwardable
-    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured
-    def_delegators :@fact_attributes, :user_query=, :filter_tokens=, :structured=
+    def_delegators :@fact_attributes, :user_query, :filter_tokens, :structured, :file
+    def_delegators :@fact_attributes, :user_query=, :filter_tokens=
 
     attr_reader :name, :klass, :type
-    attr_accessor :file, :options
 
     def initialize(name, klass, type, fact_attributes)
       @name = name

--- a/spec/custom_facts/puppetlabs_spec/files.rb
+++ b/spec/custom_facts/puppetlabs_spec/files.rb
@@ -20,8 +20,8 @@ module PuppetlabsSpec
     end
 
     def self.cleanup
-      global_tempfiles ||= []
-      while (path = global_tempfiles.pop)
+      @@global_tempfiles ||= []
+      while (path = @@global_tempfiles.pop)
         raise "Not deleting tmpfile #{path} outside regular tmpdir" unless in_tmp(path)
 
         begin
@@ -45,8 +45,8 @@ module PuppetlabsSpec
       source.close!
 
       # ...record it for cleanup,
-      global_tempfiles ||= []
-      global_tempfiles << File.expand_path(path)
+      @@global_tempfiles ||= []
+      @@global_tempfiles << File.expand_path(path)
 
       # ...and bam.
       path

--- a/spec/custom_facts/util/directory_loader_spec.rb
+++ b/spec/custom_facts/util/directory_loader_spec.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../spec_helper_legacy'
@@ -8,7 +7,7 @@ describe LegacyFacter::Util::DirectoryLoader do
 
   subject(:dir_loader) { LegacyFacter::Util::DirectoryLoader.new(tmpdir('directory_loader')) }
 
-  let(:collection) { LegacyFacter::Util::Collection.new(double('internal loader'), dir_loader) }
+  let(:collection) { LegacyFacter::Util::Collection.new(instance_double(Facter::InternalFactLoader), dir_loader) }
   let(:collection_double) { instance_spy(LegacyFacter::Util::Collection) }
 
   it 'makes the directory available' do
@@ -27,6 +26,33 @@ describe LegacyFacter::Util::DirectoryLoader do
 
     before do
       allow(Facter::Log).to receive(:new).and_return(log_spy)
+    end
+
+    context 'when structured dir exists' do
+      it 'is able to load files from disk and set facts' do
+        data = { 'f1' => 'one', 'f2' => 'two' }
+        write_to_structured_file('data.yaml', YAML.dump(data))
+        dir_loader.load(collection)
+
+        expect(collection.value('f1')).to eq 'one'
+      end
+
+      it 'adds fact with structured: true' do
+        data = 'key1.key2=value'
+        write_to_structured_file('data.txt', data)
+        dir_loader.load(collection_double)
+
+        expect(collection_double).to have_received(:add)
+          .with('key1.key2', value: 'value', fact_type: :external, file: anything, structured: true)
+      end
+
+      it "ignores files that begin with '.'" do
+        data = { 'f1' => 'one', 'f2' => 'two' }
+        write_to_structured_file('.data.yaml', YAML.dump(data))
+        dir_loader.load(collection_double)
+
+        expect(collection_double).not_to have_received(:add)
+      end
     end
 
     it 'is able to load files from disk and set facts' do
@@ -50,29 +76,27 @@ describe LegacyFacter::Util::DirectoryLoader do
     end
 
     it "ignores files that begin with '.'" do
-      not_to_be_used_collection = double('collection should not be used')
-      expect(not_to_be_used_collection).not_to receive(:add)
-
       data = { 'f1' => 'one', 'f2' => 'two' }
       write_to_file('.data.yaml', YAML.dump(data))
+      dir_loader.load(collection_double)
 
-      dir_loader.load(not_to_be_used_collection)
+      expect(collection_double).not_to have_received(:add)
     end
 
     %w[bak orig].each do |ext|
       it "ignores files with an extension of '#{ext}'" do
-        expect(log_spy).to receive(:debug).with(/#{ext}/)
         write_to_file('data' + ".#{ext}", 'foo=bar')
-
         dir_loader.load(collection)
+
+        expect(log_spy).to have_received(:debug).with(/#{ext}/)
       end
     end
 
     it 'warns when trying to parse unknown file types' do
       write_to_file('file.unknownfiletype', 'stuff=bar')
-      expect(log_spy).to receive(:debug).with(/file.unknownfiletype/)
-
       dir_loader.load(collection)
+
+      expect(log_spy).to have_received(:debug).with(/file.unknownfiletype/)
     end
 
     it 'external facts should almost always precedence over all other facts' do
@@ -120,6 +144,13 @@ describe LegacyFacter::Util::DirectoryLoader do
 
   def write_to_file(file_name, to_write)
     file = File.join(dir_loader.directories[0], file_name)
+    File.open(file, 'w') { |f| f.print to_write }
+  end
+
+  def write_to_structured_file(file_name, to_write)
+    structured_dir = File.join(dir_loader.directories[0], 'structured')
+    FileUtils.mkdir_p(structured_dir)
+    file = File.join(structured_dir, file_name)
     File.open(file, 'w') { |f| f.print to_write }
   end
 end

--- a/spec/custom_facts/util/directory_loader_spec.rb
+++ b/spec/custom_facts/util/directory_loader_spec.rb
@@ -45,7 +45,8 @@ describe LegacyFacter::Util::DirectoryLoader do
       dir_loader.load(collection_double)
       file = File.join(dir_loader.directories[0], 'data.yaml')
 
-      expect(collection_double).to have_received(:add).with('f1', value: 'one', fact_type: :external, file: file)
+      expect(collection_double).to have_received(:add)
+        .with('f1', value: 'one', fact_type: :external, file: file, structured: false)
     end
 
     it "ignores files that begin with '.'" do

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -98,6 +98,11 @@ describe Facter::Util::Fact do
       expect(fact.resolution('named')).to be_a_kind_of Facter::Core::Aggregate
     end
 
+    it 'creates an simple resolution when the type is :structured' do
+      fact.define_resolution('named', type: :structured)
+      expect(fact.resolution('named')).to be_a_kind_of Facter::Util::Resolution
+    end
+
     # it "raises an error if there is an existing resolution with a different type" do
     #   pending "We need to stop rescuing all errors when instantiating resolutions"
     #   fact.define_resolution('named')

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -105,6 +105,11 @@ describe Facter::Util::Resolution do
       expect { resolution.options(fact_type: 'simple') }.not_to raise_error
     end
 
+    it 'can set structured' do
+      resolution.options(structured: true)
+      expect(resolution.instance_variable_get(:@structured)).to eq true
+    end
+
     it 'fails on unhandled options' do
       expect do
         resolution.options(foo: 'bar')

--- a/spec/facter/cache_manager_spec.rb
+++ b/spec/facter/cache_manager_spec.rb
@@ -5,15 +5,15 @@ describe Facter::CacheManager do
 
   let(:cache_dir) { '/etc/facter/cache' }
   let(:searched_core_fact) do
-    instance_spy(Facter::SearchedFact, name: 'os', fact_class: instance_spy(Facts::Linux::Os::Name),
+    instance_spy(Facter::SearchedFact, name: 'os', klass: instance_spy(Facts::Linux::Os::Name),
                                        filter_tokens: [], user_query: '', type: :core, file: nil)
   end
   let(:searched_custom_fact) do
-    instance_spy(Facter::SearchedFact, name: 'my_custom_fact', fact_class: nil, filter_tokens: [],
+    instance_spy(Facter::SearchedFact, name: 'my_custom_fact', klass: nil, filter_tokens: [],
                                        user_query: '', type: :custom, file: nil)
   end
   let(:searched_external_fact) do
-    instance_spy(Facter::SearchedFact, name: 'my_external_fact', fact_class: nil, filter_tokens: [],
+    instance_spy(Facter::SearchedFact, name: 'my_external_fact', klass: nil, filter_tokens: [],
                                        user_query: '', type: :file, file: '/tmp/ext_file.txt')
   end
   let(:searched_facts) { [searched_core_fact, searched_custom_fact, searched_external_fact] }

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -200,14 +200,14 @@ describe Facter do
   describe '#value' do
     it 'returns a value' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter.value('os.name')).to eq('Ubuntu')
     end
 
     it 'return no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return(nil)
 
       expect(Facter.value('os.name')).to be nil
     end
@@ -219,7 +219,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter.value('os.name')).to eq('Ubuntu')
       end
@@ -229,20 +229,21 @@ describe Facter do
   describe '#fact' do
     it 'returns a fact' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter.fact('os.name')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: 'Ubuntu')
     end
 
     it 'can be interpolated' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
+
       expect("#{Facter.fact('os.name')}-test").to eq('Ubuntu-test')
     end
 
     it 'returns no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil, key_error)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_raise(key_error)
 
       expect(Facter.fact('os.name')).to be_nil
     end
@@ -272,7 +273,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter.fact('os.name'))
           .to be_instance_of(Facter::ResolvedFact)
@@ -284,14 +285,14 @@ describe Facter do
   describe '#[]' do
     it 'returns a fact' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter['os.name']).to be_instance_of(Facter::ResolvedFact).and(having_attributes(value: 'Ubuntu'))
     end
 
     it 'return no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil, key_error)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_raise(key_error)
 
       expect(Facter['os.name']).to be_nil
     end
@@ -303,7 +304,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter['os.name'])
           .to be_instance_of(Facter::ResolvedFact)

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -80,6 +80,7 @@ describe Facter::FactCollection do
       let(:resolved_fact2) { Facter::ResolvedFact.new('mygroup.fact1.subfact1', 'g1_sg1_f1_value', type) }
 
       it 'logs error' do
+        resolved_fact2.options = {}
         fact_collection.build_fact_collection!([resolved_fact, resolved_fact2])
 
         expect(logger).to have_received(:error)

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -148,7 +148,6 @@ describe Facter::FactCollection do
       end
 
       it 'logs error' do
-        resolved_fact2.options = {}
         fact_collection.build_fact_collection!([resolved_fact, resolved_fact2])
 
         expect(logger).to have_received(:error)

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -5,7 +5,12 @@ describe Facter::FactCollection do
 
   describe '#build_fact_collection!' do
     let(:user_query) { 'os' }
-    let(:resolved_fact) { Facter::ResolvedFact.new(fact_name, fact_value, type) }
+    let(:fact_attributes) do
+      Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: true)
+    end
+    let(:resolved_fact) do
+      Facter::ResolvedFact.new(fact_name, fact_value, type, fact_attributes)
+    end
     let(:logger) { instance_spy(Facter::Log) }
 
     before do
@@ -76,8 +81,9 @@ describe Facter::FactCollection do
       let(:fact_name) { 'mygroup.fact1' }
       let(:fact_value) { 'g1_f1_value' }
       let(:type) { :custom }
-
-      let(:resolved_fact2) { Facter::ResolvedFact.new('mygroup.fact1.subfact1', 'g1_sg1_f1_value', type) }
+      let(:resolved_fact2) do
+        Facter::ResolvedFact.new('mygroup.fact1.subfact1', 'g1_sg1_f1_value', type, fact_attributes)
+      end
 
       it 'logs error' do
         resolved_fact2.options = {}

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -5,8 +5,9 @@ describe Facter::FactCollection do
 
   describe '#build_fact_collection!' do
     let(:user_query) { 'os' }
+    let(:structured) { false }
     let(:fact_attributes) do
-      Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: true)
+      Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: structured)
     end
     let(:resolved_fact) do
       Facter::ResolvedFact.new(fact_name, fact_value, type, fact_attributes)
@@ -30,6 +31,66 @@ describe Facter::FactCollection do
         expected_hash = { 'os' => { 'version' => fact_value } }
 
         expect(fact_collection).to eq(expected_hash)
+      end
+    end
+
+    context 'with custom facts' do
+      context 'when structured' do
+        let(:structured) { true }
+        let(:fact_name) { 'my.fact' }
+        let(:fact_value) { 'val' }
+        let(:type) { :custom }
+
+        it 'splits by dot' do
+          fact_collection.build_fact_collection!([resolved_fact])
+          expected_hash = { 'my' => { 'fact' => fact_value } }
+
+          expect(fact_collection).to eq(expected_hash)
+        end
+      end
+
+      context 'when not structured' do
+        let(:structured) { false }
+        let(:fact_name) { 'my.fact' }
+        let(:fact_value) { 'val' }
+        let(:type) { :custom }
+
+        it 'keeps fact name' do
+          fact_collection.build_fact_collection!([resolved_fact])
+          expected_hash = { 'my.fact' => fact_value }
+
+          expect(fact_collection).to eq(expected_hash)
+        end
+      end
+    end
+
+    context 'with external facts' do
+      context 'when structured' do
+        let(:structured) { true }
+        let(:fact_name) { 'my.fact' }
+        let(:fact_value) { 'val' }
+        let(:type) { :external }
+
+        it 'splits by dot' do
+          fact_collection.build_fact_collection!([resolved_fact])
+          expected_hash = { 'my' => { 'fact' => fact_value } }
+
+          expect(fact_collection).to eq(expected_hash)
+        end
+      end
+
+      context 'when not structured' do
+        let(:structured) { false }
+        let(:fact_name) { 'my.fact' }
+        let(:fact_value) { 'val' }
+        let(:type) { :external }
+
+        it 'keeps fact name' do
+          fact_collection.build_fact_collection!([resolved_fact])
+          expected_hash = { 'my.fact' => fact_value }
+
+          expect(fact_collection).to eq(expected_hash)
+        end
       end
     end
 
@@ -78,6 +139,7 @@ describe Facter::FactCollection do
     end
 
     context 'when fact cannot be added to collection' do
+      let(:structured) { true }
       let(:fact_name) { 'mygroup.fact1' }
       let(:fact_value) { 'g1_f1_value' }
       let(:type) { :custom }

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -8,9 +8,10 @@ describe Facter::QueryParser do
       os_name_class = 'Facter::Ubuntu::OsName'
       os_family_class = 'Facter::Ubuntu::OsFamily'
 
-      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class, type: :core, file: nil)
+      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class,
+                                                       type: :core, file: nil, options: {})
       loaded_fact_os_family = double(Facter::LoadedFact, name: 'os.family', klass: os_family_class, type: :core,
-                                                         file: nil)
+                                                         file: nil, options: {})
       loaded_facts = [loaded_fact_os_name, loaded_fact_os_family]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -24,7 +25,8 @@ describe Facter::QueryParser do
 
       os_name_class = 'Facter::Ubuntu::OsName'
 
-      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.release', klass: os_name_class, type: :core, file: nil)
+      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.release', klass: os_name_class,
+                                                       type: :core, file: nil, options: {})
       loaded_facts = [loaded_fact_os_name]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -39,9 +41,9 @@ describe Facter::QueryParser do
       os_family_class = 'Facter::Ubuntu::OsFamily'
 
       loaded_fact_networking = double(Facter::LoadedFact, name: 'ipaddress_.*', klass: networking_class, type: :legacy,
-                                                          file: nil)
+                                                          file: nil, options: {})
       loaded_fact_os_family = double(Facter::LoadedFact, name: 'os.family', klass: os_family_class, type: :core,
-                                                         file: nil)
+                                                         file: nil, options: {})
       loaded_facts = [loaded_fact_networking, loaded_fact_os_family]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -56,8 +58,9 @@ describe Facter::QueryParser do
       ssh_class = 'Facter::El::Ssh'
       ssh_key_class = 'Facter::El::Sshalgorithmkey'
 
-      loaded_fact_ssh_key = instance_spy(Facter::LoadedFact, name: 'ssh.*key', klass: ssh_key_class, type: :legacy)
-      loaded_fact_ssh = instance_spy(Facter::LoadedFact, name: 'ssh', klass: ssh_class, type: :core)
+      loaded_fact_ssh_key = instance_spy(Facter::LoadedFact, name: 'ssh.*key', klass: ssh_key_class,
+                                                             type: :legacy, options: {})
+      loaded_fact_ssh = instance_spy(Facter::LoadedFact, name: 'ssh', klass: ssh_class, type: :core, options: {})
       loaded_facts = [loaded_fact_ssh_key, loaded_fact_ssh]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -70,8 +73,10 @@ describe Facter::QueryParser do
       query_list = ['custom_fact']
       os_name_class = 'Facter::Ubuntu::OsName'
 
-      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class, type: :core, file: nil)
-      loaded_fact_custom_fact = double(Facter::LoadedFact, name: 'custom_fact', klass: nil, type: :custom, file: nil)
+      loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class,
+                                                       type: :core, file: nil, options: {})
+      loaded_fact_custom_fact = double(Facter::LoadedFact, name: 'custom_fact', klass: nil,
+                                                           type: :custom, file: nil, options: {})
       loaded_facts = [loaded_fact_os_name, loaded_fact_custom_fact]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -83,7 +88,8 @@ describe Facter::QueryParser do
     it 'queries if param is symbol' do
       query_list = [:path]
       path_class = 'Facter::Ubuntu::Path'
-      loaded_fact_path = double(Facter::LoadedFact, name: 'path', klass: path_class, type: :core, file: nil)
+      loaded_fact_path = double(Facter::LoadedFact, name: 'path', klass: path_class,
+                                                    type: :core, file: nil, options: {})
       loaded_facts = [loaded_fact_path]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -109,9 +115,10 @@ describe Facter::QueryParser do
       let(:loaded_facts) do
         [
           instance_double(
-            Facter::LoadedFact, name: 'os.name', klass: 'Facter::Ubuntu::Os::Name', type: :core, file: nil
+            Facter::LoadedFact, name: 'os.name', klass: 'Facter::Ubuntu::Os::Name',
+                                type: :core, file: nil, options: {}
           ),
-          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil)
+          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil, options: {})
         ]
       end
 

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -9,15 +9,15 @@ describe Facter::QueryParser do
       os_family_class = 'Facter::Ubuntu::OsFamily'
 
       loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class,
-                                                       type: :core, file: nil, options: {})
+                                                       type: :core, file: nil, structured: false)
       loaded_fact_os_family = double(Facter::LoadedFact, name: 'os.family', klass: os_family_class, type: :core,
-                                                         file: nil, options: {})
+                                                         file: nil, structured: false)
       loaded_facts = [loaded_fact_os_name, loaded_fact_os_family]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
 
       expect(matched_facts).to be_an_instance_of(Array).and \
-        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: os_name_class)))
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(klass: os_name_class)))
     end
 
     it 'compose filter_tokens correctly' do
@@ -26,7 +26,7 @@ describe Facter::QueryParser do
       os_name_class = 'Facter::Ubuntu::OsName'
 
       loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.release', klass: os_name_class,
-                                                       type: :core, file: nil, options: {})
+                                                       type: :core, file: nil, structured: false)
       loaded_facts = [loaded_fact_os_name]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
@@ -41,15 +41,15 @@ describe Facter::QueryParser do
       os_family_class = 'Facter::Ubuntu::OsFamily'
 
       loaded_fact_networking = double(Facter::LoadedFact, name: 'ipaddress_.*', klass: networking_class, type: :legacy,
-                                                          file: nil, options: {})
+                                                          file: nil, structured: false)
       loaded_fact_os_family = double(Facter::LoadedFact, name: 'os.family', klass: os_family_class, type: :core,
-                                                         file: nil, options: {})
+                                                         file: nil, structured: false)
       loaded_facts = [loaded_fact_networking, loaded_fact_os_family]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
 
       expect(matched_facts).to be_an_instance_of(Array).and \
-        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: networking_class)))
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(klass: networking_class)))
     end
 
     it 'creates a searched fact correctly without name collision' do
@@ -59,14 +59,14 @@ describe Facter::QueryParser do
       ssh_key_class = 'Facter::El::Sshalgorithmkey'
 
       loaded_fact_ssh_key = instance_spy(Facter::LoadedFact, name: 'ssh.*key', klass: ssh_key_class,
-                                                             type: :legacy, options: {})
-      loaded_fact_ssh = instance_spy(Facter::LoadedFact, name: 'ssh', klass: ssh_class, type: :core, options: {})
+                                                             type: :legacy, structured: false)
+      loaded_fact_ssh = instance_spy(Facter::LoadedFact, name: 'ssh', klass: ssh_class, type: :core, structured: false)
       loaded_facts = [loaded_fact_ssh_key, loaded_fact_ssh]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
 
       expect(matched_facts).to be_an_instance_of(Array).and \
-        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: ssh_class)))
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(klass: ssh_class)))
     end
 
     it 'creates one custom searched fact' do
@@ -74,28 +74,28 @@ describe Facter::QueryParser do
       os_name_class = 'Facter::Ubuntu::OsName'
 
       loaded_fact_os_name = double(Facter::LoadedFact, name: 'os.name', klass: os_name_class,
-                                                       type: :core, file: nil, options: {})
+                                                       type: :core, file: nil, structured: false)
       loaded_fact_custom_fact = double(Facter::LoadedFact, name: 'custom_fact', klass: nil,
-                                                           type: :custom, file: nil, options: {})
+                                                           type: :custom, file: nil, structured: false)
       loaded_facts = [loaded_fact_os_name, loaded_fact_custom_fact]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
 
       expect(matched_facts).to be_an_instance_of(Array).and \
-        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: nil, type: :custom)))
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(klass: nil, type: :custom)))
     end
 
     it 'queries if param is symbol' do
       query_list = [:path]
       path_class = 'Facter::Ubuntu::Path'
       loaded_fact_path = double(Facter::LoadedFact, name: 'path', klass: path_class,
-                                                    type: :core, file: nil, options: {})
+                                                    type: :core, file: nil, structured: false)
       loaded_facts = [loaded_fact_path]
 
       matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
 
       expect(matched_facts).to be_an_instance_of(Array).and \
-        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: path_class)))
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(klass: path_class)))
     end
 
     context 'when fact does not exist' do
@@ -116,9 +116,9 @@ describe Facter::QueryParser do
         [
           instance_double(
             Facter::LoadedFact, name: 'os.name', klass: 'Facter::Ubuntu::Os::Name',
-                                type: :core, file: nil, options: {}
+                                type: :core, file: nil, structured: false
           ),
-          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil, options: {})
+          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil, structured: false)
         ]
       end
 
@@ -127,7 +127,7 @@ describe Facter::QueryParser do
 
         expect(matched_facts).to be_an_instance_of(Array).and \
           contain_exactly(an_instance_of(Facter::SearchedFact)
-          .and(having_attributes(name: 'os', fact_class: nil, type: :custom)))
+          .and(having_attributes(name: 'os', klass: nil, type: :custom)))
       end
     end
   end

--- a/spec/framework/core/fact/external/external_fact_manager_spec.rb
+++ b/spec/framework/core/fact/external/external_fact_manager_spec.rb
@@ -4,7 +4,14 @@ describe Facter::ExternalFactManager do
   describe '#resolve' do
     let(:custom_fact_name) { 'my_custom_fact' }
     let(:custom_fact_value) { 'custom_fact_value' }
-    let(:custom_fact) { Facter::Util::Fact.new(custom_fact_name) }
+    let(:custom_fact) do
+      instance_spy(
+        Facter::Util::Fact,
+        name: custom_fact_name,
+        value: custom_fact_value,
+        options: { fact_type: :external, value: 'external' }
+      )
+    end
     let(:fact_attributes) do
       Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: false)
     end
@@ -15,7 +22,6 @@ describe Facter::ExternalFactManager do
 
     before do
       allow(LegacyFacter).to receive(:[]).with(custom_fact_name).and_return(custom_fact)
-      allow(custom_fact).to receive(:value).and_return(custom_fact_value)
     end
 
     it 'resolves one custom fact' do
@@ -31,6 +37,20 @@ describe Facter::ExternalFactManager do
     it 'resolves custom fact with value custom_fact_value' do
       resolved_facts = custom_fact_manager.resolve_facts([searched_fact])
       expect(resolved_facts.first.value).to eq(custom_fact_value)
+    end
+
+    context 'with structured external facts' do
+      let(:fact_attributes) do
+        Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: true)
+      end
+      let(:searched_fact) do
+        Facter::SearchedFact.new(custom_fact_name, nil, :external, fact_attributes)
+      end
+
+      it 'reads the value from fact options' do
+        resolved_facts = custom_fact_manager.resolve_facts([searched_fact])
+        expect(resolved_facts.first.value).to eq('external')
+      end
     end
   end
 end

--- a/spec/framework/core/fact/external/external_fact_manager_spec.rb
+++ b/spec/framework/core/fact/external/external_fact_manager_spec.rb
@@ -5,7 +5,12 @@ describe Facter::ExternalFactManager do
     let(:custom_fact_name) { 'my_custom_fact' }
     let(:custom_fact_value) { 'custom_fact_value' }
     let(:custom_fact) { Facter::Util::Fact.new(custom_fact_name) }
-    let(:searched_fact) { Facter::SearchedFact.new(custom_fact_name, nil, [], '', :custom) }
+    let(:fact_attributes) do
+      Facter::FactAttributes.new(user_query: '', filter_tokens: [], structured: false)
+    end
+    let(:searched_fact) do
+      Facter::SearchedFact.new(custom_fact_name, nil, :custom, fact_attributes)
+    end
     let(:custom_fact_manager) { Facter::ExternalFactManager.new }
 
     before do

--- a/spec/framework/core/fact/internal/internal_fact_manager_spec.rb
+++ b/spec/framework/core/fact/internal/internal_fact_manager_spec.rb
@@ -10,7 +10,7 @@ describe Facter::InternalFactManager do
       resolved_fact = mock_resolved_fact('os', 'Debian', nil, [])
       allow(os_name_class_spy).to receive(:new).and_return(os_name_instance_spy)
       allow(os_name_instance_spy).to receive(:call_the_resolver).and_return(resolved_fact)
-      searched_fact = instance_spy(Facter::SearchedFact, name: 'os', fact_class: os_name_class_spy, filter_tokens: [],
+      searched_fact = instance_spy(Facter::SearchedFact, name: 'os', klass: os_name_class_spy, filter_tokens: [],
                                                          user_query: '', type: :core)
 
       resolved_facts = internal_fact_manager.resolve_facts([searched_fact])
@@ -24,7 +24,7 @@ describe Facter::InternalFactManager do
       resolved_fact = mock_resolved_fact('network_Ethernet0', '192.168.5.121', nil, [], :legacy)
       allow(networking_interface_class_spy).to receive(:new).and_return(windows_networking_interface)
       allow(windows_networking_interface).to receive(:call_the_resolver).and_return(resolved_fact)
-      searched_fact = instance_spy(Facter::SearchedFact, name: 'network_.*', fact_class: networking_interface_class_spy,
+      searched_fact = instance_spy(Facter::SearchedFact, name: 'network_.*', klass: networking_interface_class_spy,
                                                          filter_tokens: [], user_query: '', type: :core)
 
       resolved_facts = internal_fact_manager.resolve_facts([searched_fact])
@@ -34,7 +34,7 @@ describe Facter::InternalFactManager do
 
     context 'when resolved fact is of type nil' do
       let(:searched_fact) do
-        instance_spy(Facter::SearchedFact, name: 'missing_fact', fact_class: nil,
+        instance_spy(Facter::SearchedFact, name: 'missing_fact', klass: nil,
                                            filter_tokens: [], user_query: '', type: :nil)
       end
       let(:resolved_fact) { instance_spy(Facter::ResolvedFact) }
@@ -57,11 +57,11 @@ describe Facter::InternalFactManager do
         allow(os_name_class_spy).to receive(:new).and_return(os_name_instance_spy)
         allow(os_name_instance_spy).to receive(:call_the_resolver).and_return(resolved_fact)
 
-        searched_fact = instance_spy(Facter::SearchedFact, name: 'os.name', fact_class: os_name_class_spy,
+        searched_fact = instance_spy(Facter::SearchedFact, name: 'os.name', klass: os_name_class_spy,
                                                            filter_tokens: [], user_query: '', type: :core)
 
         searched_fact_with_alias = instance_spy(Facter::SearchedFact, name: 'operatingsystem',
-                                                                      fact_class: os_name_class_spy, filter_tokens: [],
+                                                                      klass: os_name_class_spy, filter_tokens: [],
                                                                       user_query: '', type: :core)
 
         internal_fact_manager.resolve_facts([searched_fact, searched_fact_with_alias])
@@ -76,7 +76,7 @@ describe Facter::InternalFactManager do
       let(:searched_fact) do
         instance_spy(Facter::SearchedFact,
                      name: 'os',
-                     fact_class: os_name_class_spy,
+                     klass: os_name_class_spy,
                      filter_tokens: [],
                      user_query: '',
                      type: :core)

--- a/spec/framework/core/fact_manager_spec.rb
+++ b/spec/framework/core/fact_manager_spec.rb
@@ -50,12 +50,12 @@ describe Facter::FactManager do
       [
         instance_double(
           Facter::SearchedFact,
-          name: os, fact_class: os_klass, filter_tokens: [],
+          name: os, klass: os_klass, filter_tokens: [],
           user_query: '', type: :core
         ),
         instance_double(
           Facter::SearchedFact,
-          name: 'my_custom_fact', fact_class: nil,
+          name: 'my_custom_fact', klass: nil,
           filter_tokens: [], user_query: '', type: :custom
         )
       ]
@@ -89,7 +89,7 @@ describe Facter::FactManager do
         [
           instance_double(
             Facter::SearchedFact,
-            name: fact_name, fact_class: nil,
+            name: fact_name, klass: nil,
             filter_tokens: [], user_query: '', type: :custom
           )
         ]
@@ -219,17 +219,17 @@ describe Facter::FactManager do
         [
           instance_double(
             Facter::SearchedFact,
-            name: 'os', fact_class: os_klass, filter_tokens: [],
+            name: 'os', klass: os_klass, filter_tokens: [],
             user_query: '', type: :core
           ),
           instance_double(
             Facter::SearchedFact,
-            name: 'fips_enabled', fact_class: bool_klass, filter_tokens: [],
+            name: 'fips_enabled', klass: bool_klass, filter_tokens: [],
             user_query: '', type: :core
           ),
           instance_double(
             Facter::SearchedFact,
-            name: 'virtual', fact_class: nil_klass, filter_tokens: [],
+            name: 'virtual', klass: nil_klass, filter_tokens: [],
             user_query: '', type: :core
           )
         ]
@@ -374,7 +374,7 @@ describe Facter::FactManager do
     let(:searched_fact) do
       instance_double(
         Facter::SearchedFact,
-        name: 'os', fact_class: ubuntu_os_name,
+        name: 'os', klass: ubuntu_os_name,
         filter_tokens: [], user_query: '', type: :core
       )
     end

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -43,8 +43,7 @@ describe Facter::OptionStore do
         timing: false,
         external_dir: [],
         custom_dir: [],
-        allow_external_loggers: true,
-        structured_external_facts: false
+        allow_external_loggers: true
       )
     end
   end

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -43,7 +43,8 @@ describe Facter::OptionStore do
         timing: false,
         external_dir: [],
         custom_dir: [],
-        allow_external_loggers: true
+        allow_external_loggers: true,
+        structured_external_facts: false
       )
     end
   end

--- a/spec/spec_helper_legacy.rb
+++ b/spec/spec_helper_legacy.rb
@@ -17,7 +17,12 @@ require "#{ROOT_DIR}/spec/custom_facts/puppetlabs_spec/files"
 # end
 
 RSpec.configure do |config|
-  # config.mock_with :mocha
+  config.extend PuppetlabsSpec::Files
+
+  # This will cleanup any files that were created with tmpdir or tmpfile
+  config.after do
+    PuppetlabsSpec::Files.cleanup
+  end
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
#### Custom and external facts are not converted by default to structured facts. They behave the same way they did in Facter 3.


**Custom facts** have a new type `structured` that transforms them into structured facts if they use `.` in their name.

e.g.
```
Facter.add('my_org.fact1', type: :structured) do
  has_weight(10)
  setcode do
    '1111111111'
  end
end
```

**External facts** can become structured facts if a new flag `structured-external-facts` in `facter.conf` is set to true
e.g.
``` 
global : {
    structured-external-facts : true
}

```
