### PR TITLE
(FACT-3046) Concatenate facter 4 flags

### DIFF
--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -97,6 +97,11 @@ module Facter
                  type: :boolean,
                  desc: 'Resolve facts sequentially'
 
+    class_option :puppet,
+                 type: :boolean,
+                 aliases: '-p',
+                 desc: 'Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.'
+
     desc '--man', 'Display manual.', hide: true
     map ['--man'] => :man
     def man(*args)
@@ -111,6 +116,7 @@ module Facter
 
     desc 'query', 'Default method', hide: true
     def query(*args)
+      Facter.puppet_facts if options[:puppet]
       output, status = Facter.to_user_output(@options, *args)
       puts output
 
@@ -154,18 +160,6 @@ module Facter
       cache_groups.gsub!(/:\s*\n/, "\n")
 
       puts cache_groups
-    end
-
-    desc '--puppet, -p', 'Load the Puppet libraries, thus allowing Facter to load Puppet-specific facts.'
-    map ['--puppet', '-p'] => :puppet
-    def puppet(*args)
-      Facter.puppet_facts
-
-      output, status = Facter.to_user_output(@options, *args)
-      puts output
-
-      status = 1 if Facter::Log.errors?
-      exit status
     end
 
     desc '--help, -h', 'Help for all arguments'

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -119,7 +119,6 @@ describe Facter::Resolvers::Ec2 do
 
     let(:token) { 'v2_token' }
     let(:headers) { { 'X-aws-ec2-metadata-token' => token } }
-    let(:expected_header) { headers }
 
     it_behaves_like 'ec2'
   end
@@ -131,7 +130,6 @@ describe Facter::Resolvers::Ec2 do
 
     let(:token) { nil }
     let(:headers) { { 'Accept' => '*/*' } }
-    let(:expected_header) { {} }
 
     it_behaves_like 'ec2'
   end
@@ -139,8 +137,8 @@ describe Facter::Resolvers::Ec2 do
   it 'does not add headers if token is nil' do
     allow(Facter::Resolvers::Ec2).to receive(:v2_token).and_return(nil)
 
-    stub_request(:any, metadata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
-    stub_request(:any, userdata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
+    stub_request(:get, metadata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
+    stub_request(:get, userdata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
 
     ec2.resolve(:userdata)
   end

--- a/spec_integration/facter_to_hash_spec.rb
+++ b/spec_integration/facter_to_hash_spec.rb
@@ -35,6 +35,46 @@ describe Facter do
       end
     end
 
+    context 'when concatenating short flags' do
+      it 'returns no error' do
+        _, err = IntegrationHelper.exec_facter('-pjdt')
+
+        expect(err).not_to match(/ERROR Facter::OptionsValidator - unrecognised option/)
+      end
+
+      it 'returns error' do
+        _, err = IntegrationHelper.exec_facter('-pjdtz')
+
+        expect(err).to match(/ERROR Facter::OptionsValidator - .*unrecognised option '-z'/)
+      end
+
+      context 'when concatenating JSON and DEBUG flags' do
+        out, err = IntegrationHelper.exec_facter('-jd')
+
+        it 'outputs in valid JSON format' do
+          expect do
+            JSON.parse(out)
+          end.not_to raise_exception
+        end
+
+        it 'outputs DEBUG logs' do
+          expect(err).to match(/DEBUG/)
+        end
+      end
+
+      context 'when concatenating timing and DEBUG flags' do
+        out, err = IntegrationHelper.exec_facter('-td')
+
+        it 'outputs timings of facts' do
+          expect(out).to match(/fact .*, took: .* seconds/)
+        end
+
+        it 'outputs DEBUG logs' do
+          expect(err).to match(/DEBUG/)
+        end
+      end
+    end
+
     context 'with user query' do
       it 'returns fqdn' do
         out, = IntegrationHelper.exec_facter('fqdn')

--- a/spec_integration/facter_to_hash_spec.rb
+++ b/spec_integration/facter_to_hash_spec.rb
@@ -35,17 +35,21 @@ describe Facter do
       end
     end
 
-    context 'when concatenating short flags' do
-      it 'returns no error' do
-        _, err = IntegrationHelper.exec_facter('-pjdt')
+    context 'when concatenating short options' do
+      context 'when using valid flags' do
+        it 'returns no error' do
+          _, err = IntegrationHelper.exec_facter('-pjdt')
 
-        expect(err).not_to match(/ERROR Facter::OptionsValidator - unrecognised option/)
+          expect(err).not_to match(/ERROR Facter::OptionsValidator - unrecognised option/)
+        end
       end
 
-      it 'returns error' do
-        _, err = IntegrationHelper.exec_facter('-pjdtz')
+      context 'when using flags and subcommands' do
+        it 'returns validation error' do
+          _, err = IntegrationHelper.exec_facter('-pjdtz')
 
-        expect(err).to match(/ERROR Facter::OptionsValidator - .*unrecognised option '-z'/)
+          expect(err).to match(/ERROR Facter::OptionsValidator - .*unrecognised option '-z'/)
+        end
       end
 
       context 'when concatenating JSON and DEBUG flags' do


### PR DESCRIPTION
This PR moves `--puppet` and `-p` subcommand to Thor class_option so it
can be concatenated with other class_option flags.

Now -p flag can be concatenated with -j(json), -y(yaml), -d(debug) and
-t(timing) flags.