### PR TITLE
(FACT-2997) continue searching when cannot load ffi

### DIFF
--- a/lib/facter/resolvers/linux/hostname.rb
+++ b/lib/facter/resolvers/linux/hostname.rb
@@ -37,15 +37,20 @@ module Facter
           end
 
           def retrieving_hostname
-            output = Socket.gethostname
-            if !output || output.empty? || output['0.0.0.0']
-              require 'facter/util/resolvers/ffi/hostname'
+            output = Socket.gethostname || ''
+            if output.empty? || output['0.0.0.0']
+              begin
+                require 'facter/util/resolvers/ffi/hostname'
 
-              output = Facter::Util::Resolvers::Ffi::Hostname.getffihostname
+                output = Facter::Util::Resolvers::Ffi::Hostname.getffihostname
+              rescue LoadError => e
+                log.debug(e.message)
+                output = nil
+              end
             end
 
             log.debug("Tried to retrieve hostname and got: #{output}")
-            output && !output.empty? ? output : nil
+            return output unless output&.empty?
           end
 
           def parse_fqdn(output)
@@ -76,6 +81,9 @@ module Facter
             fqdn = Facter::Util::Resolvers::Ffi::Hostname.getffiaddrinfo(host)
             log.debug("FFI getaddrinfo was called and it retrieved: #{fqdn}")
             fqdn
+          rescue LoadError => e
+            log.debug(e.message)
+            nil
           end
 
           def exists_and_valid_fqdn?(fqdn, hostname)


### PR DESCRIPTION
When searching for domain and hostname, Facter should
not stop if it cannot load FFI, it must continue
with the other ways and try to resolve the facts.

Passing puppetserver-ca-cli build: https://travis-ci.com/github/gimmyxd/puppetserver-ca-cli/builds/221159922
```
D, [2021-03-25T09:46:31.943298 #4346] DEBUG -- : Facter::QueryParser - List of resolvable facts: [#<Facter::SearchedFact:0x0000000003a03a90 @name="hostname", @fact_class=Facts::Linux::Networking::Hostname, @filter_tokens=[], @user_query="hostname", @type=:legacy, @file=nil>]
D, [2021-03-25T09:46:31.943372 #4346] DEBUG -- : Facter::InternalFactManager - Resolving facts sequentially
D, [2021-03-25T09:46:31.943563 #4346] DEBUG -- : Facter::Resolvers::Linux::Hostname - Tried to retrieve hostname and got: travis-job-e4a3c195-48d0-4a51-ad89-4df0324c2932
D, [2021-03-25T09:46:31.943610 #4346] DEBUG -- : Facter::Resolvers::Linux::Hostname - Only managed to read hostname: travis-job-e4a3c195-48d0-4a51-ad89-4df0324c2932, no domain was found.
D, [2021-03-25T09:46:31.944771 #4346] DEBUG -- : Facter::Resolvers::Linux::Hostname - cannot load such file -- ffi
D, [2021-03-25T09:46:31.944928 #4346] DEBUG -- : Facter::FactLoader - Loading external facts
D, [2021-03-25T09:46:31.945046 #4346] DEBUG -- : Facter::QueryParser - User query is: ["hostname"]
D, [2021-03-25T09:46:31.945076 #4346] DEBUG -- : Facter::QueryParser - Query is hostname
D, [2021-03-25T09:46:31.945098 #4346] DEBUG -- : Facter::QueryParser - Checking query tokens hostname
D, [2021-03-25T09:46:31.945116 #4346] DEBUG -- : Facter::QueryParser - List of resolvable facts: []
D, [2021-03-25T09:46:31.945163 #4346] DEBUG -- : Facter::FactManager - fact "hostname" has resolved to: travis-job-e4a3c195-48d0-4a51-ad89-4df0324c2932
D, [2021-03-25T09:46:31.945220 #4346] DEBUG -- : Facter::FactManager - resolving fact with user_query: domain
D, [2021-03-25T09:46:31.945301 #4346] DEBUG -- : Facter::FactManager - Searching fact: domain in file: domain.rb
D, [2021-03-25T09:46:31.946088 #4346] DEBUG -- : Facter::FactManager - Searching fact: domain in core facts and external facts
D, [2021-03-25T09:46:31.946124 #4346] DEBUG -- : Facter::FactLoader - Loading internal facts
D, [2021-03-25T09:46:31.946146 #4346] DEBUG -- : Facter::FactLoader - Loading all internal facts
D, [2021-03-25T09:46:31.946258 #4346] DEBUG -- : Facter::QueryParser - User query is: ["domain"]
D, [2021-03-25T09:46:31.946279 #4346] DEBUG -- : Facter::QueryParser - Query is domain
D, [2021-03-25T09:46:31.946332 #4346] DEBUG -- : Facter::QueryParser - Checking query tokens domain
D, [2021-03-25T09:46:31.947890 #4346] DEBUG -- : Facter::QueryParser - List of resolvable facts: [#<Facter::SearchedFact:0x0000000003988fe8 @name="domain", @fact_class=Facts::Linux::Networking::Domain, @filter_tokens=[], @user_query="domain", @type=:legacy, @file=nil>]
D, [2021-03-25T09:46:31.947947 #4346] DEBUG -- : Facter::InternalFactManager - Resolving facts sequentially
D, [2021-03-25T09:46:31.948011 #4346] DEBUG -- : Facter::FactLoader - Loading external facts
D, [2021-03-25T09:46:31.948045 #4346] DEBUG -- : Facter::QueryParser - User query is: ["domain"]
D, [2021-03-25T09:46:31.948070 #4346] DEBUG -- : Facter::QueryParser - Query is domain
D, [2021-03-25T09:46:31.948098 #4346] DEBUG -- : Facter::QueryParser - Checking query tokens domain
D, [2021-03-25T09:46:31.948121 #4346] DEBUG -- : Facter::QueryParser - List of resolvable facts: []
D, [2021-03-25T09:46:31.948163 #4346] DEBUG -- : Facter::FactManager - fact "domain" has resolved to: c.travis-ci-prod-3.internal
    logs success and returns zero if revoked and cleaned
```

Fixes the issues reported in: https://github.com/puppetlabs/puppetserver-ca-cli/pull/74