### PR TITLE
(FACT-2983) Only convert hypervisors to bool

### DIFF
--- a/lib/facter/facts/solaris/hypervisors/ldom.rb
+++ b/lib/facter/facts/solaris/hypervisors/ldom.rb
@@ -17,7 +17,7 @@ module Facts
           fact_value = %i[
             chassis_serial control_domain domain_name
             domain_uuid role_control role_io role_root role_service
-          ].map! { |key| [key, Facter::Resolvers::Solaris::Ldom.resolve(key)] }.to_h
+          ].map! { |key| [key, Facter::Utils.try_to_bool(Facter::Resolvers::Solaris::Ldom.resolve(key))] }.to_h
 
           Facter::ResolvedFact.new(FACT_NAME, fact_value)
         end

--- a/lib/facter/resolvers/solaris/ldom.rb
+++ b/lib/facter/resolvers/solaris/ldom.rb
@@ -43,7 +43,7 @@ module Facter
             return if output_hash.empty?
 
             VIRTINFO_MAPPING.each do |key, value|
-              @fact_list[key] = Facter::Utils.try_to_bool(output_hash.dig(*value)&.strip)
+              @fact_list[key] = output_hash.dig(*value)&.strip
             end
 
             @fact_list[fact_name]

--- a/spec/facter/facts/solaris/hypervisors/ldom_spec.rb
+++ b/spec/facter/facts/solaris/hypervisors/ldom_spec.rb
@@ -15,10 +15,10 @@ describe Facts::Solaris::Hypervisors::Ldom do
           'control_domain' => 'opdx-a0-sun2',
           'domain_name' => 'sol11-9',
           'domain_uuid' => 'd7a3a4df-ce8c-47a9-b396-cb5a5f30c0b2',
-          'role_control' => 'false',
-          'role_io' => 'false',
-          'role_root' => 'false',
-          'role_service' => 'false'
+          'role_control' => false,
+          'role_io' => false,
+          'role_root' => false,
+          'role_service' => false
         }
       end
 

--- a/spec/facter/resolvers/solaris/ldom_spec.rb
+++ b/spec/facter/resolvers/solaris/ldom_spec.rb
@@ -37,19 +37,19 @@ describe Facter::Resolvers::Solaris::Ldom do
     end
 
     it 'parses role_control' do
-      expect(resolver.resolve(:role_control)).to eq(false)
+      expect(resolver.resolve(:role_control)).to eq('false')
     end
 
     it 'parses role_io' do
-      expect(resolver.resolve(:role_io)).to eq(false)
+      expect(resolver.resolve(:role_io)).to eq('false')
     end
 
     it 'parses role_root' do
-      expect(resolver.resolve(:role_root)).to eq(false)
+      expect(resolver.resolve(:role_root)).to eq('false')
     end
 
     it 'parses role_service' do
-      expect(resolver.resolve(:role_service)).to eq(false)
+      expect(resolver.resolve(:role_service)).to eq('false')
     end
   end
 


### PR DESCRIPTION
In 9421cf371f2e4d202dbc1c199125eba96c13e67c the Solaris LDOM resolver was changed to always return boolean values for 'true' or 'false'. However, Facter 3 only reported bool values for the `hypervisors` fact, not the `ldom` fact, and the same resolver provides data for both facts.

This broke the `virtual` fact since it specifically checked for a string value and we returned a boolean value.

To match the output of Facter 3, try to convert only the `hypervisors` fact to bool.