### PR TITLE
(maint) cleanup tmp dirs and files

### DIFF
--- a/spec/custom_facts/puppetlabs_spec/files.rb
+++ b/spec/custom_facts/puppetlabs_spec/files.rb
@@ -20,8 +20,8 @@ module PuppetlabsSpec
     end
 
     def self.cleanup
-      global_tempfiles ||= []
-      while (path = global_tempfiles.pop)
+      @@global_tempfiles ||= []
+      while (path = @@global_tempfiles.pop)
         raise "Not deleting tmpfile #{path} outside regular tmpdir" unless in_tmp(path)
 
         begin
@@ -45,8 +45,8 @@ module PuppetlabsSpec
       source.close!
 
       # ...record it for cleanup,
-      global_tempfiles ||= []
-      global_tempfiles << File.expand_path(path)
+      @@global_tempfiles ||= []
+      @@global_tempfiles << File.expand_path(path)
 
       # ...and bam.
       path

--- a/spec/spec_helper_legacy.rb
+++ b/spec/spec_helper_legacy.rb
@@ -17,7 +17,12 @@ require "#{ROOT_DIR}/spec/custom_facts/puppetlabs_spec/files"
 # end
 
 RSpec.configure do |config|
-  # config.mock_with :mocha
+  config.extend PuppetlabsSpec::Files
+
+  # This will cleanup any files that were created with tmpdir or tmpfile
+  config.after do
+    PuppetlabsSpec::Files.cleanup
+  end
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
PuppetlabsSpec::Files can be used to create temporary
directories but rspec was not configured to also
clean the files after the tests are run.

This commit fixes the cleanup method and adds an
after hook to rspec in order to clean the temporary
files.
