### PR TITLE
(FACT-2938) build Facter nightly gem

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
 
-  spec.summary       = 'New version of Facter'
-  spec.description   = 'New version of Facter'
+  spec.summary       = 'Facter, a system inventory tool'
+  spec.description   = 'You can prove anything with facts!'
 
   spec.files = Dir['bin/facter-ng'] +
                Dir['lib/**/*.rb'] +
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
                Dir['agent/**/*'] +
                Dir['lib/**/*.erb']
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '>= 2.3', '< 4.0'
 
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,3 +1,4 @@
 ---
 build_gem: TRUE
 project: facter
+nonfinal_gem_path: '/opt/repository-nightlies/downloads/gems/facter-nightly'

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -1,1 +1,17 @@
-build_defaults.yaml
+---
+project: 'facter'
+author: 'Puppet Labs'
+email: 'team-nw@puppet.com'
+homepage: 'https://github.com/puppetlabs/facter'
+summary: 'Facter, a system inventory tool'
+description: 'You can prove anything with facts!'
+version_file: 'lib/facter/version.rb'
+files: 'bin/facter lib/facter.rb lib/**/*.rb'
+gem_files: 'bin/facter lib/facter.rb lib/**/*.rb'
+gem_require_path: 'lib'
+gem_executables: 'facter'
+gem_default_executables: 'facter'
+gem_required_ruby_version: ['>= 2.3', '< 4.0']
+gem_runtime_dependencies:
+  hocon: ~> 1.3
+  thor: ['>= 1.0.1', '< 2.0']

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'
 
-  spec.summary       = 'New version of Facter'
-  spec.description   = 'New version of Facter'
+  spec.summary       = 'Facter, a system inventory tool'
+  spec.description   = 'You can prove anything with facts!'
   spec.license       = 'MIT'
 
   spec.files = Dir['bin/facter'] +


### PR DESCRIPTION
Add `project_data.yaml` in order to be able to use
the nightly gem build rake task from packaging.

Add `nonfinal_gem_path` to `build_defaults.yaml`
to specify the nightly gem ship location.

```
❯ gem info facter
*** LOCAL GEMS ***

facter (4.1.0.73.g564b9d0.dirty)
    Author: Puppet Labs
    Homepage: https://github.com/puppetlabs/facter
    Installed at: /Users/gheorghe.popescu/.rvm/gems/ruby-2.7.2

    Facter, a system inventory tool

❯ gem dependency facter
Gem facter-4.1.0.73.g564b9d0.dirty
  hocon (~> 1.3)
  thor (>= 1.0.1, < 2.0)  
```