### PR TITLE
(maint) Include LICENSE in the gem

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'You can prove anything with facts!'
 
   spec.files = Dir['bin/facter-ng'] +
+               Dir['LICENSE'] +
                Dir['lib/**/*.rb'] +
                Dir['lib/**/*.json'] +
                Dir['lib/**/*.conf'] +

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files = Dir['bin/facter'] +
+               Dir['LICENSE'] +
                Dir['lib/**/*.rb'] +
                Dir['lib/**/*.json'] +
                Dir['lib/**/*.conf'] +


### PR DESCRIPTION
It's a good practice to include the full license text in the gem.

CHANGELOG.md isn't included since it hasn't been updated since 4.0.44.