### PR TITLE
(FACT-3041) Fix rubysitedir fact

### DIFF
--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -38,12 +38,14 @@ test_name "C100305: The Ruby fact should resolve as expected in AIO" do
           end
       end
 
+      has_sitedir = !on(agent, 'ruby -e"puts RbConfig::CONFIG[\'sitedir\']"').output.chomp.empty?
+
       ruby_version   = /2\.\d+\.\d+/
       expected_facts = {
           'ruby.platform' => ruby_platform,
-          'ruby.sitedir'  => /\/site_ruby/,
           'ruby.version'  => ruby_version
       }
+      expected_facts['ruby.sitedir'] = /\/site_ruby/ if has_sitedir
 
       step("verify that ruby structured fact contains facts") do
         on(agent, facter("--json ruby")) do |facter_results|

--- a/lib/facter/resolvers/ruby.rb
+++ b/lib/facter/resolvers/ruby.rb
@@ -13,7 +13,7 @@ module Facter
         end
 
         def retrieve_ruby_information(fact_name)
-          @fact_list[:sitedir] = RbConfig::CONFIG['sitelibdir']
+          @fact_list[:sitedir] = RbConfig::CONFIG['sitelibdir'] if RbConfig::CONFIG['sitedir']
           @fact_list[:platform] = RUBY_PLATFORM
           @fact_list[:version] = RUBY_VERSION
           @fact_list[fact_name]

--- a/spec/facter/resolvers/ruby_spec.rb
+++ b/spec/facter/resolvers/ruby_spec.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Ruby do
+  before do
+    Facter::Resolvers::Ruby.invalidate_cache
+  end
+
   describe '#resolve ruby facts' do
     it 'detects ruby sitedir' do
       expect(Facter::Resolvers::Ruby.resolve(:sitedir)).to eql(RbConfig::CONFIG['sitelibdir'])
+    end
+
+    it 'does not resolve the sitedir fact if sitedir does not exist' do
+      allow(RbConfig::CONFIG).to receive(:[]).with('sitedir').and_return(nil)
+      expect(Facter::Resolvers::Ruby.resolve(:sitedir)).to be(nil)
     end
 
     it 'detects ruby platform' do


### PR DESCRIPTION
Facter uses the `sitelibdir` RbConfig key to fill the `rubysitedir` fact. If ruby is compiled without sitedir, this value is invalid. Make sure `sitedir` exists by checking that RbConfig key first.