### PR TITLE
(FACT-2956) fix loading of env facts

### DIFF
--- a/acceptance/tests/api/value/env_fact.rb
+++ b/acceptance/tests/api/value/env_fact.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+test_name 'Facter.value(env_fact)' do
+  confine :to, platform: 'ubuntu'
+  tag 'audit:high'
+
+  require 'facter/acceptance/base_fact_utils'
+  require 'facter/acceptance/api_utils'
+  extend Facter::Acceptance::BaseFactUtils
+  extend Facter::Acceptance::ApiUtils
+
+  agents.each do |agent|
+    fact_name = 'env_fact'
+    fact_value = 'env_value'
+
+    step 'resolves the fact with the correct value' do
+      facter_rb = facter_value_rb(agent, fact_name)
+
+      env = { "FACTER_#{fact_name}" => fact_value }
+
+      on(agent, "#{ruby_command(agent)} #{facter_rb}", environment: env) do |result|
+        assert_match(fact_value, result.stdout.chomp, 'Incorrect fact value for env fact')
+      end
+    end
+  end
+end

--- a/acceptance/tests/env_fact.rb
+++ b/acceptance/tests/env_fact.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+test_name 'Can use environment facts' do
+  step 'FACTER_ env fact correctly is resolved' do
+    fact_name = 'env_name'
+    fact_value = 'env_value'
+
+    on(agent, facter(fact_name, environment: { "FACTER_#{fact_name}" => fact_value })) do |facter_output|
+      assert_equal(
+        fact_value,
+        facter_output.stdout.chomp,
+        'Expected `FACTER_` to be resolved from environment'
+      )
+    end
+  end
+end

--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -20,8 +20,8 @@ module Facter
 
     def load(options)
       @internal_facts = load_internal_facts(options)
-      @external_facts = load_external_facts(options)
       @custom_facts = load_custom_facts(options)
+      @external_facts = load_external_facts(options)
 
       filter_env_facts
 


### PR DESCRIPTION
https://github.com/puppetlabs/facter/pull/2306 changed
the order of fact loading when all facts are loaded,
which made environment facts not to be loaded anymore
if there is no other fact already loaded with the
same name.

This commit changes back to the same order of loading
facts.