### PR TITLE
(FACT-2914) Fix output for major version fact on Big Sur

### DIFF
--- a/lib/facter/facts/macosx/os/macosx/version.rb
+++ b/lib/facter/facts/macosx/os/macosx/version.rb
@@ -10,13 +10,21 @@ module Facts
 
           def call_the_resolver
             fact_value = Facter::Resolvers::SwVers.resolve(:productversion)
-            versions = fact_value.split('.')
-            ver = { 'full' => fact_value, 'major' => "#{versions[0]}.#{versions[1]}", 'minor' => versions[-1] }
+            ver = version_hash(fact_value)
 
             [Facter::ResolvedFact.new(FACT_NAME, ver),
              Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
              Facter::ResolvedFact.new(ALIASES[1], ver['major'], :legacy),
              Facter::ResolvedFact.new(ALIASES[2], ver['minor'], :legacy)]
+          end
+
+          def version_hash(fact_value)
+            versions = fact_value.split('.')
+            if versions[0] == '10'
+              { 'full' => fact_value, 'major' => "#{versions[0]}.#{versions[1]}", 'minor' => versions[-1] }
+            else
+              { 'full' => fact_value, 'major' => versions[0], 'minor' => "#{versions[1]}.#{versions[-1]}" }
+            end
           end
         end
       end

--- a/spec/facter/facts/macosx/os/macosx/version_spec.rb
+++ b/spec/facter/facts/macosx/os/macosx/version_spec.rb
@@ -4,28 +4,56 @@ describe Facts::Macosx::Os::Macosx::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Macosx::Os::Macosx::Version.new }
 
-    let(:resolver_output) { '10.9.8' }
-    let(:version) { { 'full' => '10.9.8', 'major' => '10.9', 'minor' => '8' } }
+    context 'when macOS version < 11' do
+      let(:resolver_output) { '10.9.8' }
+      let(:version) { { 'full' => '10.9.8', 'major' => '10.9', 'minor' => '8' } }
 
-    before do
-      allow(Facter::Resolvers::SwVers).to \
-        receive(:resolve).with(:productversion).and_return(resolver_output)
-    end
+      before do
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversion).and_return(resolver_output)
+      end
 
-    it 'calls Facter::Resolvers::SwVers' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
-    end
+      it 'calls Facter::Resolvers::SwVers' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
+      end
 
-    it 'returns a resolved fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
-                        an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
-                                                    type: :legacy),
-                        an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
-                                                    type: :legacy),
-                        an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
-                                                    type: :legacy))
+      it 'returns a resolved fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
+                          an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                      type: :legacy))
+      end
+
+      context 'when macOS version >= 11' do
+        let(:resolver_output) { '11.2.1' }
+        let(:version) { { 'full' => '11.2.1', 'major' => '11', 'minor' => '2.1' } }
+
+        before do
+          allow(Facter::Resolvers::SwVers).to \
+            receive(:resolve).with(:productversion).and_return(resolver_output)
+        end
+
+        it 'calls Facter::Resolvers::SwVers' do
+          fact.call_the_resolver
+          expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
+        end
+
+        it 'returns a resolved fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+            contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
+                            an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
+                                                        type: :legacy),
+                            an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
+                                                        type: :legacy),
+                            an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                        type: :legacy))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Starting with macOS 11, Apple is incrementing the second component of the release number for point releases (e.g., 11.0, 11.1, 11.2). It's assumed that going forward a new major version would be 12, 13, etc.
We fix this by changing the output of the major version fact depending on the macOS version. 

Example output for macOS 11 :
```
{
  full => "11.2.1",
  major => "11",
  minor => "2.1"
}
```



