### PR TITLE
(maint) Fix few windows random spec failures

### DIFF
--- a/lib/facter/custom_facts/util/windows_root.rb
+++ b/lib/facter/custom_facts/util/windows_root.rb
@@ -4,7 +4,8 @@ module LegacyFacter
   module Util
     module Root
       def self.root?
-        Facter::Resolvers::Identity.resolve(:privileged)
+        require 'facter/resolvers/windows/ffi/identity_ffi'
+        IdentityFFI.privileged?
       end
     end
   end

--- a/lib/facter/resolvers/windows/ffi/identity_ffi.rb
+++ b/lib/facter/resolvers/windows/ffi/identity_ffi.rb
@@ -12,4 +12,9 @@ module IdentityFFI
   ffi_convention :stdcall
   ffi_lib :shell32
   attach_function :IsUserAnAdmin, [], :win32_bool
+
+  def self.privileged?
+    result = self.IsUserAnAdmin()
+    result && result != FFI::WIN32FALSE
+  end
 end

--- a/lib/facter/resolvers/windows/identity.rb
+++ b/lib/facter/resolvers/windows/identity.rb
@@ -31,12 +31,7 @@ module Facter
             return
           end
 
-          { user: name_ptr.read_wide_string_with_length(size_ptr.read_uint32), privileged: privileged? }
-        end
-
-        def privileged?
-          result = IdentityFFI::IsUserAnAdmin()
-          result && result != FFI::WIN32FALSE
+          { user: name_ptr.read_wide_string_with_length(size_ptr.read_uint32), privileged: IdentityFFI.privileged? }
         end
 
         def retrieve_facts(fact_name)

--- a/spec/mocks/ffi.rb
+++ b/spec/mocks/ffi.rb
@@ -81,6 +81,10 @@ module FFI
 
     def read_int; end
 
+    def read_uint32(); end
+
+    def read_wide_string_with_length(*); end
+
     def self.size; end
   end
 


### PR DESCRIPTION
 - seed 56967: mock read_uint32/read_wide_string_with_length ffi methods
 - seeds 52936 & 62613: do not call Identity resolver while initializing
 on Windows
