### PR TITLE
(FACT-3002) add option to sanitize fact name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Facter can be configured via a HOCON config file of the following format:
 global : {
     external-dir     : [ "path1", "path2" ],
     custom-dir       : [ "custom/path" ],
-    no-exernal-facts : false,
+    no-external-facts : false,
     no-custom-facts  : false,
     no-ruby          : false
 }

--- a/exe/facter.cc
+++ b/exe/facter.cc
@@ -266,7 +266,11 @@ int main(int argc, char **argv)
             blocklist.insert(facts_to_block.begin(), facts_to_block.end());
         }
         bool ignore_cache = vm.count("no-cache");
-        collection facts(blocklist, ttls, ignore_cache);
+        bool sanitize_fact_name = false;
+        if (vm.count("sanitize-fact-name")) {
+            sanitize_fact_name = vm["sanitize-fact-name"].as<bool>();
+        }
+        collection facts(blocklist, ttls, ignore_cache, sanitize_fact_name);
         facts.add_default_facts(ruby);
 
         if (ruby && !vm["no-custom-facts"].as<bool>()) {

--- a/lib/inc/facter/facts/collection.hpp
+++ b/lib/inc/facter/facts/collection.hpp
@@ -95,10 +95,11 @@ namespace facter { namespace facts {
          * @param ttls a map of resolver names to cache intervals (times-to-live)
          *        for the facts they resolve
          * @param ignore_cache true if the cache should not be consulted when resolving facts
+         * @param sanitize_fact_name true if the facts names shoule be sanitized before saving
          */
         collection(std::set<std::string> const& blocklist = std::set<std::string>(),
                    std::unordered_map<std::string, int64_t> const& ttls = std::unordered_map<std::string, int64_t>{},
-                   bool ignore_cache = false);
+                   bool ignore_cache = false, bool sanitize_fact_name = false);
 
         /**
          * Destructor for fact collection.
@@ -318,6 +319,13 @@ namespace facter { namespace facts {
          */
         std::map<std::string, std::vector<std::string>> get_external_facts_groups(std::vector<std::string> const& directories);
 
+        /**
+         *  Gets sanitize_fact_name flag value
+         *  @param directories The directories to search for external facts.  If empty, the default search paths will be used.
+         * @return true if facts names were sanitized, false otherwise
+         */
+        bool get_sanitize_fact_name();
+
      protected:
         /**
          *  Gets external fact directories for the current platform.
@@ -352,6 +360,7 @@ namespace facter { namespace facts {
         std::set<std::string> _blocklist;
         std::unordered_map<std::string, int64_t> _ttls;
         bool _ignore_cache;
+        bool _sanitize_fact_name;
     };
 
 }}  // namespace facter::facts

--- a/lib/inc/facter/util/string.hpp
+++ b/lib/inc/facter/util/string.hpp
@@ -70,11 +70,9 @@ namespace facter { namespace util {
     boost::optional<int> maybe_stoi(std::string const& str);
 
     /**
-     * Converts the given string to a sanitized string using the same algorithm
-     * as in puppet:
-https://github.com/puppetlabs/puppet/blob/85bd9ed07e3e6c956f1972624a50be914292e1ab/lib/puppet/pops/lookup/sub_lookup.rb#L6-L44
+     * If the string is fully surrounded in quotes/ticks, remove them
      * @param str The string to sanitize.
-     * @return Returns the sanitize string
+     * @return Returns the sanitized string
      */
     std::string sanitize_fact_name(std::string str);
 

--- a/lib/inc/facter/util/string.hpp
+++ b/lib/inc/facter/util/string.hpp
@@ -69,4 +69,14 @@ namespace facter { namespace util {
      */
     boost::optional<int> maybe_stoi(std::string const& str);
 
+    /**
+     * Converts the given string to a sanitized string using the same algorithm
+     * as in puppet:
+https://github.com/puppetlabs/puppet/blob/85bd9ed07e3e6c956f1972624a50be914292e1ab/lib/puppet/pops/lookup/sub_lookup.rb#L6-L44
+     * @param str The string to sanitize.
+     * @return Returns the sanitize string
+     */
+    std::string sanitize_fact_name(std::string str);
+
+
 }}  // namespace facter::util

--- a/lib/src/ruby/module.cc
+++ b/lib/src/ruby/module.cc
@@ -388,7 +388,8 @@ namespace facter { namespace ruby {
         if (vm.count(cached_custom_facts)) {
             auto facts_to_cache = vm[cached_custom_facts].as<vector<string>>();
             cached_custom_facts_list.insert(cached_custom_facts_list.end(), facts_to_cache.begin(), facts_to_cache.end());
-            if (_collection.get_sanitize_fact_name()) { // collection fact names were sanitized, we must sanitize also cached custom facts
+            if (_collection.get_sanitize_fact_name()) {
+                //  collection fact names were sanitized, we must sanitize also cached custom facts
                 std::transform(cached_custom_facts_list.begin(), cached_custom_facts_list.end(), cached_custom_facts_list.begin(),
                                [](string s) -> string { return (sanitize_fact_name(s)); });
             }

--- a/lib/src/util/config/config.cc
+++ b/lib/src/util/config/config.cc
@@ -51,6 +51,7 @@ namespace facter { namespace util { namespace config {
             ("external-dir", po::value<vector<string>>(), "A directory or list of directories to use for external facts.")
             ("no-custom-facts", po::value<bool>()->default_value(false), "Disables custom facts.")
             ("no-external-facts", po::value<bool>()->default_value(false), "Disables external facts.")
+            ("sanitize-fact-name", po::value<bool>()->default_value(false), "Sanitize fact name.")
             ("no-ruby", po::value<bool>()->default_value(false), "Disables loading Ruby, facts requiring Ruby, and custom facts.");
         return global_options;
     }

--- a/lib/src/util/string.cc
+++ b/lib/src/util/string.cc
@@ -179,38 +179,11 @@ namespace facter { namespace util {
     string trim(const string &s) { return ltrim(rtrim(s)); }
 
     string sanitize_fact_name(string name) {
-      const boost::regex SPECIAL(".*['\"\\.].*");
-      if (!boost::regex_match(name, SPECIAL)) {
+        if ((name[0] == '"' && name[name.length() - 1] == '"') ||
+            (name[0] == '\'' && name[name.length() - 1] == '\'')) {
+            name.erase(name.begin());    // Remove first char
+            name.erase(name.end() - 1);  // Remove last char
+        }
         return name;
-      }
-
-      const boost::regex DELIMITER(
-          "(\\s*\"[^\"]+\"\\s*|\\s*'[^']+'\\s*|[^.]+)");
-
-      ostringstream o_sanitized_name;
-      auto match_begin =
-          boost::sregex_iterator(name.begin(), name.end(), DELIMITER);
-      auto match_end = boost::sregex_iterator();
-
-      for (auto match_iter = match_begin; match_iter != match_end;
-           match_iter++) {
-        auto k = (*match_iter).str();
-        if (k == ".") {
-          continue;
-        }
-        k = trim(k);
-        if ((k[0] == '"' && k[k.length() - 1] == '"') ||
-            (k[0] == '\'' && k[k.length() - 1] == '\'')) {
-              k.erase(k.begin());    // Remove first char
-              k.erase(k.end() - 1);  // Remove last char
-        }
-
-        o_sanitized_name << k << ".";
-      }
-
-      auto sanitized_name = o_sanitized_name.str();
-      sanitized_name.erase(sanitized_name.end() - 1);
-
-      return sanitized_name;
     }
 }}  // namespace facter::util

--- a/lib/src/util/string.cc
+++ b/lib/src/util/string.cc
@@ -167,4 +167,50 @@ namespace facter { namespace util {
             return boost::optional<int>();
         }
     }
+
+    string ltrim(const string &s) {
+      return boost::regex_replace(s, boost::regex("^\\s+"), string(""));
+    }
+
+    string rtrim(const string &s) {
+      return boost::regex_replace(s, boost::regex("\\s+$"), string(""));
+    }
+
+    string trim(const string &s) { return ltrim(rtrim(s)); }
+
+    string sanitize_fact_name(string name) {
+      const boost::regex SPECIAL(".*['\"\\.].*");
+      if (!boost::regex_match(name, SPECIAL)) {
+        return name;
+      }
+
+      const boost::regex DELIMITER(
+          "(\\s*\"[^\"]+\"\\s*|\\s*'[^']+'\\s*|[^.]+)");
+
+      ostringstream o_sanitized_name;
+      auto match_begin =
+          boost::sregex_iterator(name.begin(), name.end(), DELIMITER);
+      auto match_end = boost::sregex_iterator();
+
+      for (auto match_iter = match_begin; match_iter != match_end;
+           match_iter++) {
+        auto k = (*match_iter).str();
+        if (k == ".") {
+          continue;
+        }
+        k = trim(k);
+        if ((k[0] == '"' && k[k.length() - 1] == '"') ||
+            (k[0] == '\'' && k[k.length() - 1] == '\'')) {
+              k.erase(k.begin());    // Remove first char
+              k.erase(k.end() - 1);  // Remove last char
+        }
+
+        o_sanitized_name << k << ".";
+      }
+
+      auto sanitized_name = o_sanitized_name.str();
+      sanitized_name.erase(sanitized_name.end() - 1);
+
+      return sanitized_name;
+    }
 }}  // namespace facter::util

--- a/lib/tests/util/string.cc
+++ b/lib/tests/util/string.cc
@@ -287,3 +287,42 @@ SCENARIO("converting strings to integers") {
         }
     }
 }
+
+
+SCENARIO("sanityzing fact names") {
+    GIVEN("an empty string") {
+        THEN("it should remain empty") {
+          REQUIRE(sanitize_fact_name("") == "");
+        }
+    }
+    GIVEN("a simple string") {
+        THEN("it should remain the same") {
+          REQUIRE(sanitize_fact_name("abc") == "abc");
+        }
+    }
+    GIVEN("a dotted string") {
+        THEN("it should remain the same") {
+          REQUIRE(sanitize_fact_name("a.b.c") == "a.b.c");
+        }
+    }
+    GIVEN("quotes protected facts in string") {
+        THEN("should remove quotes") {
+          REQUIRE(sanitize_fact_name("\"a.b\".c") == "a.b.c");
+        }
+    }
+    GIVEN("ticks protected facts in string") {
+        THEN("should remove ticks") {
+          REQUIRE(sanitize_fact_name("a.'b.c'") == "a.b.c");
+        }
+    }
+    GIVEN("unbalanced tick in string") {
+        THEN("should keep tick") {
+          REQUIRE(sanitize_fact_name("a.b'.c") == "a.b'.c");
+        }
+    }
+    GIVEN("unbalanced quote in string") {
+        THEN("should keep quote") {
+          REQUIRE(sanitize_fact_name("a.\"b.c") == "a.\"b.c");
+        }
+    }
+}

--- a/lib/tests/util/string.cc
+++ b/lib/tests/util/string.cc
@@ -306,23 +306,23 @@ SCENARIO("sanityzing fact names") {
         }
     }
     GIVEN("quotes protected facts in string") {
-        THEN("should remove quotes") {
-          REQUIRE(sanitize_fact_name("\"a.b\".c") == "a.b.c");
+        THEN("should remove quotes in fully quoted string") {
+          REQUIRE(sanitize_fact_name("\"a.b.c\"") == "a.b.c");
+        }
+    }
+    GIVEN("quotes protected facts in string") {
+        THEN("should not remove quotes in partial quoted string") {
+          REQUIRE(sanitize_fact_name("\"a.b\".c") == "\"a.b\".c");
         }
     }
     GIVEN("ticks protected facts in string") {
-        THEN("should remove ticks") {
-          REQUIRE(sanitize_fact_name("a.'b.c'") == "a.b.c");
+        THEN("should remove quotes in fully ticked string") {
+          REQUIRE(sanitize_fact_name("'a.b.c'") == "a.b.c");
         }
     }
-    GIVEN("unbalanced tick in string") {
-        THEN("should keep tick") {
-          REQUIRE(sanitize_fact_name("a.b'.c") == "a.b'.c");
-        }
-    }
-    GIVEN("unbalanced quote in string") {
-        THEN("should keep quote") {
-          REQUIRE(sanitize_fact_name("a.\"b.c") == "a.\"b.c");
+    GIVEN("ticks protected facts in string") {
+        THEN("should not remove quotes in partial ticked string") {
+          REQUIRE(sanitize_fact_name("a.'b.c'") == "a.'b.c'");
         }
     }
 }


### PR DESCRIPTION
To enable fact name sanitize option, add `sanitize-fact-name` to
`global` section and set it to `true`:
```
global : {
    sanitize-fact-name : true
}
```

The sanitize option will sanitize facts names containing `"` or ```
using the following algorithm:
 - name will be split in segments that either:
   - are quoted or ticked strings
   - are not containing `.`
 - segments are joined using `.` separator

This will happen just before fact is saved in the collection

