### PR TITLE
(FACT-3007) Use VirtualDetector in xen fact

### DIFF
--- a/lib/facter/facts/linux/hypervisors/xen.rb
+++ b/lib/facter/facts/linux/hypervisors/xen.rb
@@ -8,6 +8,7 @@ module Facts
 
         def initialize
           @log = Facter::Log.new(self)
+          @virtual = Facter::Util::Facts::VirtualDetector.new
         end
 
         def call_the_resolver
@@ -28,10 +29,7 @@ module Facts
         private
 
         def xen?
-          Facter::Resolvers::VirtWhat.resolve(:vm) =~ /xen/ ||
-            Facter::Resolvers::Xen.resolve(:vm) =~ /xen/ ||
-            discover_hypervisor == 'xenhvm' ||
-            Facter::Resolvers::Lspci.resolve(:vm) =~ /xen/
+          @virtual.platform =~ /xen/
         end
 
         def hvm?

--- a/lib/facter/util/facts/virtual_detector.rb
+++ b/lib/facter/util/facts/virtual_detector.rb
@@ -9,12 +9,14 @@ module Facter
         end
 
         def platform
-          fact_value = check_docker_lxc || check_freebsd || check_gce || retrieve_from_virt_what
-          fact_value ||= check_vmware || check_open_vz || check_vserver || check_xen || check_other_facts
-          fact_value ||= check_lspci || 'physical'
+          @@fact_value ||= check_docker_lxc || check_freebsd || check_gce || retrieve_from_virt_what
+          @@fact_value ||= check_vmware || check_open_vz || check_vserver || check_xen || check_other_facts
+          @@fact_value ||= check_lspci || 'physical'
 
-          fact_value
+          @@fact_value
         end
+
+        private
 
         def check_docker_lxc
           @log.debug('Checking Docker and LXC')

--- a/spec/facter/facts/linux/hypervisors/xen_spec.rb
+++ b/spec/facter/facts/linux/hypervisors/xen_spec.rb
@@ -3,19 +3,22 @@
 describe Facts::Linux::Hypervisors::Xen do
   subject(:fact) { Facts::Linux::Hypervisors::Xen.new }
 
+  let(:virtual_detector_double) { instance_spy(Facter::Util::Facts::VirtualDetector) }
+
   describe '#call_the_resolver' do
+    before do
+      allow(Facter::Util::Facts::VirtualDetector).to receive(:new).and_return(virtual_detector_double)
+    end
+
     context 'when xen hypervisor' do
-      context 'when VirtWhat resolver returns xen' do
+      before do
+        allow(virtual_detector_double).to receive(:platform).and_return('xen')
+      end
+
+      context 'when Xen resolver returns privileged false' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('xen')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('xenhvm')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(false)
-        end
-
-        it 'calls Facter::Resolvers::VirtWhat' do
-          fact.call_the_resolver
-
-          expect(Facter::Resolvers::VirtWhat).to have_received(:resolve).with(:vm)
         end
 
         it 'returns xen' do
@@ -26,16 +29,9 @@ describe Facts::Linux::Hypervisors::Xen do
 
       context 'when Xen resolver returns xen0' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return('xen0')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('HVM domU')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(true)
-        end
-
-        it 'calls Facter::Resolvers::Xen' do
-          fact.call_the_resolver
-
-          expect(Facter::Resolvers::Xen).to have_received(:resolve).with(:vm)
         end
 
         it 'returns xen' do
@@ -46,7 +42,6 @@ describe Facts::Linux::Hypervisors::Xen do
 
       context 'when DmiBios resolver return HVM domU' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('HVM domU')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(true)
@@ -55,7 +50,7 @@ describe Facts::Linux::Hypervisors::Xen do
         it 'calls Facter::Resolvers::Linux::DmiBios' do
           fact.call_the_resolver
 
-          expect(Facter::Resolvers::Linux::DmiBios).to have_received(:resolve).with(:product_name).twice
+          expect(Facter::Resolvers::Linux::DmiBios).to have_received(:resolve).with(:product_name)
         end
 
         it 'returns xen' do
@@ -66,7 +61,6 @@ describe Facts::Linux::Hypervisors::Xen do
 
       context 'when Lspci resolver returns xenhvm' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(true)
@@ -76,7 +70,7 @@ describe Facts::Linux::Hypervisors::Xen do
         it 'calls Facter::Resolvers::Linux::DmiBios' do
           fact.call_the_resolver
 
-          expect(Facter::Resolvers::Lspci).to have_received(:resolve).with(:vm).twice
+          expect(Facter::Resolvers::Lspci).to have_received(:resolve).with(:vm)
         end
 
         it 'returns xen' do
@@ -87,7 +81,6 @@ describe Facts::Linux::Hypervisors::Xen do
 
       context 'when pv context' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('xen')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
           allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return('unknown')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(false)
@@ -101,7 +94,6 @@ describe Facts::Linux::Hypervisors::Xen do
 
       context 'when privileged' do
         before do
-          allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('xen')
           allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('xenhvm')
           allow(Facter::Resolvers::Xen).to receive(:resolve).with(:privileged).and_return(true)
         end
@@ -115,10 +107,7 @@ describe Facts::Linux::Hypervisors::Xen do
 
     context 'when not xen hypervisor' do
       before do
-        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('unknown')
-        allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return('unknown')
-        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
-        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return('unknown')
+        allow(virtual_detector_double).to receive(:platform).and_return(nil)
       end
 
       it 'returns empty array' do

--- a/spec/facter/util/facts/virtual_detector_spec.rb
+++ b/spec/facter/util/facts/virtual_detector_spec.rb
@@ -7,6 +7,7 @@ describe Facter::Util::Facts::VirtualDetector do
     let(:logger_mock) { instance_spy(Facter::Log) }
 
     before do
+      Facter::Util::Facts::VirtualDetector.class_variable_set(:@@fact_value, nil)
       allow(Facter::Log).to receive(:new).and_return(logger_mock)
     end
 


### PR DESCRIPTION
Previously we could end up in a situation where both `kvm` and `xen` facts were resolved. This happens on Amazon 7 where the real hypervisor (reported by `virt-what`) is `kvm`, but the disk devices are still named `/dev/xvda` which causes `xen` to also be detected.

Use the value returned by `VirtualDetector#platform` to determine if we're running on `xen`.

`VirtualDetector#platform` is called at least 6 times in Facter which causes debug logs pollution and potential performance issues. Since we do not expect this value to change during Facter execution, memoize the value.



