### PR TITLE
(FACT-2946) Fix networking fact to discover interfaces with dot in name

### DIFF
--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -42,7 +42,7 @@ module Facter
 
         def parse_interfaces_response(response)
           parsed_interfaces_data = {}
-          interfaces_data = Hash[*response.split(/^([A-Za-z0-9_]+): /)[1..-1]]
+          interfaces_data = Hash[*response.split(/^([A-Za-z0-9_\.]+): /)[1..-1]]
 
           interfaces_data.each do |interface_name, raw_data|
             parsed_interface_data = {}

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -15,6 +15,8 @@ describe Facter::Resolvers::Networking do
       allow(Facter::Core::Execution)
         .to receive(:execute).with('ipconfig getoption en0 server_identifier', logger: log_spy).and_return(dhcp)
       allow(Facter::Core::Execution)
+        .to receive(:execute).with('ipconfig getoption en0.1 server_identifier', logger: log_spy).and_return(dhcp)
+      allow(Facter::Core::Execution)
         .to receive(:execute).with('ipconfig getoption llw0 server_identifier', logger: log_spy).and_return('')
       allow(Facter::Core::Execution)
         .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', logger: log_spy).and_return(dhcp)
@@ -25,7 +27,7 @@ describe Facter::Resolvers::Networking do
     end
 
     let(:interfaces) { load_fixture('ifconfig_mac').read }
-    let(:dhcp) { '192.168.143.1 ' }
+    let(:dhcp) { '192.168.143.1' }
     let(:primary) { 'en0' }
 
     it 'detects primary interface' do
@@ -37,7 +39,7 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'detects all interfaces' do
-      expected = %w[lo0 gif0 stf0 en0 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2]
+      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2]
       expect(networking.resolve(:interfaces).keys).to match_array(expected)
     end
 

--- a/spec/fixtures/ifconfig_mac
+++ b/spec/fixtures/ifconfig_mac
@@ -12,6 +12,15 @@ en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
 	inet 192.168.143.212 netmask 0xffffff00 broadcast 192.168.143.255
 	media: autoselect
 	status: active
+en0.1: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=3<RXCSUM,TXCSUM>
+	ether 08:00:27:f5:23:f7
+	inet 0.0.0.0 netmask 0xff000000 broadcast 255.255.255.255
+	groups: vlan
+	vlan: 1 vlanpcp: 0 parent interface: em0
+	media: autoselect
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
 en1: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
 	options=460<TSO4,TSO6,CHANNEL_IO>
 	ether 82:17:0e:93:9d:00 


### PR DESCRIPTION
Before this commit, VLAN interfaces with dot in their name (on operating systems such as FreeBSD) were not correctly displayed in the networking fact.

Confirmed behaviour on FreeBSD 12.2 with the following steps:
1. Initial interfaces:
```sh-session
➜ ifconfig -a
em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	options=81009b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM,VLAN_HWFILTER>
	ether 08:00:ff:11:20:ff
	inet 12.12.12.15 netmask 0xffffff00 broadcast 12.12.12.255
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
	options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
	inet 127.0.0.1 netmask 0xff000000
	groups: lo
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
```
2. Initial networking fact output:
```sh-session
➜ facter networking
{
  domain => "localdomain",
  fqdn => "freebsd12.localdomain",
  hostname => "freebsd12",
  interfaces => {
    em0 => {
      bindings => [
        {
          address => "12.12.12.15",
          netmask => "255.255.255.0",
          network => "12.12.12.0"
        }
      ],
      ip => "12.12.12.15",
      mac => "08:00:ff:11:20:ff",
      mtu => 1500,
      netmask => "255.255.255.0",
      network => "12.12.12.0"
    },
    lo0 => {
      bindings => [
        {
          address => "127.0.0.1",
          netmask => "255.0.0.0",
          network => "127.0.0.0"
        }
      ],
      bindings6 => [
        {
          address => "::1",
          netmask => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
          network => "::1",
          scope6 => "host"
        },
        {
          address => "fe80::1",
          netmask => "ffff:ffff:ffff:ffff::",
          network => "fe80::",
          scope6 => "link"
        }
      ],
      ip => "127.0.0.1",
      ip6 => "::1",
      mtu => 16384,
      netmask => "255.0.0.0",
      netmask6 => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
      network => "127.0.0.0",
      network6 => "::1",
      scope6 => "host"
    }
  },
  ip => "12.12.12.15",
  mac => "08:00:ff:11:20:ff",
  mtu => 1500,
  netmask => "255.255.255.0",
  network => "12.12.12.0",
  primary => "em0"
}
```
3. Created a new interface with dot in name:
```sh-session
➜ ifconfig em0.1 create
➜ ifconfig -a
em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	options=81009b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM,VLAN_HWFILTER>
	ether 08:00:ff:11:20:ff
	inet 12.12.12.15 netmask 0xffffff00 broadcast 12.12.12.255
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
	options=680003<RXCSUM,TXCSUM,LINKSTATE,RXCSUM_IPV6,TXCSUM_IPV6>
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
	inet 127.0.0.1 netmask 0xff000000
	groups: lo
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
em0.1: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	options=3<RXCSUM,TXCSUM>
	ether 08:00:ff:11:20:ff
	inet 0.0.0.0 netmask 0xff000000 broadcast 255.255.255.255
	groups: vlan
	vlan: 1 vlanpcp: 0 parent interface: em0
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
```
4. Facter output with the new interface (follow `0.0.0.0` to spot the differences between this and 5):
```sh-session
➜ facter networking
{
  domain => "localdomain",
  fqdn => "freebsd12.localdomain",
  hostname => "freebsd12",
  interfaces => {
    em0 => {
      bindings => [
        {
          address => "12.12.12.15",
          netmask => "255.255.255.0",
          network => "12.12.12.0"
        }
      ],
      ip => "12.12.12.15",
      mac => "08:00:ff:11:20:ff",
      mtu => 1500,
      netmask => "255.255.255.0",
      network => "12.12.12.0"
    },
    lo0 => {
      bindings => [
        {
          address => "127.0.0.1",
          netmask => "255.0.0.0",
          network => "127.0.0.0"
        },
        {
          address => "0.0.0.0",
          netmask => "255.0.0.0",
          network => "0.0.0.0"
        }
      ],
      bindings6 => [
        {
          address => "::1",
          netmask => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
          network => "::1",
          scope6 => "host"
        },
        {
          address => "fe80::1",
          netmask => "ffff:ffff:ffff:ffff::",
          network => "fe80::",
          scope6 => "link"
        }
      ],
      ip => "0.0.0.0",
      ip6 => "::1",
      mac => "08:00:ff:11:20:ff",
      mtu => 16384,
      netmask => "255.0.0.0",
      netmask6 => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
      network => "0.0.0.0",
      network6 => "::1",
      scope6 => "host"
    }
  },
  ip => "12.12.12.15",
  mac => "08:00:ff:11:20:ff",
  mtu => 1500,
  netmask => "255.255.255.0",
  network => "12.12.12.0",
  primary => "em0"
}
```
5. Output of networking fact with the fix:
```sh-session
➜ facter networking
{
  domain => "localdomain",
  fqdn => "freebsd12.localdomain",
  hostname => "freebsd12",
  interfaces => {
    em0 => {
      bindings => [
        {
          address => "12.12.12.15",
          netmask => "255.255.255.0",
          network => "12.12.12.0"
        }
      ],
      ip => "12.12.12.15",
      mac => "08:00:ff:11:20:ff",
      mtu => 1500,
      netmask => "255.255.255.0",
      network => "12.12.12.0"
    },
    em0.1 => {
      bindings => [
        {
          address => "0.0.0.0",
          netmask => "255.0.0.0",
          network => "0.0.0.0"
        }
      ],
      ip => "0.0.0.0",
      mac => "08:00:ff:11:20:ff",
      mtu => 1500,
      netmask => "255.0.0.0",
      network => "0.0.0.0"
    },
    lo0 => {
      bindings => [
        {
          address => "127.0.0.1",
          netmask => "255.0.0.0",
          network => "127.0.0.0"
        }
      ],
      bindings6 => [
        {
          address => "::1",
          netmask => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
          network => "::1",
          scope6 => "host"
        },
        {
          address => "fe80::1",
          netmask => "ffff:ffff:ffff:ffff::",
          network => "fe80::",
          scope6 => "link"
        }
      ],
      ip => "127.0.0.1",
      ip6 => "::1",
      mtu => 16384,
      netmask => "255.0.0.0",
      netmask6 => "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
      network => "127.0.0.0",
      network6 => "::1",
      scope6 => "host"
    }
  },
  ip => "12.12.12.15",
  mac => "08:00:ff:11:20:ff",
  mtu => 1500,
  netmask => "255.255.255.0",
  network => "12.12.12.0",
  primary => "em0"
}
```