### PR TITLE
(FACT-2956) Don't filter out false core facts

### DIFF
--- a/lib/facter/framework/core/fact_manager.rb
+++ b/lib/facter/framework/core/fact_manager.rb
@@ -104,7 +104,7 @@ module Facter
       resolved_facts = override_core_facts(core_facts, resolved_facts)
       resolved_facts = resolved_facts.concat(cached_facts)
 
-      resolved_facts if resolved_facts.map(&:value).any?
+      resolved_facts unless resolved_facts.map(&:value).compact.empty?
     end
 
     def all_custom_facts


### PR DESCRIPTION
When a core fact is resolved, do not filter it out
if the resolved value is false.

Tested also with external facts, YAML(nil, null), python(False, None) and got the same results as cfacter.
