### PR TITLE
(FACT-3048) Remove CURRENT_PROCESS from ffi_lib call

### DIFF
--- a/lib/facter/resolvers/windows/ffi/kernel_ffi.rb
+++ b/lib/facter/resolvers/windows/ffi/kernel_ffi.rb
@@ -7,7 +7,7 @@ module KernelFFI
   extend FFI::Library
 
   ffi_convention :stdcall
-  ffi_lib [FFI::CURRENT_PROCESS, :ntdll]
+  ffi_lib :ntdll
   attach_function :RtlGetVersion, [:pointer], :int32
 
   STATUS_SUCCESS = 0


### PR DESCRIPTION
This happened to work because ffi_lib will fail to load CURRENT_PROCESS as a dll
and fallback to ntdll.