### PR TITLE
 (maint) Show exception source in debug message

### DIFF
--- a/lib/facter/resolvers/base_resolver.rb
+++ b/lib/facter/resolvers/base_resolver.rb
@@ -28,10 +28,10 @@ module Facter
           cache_nil_for_unresolved_facts(fact_name)
         end
       rescue NoMethodError => e
-        log.debug("Could not resolve #{fact_name}, got #{e}")
+        log.debug("Could not resolve #{fact_name}, got #{e} at #{e.backtrace[0]}")
         @fact_list[fact_name] = nil
       rescue LoadError, NameError => e
-        log.debug("resolving fact #{fact_name}, but #{e}")
+        log.debug("Resolving fact #{fact_name}, but got #{e} at #{e.backtrace[0]}")
         @fact_list[fact_name] = nil
       end
 

--- a/spec/facter/resolvers/augeas_spec.rb
+++ b/spec/facter/resolvers/augeas_spec.rb
@@ -80,7 +80,7 @@ describe Facter::Resolvers::Augeas do
       it 'raises a LoadError error' do
         augeas.resolve(:augeas_version)
 
-        expect(log_spy).to have_received(:debug).with('resolving fact augeas_version, but load_error_message')
+        expect(log_spy).to have_received(:debug).with(/Resolving fact augeas_version, but got load_error_message/)
       end
     end
   end

--- a/spec/facter/resolvers/base_resolver_spec.rb
+++ b/spec/facter/resolvers/base_resolver_spec.rb
@@ -83,7 +83,7 @@ describe Facter::Resolvers::BaseResolver do
       it 'logs the Load Error exception' do
         resolver.resolve(fact)
 
-        expect(resolver.log).to have_received(:debug).with("resolving fact #{fact}, but LoadError")
+        expect(resolver.log).to have_received(:debug).with(/Resolving fact #{fact}, but got LoadError/)
       end
 
       it 'sets the fact to nil' do


### PR DESCRIPTION
In case an exception occurs in resolvers, we catch the exception and
display only the message as a debug log, without showing the exact
location where exception occurred

This commit adds the location of the error to the debug log message,
making the debug easier
