### PR TITLE
(FACT-3000) allow segments wrapped in quotes

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -129,7 +129,7 @@ module Facter
       user_query = user_query.to_s
       resolved_facts = Facter::FactManager.instance.resolve_core([user_query])
       fact_collection = FactCollection.new.build_fact_collection!(resolved_facts)
-      splitted_user_query = Facter::Utils.split_user_query(user_query)
+      splitted_user_query = Facter::Framework::Lookup.split_key(user_query)
       fact_collection.dig(*splitted_user_query)
     end
 
@@ -551,7 +551,7 @@ module Facter
       # Nil facts should not be packaged as ResolvedFacts! (add_fact_to_searched_facts packages facts)
       resolved_facts = resolved_facts.reject { |fact| fact.type == :nil }
       fact_collection = FactCollection.new.build_fact_collection!(resolved_facts)
-      splitted_user_query = Facter::Utils.split_user_query(user_query)
+      splitted_user_query = Facter::Framework::Lookup.split_key(user_query)
 
       begin
         value = fact_collection.value(*splitted_user_query)

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -60,3 +60,4 @@ load_dir(%w[framework utils])
 
 require 'facter/framework/core/fact_augmenter'
 require 'facter/framework/parsers/query_parser'
+require 'facter/framework/lookup'

--- a/lib/facter/framework/formatters/formatter_helper.rb
+++ b/lib/facter/framework/formatters/formatter_helper.rb
@@ -8,7 +8,7 @@ module Facter
         user_queries.each do |user_query|
           fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
 
-          splitted_user_query = Utils.split_user_query(user_query)
+          splitted_user_query = Facter::Framework::Lookup.split_key(user_query)
           printable_value = fact_collection.dig(*splitted_user_query)
           facts_to_display.merge!(user_query => printable_value)
         end
@@ -24,7 +24,7 @@ module Facter
       def retrieve_fact_value_for_single_query(user_query, resolved_facts)
         fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
         fact_collection = Utils.sort_hash_by_key(fact_collection)
-        splitted_user_query = Utils.split_user_query(user_query)
+        splitted_user_query = Facter::Framework::Lookup.split_key(user_query)
         fact_collection.dig(*splitted_user_query)
       end
 

--- a/lib/facter/framework/formatters/legacy_fact_formatter.rb
+++ b/lib/facter/framework/formatters/legacy_fact_formatter.rb
@@ -15,7 +15,7 @@ module Facter
       user_query = user_queries.first
       return format_for_no_query(resolved_facts) if user_query.empty?
 
-      format_for_single_user_query(user_queries.first, resolved_facts)
+      format_for_single_user_query(user_query, resolved_facts)
     end
 
     private

--- a/lib/facter/framework/lookup.rb
+++ b/lib/facter/framework/lookup.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Facter
+  module Framework
+    module Lookup
+      class << self
+        SPECIAL = /['"\.]/.freeze
+        SEGMENTS_REGEX = /(\s*"[^"]+"\s*|\s*'[^']+'\s*|[^'".]+)/.freeze
+
+        # Split key into segments. A segment may be a quoted string (both single and double quotes can
+        # be used) and the segment separator is the '.' character. Whitespace will be trimmed off on
+        # both sides of each segment. Whitespace within quotes are not trimmed.
+        #
+        # If the key cannot be parsed, the inital key is returned
+        #
+        # Example:
+        # "a.b.c"     => ["a", "b", "c"]
+        # "a.\"b.c\"" => ["a", "b.c"]
+        # "a.\"b.c"   => ["a.\"b.c"]
+        # "\"a.b.c\"" => ["a.b.c"]
+        #
+        # @param key [String] the String to split
+        # @return [Array<String>] the Array of segments
+        def split_key(key)
+          return [key] unless key =~ SPECIAL
+
+          segments = key.split(SEGMENTS_REGEX)
+
+          # Only happens if the original key was an empty string
+          return [key] if segments.empty?
+
+          return [key] unless segments.shift == ''
+
+          count = segments.size
+          return [key] unless count.positive?
+
+          segments.keep_if { |seg| seg != '.' }
+          return [key] unless segments.size * 2 == count + 1
+
+          generate_segments!(segments)
+        end
+
+        # Joins an array of Strings using the '.' character. Wraps segments with qoutes
+        # Example:
+        # ["a", "b", "c"] => "a.b.c"
+        # ["a", "b.c"]    => "a.\"b.c\""
+        # ["a.\"b.c"]     => "a.\"b.c"
+        # ["a.b.c"]       => "\"a.b.c\""
+        #
+        # @param arr [Array<String>] the Array of Strings
+        # @return [String] the joined String
+        def join_keys(arr)
+          return arr[0] if arr.size == 1 && arr[0] !~ /^((\w+\.\w+)+(\.\w+)?)$/
+
+          arr.map do |el|
+            if el.instance_of?(String) && el.include?('.')
+              "\"#{el}\""
+            else
+              el
+            end
+          end.join('.')
+        end
+
+        private
+
+        def generate_segments!(arr)
+          arr.map! do |segment|
+            segment.strip!
+            if segment.start_with?('"', "'")
+              segment[1..-2]
+            elsif segment =~ /^(:?[+-]?[0-9]+)$/
+              segment.to_i
+            else
+              segment
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -49,7 +49,14 @@ module Facter
     end
 
     def extract_fact_name(fact)
-      fact.type == :legacy ? [fact.name] : fact.name.split('.')
+      case fact.type
+      when :legacy
+        [fact.name]
+      when :custom, :external
+        Facter::Framework::Lookup.split_key(fact.name)
+      else
+        fact.name.split('.')
+      end
     end
   end
 end

--- a/spec/facter/framework/lookup_spec.rb
+++ b/spec/facter/framework/lookup_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+describe Facter::Framework::Lookup do
+  describe '.split_key' do
+    subject(:split_key) { Facter::Framework::Lookup.split_key(key) }
+
+    context 'when key is nil' do
+      let(:key) { nil }
+
+      it { is_expected.to eql([nil]) }
+    end
+
+    context 'when key is empty string' do
+      let(:key) { '' }
+
+      it { is_expected.to eql(['']) }
+    end
+
+    context 'when key is simple string' do
+      let(:key) { 'abc' }
+
+      it { is_expected.to eql(['abc']) }
+    end
+
+    context 'when key is a number representation' do
+      let(:key) { '123' }
+
+      it { is_expected.to eql(['123']) }
+    end
+
+    context 'when key is simple string and quoted' do
+      let(:key) { '"abc"' }
+
+      it { is_expected.to eql(['abc']) }
+    end
+
+    context 'when key is special string and quoted' do
+      let(:key) { '"a.b.c"' }
+
+      it { is_expected.to eql(['a.b.c']) }
+    end
+
+    context 'when simple segment is quoted' do
+      let(:key) { 'a."b"' }
+
+      it { is_expected.to eql(%w[a b]) }
+    end
+
+    context 'when composed segment is quoted' do
+      let(:key) { 'a."b.c"' }
+
+      it { is_expected.to eql(['a', 'b.c']) }
+    end
+
+    context 'when composed segment is quoted and has digits' do
+      let(:key) { 'a."1"' }
+
+      it { is_expected.to eql(%w[a 1]) }
+    end
+
+    context 'when key contains unbalanced quotes' do
+      let(:key) { 'a."b.c' }
+
+      it { is_expected.to eql(['a."b.c']) }
+    end
+
+    context 'when key contains unbalanced single quote' do
+      let(:key) { "a.b'.c" }
+
+      it { is_expected.to eql(["a.b'.c"]) }
+    end
+
+    context 'when key is special and contains unbalanced quote' do
+      let(:key) { 'a."b.c".d"' }
+
+      it { is_expected.to eql(['a."b.c".d"']) }
+    end
+
+    context 'when key is special but not all parts are valid segments' do
+      let(:key) { 'a.b."c.d""f.e"' }
+
+      it { is_expected.to eql(['a.b."c.d""f.e"']) }
+    end
+  end
+
+  describe '.join_keys' do
+    subject(:join_keys) { Facter::Framework::Lookup.join_keys(segments) }
+
+    context 'when segments are [nil]' do
+      let(:segments) { [nil] }
+
+      it { is_expected.to be(nil) }
+    end
+
+    context 'when segments are an empty string' do
+      let(:segments) { [''] }
+
+      it { is_expected.to eql('') }
+    end
+
+    context 'when segments are a simple string' do
+      let(:segments) { ['abc'] }
+
+      it { is_expected.to eql('abc') }
+    end
+
+    context 'when segments are a simple quoted string' do
+      let(:segments) { ['"abc"'] }
+
+      it { is_expected.to eql('"abc"') }
+    end
+
+    context 'when segments are a simple quoted number string' do
+      let(:segments) { ['123'] }
+
+      it { is_expected.to eql('123') }
+    end
+
+    context 'when segments are a special quoted string' do
+      let(:segments) { ['a.b.c'] }
+
+      it { is_expected.to eql('"a.b.c"') }
+    end
+
+    context 'when segments contain a quoted string' do
+      let(:segments) { %w[a b] }
+
+      it { is_expected.to eql('a.b') }
+    end
+
+    context 'when segments contain a composed string' do
+      let(:segments) { ['a', 'b.c'] }
+
+      it { is_expected.to eql('a."b.c"') }
+    end
+
+    context 'when segments contain a composed string with numbers' do
+      let(:segments) { ['a', 12, 13] }
+
+      it { is_expected.to eql('a.12.13') }
+    end
+
+    context 'when segments contain a unbalanced simple string' do
+      let(:segments) { ['a."b.c'] }
+
+      it { is_expected.to eql('a."b.c') }
+    end
+
+    context 'when segments contain a unbalanced special string' do
+      let(:segments) { ['a."b.c".d"'] }
+
+      it { is_expected.to eql('a."b.c".d"') }
+    end
+
+    context 'when segments contain a special string but not all parts are valid segments' do
+      let(:segments) { ['a.b."c.d""f.e"'] }
+
+      it { is_expected.to eql('a.b."c.d""f.e"') }
+    end
+  end
+end


### PR DESCRIPTION
```

Facter.add('"f.g.h"') do
  setcode { "no_space" }
end

# Facter 4 -> "f.g.h" -> { "f.g.h": "no_space" }  -> $facts["f.g.h"]

Facter.value('"f.g.h"')
 => "no_space"

❯ bx facter \"f.g.h\"
no_space								

-------------------------------------

Facter.add('m."n.p"') do
  setcode { "structured" }
end

# Facter 4 -> "m.\"n.p\"" -> { "m" => { "n.p": "structured" } }  -> $facts["m"]["n.p"]

❯ bx facter m
{
  n.p => "structured"
}

❯ bx facter m.n


❯ bx facter m.n.p


❯ bx facter m."n.p"


❯ bx facter 'm."n.p"'
structured
```