### PR TITLE
(FACT-2984) Align mount options fact on OSX with Facter 3

### DIFF
--- a/lib/facter/resolvers/macosx/mountpoints.rb
+++ b/lib/facter/resolvers/macosx/mountpoints.rb
@@ -21,7 +21,7 @@ module Facter
               device = fs.name
               filesystem = fs.mount_type
               path = fs.mount_point
-              options = fs.options.split(',').map(&:strip).map { |o| o == 'rootfs' ? 'root' : o }
+              options = read_options(fs.options)
 
               mounts[path] = read_stats(path).tap do |hash|
                 hash[:device] = device
@@ -52,6 +52,19 @@ module Facter
               available: Facter::Util::Facts::UnitConverter.bytes_to_human_readable(available_bytes),
               used: Facter::Util::Facts::UnitConverter.bytes_to_human_readable(used_bytes)
             }
+          end
+
+          def read_options(options)
+            options_map = {
+              'read-only' => 'readonly',
+              'asynchronous' => 'async',
+              'synchronous' => 'noasync',
+              'quotas' => 'quota',
+              'rootfs' => 'root',
+              'defwrite' => 'deferwrites'
+            }
+
+            options.split(',').map(&:strip).map { |o| options_map.key?(o) ? options_map[o] : o }
           end
         end
       end

--- a/spec/facter/resolvers/macosx/mountpoints_spec.rb
+++ b/spec/facter/resolvers/macosx/mountpoints_spec.rb
@@ -9,8 +9,8 @@ describe Facter::Resolvers::Macosx::Mountpoints do
   end
 
   let(:mount) do
-    double(Sys::Filesystem::Mount, mount_type: 'ext4', mount_point: '/proc/a', options: 'rw', name: '/dev/nvme0n1p2',
-                                   dump_frequency: 0, pass_number: 0)
+    double(Sys::Filesystem::Mount, mount_type: 'ext4', mount_point: '/proc/a', options: mount_options,
+                                   name: '/dev/nvme0n1p2', dump_frequency: 0, pass_number: 0)
   end
 
   let(:stat) do
@@ -25,12 +25,15 @@ describe Facter::Resolvers::Macosx::Mountpoints do
                      capacity: '85.43%',
                      device: '/dev/nvme0n1p2',
                      filesystem: 'ext4',
-                     options: ['rw'],
+                     options: fact_options,
                      size: '434.42 GiB',
                      size_bytes: 466_449_743_872,
                      used: '371.10 GiB',
                      used_bytes: 398_470_057_984 } }
   end
+
+  let(:mount_options) { 'rw' }
+  let(:fact_options) { %w[rw] }
 
   before do
     allow(Facter::Util::Resolvers::FilesystemHelper).to receive(:read_mountpoints).and_return([mount])
@@ -51,8 +54,12 @@ describe Facter::Resolvers::Macosx::Mountpoints do
   end
 
   describe '.root_device' do
+    let(:mount_options) { 'rw,noatime' }
+    let(:fact_options) { %w[rw noatime] }
+
     let(:mount) do
-      double(Sys::Filesystem::Mount, mount_point: '/', mount_type: 'ext4', options: 'rw,noatime', name: '/dev/root')
+      double(Sys::Filesystem::Mount, mount_point: '/', mount_type: 'ext4', options: mount_options,
+                                     name: '/dev/root')
     end
 
     it 'looks up the actual device if /dev/root' do
@@ -61,13 +68,13 @@ describe Facter::Resolvers::Macosx::Mountpoints do
     end
 
     context 'when mountpoint cannot be accessed' do
-      let(:expected_fact) do
+      let(:fact) do
         { '/' => { available: '0 bytes',
                    available_bytes: 0,
                    capacity: '100%',
                    device: '/dev/root',
                    filesystem: 'ext4',
-                   options: %w[rw noatime],
+                   options: fact_options,
                    size: '0 bytes',
                    size_bytes: 0,
                    used: '0 bytes',
@@ -81,8 +88,28 @@ describe Facter::Resolvers::Macosx::Mountpoints do
 
       it 'fallbacks to default values' do
         result = Facter::Resolvers::Macosx::Mountpoints.resolve(:mountpoints)
-        expect(result).to eq(expected_fact)
+        expect(result).to eq(fact)
       end
     end
+  end
+
+  describe '.read_options' do
+    shared_examples_for 'a valid option' do |input, output|
+      let(:mount_options) { input }
+      let(:fact_options) { [output] }
+
+      it "transforms '#{input}' into '#{output}' to match Facter 3 output" do
+        result = Facter::Resolvers::Macosx::Mountpoints.resolve(:mountpoints)
+        expect(result).to match(fact)
+      end
+    end
+
+    it_behaves_like 'a valid option', 'read-only', 'readonly'
+    it_behaves_like 'a valid option', 'asynchronous', 'async'
+    it_behaves_like 'a valid option', 'synchronous', 'noasync'
+    it_behaves_like 'a valid option', 'quotas', 'quota'
+    it_behaves_like 'a valid option', 'rootfs', 'root'
+    it_behaves_like 'a valid option', 'defwrite', 'deferwrites'
+    it_behaves_like 'a valid option', 'nodev', 'nodev'
   end
 end


### PR DESCRIPTION
This commit adds partial remapping of mountpoints options to match with Facter 3 output.
Before:
```ruby
OPT_NAMES[MNT_RDONLY]      = 'read-only'
OPT_NAMES[MNT_ASYNC]       = 'asynchronous'
OPT_NAMES[MNT_SYNCHRONOUS] = 'synchronous'
OPT_NAMES[MNT_QUOTA]       = 'quotas'
OPT_NAMES[MNT_ROOTFS]      = 'rootfs'
OPT_NAMES[MNT_DEFWRITE]    = 'defwrite'
```
After:
```ruby
OPT_NAMES[MNT_RDONLY]      = 'readonly'
OPT_NAMES[MNT_ASYNC]       = 'async'
OPT_NAMES[MNT_SYNCHRONOUS] = 'noasync'
OPT_NAMES[MNT_QUOTA]       = 'quota'
OPT_NAMES[MNT_ROOTFS]      = 'root'
OPT_NAMES[MNT_DEFWRITE]    = 'deferwrites'
```

See https://github.com/puppetlabs/facter/blob/3.x/lib/src/facts/bsd/filesystem_resolver.cc#L55-L76 and https://github.com/djberg96/sys-filesystem/blob/9880f127465e680534263ec0de078179d73ef18b/lib/sys/unix/sys/filesystem.rb#L16-L35 for comparisson.