### PR TITLE
(FACT-2965) Align value of the processors.speed fact with Facter 3 

### DIFF
--- a/lib/facter/util/facts/unit_converter.rb
+++ b/lib/facter/util/facts/unit_converter.rb
@@ -19,7 +19,7 @@ module Facter
 
             validated_speed, metric_prefix = determine_metric_prefix(speed)
 
-            format('%<displayed_speed>.2f', displayed_speed: validated_speed).to_s + ' ' + metric_prefix + 'Hz'
+            format('%<displayed_speed>.2f', displayed_speed: validated_speed.round(2)).to_s + ' ' + metric_prefix + 'Hz'
           end
 
           def bytes_to_human_readable(bytes)

--- a/spec/facter/util/facts/unit_converter_spec.rb
+++ b/spec/facter/util/facts/unit_converter_spec.rb
@@ -45,6 +45,18 @@ describe Facter::Util::Facts::UnitConverter do
     it 'converts to Hz even if argument is string' do
       expect(converter.hertz_to_human_readable('2400')).to eql('2.40 kHz')
     end
+
+    it 'rounds down when 3rd decimal is lower than 5' do
+      expect(converter.hertz_to_human_readable(2_363_000_000)).to eql('2.36 GHz')
+    end
+
+    it 'rounds up when 3rd decimal is equal with 5' do
+      expect(converter.hertz_to_human_readable(2_365_000_000)).to eql('2.37 GHz')
+    end
+
+    it 'rounds up when 3rd decimal is greater than 5' do
+      expect(converter.hertz_to_human_readable(2_367_000_000)).to eql('2.37 GHz')
+    end
   end
 
   describe '#bytes_to_human_readable' do


### PR DESCRIPTION
Fix Facter 4 outputting processors.speed fact differently on AIX by rounding up the value before formatting.

Before the fix Facter 4 and Facter 3 had different output:
```
"processors.speed": {
  "new_value" : "3.42 GHz",
  "old_value" : "3.43 GHz"
}
```
After the fix Facter 4 and Facter 3 have the same output:
```
"processors.speed": {
  "new_value" : "3.43 GHz",
  "old_value" : "3.43 GHz"
}
```
