### PR TITLE
(FACT-2930) Facter 4 Date and Time no support

### DIFF
--- a/lib/facter/custom_facts/util/normalization.rb
+++ b/lib/facter/custom_facts/util/normalization.rb
@@ -16,8 +16,6 @@ module LegacyFacter
       # @return [void]
       def normalize(value)
         case value
-        when Integer, Float, TrueClass, FalseClass, NilClass, Symbol, Date
-          value
         when String
           normalize_string(value)
         when Array
@@ -25,7 +23,7 @@ module LegacyFacter
         when Hash
           normalize_hash(value)
         else
-          raise NormalizationError, "Expected #{value} to be one of #{VALID_TYPES.inspect}, but was #{value.class}"
+          value
         end
       end
 

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -196,6 +196,22 @@ describe Facter::Util::Fact do
         having_attributes(value: '1', used_resolution_weight: 1)
       )
     end
+
+    [
+      222,
+      'test string',
+      Time.now,
+      Date.new(2020),
+      StandardError.new('test')
+    ].each do |value|
+      it 'returns ruby objects' do
+        fact.add do
+          setcode { value }
+        end
+
+        expect(fact.value.class).to eq value.class
+      end
+    end
   end
 
   describe '#flush' do

--- a/spec/custom_facts/util/normalization_spec.rb
+++ b/spec/custom_facts/util/normalization_spec.rb
@@ -95,17 +95,9 @@ describe LegacyFacter::Util::Normalization do
     end
   end
 
-  [1, 1.0, true, false, nil].each do |val|
+  [1, 1.0, true, false, nil, Object.new, Set.new].each do |val|
     it "accepts #{val.inspect}:#{val.class}" do
       expect(normalization.normalize(val)).to eq(val)
-    end
-  end
-
-  [Object.new, Set.new].each do |val|
-    it "rejects #{val.inspect}:#{val.class}" do
-      expect do
-        normalization.normalize(val)
-      end.to raise_error(LegacyFacter::Util::Normalization::NormalizationError, /Expected .*but was #{val.class}/)
     end
   end
 end


### PR DESCRIPTION
As facter 3 did not support Date and Time types, facter 4 should not
support them.

Using the following custom fact,
```
Facter.add(:now) do
  setcode { Time.now }
end
```

Facter 3 outputs empty fact:
...
now =>
...

Facter 4 outputs an error and no empty fact
ERROR Facter - Fact resolution fact='now', resolution='<anonymous>' resolved to an invalid value: Expected 2021-03-10 12:12:45 +0200 to be one of [Integer, Float, TrueClass, FalseClass, NilClass, Symbol, String, Array, Hash], but was Time