### PR TITLE
(FACT-2994) Check for config file when resolving selinux

### DIFF
--- a/spec/facter/resolvers/selinux_spec.rb
+++ b/spec/facter/resolvers/selinux_spec.rb
@@ -16,10 +16,10 @@ describe Facter::Resolvers::SELinux do
       .and_return(load_fixture(file).read)
   end
 
-  context 'when selinux is disabled' do
+  context 'when no selinuxfs is mounted' do
     let(:file) { 'proc_self_mounts' }
 
-    it 'returns false when selinux is not enabled' do
+    it 'returns enabled false' do
       expect(selinux_resolver.resolve(:enabled)).to be(false)
     end
 
@@ -28,81 +28,82 @@ describe Facter::Resolvers::SELinux do
     end
   end
 
-  context 'when selinux is enabled but selinux/config file does not exists' do
+  context 'when selinuxfs is mounted' do
     let(:file) { 'proc_self_mounts_selinux' }
 
-    before do
-      allow(Facter::Util::FileHelper).to receive(:safe_readlines).with('/etc/selinux/config').and_return([])
+    context 'when config file does not exist' do
+      before do
+        allow(Facter::Util::FileHelper).to receive(:safe_readlines).with('/etc/selinux/config').and_return([])
+      end
+
+      it 'sets enabled to false' do
+        expect(selinux_resolver.resolve(:enabled)).to be(false)
+      end
+
+      it 'returns nil for config_mode' do
+        expect(selinux_resolver.resolve(:config_mode)).to be(nil)
+      end
     end
 
-    it 'returns true when selinux is enabled' do
-      expect(selinux_resolver.resolve(:enabled)).to be(true)
-    end
+    context 'when config file exists' do
+      before do
+        allow(Facter::Util::FileHelper).to receive(:safe_readlines)
+          .with('/etc/selinux/config').and_return(load_fixture('selinux_config').readlines)
+      end
 
-    it 'returns nil for config_mode' do
-      expect(selinux_resolver.resolve(:config_mode)).to be(nil)
-    end
-  end
+      context 'when policyvers and enforce files are readable' do
+        before do
+          allow(Facter::Util::FileHelper).to receive(:safe_read)
+            .with('/sys/fs/selinux/policyvers', nil).and_return('31')
+          allow(Facter::Util::FileHelper).to receive(:safe_read)
+            .with('/sys/fs/selinux/enforce').and_return('1')
+        end
 
-  context 'when selinux is enabled and selinux/config file exists' do
-    let(:file) { 'proc_self_mounts_selinux' }
+        it 'returns enabled true' do
+          expect(selinux_resolver.resolve(:enabled)).to be(true)
+        end
 
-    before do
-      allow(Facter::Util::FileHelper).to receive(:safe_readlines)
-        .with('/etc/selinux/config').and_return(load_fixture('selinux_config').readlines)
-      allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/sys/fs/selinux/policyvers', nil).and_return('31')
-      allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/sys/fs/selinux/enforce').and_return('1')
-    end
+        it 'returns config_mode enabled' do
+          expect(selinux_resolver.resolve(:config_mode)).to eql('enabled')
+        end
 
-    it 'returns enabled true' do
-      expect(selinux_resolver.resolve(:enabled)).to be(true)
-    end
+        it 'returns config_policy targeted' do
+          expect(selinux_resolver.resolve(:config_policy)).to eql('targeted')
+        end
 
-    it 'returns config_mode enabled' do
-      expect(selinux_resolver.resolve(:config_mode)).to eql('enabled')
-    end
+        it 'returns policy_version 31' do
+          expect(selinux_resolver.resolve(:policy_version)).to eql('31')
+        end
 
-    it 'returns config_policy targeted' do
-      expect(selinux_resolver.resolve(:config_policy)).to eql('targeted')
-    end
+        it 'returns enforced true' do
+          expect(selinux_resolver.resolve(:enforced)).to be(true)
+        end
 
-    it 'returns policy_version 31' do
-      expect(selinux_resolver.resolve(:policy_version)).to eql('31')
-    end
+        it 'returns current_mode enforcing' do
+          expect(selinux_resolver.resolve(:current_mode)).to eql('enforcing')
+        end
+      end
 
-    it 'returns enforced true' do
-      expect(selinux_resolver.resolve(:enforced)).to be(true)
-    end
+      context 'when policyvers and enforce files are not readable' do
+        before do
+          allow(Facter::Util::FileHelper).to receive(:safe_read)
+            .with('/sys/fs/selinux/policyvers', nil).and_return(nil)
+          allow(Facter::Util::FileHelper).to receive(:safe_read)
+            .with('/sys/fs/selinux/enforce').and_return('')
+        end
 
-    it 'returns current_mode enforcing' do
-      expect(selinux_resolver.resolve(:current_mode)).to eql('enforcing')
-    end
-  end
+        it 'returns no policy_version' do
+          expect(selinux_resolver.resolve(:policy_version)).to be(nil)
+        end
 
-  context 'when selinux is enabled but enforce and policyvers files are not readable' do
-    let(:file) { 'proc_self_mounts_selinux' }
+        it 'returns enforced false' do
+          expect(selinux_resolver.resolve(:enforced)).to be(false)
+        end
 
-    before do
-      allow(Facter::Util::FileHelper).to receive(:safe_readlines)
-        .with('/etc/selinux/config').and_return(load_fixture('selinux_config').read.split("\n"))
-      allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/sys/fs/selinux/policyvers', nil).and_return(nil)
-      allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/sys/fs/selinux/enforce').and_return('')
-    end
-
-    it 'returns no policy_version' do
-      expect(selinux_resolver.resolve(:policy_version)).to be(nil)
-    end
-
-    it 'returns enforced false' do
-      expect(selinux_resolver.resolve(:enforced)).to be(false)
-    end
-
-    it 'returns current_mode enforcing on permissive' do
-      expect(selinux_resolver.resolve(:current_mode)).to eql('permissive')
+        it 'returns current_mode enforcing on permissive' do
+          expect(selinux_resolver.resolve(:current_mode)).to eql('permissive')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Previously we considered `selinux.enabled` to be true just by checking for a `selinuxfs` mountpoint. Facter 3 also checks for the existence of the `/etc/selinux/config` file.

This commit aligns the behavior of Facter 4 with Facter 3, and rearranges the tests based on possible use cases.

Facter 3 commit: https://github.com/puppetlabs/facter/commit/125a79e4da408bb4d4a86ebb7dd71c0ca27e288f