### PR TITLE
(FACT-3024) fix return value for Facter.fact

### DIFF
--- a/spec_integration/facter_spec.rb
+++ b/spec_integration/facter_spec.rb
@@ -551,4 +551,38 @@ describe 'Facter' do
       end
     end
   end
+
+  describe '.fact' do
+    context 'with custom facts' do
+      context 'when fact has value' do
+        before do
+          Facter.add('my_fact') do
+            setcode { 'my_value' }
+          end
+        end
+
+        it 'returns a ResolvedFact with value' do
+          expect(Facter.fact('my_fact')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: 'my_value')
+        end
+      end
+
+      context 'when fact value is nil' do
+        before do
+          Facter.add('custom1', weight: 999) do
+            setcode { nil }
+          end
+        end
+
+        it 'returns a ResolvedFact with value: nil' do
+          expect(Facter.fact('custom1')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: nil)
+        end
+      end
+    end
+
+    context 'when searching for a fact that does not exists' do
+      it 'returns nil' do
+        expect(Facter.fact('non_existent')).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
The behavior of Facter.fact has changed between
4.0.52 and 4.1.0. Instead of returning nil if a
fact does not exist, it now returns an object of
type ResolvedFact with its value set to nil.
