### PR TITLE
(FACT-3031) Report major/minor/patch on macOS

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -230,7 +230,7 @@ module Facter
           'os.macosx.build' => /\d+[A-Z]\d{1,4}\w?/,
           'os.macosx.product' => agent['platform'] =~ /osx-10/ ? 'Mac OS X' : 'macOS',
           'os.macosx.version.major' => major_version,
-          'os.macosx.version.minor' => agent['platform'] =~ /osx-10/ ? /\d+/ : /\d+\.\d+/,
+          'os.macosx.version.minor' => /\d+/,
           'os.release.full' => /\d+\.\d+\.\d+/,
           'os.release.major' => /\d+/,
           'os.release.minor' => /\d+/,
@@ -243,7 +243,13 @@ module Facter
           'kernelversion' => /\d+\.\d+\.\d+/,
           'kernelmajversion' => /\d+\.\d+/
         }
-        expected_facts['os.macosx.version.full'] = /#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}/
+
+        if agent['platform'] =~ /osx-10/
+          expected_facts['os.macosx.version.full'] = /#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}/
+        else
+          expected_facts['os.macosx.version.patch'] = /\d+/
+          expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.#{expected_facts['os.macosx.version.patch']}$/
+        end
         expected_facts
       end
 

--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -166,6 +166,7 @@ module Facter
           macosx_productversion
           macosx_productversion_major
           macosx_productversion_minor
+          macosx_productversion_patch
           windows_edition_id
           windows_installation_type
           windows_product_name
@@ -301,6 +302,7 @@ module Facter
           'macosx_productversion',
           'macosx_productversion_major',
           'macosx_productversion_minor',
+          'macosx_productversion_patch',
           'manufacturer',
           'memoryfree',
           'memoryfree_mb',

--- a/lib/facter/facts/macosx/os/macosx/version.rb
+++ b/lib/facter/facts/macosx/os/macosx/version.rb
@@ -6,7 +6,8 @@ module Facts
       module Macosx
         class Version
           FACT_NAME = 'os.macosx.version'
-          ALIASES = %w[macosx_productversion macosx_productversion_major macosx_productversion_minor].freeze
+          ALIASES = %w[macosx_productversion macosx_productversion_major macosx_productversion_minor
+                       macosx_productversion_patch].freeze
 
           def call_the_resolver
             fact_value = Facter::Resolvers::SwVers.resolve(:productversion)
@@ -15,7 +16,8 @@ module Facts
             [Facter::ResolvedFact.new(FACT_NAME, ver),
              Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
              Facter::ResolvedFact.new(ALIASES[1], ver['major'], :legacy),
-             Facter::ResolvedFact.new(ALIASES[2], ver['minor'], :legacy)]
+             Facter::ResolvedFact.new(ALIASES[2], ver['minor'], :legacy),
+             Facter::ResolvedFact.new(ALIASES[3], ver['patch'], :legacy)]
           end
 
           def version_hash(fact_value)
@@ -23,7 +25,8 @@ module Facts
             if versions[0] == '10'
               { 'full' => fact_value, 'major' => "#{versions[0]}.#{versions[1]}", 'minor' => versions[-1] }
             else
-              { 'full' => fact_value, 'major' => versions[0], 'minor' => "#{versions[1]}.#{versions[-1]}" }
+              { 'full' => fact_value, 'major' => versions[0], 'minor' => versions.fetch(1, '0'),
+                'patch' => versions.fetch(2, '0') }
             end
           end
         end

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -724,6 +724,13 @@ macosx_productversion_minor:
     resolution: |
         Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product minor version.
 
+macosx_productversion_patch:
+    type: string
+    hidden: true
+    description: Return the Mac OSX product patch version.
+    resolution: |
+        Mac OSX: use the `sw_vers` utility to retrieve the Mac OSX product patch version.
+
 manufacturer:
     type: string
     hidden: true
@@ -1184,6 +1191,9 @@ os:
                         minor:
                             type: string
                             description: The minor Mac OSX version number.
+                        patch:
+                            type: string
+                            description: The patch Mac OSX version number.
         name:
             type: string
             description: The operating system's name.

--- a/spec/facter/facts/macosx/os/macosx/version_spec.rb
+++ b/spec/facter/facts/macosx/os/macosx/version_spec.rb
@@ -26,12 +26,14 @@ describe Facts::Macosx::Os::Macosx::Version do
                           an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
                                                       type: :legacy),
                           an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
                                                       type: :legacy))
       end
 
       context 'when macOS version >= 11' do
         let(:resolver_output) { '11.2.1' }
-        let(:version) { { 'full' => '11.2.1', 'major' => '11', 'minor' => '2.1' } }
+        let(:version) { { 'full' => '11.2.1', 'major' => '11', 'minor' => '2', 'patch' => '1' } }
 
         before do
           allow(Facter::Resolvers::SwVers).to \
@@ -51,6 +53,8 @@ describe Facts::Macosx::Os::Macosx::Version do
                             an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
                                                         type: :legacy),
                             an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                        type: :legacy),
+                            an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
                                                         type: :legacy))
         end
       end


### PR DESCRIPTION
See https://developer.apple.com/documentation/foundation/nsoperatingsystemversion?language=objc

On macOS 11:
```
$ facter os.macosx.version
{
  full => "11.3",
  major => "11",
  minor => "3",
  patch => "0"
}
$ facter --show-legacy | grep productversion
macosx_productversion => 11.3
macosx_productversion_major => 11
macosx_productversion_minor => 3
macosx_productversion_patch => 0
```

On macOS 10.15:
```
$ facter os.macosx.version
{
  full => "10.15.7",
  major => "10.15",
  minor => "7",
}
$ facter --show-legacy | grep productversion
macosx_productversion => 10.15.7
macosx_productversion_major => 10.15
macosx_productversion_minor => 7
```
