### PR TITLE
(FACT-2983) Convert ldom facts to bool where possible

### DIFF
--- a/lib/facter/resolvers/solaris/ldom.rb
+++ b/lib/facter/resolvers/solaris/ldom.rb
@@ -43,7 +43,7 @@ module Facter
             return if output_hash.empty?
 
             VIRTINFO_MAPPING.each do |key, value|
-              @fact_list[key] = output_hash.dig(*value)&.strip
+              @fact_list[key] = Facter::Utils.try_to_bool(output_hash.dig(*value)&.strip)
             end
 
             @fact_list[fact_name]

--- a/lib/facter/util/utils.rb
+++ b/lib/facter/util/utils.rb
@@ -29,5 +29,16 @@ module Facter
         object
       end
     end
+
+    def self.try_to_bool(val)
+      case val.to_s
+      when 'true'
+        true
+      when 'false'
+        false
+      else
+        val
+      end
+    end
   end
 end

--- a/spec/facter/resolvers/solaris/ldom_spec.rb
+++ b/spec/facter/resolvers/solaris/ldom_spec.rb
@@ -37,19 +37,19 @@ describe Facter::Resolvers::Solaris::Ldom do
     end
 
     it 'parses role_control' do
-      expect(resolver.resolve(:role_control)).to eq('false')
+      expect(resolver.resolve(:role_control)).to eq(false)
     end
 
     it 'parses role_io' do
-      expect(resolver.resolve(:role_io)).to eq('false')
+      expect(resolver.resolve(:role_io)).to eq(false)
     end
 
     it 'parses role_root' do
-      expect(resolver.resolve(:role_root)).to eq('false')
+      expect(resolver.resolve(:role_root)).to eq(false)
     end
 
     it 'parses role_service' do
-      expect(resolver.resolve(:role_service)).to eq('false')
+      expect(resolver.resolve(:role_service)).to eq(false)
     end
   end
 

--- a/spec/framework/utils/utils_spec.rb
+++ b/spec/framework/utils/utils_spec.rb
@@ -4,9 +4,23 @@ describe Facter::Utils do
   let(:hash_to_change) { { this: { is: [{ 1 => 'test' }] } } }
   let(:result) { { 'this' => { 'is' => [{ '1' => 'test' }] } } }
 
-  describe '#deep_stringify_keys' do
-    it 'stringify keys in hash' do
+  describe '.deep_stringify_keys' do
+    it 'stringifies keys in hash' do
       expect(Facter::Utils.deep_stringify_keys(hash_to_change)).to eql(result)
+    end
+  end
+
+  describe '.try_to_bool' do
+    it 'converts to bool when truthy' do
+      expect(Facter::Utils.try_to_bool('true')).to be true
+    end
+
+    it 'converts to bool when falsey' do
+      expect(Facter::Utils.try_to_bool('false')).to be false
+    end
+
+    it 'leaves the string unchanged otherwise' do
+      expect(Facter::Utils.try_to_bool('something else')).to eql('something else')
     end
   end
 end


### PR DESCRIPTION
Facter 3 reports true/false LDOM facts as boolean instead of string.

This commit makes Facter 4 do the same if the fact value is 'true' or 'false'.