### PR TITLE
(maint) Fix order dependent spec failure

### DIFF
--- a/spec/facter/resolvers/windows/identity_spec.rb
+++ b/spec/facter/resolvers/windows/identity_spec.rb
@@ -19,6 +19,7 @@ describe Facter::Resolvers::Identity do
 
   after do
     Facter::Resolvers::Identity.invalidate_cache
+    Facter::Resolvers::Identity.instance_variable_set(:@log, nil)
   end
 
   describe '#resolve when user is administrator' do


### PR DESCRIPTION
Reproducible on Windows using:

    bundle exec rspec -fd \
      './spec/custom_facts/util/config_spec.rb[1:1:1]' \
      './spec/facter/resolvers/windows/identity_spec.rb[1:4:1]' \
      --order random:54046