### PR TITLE
(FACT-3004) Disable default auto-promotion of dotted facts

### DIFF
--- a/Extensibility.md
+++ b/Extensibility.md
@@ -91,3 +91,15 @@ Facter 4 supports all 4 forms of "external facts" which Facter 3 supports:
 * YAML files with the .yaml extension whose key-value pairs will be mapped to fact-value pairs.
 * Text files with the .txt extension containing `fact=some_value` strings
 * Executable files returning `fact=some_value` strings
+
+Enable auto promotion of dotted facts to structured
+---------------------------
+
+By default Facter 4 considers dots in fact names as normal characters.
+If you want to enable the new behavior, that promotes dotted facts to structured you need to set the following config:
+
+```
+global : {
+    autopromote-dotted-facts : true
+}
+```

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -551,10 +551,9 @@ module Facter
       # Nil facts should not be packaged as ResolvedFacts! (add_fact_to_searched_facts packages facts)
       resolved_facts = resolved_facts.reject { |fact| fact.type == :nil }
       fact_collection = FactCollection.new.build_fact_collection!(resolved_facts)
-      splitted_user_query = Facter::Utils.split_user_query(user_query)
 
       begin
-        value = fact_collection.value(*splitted_user_query)
+        value = fact_collection.value(user_query)
         add_fact_to_searched_facts(user_query, value)
       rescue KeyError
         nil

--- a/lib/facter/framework/core/options/config_file_options.rb
+++ b/lib/facter/framework/core/options/config_file_options.rb
@@ -18,6 +18,12 @@ module Facter
 
       private
 
+      def augment_structured_facts(global_conf)
+        return if !global_conf || global_conf['autopromote-dotted-facts'].nil?
+
+        @options[:autopromote_dotted_facts] = global_conf['autopromote-dotted-facts']
+      end
+
       def augment_all
         augment_cli(Facter::ConfigReader.cli) if Options.cli?
         augment_globals
@@ -27,6 +33,7 @@ module Facter
       def augment_globals
         augment_ruby(Facter::ConfigReader.global)
 
+        augment_structured_facts(Facter::ConfigReader.global)
         augment_custom(Facter::ConfigReader.global)
         augment_external(Facter::ConfigReader.global)
         augment_show_legacy(Facter::ConfigReader.global)

--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -35,6 +35,7 @@ module Facter
     @custom_dir = []
     @hocon = false
     @allow_external_loggers = true
+    @autopromote_dotted_facts = false
 
     class << self
       attr_reader :debug, :verbose, :log_level, :show_legacy,
@@ -42,7 +43,7 @@ module Facter
 
       attr_accessor :config, :strict, :json,
                     :cache, :yaml, :puppet, :ttls, :block, :cli, :config_file_custom_dir,
-                    :config_file_external_dir, :default_external_dir, :fact_groups,
+                    :config_file_external_dir, :default_external_dir, :fact_groups, :autopromote_dotted_facts,
                     :block_list, :color, :trace, :sequential, :timing, :hocon, :allow_external_loggers
 
       attr_writer :external_dir
@@ -202,6 +203,7 @@ module Facter
 
       def reset_facts
         @custom_facts = true
+        @autopromote_dotted_facts = false
         @external_dir = []
         @custom_dir = []
       end

--- a/lib/facter/framework/formatters/formatter_helper.rb
+++ b/lib/facter/framework/formatters/formatter_helper.rb
@@ -9,7 +9,7 @@ module Facter
           fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
 
           splitted_user_query = Utils.split_user_query(user_query)
-          printable_value = fact_collection.dig(*splitted_user_query)
+          printable_value = fact_collection.dig(*splitted_user_query) || fact_collection.dig(user_query)
           facts_to_display.merge!(user_query => printable_value)
         end
 
@@ -25,7 +25,7 @@ module Facter
         fact_collection = build_fact_collection_for_user_query(user_query, resolved_facts)
         fact_collection = Utils.sort_hash_by_key(fact_collection)
         splitted_user_query = Utils.split_user_query(user_query)
-        fact_collection.dig(*splitted_user_query)
+        fact_collection.dig(*splitted_user_query) || fact_collection.dig(user_query)
       end
 
       private

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -17,9 +17,12 @@ module Facter
       self
     end
 
-    def value(*keys)
-      keys.reduce(self) do |memo, key|
-        memo.fetch(key.to_s)
+    def value(user_query)
+      fetch(user_query) do
+        split_user_query = Facter::Utils.split_user_query(user_query)
+        split_user_query.reduce(self) do |memo, key|
+          memo.fetch(key.to_s)
+        end
       end
     end
 
@@ -49,7 +52,14 @@ module Facter
     end
 
     def extract_fact_name(fact)
-      fact.type == :legacy ? [fact.name] : fact.name.split('.')
+      case fact.type
+      when :legacy
+        [fact.name]
+      when :custom, :external
+        Options[:autopromote_dotted_facts] == true ? fact.name.split('.') : [fact.name]
+      else
+        fact.name.split('.')
+      end
     end
   end
 end

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -200,14 +200,14 @@ describe Facter do
   describe '#value' do
     it 'returns a value' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter.value('os.name')).to eq('Ubuntu')
     end
 
     it 'return no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return(nil)
 
       expect(Facter.value('os.name')).to be nil
     end
@@ -219,7 +219,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter.value('os.name')).to eq('Ubuntu')
       end
@@ -229,20 +229,21 @@ describe Facter do
   describe '#fact' do
     it 'returns a fact' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter.fact('os.name')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: 'Ubuntu')
     end
 
     it 'can be interpolated' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
+
       expect("#{Facter.fact('os.name')}-test").to eq('Ubuntu-test')
     end
 
     it 'returns no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil, key_error)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_raise(key_error)
 
       expect(Facter.fact('os.name')).to be_nil
     end
@@ -272,7 +273,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter.fact('os.name'))
           .to be_instance_of(Facter::ResolvedFact)
@@ -284,14 +285,14 @@ describe Facter do
   describe '#[]' do
     it 'returns a fact' do
       mock_fact_manager(:resolve_fact, [os_fact])
-      mock_collection(:value, 'Ubuntu')
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
       expect(Facter['os.name']).to be_instance_of(Facter::ResolvedFact).and(having_attributes(value: 'Ubuntu'))
     end
 
     it 'return no value' do
       mock_fact_manager(:resolve_fact, [])
-      mock_collection(:value, nil, key_error)
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_raise(key_error)
 
       expect(Facter['os.name']).to be_nil
     end
@@ -303,7 +304,7 @@ describe Facter do
 
       it 'returns the custom fact' do
         mock_fact_manager(:resolve_fact, [os_fact])
-        mock_collection(:value, 'Ubuntu')
+        allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
 
         expect(Facter['os.name'])
           .to be_instance_of(Facter::ResolvedFact)

--- a/spec/facter/model/fact_collection_spec.rb
+++ b/spec/facter/model/fact_collection_spec.rb
@@ -80,6 +80,7 @@ describe Facter::FactCollection do
       let(:resolved_fact2) { Facter::ResolvedFact.new('mygroup.fact1.subfact1', 'g1_sg1_f1_value', type) }
 
       it 'logs error' do
+        allow(Facter::Options).to receive(:[]).with(:autopromote_dotted_facts).and_return(true)
         fact_collection.build_fact_collection!([resolved_fact, resolved_fact2])
 
         expect(logger).to have_received(:error)

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -43,7 +43,8 @@ describe Facter::OptionStore do
         timing: false,
         external_dir: [],
         custom_dir: [],
-        allow_external_loggers: true
+        allow_external_loggers: true,
+        autopromote_dotted_facts: false
       )
     end
   end

--- a/spec_integration/facter_block_legacy_spec.rb
+++ b/spec_integration/facter_block_legacy_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
-require_relative 'integration_helper'
+require_relative 'spec_helper'
 
 describe 'Facter' do
   context 'when legacy facts is blocked' do

--- a/spec_integration/facter_resolve_spec.rb
+++ b/spec_integration/facter_resolve_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'integration_helper'
+require_relative 'spec_helper'
 
 describe Facter do
   context 'when calling the ruby API resolve' do

--- a/spec_integration/facter_spec.rb
+++ b/spec_integration/facter_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+require_relative '../spec/spec_helper_legacy'
+
+describe 'Facter' do
+  include PuppetlabsSpec::Files
+
+  let(:ext_facts_dir) { tmpdir('external_facts') }
+
+  def write_to_file(file_name, to_write)
+    file = File.join(ext_facts_dir, file_name)
+    File.open(file, 'w') { |f| f.print to_write }
+  end
+
+  describe '.value' do
+    context 'when structured facts are disabled' do
+      context 'with custom fact' do
+        let(:fact_name) { 'a.b.c' }
+
+        before do
+          Facter::Options[:autopromote_dotted_facts] = false
+
+          Facter.add(fact_name) do
+            setcode { 'custom' }
+          end
+        end
+
+        it 'works with fact name' do
+          expect(Facter.value('a.b.c')).to eql('custom')
+        end
+
+        it 'does not work with partial fact name' do
+          expect(Facter.value('a.b')).to be(nil)
+        end
+
+        it 'does not work with first fact segment' do
+          expect(Facter.value('a')).to be(nil)
+        end
+      end
+
+      context 'with external fact' do
+        before do
+          Facter.search_external([ext_facts_dir])
+          data = { 'a.b.c' => 'external' }
+          write_to_file('data.yaml', YAML.dump(data))
+        end
+
+        it 'works with full fact name' do
+          expect(Facter.value('a.b.c')).to eql('external')
+        end
+
+        it 'does not work with partial fact name' do
+          expect(Facter.value('a.b')).to be(nil)
+        end
+
+        it 'does not work with first fact segment' do
+          expect(Facter.value('a')).to be(nil)
+        end
+      end
+    end
+
+    context 'when structured facts are enabled' do
+      before do
+        Facter::Options[:autopromote_dotted_facts] = true
+      end
+
+      after do
+        Facter::Options[:autopromote_dotted_facts] = false
+      end
+
+      context 'with custom fact' do
+        let(:fact_name) { 'a.b.c' }
+
+        before do
+          Facter.add(fact_name) do
+            setcode { 'custom' }
+          end
+        end
+
+        it 'works with fact name' do
+          expect(Facter.value('a.b.c')).to eql('custom')
+        end
+
+        it 'works with partial fact name' do
+          expect(Facter.value('a.b')).to eql({ 'c' => 'custom' })
+        end
+
+        it 'works with first fact segment' do
+          expect(Facter.value('a')).to eql({ 'b' => { 'c' => 'custom' } })
+        end
+      end
+
+      context 'with external fact' do
+        before do
+          Facter.search_external([ext_facts_dir])
+          data = { 'a.b.c' => 'external' }
+          write_to_file('data.yaml', YAML.dump(data))
+        end
+
+        it 'works with full fact name' do
+          expect(Facter.value('a.b.c')).to eql('external')
+        end
+
+        it 'works with partial fact name' do
+          expect(Facter.value('a.b')).to eql({ 'c' => 'external' })
+        end
+
+        it 'works with first fact segment' do
+          expect(Facter.value('a')).to eql({ 'b' => { 'c' => 'external' } })
+        end
+      end
+    end
+  end
+
+  describe '.to_user_output' do
+    context 'when structured facts are disabled' do
+      context 'with custom fact' do
+        let(:fact_name) { 'a.b.c' }
+
+        before do
+          Facter::Options[:autopromote_dotted_facts] = false
+
+          Facter.add(fact_name) do
+            setcode { 'custom' }
+          end
+        end
+
+        it 'works with fact name' do
+          expect(Facter.to_user_output({}, 'a.b.c')).to eql(['custom', 0])
+        end
+
+        it 'does not work with partial fact name' do
+          expect(Facter.to_user_output({}, 'a.b')).to eql(['', 0])
+        end
+
+        it 'does not work with first fact segment' do
+          expect(Facter.to_user_output({}, 'a')).to eql(['', 0])
+        end
+      end
+
+      context 'with external fact' do
+        before do
+          Facter.search_external([ext_facts_dir])
+          data = { 'a.b.c' => 'external' }
+          write_to_file('data.yaml', YAML.dump(data))
+        end
+
+        it 'works with full fact name' do
+          expect(Facter.to_user_output({}, 'a.b.c')).to eql(['external', 0])
+        end
+
+        it 'does not work with partial fact name' do
+          expect(Facter.to_user_output({}, 'a.b')).to eql(['', 0])
+        end
+
+        it 'does not work with first fact segment' do
+          expect(Facter.to_user_output({}, 'a')).to eql(['', 0])
+        end
+      end
+    end
+
+    context 'when structured facts are enabled' do
+      before do
+        Facter::Options[:autopromote_dotted_facts] = true
+      end
+
+      after do
+        Facter::Options[:autopromote_dotted_facts] = false
+      end
+
+      context 'with custom fact' do
+        let(:fact_name) { 'a.b.c' }
+
+        before do
+          Facter.add(fact_name) do
+            setcode { 'custom' }
+          end
+        end
+
+        it 'works with fact name' do
+          expect(Facter.to_user_output({}, 'a.b.c')).to eql(['custom', 0])
+        end
+
+        it 'works with partial fact name' do
+          expect(Facter.to_user_output({}, 'a.b')).to eql(["{\n  c => \"custom\"\n}", 0])
+        end
+
+        it 'works with first fact segment' do
+          expect(Facter.to_user_output({}, 'a')).to eql(["{\n  b => {\n    c => \"custom\"\n  }\n}", 0])
+        end
+      end
+
+      context 'with external fact' do
+        before do
+          Facter.search_external([ext_facts_dir])
+          data = { 'a.b.c' => 'external' }
+          write_to_file('data.yaml', YAML.dump(data))
+        end
+
+        it 'works with full fact name' do
+          expect(Facter.to_user_output({}, 'a.b.c')).to eql(['external', 0])
+        end
+
+        it 'works with partial fact name' do
+          expect(Facter.to_user_output({}, 'a.b')).to eql(["{\n  c => \"external\"\n}", 0])
+        end
+
+        it 'works with first fact segment' do
+          expect(Facter.to_user_output({}, 'a')).to eql(["{\n  b => {\n    c => \"external\"\n  }\n}", 0])
+        end
+      end
+    end
+  end
+end

--- a/spec_integration/facter_to_hash_spec.rb
+++ b/spec_integration/facter_to_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'integration_helper'
+require_relative 'spec_helper'
 
 describe Facter do
   context 'when calling facter cli' do

--- a/spec_integration/spec_helper.rb
+++ b/spec_integration/spec_helper.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require_relative 'integration_helper'
 
 ROOT_DIR = Pathname.new(File.expand_path('..', __dir__)) unless defined?(ROOT_DIR)
+
+# prevent facter from loading its spec files as facts
+$LOAD_PATH.delete_if { |entry| entry =~ %r{facter/spec} }
 
 ENV['RACK_ENV'] = 'test'
 
 require 'bundler/setup'
-
-require 'open3'
-require 'thor'
-require 'fileutils'
-
-require_relative '../lib/facter/resolvers/base_resolver'
-
 require 'facter'
-require 'facter/framework/cli/cli'
-require 'facter/framework/cli/cli_launcher'
-
-require './lib/facter/framework/core/file_loader'
 
 # Configure RSpec
 RSpec.configure do |config|
@@ -49,6 +42,8 @@ RSpec.configure do |config|
   end
 
   config.after do
+    Facter.reset
+    Facter.clear
     Facter::OptionStore.reset
   end
 end


### PR DESCRIPTION
External facts that use dot in their names will no
longer be converted to structured facts.
In order to convert all custom and external facts
to a structured, one needs to use set the
`autopromote-dotted-facts` to `true` in `facter.conf`

