### PR TITLE
(FACT-2982) Rework Solaris mountpoints resolver

### DIFF
--- a/lib/facter/facts/solaris/mountpoints.rb
+++ b/lib/facter/facts/solaris/mountpoints.rb
@@ -6,7 +6,7 @@ module Facts
       FACT_NAME = 'mountpoints'
 
       def call_the_resolver
-        mountpoints = Facter::Resolvers::Mountpoints.resolve(FACT_NAME.to_sym)
+        mountpoints = Facter::Resolvers::Solaris::Mountpoints.resolve(FACT_NAME.to_sym)
         return Facter::ResolvedFact.new(FACT_NAME, nil) unless mountpoints
 
         fact = {}

--- a/spec/facter/facts/solaris/mountpoints_spec.rb
+++ b/spec/facter/facts/solaris/mountpoints_spec.rb
@@ -6,38 +6,40 @@ describe Facts::Solaris::Mountpoints do
 
     context 'when resolver returns hash' do
       let(:resolver_output) do
-        [{ available: '63.31 GiB',
-           available_bytes: 67_979_685_888,
-           capacity: '84.64%',
-           device: '/dev/nvme0n1p2',
-           filesystem: 'ext4',
-           options: %w[rw noatime],
+        [{ available: '5.59 GiB',
+           available_bytes: 6_006_294_016,
+           capacity: '41.76%',
+           device: 'rpool/ROOT/solaris',
+           filesystem: 'zfs',
+           options: ['dev=4490002'],
            path: '/',
-           size: '434.42 GiB',
-           size_bytes: 466_449_743_872,
-           used: '348.97 GiB',
-           used_bytes: 374_704_357_376 }]
+           size: '9.61 GiB',
+           size_bytes: 10_313_577_472,
+           used: '4.01 GiB',
+           used_bytes: 4_307_283_456 }]
       end
+
       let(:parsed_fact) do
-        { '/' => { 'available' => '63.31 GiB',
-                   'available_bytes' => 67_979_685_888,
-                   'capacity' => '84.64%',
-                   'device' => '/dev/nvme0n1p2',
-                   'filesystem' => 'ext4',
-                   'options' => %w[rw noatime],
-                   'size' => '434.42 GiB',
-                   'size_bytes' => 466_449_743_872,
-                   'used' => '348.97 GiB',
-                   'used_bytes' => 374_704_357_376 } }
+        { '/' => { 'available' => '5.59 GiB',
+                   'available_bytes' => 6_006_294_016,
+                   'capacity' => '41.76%',
+                   'device' => 'rpool/ROOT/solaris',
+                   'filesystem' => 'zfs',
+                   'options' => ['dev=4490002'],
+                   'size' => '9.61 GiB',
+                   'size_bytes' => 10_313_577_472,
+                   'used' => '4.01 GiB',
+                   'used_bytes' => 4_307_283_456 } }
       end
 
       before do
-        allow(Facter::Resolvers::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(resolver_output)
+        allow(Facter::Resolvers::Solaris::Mountpoints)
+          .to receive(:resolve).with(:mountpoints).and_return(resolver_output)
       end
 
       it 'calls Facter::Resolvers::Mountpoints' do
         fact.call_the_resolver
-        expect(Facter::Resolvers::Mountpoints).to have_received(:resolve).with(:mountpoints)
+        expect(Facter::Resolvers::Solaris::Mountpoints).to have_received(:resolve).with(:mountpoints)
       end
 
       it 'returns mountpoints information' do
@@ -48,7 +50,7 @@ describe Facts::Solaris::Mountpoints do
 
     context 'when resolver returns nil' do
       before do
-        allow(Facter::Resolvers::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(nil)
+        allow(Facter::Resolvers::Solaris::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(nil)
       end
 
       it 'returns mountpoints information' do

--- a/spec/facter/resolvers/solaris/mountpoints_spec.rb
+++ b/spec/facter/resolvers/solaris/mountpoints_spec.rb
@@ -2,55 +2,58 @@
 
 describe Facter::Resolvers::Solaris::Mountpoints do
   let(:resolver) { Facter::Resolvers::Solaris::Mountpoints }
-  let(:mount) do
-    class_double(Sys::Filesystem::Mount,
-                 mount_point: '/', mount_time: nil,
-                 mount_type: 'ext4', options: 'rw,noatime', name:
-                 '/dev/nvme0n1p2', dump_frequency: 0, pass_number: 0)
+  let(:mounts) do
+    [
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/', mount_time: nil,
+                    mount_type: 'zfs', options: 'dev=4490002', name:
+                    'rpool/ROOT/solaris', dump_frequency: nil, pass_number: nil),
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/devices', mount_time: nil,
+                    mount_type: 'devfs', options: 'dev=8580000', name:
+                    '/devices', dump_frequency: nil, pass_number: nil),
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/proc', mount_time: nil,
+                    mount_type: 'proc', options: 'dev=8600000', name:
+                    'proc', dump_frequency: nil, pass_number: nil),
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/net', mount_time: nil,
+                    mount_type: 'autofs', options: 'nosuid,indirect,ignore,nobrowse,dev=8900007', name:
+                    '-hosts', dump_frequency: nil, pass_number: nil),
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/home', mount_time: nil,
+                    mount_type: 'autofs', options: 'indirect,ignore,nobrowse,dev=8900008', name:
+                    'auto_home', dump_frequency: nil, pass_number: nil),
+      object_double(Sys::Filesystem::Mount,
+                    mount_point: '/home/user', mount_time: nil,
+                    mount_type: 'zfs', options: 'dev=8900009', name:
+                    'rpool/user', dump_frequency: nil, pass_number: nil)
+    ]
   end
 
+  let(:mount) { mounts.first }
+
   let(:stat) do
-    class_double(Sys::Filesystem::Stat,
-                 path: '/', base_type: nil, fragment_size: 4096, block_size: 4096, blocks: 113_879_332,
-                 blocks_available: -16_596_603, blocks_free: 22_398_776)
+    object_double('Sys::Filesystem::Stat',
+                  path: '/', base_type: 'zfs', fragment_size: 512, block_size: 131_072, blocks: 20_143_706,
+                  blocks_available: 11_731_043, blocks_free: 11_731_043)
   end
 
   let(:fact) do
-    [{ available: '63.31 GiB',
-       available_bytes: 67_979_685_888,
-       capacity: '84.64%',
-       device: '/dev/nvme0n1p2',
-       filesystem: 'ext4',
-       options: %w[rw noatime],
+    [{ available: '5.59 GiB',
+       available_bytes: 6_006_294_016,
+       capacity: '41.76%',
+       device: 'rpool/ROOT/solaris',
+       filesystem: 'zfs',
+       options: ['dev=4490002'],
        path: '/',
-       size: '434.42 GiB',
-       size_bytes: 466_449_743_872,
-       used: '348.97 GiB',
-       used_bytes: 374_704_357_376 }]
-  end
-
-  let(:ignored_mount1) do
-    [
-      class_double(
-        Sys::Filesystem::Mount, mount_type: 'zfs', mount_point: '/system/', name: '/dev/ignore', options: 'rw'
-      )
-    ]
-  end
-
-  let(:ignored_mount2) do
-    [
-      class_double(
-        Sys::Filesystem::Mount, mount_type: 'autofs', mount_point: '/mnt/auto', name: '/dev/ignore', options: 'rw'
-      )
-    ]
+       size: '9.61 GiB',
+       size_bytes: 10_313_577_472,
+       used: '4.01 GiB',
+       used_bytes: 4_307_283_456 }]
   end
 
   before do
-    allow(Facter::Util::FileHelper).to receive(:safe_read)
-      .with('/proc/cmdline')
-      .and_return(load_fixture('cmdline_root_device').read)
-
-    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return([mount])
     allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoint_stats).and_return(stat)
 
     # mock sys/filesystem methods
@@ -58,53 +61,36 @@ describe Facter::Resolvers::Solaris::Mountpoints do
     allow(stat).to receive(:bytes_available).and_return(stat.blocks_available * stat.fragment_size)
     allow(stat).to receive(:bytes_free).and_return(stat.blocks_free * stat.fragment_size)
     allow(stat).to receive(:bytes_used).and_return(stat.bytes_total - stat.bytes_free)
+
     resolver.invalidate_cache
   end
 
   it 'correctly builds the mountpoints fact' do
+    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return([mount])
     result = resolver.resolve(:mountpoints)
 
     expect(result).to eq(fact)
   end
 
-  it 'does not drop non-tmpfs mounts under /proc or /sys' do
-    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return(ignored_mount1)
+  it 'resolves all applicable mountpoints' do
+    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return(mounts)
 
-    resolver.resolve(:mountpoints)
-    expect(Facter::Util::Resolvers::FilesystemHelper).to have_received(:read_mountpoint_stats).with('/system/')
+    result = resolver.resolve(:mountpoints)
+    expect(result.map { |m| m[:path] }).to eql(%w[/ /devices /proc])
   end
 
-  it 'does not drop automounts mounts under /proc or /sys' do
-    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return(ignored_mount2)
+  it 'does not resolve mounts of type autofs' do
+    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return(mounts)
 
-    resolver.resolve(:mountpoints)
-    expect(Facter::Util::Resolvers::FilesystemHelper).to have_received(:read_mountpoint_stats).with('/mnt/auto')
+    result = resolver.resolve(:mountpoints)
+    expect(result).not_to include(hash_including(filesystem: 'autofs'))
   end
 
-  describe '.root_device' do
-    let(:mount) do
-      class_double(
-        Sys::Filesystem::Mount, mount_point: '/', mount_type: 'ext4', options: 'rw,noatime', name: '/dev/root'
-      )
-    end
+  it 'does not resolve mounts under auto_home' do
+    allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return(mounts)
 
-    it 'looks up the actual device if /dev/root' do
-      result = resolver.resolve(:mountpoints)
-      expect(result.first[:device]).to eq('/dev/mmcblk0p2')
-    end
-
-    context 'when /proc/cmdline is not accessible' do
-      before do
-        allow(Facter::Util::FileHelper).to receive(:safe_read)
-          .with('/proc/cmdline')
-          .and_return('')
-      end
-
-      it 'returns device as nil' do
-        result = resolver.resolve(:mountpoints)
-        expect(result.first[:device]).to be(nil)
-      end
-    end
+    result = resolver.resolve(:mountpoints)
+    expect(result).not_to include(hash_including(path: '/home/user'))
   end
 
   describe 'resolver key not found' do


### PR DESCRIPTION
Rework resolver based on the implementation from Facter 3, and make the fact use the Solaris resolver instead of the base one.

In addition to skipping `autofs` mounts, also skip filesystems mounted under mountpoints of type `auto_home`.

Update the tests with the new behavior, and stub mountpoints with data from an actual Solaris system.