### PR TITLE
(FACT-2966) Fix padding in Windows uptime fact

### DIFF
--- a/spec/facter/resolvers/windows/uptime_spec.rb
+++ b/spec/facter/resolvers/windows/uptime_spec.rb
@@ -17,180 +17,182 @@ describe Facter::Resolvers::Windows::Uptime do
     Facter::Resolvers::Windows::Uptime.invalidate_cache
   end
 
-  describe '#resolve system_uptime when system is up for 1 hour' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010203040506+0700' }
-    let(:last_bootup_time) { '20010203030506+0700' }
+  describe '#resolve' do
+    context 'when system is up for 1 hour' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010203040506+0700' }
+      let(:last_bootup_time) { '20010203030506+0700' }
 
-    it 'resolves uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:0 hours')
+      it 'resolves uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:00 hours')
+      end
+
+      it 'resolves seconds' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(3600)
+      end
+
+      it 'resolves hours' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
+      end
+
+      it 'resolves days' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
+      end
     end
 
-    it 'resolves seconds' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(3600)
+    context 'when system is up for 1 hour and 45 minutes' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010203045006+0700' }
+      let(:last_bootup_time) { '20010203030506+0700' }
+
+      it 'resolves uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:45 hours')
+      end
+
+      it 'resolves seconds' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(6300)
+      end
+
+      it 'resolves hours' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
+      end
+
+      it 'resolves days' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
+      end
     end
 
-    it 'resolves hours' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
+    context 'when system is up for 1 hour, 45 minutes and 20 seconds' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010203045026+0700' }
+      let(:last_bootup_time) { '20010203030506+0700' }
+
+      it 'resolves uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:45 hours')
+      end
+
+      it 'resolves seconds' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(6320)
+      end
+
+      it 'resolves hours' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
+      end
+
+      it 'resolves days' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
+      end
     end
 
-    it 'resolves days' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
-    end
-  end
+    context 'when system is up for 1 day' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010204040506+0700' }
+      let(:last_bootup_time) { '20010203040506+0700' }
 
-  describe '#resolve system_uptime when system is up for 1 hour and 45 minutes' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010203045006+0700' }
-    let(:last_bootup_time) { '20010203030506+0700' }
+      it 'resolves uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(1)
+      end
 
-    it 'resolves uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:45 hours')
-    end
+      it 'resolves seconds' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(86_400)
+      end
 
-    it 'resolves seconds' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(6300)
-    end
+      it 'resolves hours' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(24)
+      end
 
-    it 'resolves hours' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
-    end
-
-    it 'resolves days' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
-    end
-  end
-
-  describe '#resolve system_uptime when system is up for 1 hour and 45 minutes and 20 sec' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010203045026+0700' }
-    let(:last_bootup_time) { '20010203030506+0700' }
-
-    it 'resolves uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1:45 hours')
+      it 'resolvese uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1 day')
+      end
     end
 
-    it 'resolves seconds' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(6320)
+    context 'when system is up for more than 1 day' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010204040506+0700' }
+      let(:last_bootup_time) { '20010201120506+0700' }
+
+      it 'resolves uptime days' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(2)
+      end
+
+      it 'resolves seconds' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(230_400)
+      end
+
+      it 'resolves hours' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(64)
+      end
+
+      it 'resolves total uptime' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('2 days')
+      end
     end
 
-    it 'resolves hours' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(1)
+    context 'when local time is behind last bootup time' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
+      let(:local_time) { '20010201110506+0700' }
+      let(:last_bootup_time) { '20010201120506+0700' }
+
+      before do
+        allow(logger).to receive(:debug).with('Unable to determine system uptime!')
+      end
+
+      it 'logs that is unable to determine system uptime and all facts are nil' do
+        Facter::Resolvers::Windows::Uptime.resolve(:days)
+
+        expect(logger).to have_received(:debug).with('Unable to determine system uptime!')
+      end
+
+      it 'uptime fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
+      end
     end
 
-    it 'resolves days' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(0)
-    end
-  end
+    context 'when WMI query returns nil' do
+      let(:comp) { nil }
 
-  describe '#resolve system_uptime when system is up for 1 day' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010204040506+0700' }
-    let(:last_bootup_time) { '20010203040506+0700' }
+      it 'logs that query failed and days nil' do
+        allow(logger).to receive(:debug)
+          .with('WMI query returned no results'\
+                'for Win32_OperatingSystem with values LocalDateTime and LastBootUpTime.')
+        allow(logger).to receive(:debug)
+          .with('Unable to determine system uptime!')
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
+      end
 
-    it 'resolves uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(1)
-    end
+      it 'detects uptime fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
+      end
 
-    it 'resolves seconds' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(86_400)
-    end
+      it 'detects uptime.seconds fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(nil)
+      end
 
-    it 'resolves hours' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(24)
-    end
-
-    it 'resolvese uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('1 day')
-    end
-  end
-
-  describe '#resolve system_uptime when system is up for more than 1 day' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010204040506+0700' }
-    let(:last_bootup_time) { '20010201120506+0700' }
-
-    it 'resolves uptime days' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(2)
+      it 'detects uptime.hours fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(nil)
+      end
     end
 
-    it 'resolves seconds' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(230_400)
-    end
+    context 'when WMI query returns nil for LocalDateTime and LastBootUpTime' do
+      let(:comp) { double('WIN32OLE', LocalDateTime: nil, LastBootUpTime: nil) }
 
-    it 'resolves hours' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(64)
-    end
+      it 'logs that is unable to determine system uptime and days fact is nil' do
+        allow(logger).to receive(:debug)
+          .with('Unable to determine system uptime!')
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
+      end
 
-    it 'resolves total uptime' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to eql('2 days')
-    end
-  end
+      it 'detects uptime fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
+      end
 
-  describe '#resolve system_uptime when local time is behind last bootup time' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: local_time, LastBootUpTime: last_bootup_time) }
-    let(:local_time) { '20010201110506+0700' }
-    let(:last_bootup_time) { '20010201120506+0700' }
+      it 'detects uptime.seconds fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(nil)
+      end
 
-    before do
-      allow(logger).to receive(:debug).with('Unable to determine system uptime!')
-    end
-
-    it 'logs that is unable to determine system uptime and all facts are nil' do
-      Facter::Resolvers::Windows::Uptime.resolve(:days)
-
-      expect(logger).to have_received(:debug).with('Unable to determine system uptime!')
-    end
-
-    it 'uptime fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
-    end
-  end
-
-  describe '#resolve  when WMI query returns nil' do
-    let(:comp) { nil }
-
-    it 'logs that query failed and days nil' do
-      allow(logger).to receive(:debug)
-        .with('WMI query returned no results'\
-        'for Win32_OperatingSystem with values LocalDateTime and LastBootUpTime.')
-      allow(logger).to receive(:debug)
-        .with('Unable to determine system uptime!')
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
-    end
-
-    it 'detects uptime fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
-    end
-
-    it 'detects uptime.seconds fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(nil)
-    end
-
-    it 'detects uptime.hours fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(nil)
-    end
-  end
-
-  describe '#resolve  when WMI query returns nil for LocalDateTime and LastBootUpTIme' do
-    let(:comp) { double('WIN32OLE', LocalDateTime: nil, LastBootUpTime: nil) }
-
-    it 'logs that is unable to determine system uptime and days fact is nil' do
-      allow(logger).to receive(:debug)
-        .with('Unable to determine system uptime!')
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
-    end
-
-    it 'detects uptime fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:uptime)).to be(nil)
-    end
-
-    it 'detects uptime.seconds fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:seconds)).to be(nil)
-    end
-
-    it 'detects uptime.hours fact is nil' do
-      expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(nil)
+      it 'detects uptime.hours fact is nil' do
+        expect(Facter::Resolvers::Windows::Uptime.resolve(:hours)).to be(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
Fix incorrect padding in Windows uptime fact by using the UptimeHelper module. Fix a typo and use the safe navigation operator.

Update the specs with the new behavior, and separate the tested contexts.