### PR TITLE
(maint) resolve zone values as string for legacy facts

### DIFF
--- a/lib/facter/facts/solaris/zones.rb
+++ b/lib/facter/facts/solaris/zones.rb
@@ -50,6 +50,7 @@ module Facts
       def create_legacy_zone_facts(zone)
         legacy_facts = []
         %w[brand iptype name uuid id path status].each do |key|
+          zone[key.to_sym] = zone[key.to_sym].to_s if key.to_sym == :id
           legacy_facts << Facter::ResolvedFact.new("zone_#{zone[:name]}_#{key}", zone[key.to_sym], :legacy)
         end
 


### PR DESCRIPTION
Facter 3 resolves zone values as strings while structured zone facts as int where possible.
This PR updates Facter 4 to behave the same as Facter 3.