### PR TITLE
(FACT-3035) Check `lsblk` and `blkid` existence only once

### DIFF
--- a/lib/facter/resolvers/partitions.rb
+++ b/lib/facter/resolvers/partitions.rb
@@ -109,7 +109,7 @@ module Facter
 
           output = Facter::Core::Execution.execute("which #{command}", logger: log)
 
-          blkid_and_lsblk[:command_exists_key] = !output.empty?
+          blkid_and_lsblk[command_exists_key] = !output.empty?
         end
 
         def execute_and_extract_blkid_info

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -67,6 +67,18 @@ describe Facter::Resolvers::Partitions do
           .with("#{sys_block_path}/sda/sda1/size", '0').and_return('234')
       end
 
+      context 'when there is more than one partition' do
+        it 'checks for blkid only once' do
+          resolver.resolve(:partitions)
+          expect(Facter::Core::Execution).to have_received(:execute).with('which blkid', logger: logger).once
+        end
+
+        it 'checks for lsblk only once' do
+          resolver.resolve(:partitions)
+          expect(Facter::Core::Execution).to have_received(:execute).with('which lsblk', logger: logger).once
+        end
+      end
+
       context 'when device size files are readable' do
         let(:partitions) do
           { '/dev/sda1' => { filesystem: 'ext3', label: '/boot', size: '117.00 KiB',


### PR DESCRIPTION
This commit avoids checking the existence of `lsblk` and `blkid` commands for each partition resolved. Small performance improvement and debug logs cleanup are achieved through this fix.

Fix was manually tested on a `Ubuntu 18.04` with 3 partitions.

Before fix logs:
```sh-session
➜ /opt/puppetlabs/puppet/bin/facter-ng partitions --debug
[2021-05-17 07:44:04.692153 ] INFO Facter - executed with command line: partitions --debug
[2021-05-17 07:44:04.692204 ] DEBUG Facter - Facter version: 4.1.1
[2021-05-17 07:44:04.694044 ] DEBUG Facter::FactLoader - Loading internal facts
[2021-05-17 07:44:04.694077 ] DEBUG Facter::FactLoader - Loading all internal facts
[2021-05-17 07:44:04.694136 ] DEBUG Facter::FactLoader - Loading custom facts
[2021-05-17 07:44:04.696645 ] DEBUG Facter::FactLoader - Loading external facts
[2021-05-17 07:44:04.696789 ] DEBUG Facter::QueryParser - User query is: ["partitions"]
[2021-05-17 07:44:04.696816 ] DEBUG Facter::QueryParser - Query is partitions
[2021-05-17 07:44:04.696836 ] DEBUG Facter::QueryParser - Checking query tokens partitions
[2021-05-17 07:44:04.697740 ] DEBUG Facter::QueryParser - List of resolvable facts: [#<Facter::SearchedFact:0x00005596af52ca10 @name="partitions", @fact_class=Facts::Linux::Partitions, @filter_tokens=[], @user_query="partitions", @type=:core, @file=nil>]
[2021-05-17 07:44:04.697783 ] DEBUG Facter::InternalFactManager - Resolving facts sequentially
[2021-05-17 07:44:04.697971 ] DEBUG Facter::Core::Execution::Posix - Executing command: which blkid
[2021-05-17 07:44:04.699787 ] DEBUG Facter::Core::Execution::Posix - Executing command: blkid
[2021-05-17 07:44:04.859000 ] DEBUG Facter::Core::Execution::Posix - Executing command: which blkid
[2021-05-17 07:44:04.861574 ] DEBUG Facter::Core::Execution::Posix - Executing command: which blkid
[2021-05-17 07:44:04.878446 ] DEBUG Facter::FactManager - fact "partitions" has resolved to:
```

After fix logs:
```sh-session
➜ /opt/puppetlabs/puppet/bin/facter-ng partitions --debug
[2021-05-17 08:50:41.555543 ] INFO Facter - executed with command line: partitions --debug
[2021-05-17 08:50:41.555593 ] DEBUG Facter - Facter version: 4.1.1
[2021-05-17 08:50:41.557484 ] DEBUG Facter::FactLoader - Loading internal facts
[2021-05-17 08:50:41.557784 ] DEBUG Facter::FactLoader - Loading all internal facts
[2021-05-17 08:50:41.557855 ] DEBUG Facter::FactLoader - Loading custom facts
[2021-05-17 08:50:41.560272 ] DEBUG Facter::FactLoader - Loading external facts
[2021-05-17 08:50:41.560407 ] DEBUG Facter::QueryParser - User query is: ["partitions"]
[2021-05-17 08:50:41.560433 ] DEBUG Facter::QueryParser - Query is partitions
[2021-05-17 08:50:41.560453 ] DEBUG Facter::QueryParser - Checking query tokens partitions
[2021-05-17 08:50:41.561365 ] DEBUG Facter::QueryParser - List of resolvable facts: [#<Facter::SearchedFact:0x0000560371157fa0 @name="partitions", @fact_class=Facts::Linux::Partitions, @filter_tokens=[], @user_query="partitions", @type=:core, @file=nil>]
[2021-05-17 08:50:41.561406 ] DEBUG Facter::InternalFactManager - Resolving facts sequentially
[2021-05-17 08:50:41.561597 ] DEBUG Facter::Core::Execution::Posix - Executing command: which blkid
[2021-05-17 08:50:41.563461 ] DEBUG Facter::Core::Execution::Posix - Executing command: blkid
[2021-05-17 08:50:41.743994 ] DEBUG Facter::FactManager - fact "partitions" has resolved to:
```

