### PR TITLE
(FACT-2967) do not round mb values

### DIFF
--- a/lib/facter/resolvers/aix/ffi/ffi_helper.rb
+++ b/lib/facter/resolvers/aix/ffi/ffi_helper.rb
@@ -33,7 +33,7 @@ module Facter
 
           return if Libc.getkerninfo(KINFO_READ | KINFO_GET_AVENRUN, averages, averages_size, 0).negative?
 
-          averages.read_array_of_long_long(3).map { |x| (x / 65_536.0).round(5) }
+          averages.read_array_of_long_long(3).map { |x| (x / 65_536.0) }
         end
 
         def self.read_interfaces

--- a/lib/facter/util/facts/unit_converter.rb
+++ b/lib/facter/util/facts/unit_converter.rb
@@ -10,7 +10,7 @@ module Facter
 
             value_in_bytes = value_in_bytes.to_i
 
-            (value_in_bytes / (1024.0 * 1024.0)).round(2)
+            (value_in_bytes / (1024.0 * 1024.0))
           end
 
           def hertz_to_human_readable(speed)

--- a/spec/facter/facts/aix/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/swap/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::Swap::AvailableBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/swap/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::Swap::TotalBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.224921226501465 }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/system/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::System::AvailableBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/aix/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/aix/memory/system/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Aix::Memory::System::TotalBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.224921226501465 }
 
     before do
       allow(Facter::Resolvers::Aix::Memory).to \

--- a/spec/facter/facts/linux/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/swap/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::Swap::AvailableBytes do
     subject(:fact) { Facts::Linux::Memory::Swap::AvailableBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/linux/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/swap/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::Swap::TotalBytes do
     subject(:fact) { Facts::Linux::Memory::Swap::TotalBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/linux/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/system/available_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::System::AvailableBytes do
     subject(:fact) { Facts::Linux::Memory::System::AvailableBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/linux/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/linux/memory/system/total_bytes_spec.rb
@@ -5,7 +5,7 @@ describe Facts::Linux::Memory::System::TotalBytes do
     subject(:fact) { Facts::Linux::Memory::System::TotalBytes.new }
 
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Linux::Memory).to \

--- a/spec/facter/facts/solaris/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/swap/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::Swap::AvailableBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/swap/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::Swap::TotalBytes do
 
     let(:value) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:result) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.224921226501465 }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/system/available_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::System::AvailableBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_425 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.2243738174438477 }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/solaris/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/solaris/memory/system/total_bytes_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Solaris::Memory::System::TotalBytes do
 
     let(:resolver_output) { { available_bytes: 2_332_425, total_bytes: 2_332_999, used_bytes: 1024 } }
     let(:value) { 2_332_999 }
-    let(:value_mb) { 2.22 }
+    let(:value_mb) { 2.224921226501465 }
 
     before do
       allow(Facter::Resolvers::Solaris::Memory).to \

--- a/spec/facter/facts/windows/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/windows/memory/system/available_bytes_spec.rb
@@ -9,7 +9,7 @@ describe Facts::Windows::Memory::System::AvailableBytes do
 
   describe '#call_the_resolver' do
     let(:value) { 3_331_551_232 }
-    let(:value_mb) { 3177.21 }
+    let(:value_mb) { 3177.21484375 }
 
     it 'calls Facter::Resolvers::Memory' do
       expect(Facter::Resolvers::Memory).to receive(:resolve).with(:available_bytes)

--- a/spec/facter/facts/windows/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/windows/memory/system/total_bytes_spec.rb
@@ -9,7 +9,7 @@ describe Facts::Windows::Memory::System::TotalBytes do
 
   describe '#call_the_resolver' do
     let(:value) { 3_331_551_232 }
-    let(:value_mb) { 3177.21 }
+    let(:value_mb) { 3177.21484375 }
 
     it 'calls Facter::Resolvers::Memory' do
       expect(Facter::Resolvers::Memory).to receive(:resolve).with(:total_bytes)

--- a/spec/facter/util/facts/unit_converter_spec.rb
+++ b/spec/facter/util/facts/unit_converter_spec.rb
@@ -5,7 +5,7 @@ describe Facter::Util::Facts::UnitConverter do
 
   describe '#bytes_to_mb' do
     it 'converts bytes to mega bytes' do
-      expect(converter.bytes_to_mb(256_586_343)).to eq(244.7)
+      expect(converter.bytes_to_mb(256_586_343)).to eq(244.6998052597046)
     end
 
     it 'returns nil if value is nil' do
@@ -13,7 +13,7 @@ describe Facter::Util::Facts::UnitConverter do
     end
 
     it 'converts bytes if value is string' do
-      expect(converter.bytes_to_mb('2343455')).to eq(2.23)
+      expect(converter.bytes_to_mb('2343455')).to eq(2.2348928451538086)
     end
 
     it 'returns 0 if value is 0' do


### PR DESCRIPTION
This PR updates the MB computation to not round values,
Facter 3 did not round MB values:
```
puppet facts | grep memorysize_mb
    "memorysize_mb": 7813.8515625,
```
Before this change, Facter 4 rounded the value:
```
 puppet facts --facterng | grep memorysize_mb
    "memorysize_mb": 7813.85,
```
After this change Facter 4 reports the same value as Facter 3:
```
puppet facts --facterng | grep memorysize_mb
    "memorysize_mb": 7813.8515625,
```

AIX Load averages:
Before this fix:
```
/opt/puppetlabs/bin/puppet facts --facterng | grep 1m
      "1m": 0.61617,
```

Facter 3 reports:
```
/opt/puppetlabs/bin/puppet facts | grep 1m
      "1m": 1.4964447021484375,
```

After this fix, Facter 4 reports:
```
 /opt/puppetlabs/bin/puppet facts --facterng | grep 1m
      "1m": 1.4051361083984375,
```