### PR TITLE
(FACT-2960)Accept singular variant of time measure

### DIFF
--- a/lib/facter/framework/config/fact_groups.rb
+++ b/lib/facter/framework/config/fact_groups.rb
@@ -7,7 +7,10 @@ module Facter
     attr_accessor :groups_ttls
     attr_reader :groups, :block_list, :facts_ttls
 
-    STRING_TO_SECONDS = { 'seconds' => 1, 'minutes' => 60, 'hours' => 3600, 'days' => 3600 * 24 }.freeze
+    STRING_TO_SECONDS = { 'seconds' => 1, 'second' => 1,
+                          'minutes' => 60, 'minute' => 60,
+                          'hours' => 3600, 'hour' => 3600,
+                          'days' => 3600 * 24, 'day' => 3600 * 24 }.freeze
 
     def initialize
       @groups = Facter::Config::FACT_GROUPS.dup
@@ -103,7 +106,14 @@ module Facter
 
     def ttls_to_seconds(ttls)
       duration, unit = ttls.split(' ', 2)
-      duration.to_i * STRING_TO_SECONDS[unit]
+      seconds = STRING_TO_SECONDS[unit]
+      if seconds
+        duration.to_i * seconds
+      else
+        log = Log.new(self)
+        log.error("Could not parse time unit #{unit} (try second(s), minute(s), hour(s) or day(s))")
+        nil
+      end
     end
   end
 end

--- a/spec/framework/config/fact_groups_spec.rb
+++ b/spec/framework/config/fact_groups_spec.rb
@@ -99,9 +99,11 @@ describe Facter::FactGroups do
   end
 
   describe '#get_group_ttls' do
+    let(:ttls) { ['operating system' => '30 minutes'] }
+
     before do
       stub_const('Facter::Config::FACT_GROUPS', 'operating system' => %w[os os.name])
-      allow(config_reader).to receive(:ttls).and_return(['operating system' => '30 minutes'])
+      allow(config_reader).to receive(:ttls).and_return(ttls)
     end
 
     it 'returns group' do
@@ -110,6 +112,29 @@ describe Facter::FactGroups do
 
     it 'returns nil' do
       expect(fg.get_group_ttls('memory')).to be_nil
+    end
+
+    context 'when ttls has hour instead of hour' do
+      let(:ttls) { ['operating system' => '1 hour', 'memory' => '1 day', 'hostname' => '30 invalid_unit'] }
+      let(:logger) { instance_spy(Facter::Log) }
+
+      before do
+        allow(Facter::Log).to receive(:new).and_return(logger)
+      end
+
+      it 'logs an error message' do
+        fg.get_group_ttls('hostname')
+        expect(logger).to have_received(:error).with('Could not parse time unit invalid_unit'\
+                                                      ' (try second(s), minute(s), hour(s) or day(s))').twice
+      end
+
+      it 'returns os ttl in seconds' do
+        expect(fg.get_group_ttls('operating system')).to eq(3600)
+      end
+
+      it 'returns memory ttl in seconds' do
+        expect(fg.get_group_ttls('memory')).to eq(86_400)
+      end
     end
   end
 end


### PR DESCRIPTION
**Description of the problem:** Facter fails if the ttls from config file contains day (instead of days), hour (instead of hours) and so on. 
Ex: 
```
{
  "facts": {
    "blocklist": null,
    "ttls": [
      {
        "EC2": "1 day"
      }
    ]
  }
}
``` 
**Description of the fix:** Accept singular form of time measure words (second, minute, hour, day).