### PR TITLE
(FACT-2907): Follow up comment out 32bit flags

### DIFF
--- a/lib/facter/util/linux/if_inet6.rb
+++ b/lib/facter/util/linux/if_inet6.rb
@@ -15,11 +15,15 @@ module Facter
             'homeaddress' => 0x10,
             'deprecated' => 0x20,
             'tentative' => 0x40,
-            'permanent' => 0x80,
-            'managetempaddr' => 0x100,
-            'noprefixroute' => 0x200,
-            'mcautojoin' => 0x400,
-            'stableprivacy' => 0x800
+            'permanent' => 0x80
+            # /proc/net/if_inet6 only supports the old 8bit flags
+            # I have been unable to find a simple solution to accesses
+            # the full 32bit flags.  netlink is all I can could find but
+            # that will likely be ugly
+            # 'managetempaddr' => 0x100,
+            # 'noprefixroute' => 0x200,
+            # 'mcautojoin' => 0x400,
+            # 'stableprivacy' => 0x800
           }.freeze
 
           def read_flags


### PR DESCRIPTION
I have commented out the other 32 bit flags[1] as only the lower 8bits are
available in /proc/net/if_inet6[2].  Other then adding netlink to ruby
I'm not sure how to access the higher bit flags :(

follows up on #2340

[1]https://github.com/torvalds/linux/blob/fcadab740480e0e0e9fa9bd272acd409884d431a/include/uapi/linux/if_addr.h#L54-L57
[2]https://unix.stackexchange.com/questions/643692/calculating-ifa-flags-larger-then-0xff-from-proc-net-if-inet6

