### PR TITLE
(maint) add acceptance for structured facts

### DIFF
--- a/acceptance/tests/custom_facts/structured/block_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/block_structured_custom_fact.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+test_name 'strucutured custom facts can be blocked' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}') do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}') do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      blocklist : [ "#{fact_1_name}" ],
+    }
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'blocked structured custom fact is not displayed' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2")) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step 'the remaining structured fact is displayed' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3")) do |facter_output|
+        assert_equal(fact_2_value, facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/cached_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/cached_structured_custom_fact.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+test_name 'structured custom facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}') do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}') do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  partial_file_content = <<~RUBY
+    {
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+    }
+    fact-groups : {
+      cached-custom-facts : ["key1"],
+    }
+
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'creates the cache for part of the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        partial_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'creates the cache for full fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value,
+              'key3' => fact_2_value
+            }
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/define_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/define_structured_custom_fact.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+test_name 'custom facts can be defined structured' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_name = 'key1.key2'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_name}') do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'access fact with dot' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2")) do |facter_output|
+        assert_equal(fact_value, facter_output.stdout.chomp)
+      end
+
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          { 'key1' => { 'key2' => fact_value } },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/extend_structured_core_fact.rb
+++ b/acceptance/tests/custom_facts/structured/extend_structured_core_fact.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+test_name 'custom structured facts can extend core facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  core_fact = 'os'
+  fact_file = 'custom_fact.rb'
+  fact_name = 'extension'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{core_fact}.#{fact_name}') do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    builtin_value = JSON.parse(on(agent, facter('os  --json')).stdout.chomp)
+    builtin_value['os'][fact_name] = fact_value
+    expected_value = builtin_value
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'check that core fact is extended' do
+      on(agent, facter("os --custom-dir=#{fact_dir} --json")) do |facter_output|
+        assert_equal(
+          expected_value,
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/override_structured_core_fact.rb
+++ b/acceptance/tests/custom_facts/structured/override_structured_core_fact.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+test_name 'custom structured facts can override parts of core facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  core_fact = 'os'
+  fact_file = 'custom_fact.rb'
+  fact_name = 'name'
+  fact_value = 'test'
+
+  fact_content = <<-RUBY
+  Facter.add('#{core_fact}.#{fact_name}', weight: 999) do
+    setcode do
+      "#{fact_value}"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    builtin_value = JSON.parse(on(agent, facter('os  --json')).stdout.chomp)
+    builtin_value['os'][fact_name] = fact_value
+    expected_value = builtin_value
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'check that core fact is extended' do
+      on(agent, facter("os --custom-dir=#{fact_dir} --json")) do |facter_output|
+        assert_equal(
+          expected_value,
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+
+      on(agent, facter("os.name --custom-dir=#{fact_dir}")) do |facter_output|
+        assert_equal(
+          fact_value,
+          facter_output.stdout.chomp
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/custom_facts/structured/partial_cached_structured_custom_fact.rb
+++ b/acceptance/tests/custom_facts/structured/partial_cached_structured_custom_fact.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+test_name 'structured custom facts can be granually cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_file = 'custom_fact.rb'
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+
+  fact_content = <<-RUBY
+  Facter.add('#{fact_1_name}') do
+    setcode do
+      "#{fact_1_value}"
+    end
+  end
+
+  Facter.add('#{fact_2_name}') do
+    setcode do
+      "#{fact_2_value}"
+    end
+  end
+  RUBY
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "cached-custom-facts" : 3 days }
+      ]
+    }
+    fact-groups : {
+      cached-custom-facts : ["#{fact_1_name}"],
+    }
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    fact_dir = agent.tmpdir('custom_facts')
+    fact_file = File.join(fact_dir, fact_file)
+    create_remote_file(agent, fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(fact_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'does not create cache of part of the fact that is not in ttls' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key3"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(false, result)
+    end
+
+    step 'creates a cached-custom-facts cache file that contains fact information' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1.key2"))
+
+      result = agent.file_exist?("#{cache_folder}/cached-custom-facts")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/cached-custom-facts")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the fact' do
+      on(agent, facter("--custom-dir=#{fact_dir} key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value,
+              'key3' => fact_2_value
+            }
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/block_structured_external_fact.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+test_name 'strucutured external facts can be blocked' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  config_data = <<~HOCON
+    facts : {
+      blocklist : [ "#{fact_1_name}" ],
+    }
+
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    agent.mkdir_p(external_dir)
+    create_remote_file(agent, File.join(external_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(external_dir, 'fact_2.txt'), fact_2_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'blocked structured external fact is not displayed' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key2")) do |facter_output|
+        assert_equal('', facter_output.stdout.chomp)
+      end
+    end
+
+    step 'the remaining structured fact is displayed' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key3")) do |facter_output|
+        assert_equal(fact_2_value, facter_output.stdout.chomp)
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/cached_structured_external_facts.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+test_name 'strucutured external facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  cached_file_1_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  cached_file_2_content = <<~RUBY
+    {
+      "#{fact_2_name}": "#{fact_2_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "fact_1.txt" : 3 days },
+          { "fact_2.txt" : 3 days }
+      ]
+    }
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    agent.mkdir_p(external_dir)
+    create_remote_file(agent, File.join(external_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(external_dir, 'fact_2.txt'), fact_2_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'creates a fact_1.txt and fact_2.txt cache file that contains fact information' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value,
+              'key3' => fact_2_value
+            }
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+
+      assert_equal(true, agent.file_exist?("#{cache_folder}/fact_1.txt"))
+      assert_equal(true, agent.file_exist?("#{cache_folder}/fact_2.txt"))
+
+      assert_match(
+        cached_file_1_content.chomp,
+        agent.cat("#{cache_folder}/fact_1.txt").strip,
+        'Expected cached external fact file to contain fact information for fact_1'
+      )
+
+      assert_match(
+        cached_file_2_content.chomp,
+        agent.cat("#{cache_folder}/fact_2.txt").strip,
+        'Expected cached external fact file to contain fact information for fact_2'
+      )
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
+++ b/acceptance/tests/external_facts/structured/define_structured_external_fact.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+test_name 'external facts can be defined as structured' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_name = 'key1.key2'
+  fact_value = 'EXTERNAL'
+  ext_fact_content = "#{fact_name}: '#{fact_value}'"
+
+  config_data = <<~HOCON
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    agent.mkdir_p(external_dir)
+
+    ext_fact_path = File.join(external_dir, 'test.yaml')
+    create_remote_file(agent, ext_fact_path, ext_fact_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(config_dir)
+    end
+
+    step 'resolve an external structured fact' do
+      on(agent, facter("--external-dir \"#{external_dir}\" #{fact_name}")) do |facter_output|
+        assert_equal(fact_value, facter_output.stdout.chomp)
+      end
+
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
+        assert_equal(
+          { 'key1' => { 'key2' => fact_value } },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
+++ b/acceptance/tests/external_facts/structured/partial_cached_structured_external_facts.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+test_name 'strucutured external facts can be cached' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  fact_1_name = 'key1.key2'
+  fact_2_name = 'key1.key3'
+  fact_1_value = 'test1'
+  fact_2_value = 'test2'
+  fact_1_content = "#{fact_1_name}=#{fact_1_value}"
+  fact_2_content = "#{fact_2_name}=#{fact_2_value}"
+
+  cached_file_content = <<~RUBY
+    {
+      "#{fact_1_name}": "#{fact_1_value}",
+      "cache_format_version": 1
+    }
+  RUBY
+
+  config_data = <<~HOCON
+    facts : {
+      ttls : [
+          { "fact_1.txt" : 3 days }
+      ]
+    }
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    cache_folder = get_cached_facts_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    agent.mkdir_p(external_dir)
+    create_remote_file(agent, File.join(external_dir, 'fact_1.txt'), fact_1_content)
+    create_remote_file(agent, File.join(external_dir, 'fact_2.txt'), fact_2_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(cache_folder)
+    end
+
+    step 'does not create cache for part of the fact that is not in ttls' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key3"))
+      assert_equal(false, agent.file_exist?("#{cache_folder}/fact_2.txt"))
+    end
+
+    step 'creates a fact_1.txt cache file that contains fact information' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1.key2"))
+
+      result = agent.file_exist?("#{cache_folder}/fact_1.txt")
+      assert_equal(true, result)
+
+      cat_output = agent.cat("#{cache_folder}/fact_1.txt")
+      assert_match(
+        cached_file_content.chomp,
+        cat_output.strip,
+        'Expected cached custom fact file to contain fact information'
+      )
+    end
+
+    step 'resolves the entire fact' do
+      on(agent, facter("--external-dir \"#{external_dir}\" key1 --json")) do |facter_output|
+        assert_equal(
+          {
+            'key1' => {
+              'key2' => fact_1_value,
+              'key3' => fact_2_value
+            }
+          },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end

--- a/acceptance/tests/external_facts/structured/structured_external_fact_override_part_structured_custom_fact.rb
+++ b/acceptance/tests/external_facts/structured/structured_external_fact_override_part_structured_custom_fact.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+test_name 'external facts override parts of custom_facts' do
+  tag 'risk:high'
+
+  require 'facter/acceptance/user_fact_utils'
+  extend Facter::Acceptance::UserFactUtils
+
+  ext_fact_name = 'key1.key2'
+  ext_fact_value = 'EXTERNAL'
+  ext_fact_content = "#{ext_fact_name}: '#{ext_fact_value}'"
+  custom_fact_file = 'custom_fact.rb'
+
+  fact_content = <<-RUBY
+  Facter.add('ke1.key12') do
+    setcode do
+      "custom1"
+    end
+  end
+
+  Facter.add('key1.key3') do
+    setcode do
+      "custom2"
+    end
+  end
+  RUBY
+
+  config_data = <<~HOCON
+    global : {
+      force-dot-resolution : true
+    }
+  HOCON
+
+  agents.each do |agent|
+    config_dir = get_default_fact_dir(agent['platform'], on(agent, facter('kernelmajversion')).stdout.chomp.to_f)
+    config_file = File.join(config_dir, 'facter.conf')
+    agent.mkdir_p(config_dir)
+    create_remote_file(agent, config_file, config_data)
+
+    external_dir = agent.tmpdir('facts.d')
+    agent.mkdir_p(external_dir)
+    ext_fact_path = File.join(external_dir, 'test.yaml')
+    create_remote_file(agent, ext_fact_path, ext_fact_content)
+
+    custom_facts_dir = agent.tmpdir('custom_facts')
+    custom_fact_file = File.join(custom_facts_dir, custom_fact_file)
+    create_remote_file(agent, custom_fact_file, fact_content)
+
+    teardown do
+      agent.rm_rf(external_dir)
+      agent.rm_rf(config_dir)
+      agent.rm_rf(custom_facts_dir)
+    end
+
+    step 'overwtites part of the custom fact' do
+      on(
+        agent,
+        facter("--external-dir \"#{external_dir}\" --custom-dir \"#{custom_facts_dir}\" key1 --json")
+      ) do |facter_output|
+        assert_equal(
+          { 'key1' =>
+            {
+              'key2' => ext_fact_value,
+              'key3' => 'custom2'
+            } },
+          JSON.parse(facter_output.stdout.chomp)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Validate the use-cases for structured facts, including blocking and caching.
This is based on the global config switch.
```
global : {
  force-dot-resolution : true
}
```