### PR TITLE
(FACT-2988) Only query cloud provider on HyperV

### DIFF
--- a/lib/facter/facts/linux/cloud/provider.rb
+++ b/lib/facter/facts/linux/cloud/provider.rb
@@ -6,10 +6,17 @@ module Facts
       class Provider
         FACT_NAME = 'cloud.provider'
 
-        def call_the_resolver
-          az_metadata = Facter::Resolvers::Az.resolve(:metadata)
+        def initialize
+          @virtual = Facter::Util::Facts::VirtualDetector.new
+        end
 
-          Facter::ResolvedFact.new(FACT_NAME, az_metadata&.empty? ? nil : 'azure')
+        def call_the_resolver
+          provider = case @virtual.platform
+                     when 'hyperv'
+                       'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
+                     end
+
+          Facter::ResolvedFact.new(FACT_NAME, provider)
         end
       end
     end

--- a/lib/facter/facts/windows/az_metadata.rb
+++ b/lib/facter/facts/windows/az_metadata.rb
@@ -5,10 +5,6 @@ module Facts
     class AzMetadata
       FACT_NAME = 'az_metadata'
 
-      def initialize
-        @virtual = Facter::Util::Facts::VirtualDetector.new
-      end
-
       def call_the_resolver
         return Facter::ResolvedFact.new(FACT_NAME, nil) unless azure_hypervisor?
 
@@ -20,7 +16,7 @@ module Facts
       private
 
       def azure_hypervisor?
-        @virtual.platform == 'hyperv'
+        Facter::Resolvers::Virtualization.resolve(:virtual) == 'hyperv'
       end
     end
   end

--- a/lib/facter/facts/windows/cloud/provider.rb
+++ b/lib/facter/facts/windows/cloud/provider.rb
@@ -6,10 +6,17 @@ module Facts
       class Provider
         FACT_NAME = 'cloud.provider'
 
-        def call_the_resolver
-          az_metadata = Facter::Resolvers::Az.resolve(:metadata)
+        def initialize
+          @virtual = Facter::Util::Facts::VirtualDetector.new
+        end
 
-          Facter::ResolvedFact.new(FACT_NAME, az_metadata&.empty? ? nil : 'azure')
+        def call_the_resolver
+          provider = case @virtual.platform
+                     when 'hyperv'
+                       'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
+                     end
+
+          Facter::ResolvedFact.new(FACT_NAME, provider)
         end
       end
     end

--- a/lib/facter/facts/windows/cloud/provider.rb
+++ b/lib/facter/facts/windows/cloud/provider.rb
@@ -6,12 +6,9 @@ module Facts
       class Provider
         FACT_NAME = 'cloud.provider'
 
-        def initialize
-          @virtual = Facter::Util::Facts::VirtualDetector.new
-        end
-
         def call_the_resolver
-          provider = case @virtual.platform
+          virtual = Facter::Resolvers::Virtualization.resolve(:virtual)
+          provider = case virtual
                      when 'hyperv'
                        'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
                      end

--- a/lib/facter/util/resolvers/http.rb
+++ b/lib/facter/util/resolvers/http.rb
@@ -10,7 +10,7 @@ module Facter
           CONNECTION_TIMEOUT = 0.6
           SESSION_TIMEOUT = 5
 
-          # Makes a GET http request and returns it's response.
+          # Makes a GET http request and returns its response.
           #
           # Params:
           # url: String which contains the address to which the request will be made
@@ -39,6 +39,12 @@ module Facter
             uri = URI.parse(url)
             http = http_obj(uri, timeouts)
             request = request_obj(headers, uri, request_type)
+
+            # The Windows implementation of sockets does not respect net/http
+            # timeouts, so check if the target is reachable in a different way
+            if Gem.win_platform?
+              Socket.tcp(uri.host, uri.port, connect_timeout: timeouts[:connection] || CONNECTION_TIMEOUT)
+            end
 
             # Make the request
             response = http.request(request)

--- a/spec/facter/facts/linux/cloud/provider_spec.rb
+++ b/spec/facter/facts/linux/cloud/provider_spec.rb
@@ -4,25 +4,41 @@ describe Facts::Linux::Cloud::Provider do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::Cloud::Provider.new }
 
+    let(:virtual_detector) { instance_spy(Facter::Util::Facts::VirtualDetector) }
+
     before do
-      allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector)
     end
 
-    context 'when az_metadata exists' do
-      let(:value) do
-        {
-          'some' => 'fact'
-        }
+    context 'when on hyperv' do
+      before do
+        allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+        allow(virtual_detector).to receive(:platform).and_return('hyperv')
       end
 
-      it 'returns azure as cloud.provider' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'cloud.provider', value: 'azure')
+      context 'when az_metadata exists' do
+        let(:value) { { 'some' => 'fact' } }
+
+        it 'returns azure as cloud.provider' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: 'azure')
+        end
+      end
+
+      context 'when az_metadata does not exist' do
+        let(:value) { {} }
+
+        it 'returns nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: nil)
+        end
       end
     end
 
-    context 'when az_metadata does not exist' do
-      let(:value) { {} }
+    context 'when on a physical machine' do
+      before do
+        allow(virtual_detector).to receive(:platform).and_return(nil)
+      end
 
       it 'returns nil' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \

--- a/spec/facter/facts/windows/az_metadata_spec.rb
+++ b/spec/facter/facts/windows/az_metadata_spec.rb
@@ -4,10 +4,7 @@ describe Facts::Windows::AzMetadata do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Windows::AzMetadata.new }
 
-    let(:virtual_detector_double) { instance_spy(Facter::Util::Facts::VirtualDetector) }
-
     before do
-      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
       allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
     end
 
@@ -15,7 +12,7 @@ describe Facts::Windows::AzMetadata do
       let(:value) { nil }
 
       before do
-        allow(virtual_detector_double).to receive(:platform).and_return(nil)
+        allow(Facter::Resolvers::Virtualization).to receive(:resolve).with(:virtual).and_return(nil)
       end
 
       it 'returns az metadata fact as nil' do
@@ -33,7 +30,7 @@ describe Facts::Windows::AzMetadata do
       let(:value) { { 'info' => 'value' } }
 
       before do
-        allow(virtual_detector_double).to receive(:platform).and_return('hyperv')
+        allow(Facter::Resolvers::Virtualization).to receive(:resolve).with(:virtual).and_return('hyperv')
       end
 
       context 'when on Azure' do

--- a/spec/facter/facts/windows/cloud/provider_spec.rb
+++ b/spec/facter/facts/windows/cloud/provider_spec.rb
@@ -4,16 +4,10 @@ describe Facts::Windows::Cloud::Provider do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Windows::Cloud::Provider.new }
 
-    let(:virtual_detector) { instance_spy(Facter::Util::Facts::VirtualDetector) }
-
-    before do
-      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector)
-    end
-
     context 'when on hyperv' do
       before do
         allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
-        allow(virtual_detector).to receive(:platform).and_return('hyperv')
+        allow(Facter::Resolvers::Virtualization).to receive(:resolve).with(:virtual).and_return('hyperv')
       end
 
       context 'when az_metadata exists' do
@@ -37,7 +31,7 @@ describe Facts::Windows::Cloud::Provider do
 
     context 'when on a physical machine' do
       before do
-        allow(virtual_detector).to receive(:platform).and_return(nil)
+        allow(Facter::Resolvers::Virtualization).to receive(:resolve).with(:virtual).and_return(nil)
       end
 
       it 'returns nil' do

--- a/spec/facter/facts/windows/cloud/provider_spec.rb
+++ b/spec/facter/facts/windows/cloud/provider_spec.rb
@@ -4,25 +4,41 @@ describe Facts::Windows::Cloud::Provider do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Windows::Cloud::Provider.new }
 
+    let(:virtual_detector) { instance_spy(Facter::Util::Facts::VirtualDetector) }
+
     before do
-      allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector)
     end
 
-    context 'when az_metadata exists' do
-      let(:value) do
-        {
-          'some' => 'fact'
-        }
+    context 'when on hyperv' do
+      before do
+        allow(Facter::Resolvers::Az).to receive(:resolve).with(:metadata).and_return(value)
+        allow(virtual_detector).to receive(:platform).and_return('hyperv')
       end
 
-      it 'returns azure as cloud.provider' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-          have_attributes(name: 'cloud.provider', value: 'azure')
+      context 'when az_metadata exists' do
+        let(:value) { { 'some' => 'fact' } }
+
+        it 'returns azure as cloud.provider' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: 'azure')
+        end
+      end
+
+      context 'when az_metadata does not exist' do
+        let(:value) { {} }
+
+        it 'returns nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: nil)
+        end
       end
     end
 
-    context 'when az_metadata does not exist' do
-      let(:value) { {} }
+    context 'when on a physical machine' do
+      before do
+        allow(virtual_detector).to receive(:platform).and_return(nil)
+      end
 
       it 'returns nil' do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \


### PR DESCRIPTION
Due to some bug in Ruby/Windows, the Azure metadata fact takes 20+ seconds before timing out, regardless of the set timeout.

To fix this, only attempt to resolve Azure metadata if we're on HyperV.

Additionally, add a guard to the HTTP resolver to ensure long timeouts don't happen on Windows (the Linux implementation respects timeouts).