### PR TITLE
(FACT-3027 & FACT-3029) Mark compatible with Ruby 3

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,7 +14,11 @@ jobs:
     name: Ruby version
     strategy:
       matrix:
-        ruby: [ 2.3, 2.7, jruby ]
+        ruby:
+          - 2.3
+          - 2.7
+          - 3.0
+          - jruby
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout current PR

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
                Dir['lib/**/*.conf'] +
                Dir['lib/**/*.erb']
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '>= 2.3', '< 4.0'
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
This adds Ruby to the compatible Ruby versions. Without this, bundler falls back to Facter 2 which doesn't specify compatibility at all. To ensure it works, Ruby 3 is added to the unit testing matrix.