### PR TITLE
(FACT-3025) Avoid user query overwrite

### DIFF
--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -18,8 +18,8 @@ module Facter
       @external_fact_loader ||= ExternalFactLoader.new
     end
 
-    def load(options)
-      @internal_facts = load_internal_facts(options)
+    def load(user_query, options)
+      @internal_facts = load_internal_facts(user_query, options)
       @custom_facts = load_custom_facts(options)
       @external_facts = load_external_facts(options)
 
@@ -28,10 +28,10 @@ module Facter
       @facts = @internal_facts + @external_facts + @custom_facts
     end
 
-    def load_internal_facts(options)
+    def load_internal_facts(user_query, options)
       @log.debug('Loading internal facts')
       internal_facts = []
-      if options[:user_query] || options[:show_legacy]
+      if user_query || options[:show_legacy]
         # if we have a user query, then we must search in core facts and legacy facts
         @log.debug('Loading all internal facts')
         internal_facts = @internal_loader.facts

--- a/spec/framework/core/fact_loaders/fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/fact_loader_spec.rb
@@ -39,7 +39,7 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts = Facter::FactLoader.instance.load(options)
+      loaded_facts = Facter::FactLoader.instance.load(options[:user_query], options)
       expect(loaded_facts).to eq(facts_to_load)
     end
 
@@ -52,7 +52,7 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts = Facter::FactLoader.instance.load(options)
+      loaded_facts = Facter::FactLoader.instance.load(nil, options)
       expect(loaded_facts).to eq(facts_to_load)
     end
 
@@ -65,7 +65,7 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts = Facter::FactLoader.instance.load(options)
+      loaded_facts = Facter::FactLoader.instance.load(nil, options)
       expect(loaded_facts.size).to eq(0)
     end
 
@@ -78,7 +78,7 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts = Facter::FactLoader.instance.load(options)
+      loaded_facts = Facter::FactLoader.instance.load(nil, options)
       expect(loaded_facts.size).to eq(1)
     end
 
@@ -93,7 +93,7 @@ describe Facter::FactLoader do
 
       it 'blocks one custom fact' do
         options = { custom_facts: true, blocked_facts: ['custom_fact'] }
-        loaded_facts = Facter::FactLoader.instance.load(options)
+        loaded_facts = Facter::FactLoader.instance.load(nil, options)
 
         expect(loaded_facts.size).to eq(0)
       end
@@ -108,8 +108,8 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts1 = Facter::FactLoader.instance.load(options)
-      loaded_facts2 = Facter::FactLoader.instance.load(options)
+      loaded_facts1 = Facter::FactLoader.instance.load(options[:user_query], options)
+      loaded_facts2 = Facter::FactLoader.instance.load(options[:user_query], options)
       expect(loaded_facts1).to eq(loaded_facts2)
     end
 
@@ -122,8 +122,8 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return(facts_to_load)
       allow(external_fact_loader_double).to receive(:external_facts).and_return([])
 
-      loaded_facts1 = Facter::FactLoader.instance.load(options)
-      loaded_facts2 = Facter::FactLoader.instance.load(options)
+      loaded_facts1 = Facter::FactLoader.instance.load(nil, options)
+      loaded_facts2 = Facter::FactLoader.instance.load(nil, options)
       expect(loaded_facts1).to eq(loaded_facts2)
     end
 
@@ -134,7 +134,7 @@ describe Facter::FactLoader do
       allow(external_fact_loader_double).to receive(:custom_facts).and_return([])
       allow(external_fact_loader_double).to receive(:external_facts).and_return([loaded_env_custom_fact])
 
-      loaded_facts = Facter::FactLoader.instance.load(options)
+      loaded_facts = Facter::FactLoader.instance.load(nil, options)
       expect(loaded_facts).to be_an_instance_of(Array).and contain_exactly(
         loaded_env_custom_fact
       )
@@ -152,7 +152,7 @@ describe Facter::FactLoader do
       let(:options) { { block_list: 'legacy' } }
 
       it 'blocks legacy facts' do
-        loaded_facts = Facter::FactLoader.instance.load(options)
+        loaded_facts = Facter::FactLoader.instance.load(nil, options)
 
         expect(loaded_facts).to be_empty
       end


### PR DESCRIPTION
Before this commit, the user query was held in a static options hash, which meant that nested Facter calls could override the user query.

Example:
https://github.com/puppetlabs/puppetlabs-docker/blob/a3c32a1b7f5b244963cd407f6037e0a86d4a3fcb/spec/unit/lib/facter/docker_spec.rb#L9