### PR TITLE
(maint) Skip os facts in acceptance on Debian 11

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -173,7 +173,12 @@ module Facter
             'kernelrelease'            => /\d+\.\d+\.\d+/,
             'kernelversion'            => /\d+\.\d+/,
             'kernelmajversion'         => /\d+\.\d+/
-        }
+        }.reject do |fact, value|
+          # Skip os fact matching on Debian 11 as it does not report the stable
+          # version until its official release
+          fact.start_with?('os.') if os_version == /11/
+        end
+
         expected_facts
       end
 


### PR DESCRIPTION
Debian 11 still reports bullseye/sid as its version, so skip our os tests until the official release.