### PR TITLE
(FACT-2999) Handle unexpected JRuby behavior

### DIFF
--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -94,11 +94,15 @@ module Facter
             end
             log_stderr(stderr, command, logger)
           rescue StandardError => e
-            return '' if logger
+            message = "Failed while executing '#{command}': #{e.message}"
+            if logger
+              @log.debug(message)
+              return ''
+            end
+
             return on_fail unless on_fail == :raise
 
-            raise Facter::Core::Execution::ExecutionFailure.new,
-                  "Failed while executing '#{command}': #{e.message}"
+            raise Facter::Core::Execution::ExecutionFailure.new, message
           end
 
           [out.strip, stderr]


### PR DESCRIPTION
In some cases, JRuby can fail the first time it executes an external command. In our case, this happens through the `Facter::Core::Execution` module, where `Process.wait` fails in the underlying call to popen3.

The exception raised is `Errno::ENOENT` which is unexpected for waitpid, this has been traced to a JRuby issue that is still unresolved[1].

We found that even if ENOENT is raised, the output still gets filled in, so as a workaround it's enough to continue the execution if this specific exception is raised and we're running under JRuby.

Other exception types are re-raised, and the logging was improved to print a debug message in this case.

[1] https://github.com/jruby/jruby/issues/5971