### PR TITLE
(FACT-3030) fix TypeError crash

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -555,7 +555,7 @@ module Facter
       begin
         value = fact_collection.value(user_query)
         add_fact_to_searched_facts(user_query, value)
-      rescue KeyError
+      rescue KeyError, TypeError
         nil
       end
     end

--- a/lib/facter/models/fact_collection.rb
+++ b/lib/facter/models/fact_collection.rb
@@ -23,7 +23,7 @@ module Facter
 
     def dig_fact(user_query)
       value(user_query)
-    rescue KeyError
+    rescue KeyError, TypeError
       nil
     end
 


### PR DESCRIPTION
Facter allow accessing array values by indexes,
but if an nonexistent index is searched, it will
raise TypeError. This commit handles the error and
adds integration tests for multiple cases.