### PR TITLE
(FACT-3023) xen command: avoid xen-toolstack warning

### DIFF
--- a/lib/facter/resolvers/xen.rb
+++ b/lib/facter/resolvers/xen.rb
@@ -56,7 +56,12 @@ module Facter
         end
 
         def find_command
-          return XEN_TOOLSTACK if File.exist?(XEN_TOOLSTACK)
+          num_stacks = 0
+          XEN_COMMANDS.each do |command|
+            num_stacks += 1 if File.exist?(command)
+          end
+
+          return XEN_TOOLSTACK if num_stacks > 1 && File.exist?(XEN_TOOLSTACK)
 
           XEN_COMMANDS.each { |command| return command if File.exist?(command) }
         end

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1894,7 +1894,7 @@ xen:
     type: map
     description: Return metadata for the Xen hypervisor.
     resolution: |
-        POSIX platforms: use `/usr/lib/xen-common/bin/xen-toolstack` to locate xen admin commands if available, otherwise fallback to `/usr/sbin/xl` or `/usr/sbin/xm`. Use the found command to execute the `list` query.
+        POSIX platforms: if `/usr/sbin/xl` and `/usr/sbin/xm` is installed use `/usr/lib/xen-common/bin/xen-toolstack` to choose, otherwise try `/usr/sbin/xl` then `/usr/sbin/xm` in order. Use the found command to execute the `list` query.
     caveats: |
         POSIX platforms: confined to Xen privileged virtual machines.
     elements:


### PR DESCRIPTION
xen-toolstack is deprecated and so on Puppet runs in Debian buster you
receive this nettlesome message:

  warning: something called deprecated script /usr/lib/xen-common/bin/xen-toolstack

Prior to this change we used xen-toolstack if it is present, but that is
only necessary if more than one stack is installed. Instead check if we
have multiple tool stacks and if we do use xen-toolstack if it is
present.
