### PR TITLE
(FACT-2998) Fix filter tokens and fact matching

### DIFF
--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -69,19 +69,12 @@ module Facter
         resolvable_fact_list = []
 
         loaded_fact_hash.each do |loaded_fact|
-          # return the fact if toplevel namespace is found in the first query token
-          # eg. query: 'os.name' and loaded_fact_hash contains a fact with 'os' name
-          # it will construt and return the 'os' fact
-          if loaded_fact.name == query_tokens[0]
-            resolvable_fact_list = [construct_loaded_fact(query_tokens, query_token_range, loaded_fact)]
-          else
-            query_fact = query_tokens[query_token_range].join('.')
+          query_fact = query_tokens[query_token_range].join('.')
 
-            next unless found_fact?(loaded_fact.name, query_fact)
+          next unless found_fact?(loaded_fact.name, query_fact)
 
-            searched_fact = construct_loaded_fact(query_tokens, query_token_range, loaded_fact)
-            resolvable_fact_list << searched_fact
-          end
+          searched_fact = construct_loaded_fact(query_tokens, query_token_range, loaded_fact)
+          resolvable_fact_list << searched_fact
         end
 
         @log.debug "List of resolvable facts: #{resolvable_fact_list.inspect}"
@@ -113,7 +106,7 @@ module Facter
       end
 
       def construct_filter_tokens(query_tokens, query_token_range)
-        (query_tokens - query_tokens[query_token_range]).map do |token|
+        query_tokens.drop(query_token_range.size).map do |token|
           token =~ /^[0-9]+$/ ? token.to_i : token
         end
       end

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -103,25 +103,5 @@ describe Facter::QueryParser do
         )
       end
     end
-
-    context 'when root structured fact is overwritten' do
-      let(:query_list) { ['os.name'] }
-      let(:loaded_facts) do
-        [
-          instance_double(
-            Facter::LoadedFact, name: 'os.name', klass: 'Facter::Ubuntu::Os::Name', type: :core, file: nil
-          ),
-          instance_double(Facter::LoadedFact, name: 'os', klass: nil, type: :custom, file: nil)
-        ]
-      end
-
-      it 'returns the toplevel fact' do
-        matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
-
-        expect(matched_facts).to be_an_instance_of(Array).and \
-          contain_exactly(an_instance_of(Facter::SearchedFact)
-          .and(having_attributes(name: 'os', fact_class: nil, type: :custom)))
-      end
-    end
   end
 end


### PR DESCRIPTION
This reverts the behavior introduced in FACT-2950, which allowed core facts to be fully ovewritten, which broke filter_tokens for top-level facts. Due to the addition of the `force-dot-resolution` setting, we need to figure out a better way to implement this.

In addition, to avoid issues with custom facts that can have names with repeating tokens (such as: `a.b.c.b`), change how filter tokens are constructed. Previously this was done by subtracting two arrays which could remove more elements than intended.

Do the following checks when matching searched facts to resolved facts:
- if the queried fact has filter tokens, and the resolved fact is not a array or hash, do not match the facts
- if the value of the resolved fact is a hash or array, attempt to dig through it using the filter tokens of the searched fact; if not found,   do not match the facts
- if the names of the searched fact and the resolved fact are not identical, do not match the facts