### PR TITLE
(maint) add fact sets for ppc64le

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -146,6 +146,10 @@ module Facter
           os_arch                 = 'aarch64'
           os_hardware             = 'aarch64'
           processor_model_pattern = // # aarch64 does not populate a model value in /proc/cpuinfo
+        elsif agent['platform'] =~ /ppc64le/
+          os_arch                 = 'ppc64le'
+          os_hardware             = 'ppc64le'
+          processor_model_pattern = /(POWER.*)/
         else
           os_arch                 = 'i386'
           os_hardware             = 'i686'


### PR DESCRIPTION
On Power, Facter reports the following facts:
```
           "architecture": "ppc64le",
           "distro": {
             "codename": "Ootpa",
             "description": "Red Hat Enterprise Linux release 8.3 (Ootpa)",
             "id": "RedHatEnterprise",
             "release": {
               "full": "8.3",
               "major": "8",
               "minor": "3"
             }
           },
           "family": "RedHat",
           "hardware": "ppc64le",
```
This PR updates the expected values.