### PR TITLE
(FACT-2986) Fix virtual fact on Amazon 6

### DIFF
--- a/lib/facter/resolvers/dmi_decode.rb
+++ b/lib/facter/resolvers/dmi_decode.rb
@@ -37,7 +37,6 @@ module Facter
           @fact_list[:virtualbox_version] = output.match(/vboxVer_(\S+)/)&.captures&.first
           @fact_list[:virtualbox_revision] = output.match(/vboxRev_(\S+)/)&.captures&.first
           @fact_list[:vmware_version] = extract_vmware_version(output)
-          @fact_list[:vendor] = output.match(/Vendor: (\S+)/)&.captures&.first
 
           @fact_list[fact_name]
         end

--- a/lib/facter/util/facts/virtual_detector.rb
+++ b/lib/facter/util/facts/virtual_detector.rb
@@ -9,7 +9,7 @@ module Facter
         end
 
         def platform
-          fact_value = check_docker_lxc || check_dmi || check_freebsd || check_gce || retrieve_from_virt_what
+          fact_value = check_docker_lxc || check_freebsd || check_gce || retrieve_from_virt_what
           fact_value ||= check_vmware || check_open_vz || check_vserver || check_xen || check_other_facts
           fact_value ||= check_lspci || 'physical'
 
@@ -19,15 +19,6 @@ module Facter
         def check_docker_lxc
           @log.debug('Checking Docker and LXC')
           Facter::Resolvers::Containers.resolve(:vm)
-        end
-
-        def check_dmi
-          @log.debug('Checking DMI')
-          vendor = Facter::Resolvers::DmiDecode.resolve(:vendor)
-          @log.debug("dmi detected vendor: #{vendor}")
-          return 'kvm' if vendor =~ /Amazon/
-
-          'xen' if vendor =~ /Xen/
         end
 
         def check_gce

--- a/spec/facter/util/facts/virtual_detector_spec.rb
+++ b/spec/facter/util/facts/virtual_detector_spec.rb
@@ -27,54 +27,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when detecting with dmidecore' do
-      before do
-        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-      end
-
-      context 'when on Amazon' do
-        let(:platform) { 'Amazon' }
-
-        before do
-          allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(platform)
-        end
-
-        it 'calls Facter::Resolvers::DmiDecode' do
-          detector.platform
-
-          expect(Facter::Resolvers::DmiDecode).to have_received(:resolve).with(:vendor)
-        end
-
-        it 'returns vendor' do
-          expect(detector.platform).to eq('kvm')
-        end
-      end
-
-      context 'when on XEN' do
-        let(:platform) { 'Xen' }
-
-        before do
-          allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(platform)
-        end
-
-        it 'calls Facter::Resolvers::DmiDecode' do
-          detector.platform
-
-          expect(Facter::Resolvers::DmiDecode).to have_received(:resolve).with(:vendor)
-        end
-
-        it 'returns vendor' do
-          expect(detector.platform).to eq('xen')
-        end
-      end
-    end
-
-    context 'when is FreeBSD' do
+    context 'when FreeBSD' do
       let(:value) { 'jail' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return('jail')
       end
 
@@ -89,12 +46,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is gce' do
+    context 'when gce' do
       let(:value) { 'gce' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('Google Engine')
       end
@@ -110,12 +66,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is xen-hvm' do
+    context 'when xen-hvm' do
       let(:value) { 'xenhvm' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(value)
@@ -132,12 +87,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is vmware' do
+    context 'when vmware' do
       let(:value) { 'vmware_fusion' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
@@ -155,12 +109,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is openVz' do
+    context 'when openVz' do
       let(:value) { 'openvzve' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
@@ -179,12 +132,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is vserver' do
+    context 'when vserver' do
       let(:value) { 'vserver_host' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
@@ -204,12 +156,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is xen priviledged' do
+    context 'when xen' do
       let(:value) { 'xen0' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
@@ -230,12 +181,11 @@ describe Facter::Util::Facts::VirtualDetector do
       end
     end
 
-    context 'when is bochs discovered with dmi product_name' do
+    context 'when bochs' do
       let(:value) { 'bochs' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -258,17 +208,16 @@ describe Facter::Util::Facts::VirtualDetector do
         expect(Facter::Resolvers::Linux::DmiBios).to have_received(:resolve).with(:product_name)
       end
 
-      it 'returns bosch' do
+      it 'returns bochs' do
         expect(detector.platform).to eq(value)
       end
     end
 
-    context 'when is hyper-v discovered with lspci' do
+    context 'when hyper-v' do
       let(:value) { 'hyperv' }
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -296,7 +245,6 @@ describe Facter::Util::Facts::VirtualDetector do
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
@@ -308,7 +256,7 @@ describe Facter::Util::Facts::VirtualDetector do
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
       end
 
-      it 'returns physiscal' do
+      it 'returns physical' do
         expect(detector.platform).to eq(vm)
       end
     end
@@ -318,7 +266,6 @@ describe Facter::Util::Facts::VirtualDetector do
 
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
-        allow(Facter::Resolvers::DmiDecode).to receive(:resolve).with(:vendor).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)


### PR DESCRIPTION
Due to the additional `check_dmi` method in the VirtualDetector module, Facter 4 would detect `xen` as hypervisor instead of `xenhvm` on Amazon 6.

This is because in Facter 3, there is no DMI check and virt-what has higher priority. In our case, the detection stops in the `check_dmi` method, which returns `xen` and is redundant, as the same functionality is implemented below in the `check_other_facts` method.

Additionally, the dmidecode resolver doesn't need to add a `vendor` fact, since the DmiBios resolver already makes it available through the `bios_vendor` key. So, remove the key from dmidecode, and remove the `check_dmi` method from VirtualDetector.

The tests were also broken in the `xen-hvm` case, since they were stubbing the call to `DmiDecode.resolve` to return nil, which in reality returned 'Xen'. Remove the extra tests and fix some typos.

We should rework these tests with some real life scenarios if possible, as overstubbing can lead to scenarios like this.