### PR TITLE
(FACT-3050) Use empty header in Ec2 resolver when token is nil

### DIFF
--- a/lib/facter/resolvers/ec2.rb
+++ b/lib/facter/resolvers/ec2.rb
@@ -51,7 +51,7 @@ module Facter
 
         def get_data_from(url)
           headers = {}
-          headers['X-aws-ec2-metadata-token'] = v2_token
+          headers['X-aws-ec2-metadata-token'] = v2_token if v2_token
           Facter::Util::Resolvers::Http.get_request(url, headers, { session: determine_session_timeout })
         end
 

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -118,7 +118,8 @@ describe Facter::Resolvers::Ec2 do
     end
 
     let(:token) { 'v2_token' }
-    let(:headers) { { 'X-Aws-Ec2-Metadata-Token' => token } }
+    let(:headers) { { 'X-aws-ec2-metadata-token' => token } }
+    let(:expected_header) { headers }
 
     it_behaves_like 'ec2'
   end
@@ -130,7 +131,17 @@ describe Facter::Resolvers::Ec2 do
 
     let(:token) { nil }
     let(:headers) { { 'Accept' => '*/*' } }
+    let(:expected_header) { {} }
 
     it_behaves_like 'ec2'
+  end
+
+  it 'does not add headers if token is nil' do
+    allow(Facter::Resolvers::Ec2).to receive(:v2_token).and_return(nil)
+
+    stub_request(:any, metadata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
+    stub_request(:any, userdata_uri).with { |request| !request.headers.key?('X-aws-ec2-metadata-token') }
+
+    ec2.resolve(:userdata)
   end
 end


### PR DESCRIPTION
Before this commit, rspec tests for the Ec2 resolver were failing on
some GitHub Actions Ubuntu machines with ruby 2.3.8p459.

This fix checks if the token is nil before sending the HTTP request that
gathers the needed data. Based on this token the header will be filled
accordingly.