### PR TITLE
(FACT-3052) Glob relative to directory containing the gemspec

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -12,13 +12,19 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Facter, a system inventory tool'
   spec.description   = 'You can prove anything with facts!'
 
-  spec.files = Dir['bin/facter-ng'] +
-               Dir['LICENSE'] +
-               Dir['lib/**/*.rb'] +
-               Dir['lib/**/*.json'] +
-               Dir['lib/**/*.conf'] +
-               Dir['agent/**/*'] +
-               Dir['lib/**/*.erb']
+  # ruby 2.3 doesn't support `base` keyword arg
+  dirs =
+    Dir[File.join(__dir__, 'bin/facter-ng')] +
+    Dir[File.join(__dir__, 'LICENSE')] +
+    Dir[File.join(__dir__, 'lib/**/*.rb')] +
+    Dir[File.join(__dir__, 'lib/**/*.json')] +
+    Dir[File.join(__dir__, 'lib/**/*.conf')] +
+    Dir[File.join(__dir__, 'agent/**/*')] +
+    Dir[File.join(__dir__, 'lib/**/*.erb')]
+  base = Pathname.new(__dir__)
+  spec.files = dirs.map do |path|
+    Pathname.new(path).relative_path_from(base).to_path
+  end
 
   spec.required_ruby_version = '>= 2.3', '< 4.0'
 

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -14,12 +14,18 @@ Gem::Specification.new do |spec|
   spec.description   = 'You can prove anything with facts!'
   spec.license       = 'MIT'
 
-  spec.files = Dir['bin/facter'] +
-               Dir['LICENSE'] +
-               Dir['lib/**/*.rb'] +
-               Dir['lib/**/*.json'] +
-               Dir['lib/**/*.conf'] +
-               Dir['lib/**/*.erb']
+  # ruby 2.3 doesn't support `base` keyword arg
+  dirs =
+    Dir[File.join(__dir__, 'bin/facter')] +
+    Dir[File.join(__dir__, 'LICENSE')] +
+    Dir[File.join(__dir__, 'lib/**/*.rb')] +
+    Dir[File.join(__dir__, 'lib/**/*.json')] +
+    Dir[File.join(__dir__, 'lib/**/*.conf')] +
+    Dir[File.join(__dir__, 'lib/**/*.erb')]
+  base = Pathname.new(__dir__)
+  spec.files = dirs.map do |path|
+    Pathname.new(path).relative_path_from(base).to_path
+  end
 
   spec.required_ruby_version = '>= 2.3', '< 4.0'
   spec.bindir = 'bin'


### PR DESCRIPTION
Previously, we globbed relative to the current working directory. The puppet
agent service runs in /, which meant we were scanning everything in /bin and
/lib.