### PR TITLE
(FACT-2987) Align hypervisors.zone.id fact on Solaris with Facter 3

### DIFF
--- a/lib/facter/resolvers/solaris/zone.rb
+++ b/lib/facter/resolvers/solaris/zone.rb
@@ -32,13 +32,12 @@ module Facter
               id, name, status, path, uuid, brand, ip_type = zone_line.split(':')
               zones_fact << {
                 brand: brand,
-                id: id,
+                id: Facter::Utils.try_to_int(id),
                 iptype: ip_type.chomp,
                 name: name,
                 uuid: uuid,
                 status: status,
                 path: path
-
               }
             end
             zones_fact

--- a/lib/facter/util/utils.rb
+++ b/lib/facter/util/utils.rb
@@ -30,14 +30,14 @@ module Facter
       end
     end
 
-    def self.try_to_bool(val)
-      case val.to_s
+    def self.try_to_bool(value)
+      case value.to_s
       when 'true'
         true
       when 'false'
         false
       else
-        val
+        value
       end
     end
   end

--- a/lib/facter/util/utils.rb
+++ b/lib/facter/util/utils.rb
@@ -40,5 +40,11 @@ module Facter
         value
       end
     end
+
+    def self.try_to_int(value)
+      Integer(value)
+    rescue ArgumentError, TypeError
+      value
+    end
   end
 end

--- a/spec/facter/resolvers/solaris/zone_spec.rb
+++ b/spec/facter/resolvers/solaris/zone_spec.rb
@@ -20,7 +20,7 @@ describe Facter::Resolvers::Solaris::Zone do
     let(:output) { '0:global:running:/::solaris:shared:-:none:' }
     let(:zone) do
       [{ brand: 'solaris',
-         id: '0',
+         id: 0,
          iptype: 'shared',
          name: 'global',
          uuid: '',

--- a/spec/framework/utils/utils_spec.rb
+++ b/spec/framework/utils/utils_spec.rb
@@ -23,4 +23,50 @@ describe Facter::Utils do
       expect(Facter::Utils.try_to_bool('something else')).to eql('something else')
     end
   end
+
+  describe '.try_to_int' do
+    context 'when possible, converts to int' do
+      it 'leaves int as it is' do
+        expect(Facter::Utils.try_to_int(7)).to be(7)
+      end
+
+      it 'converts string int' do
+        expect(Facter::Utils.try_to_int('7')).to be(7)
+      end
+
+      it 'converts positive string int' do
+        expect(Facter::Utils.try_to_int('+7')).to be(7)
+      end
+
+      it 'converts negative string int' do
+        expect(Facter::Utils.try_to_int('-7')).to be(-7)
+      end
+
+      it 'converts float' do
+        expect(Facter::Utils.try_to_int(7.10)).to be(7)
+      end
+    end
+
+    context 'when not possible, does not convert to int' do
+      it 'does not convert non-numerical string' do
+        expect(Facter::Utils.try_to_int('string')).to be('string')
+      end
+
+      it 'does not convert partial string int' do
+        expect(Facter::Utils.try_to_int('7string')).to be('7string')
+      end
+
+      it 'does not convert boolean true' do
+        expect(Facter::Utils.try_to_int(true)).to be(true)
+      end
+
+      it 'does not convert boolean false' do
+        expect(Facter::Utils.try_to_int(false)).to be(false)
+      end
+
+      it 'does not convert string float' do
+        expect(Facter::Utils.try_to_int('7.10')).to be('7.10')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit converts the `hypervisors.zone.id` fact value into integer on Solaris (from string) to align with Facter 3 output.