### PR TITLE
(maint) fix gem build from source

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -15,15 +17,18 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   # ruby 2.3 doesn't support `base` keyword arg
+  # we are building from `facter/agent` so we need to move
+  # one level up in the `facter` folder.
+  root_dir = Pathname.new(File.expand_path('..', __dir__))
   dirs =
-    Dir[File.join(__dir__, 'bin/facter-ng')] +
-    Dir[File.join(__dir__, 'LICENSE')] +
-    Dir[File.join(__dir__, 'lib/**/*.rb')] +
-    Dir[File.join(__dir__, 'lib/**/*.json')] +
-    Dir[File.join(__dir__, 'lib/**/*.conf')] +
-    Dir[File.join(__dir__, 'agent/**/*')] +
-    Dir[File.join(__dir__, 'lib/**/*.erb')]
-  base = Pathname.new(__dir__)
+    Dir[File.join(root_dir, 'bin/facter-ng')] +
+    Dir[File.join(root_dir, 'LICENSE')] +
+    Dir[File.join(root_dir, 'lib/**/*.rb')] +
+    Dir[File.join(root_dir, 'lib/**/*.json')] +
+    Dir[File.join(root_dir, 'lib/**/*.conf')] +
+    Dir[File.join(root_dir, 'agent/**/*')] +
+    Dir[File.join(root_dir, 'lib/**/*.erb')]
+  base = Pathname.new(root_dir)
   spec.files = dirs.map do |path|
     Pathname.new(path).relative_path_from(base).to_path
   end

--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
-  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.74.0'
   spec.add_development_dependency 'rubycritic', '~> 4.1.0'

--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -8,9 +8,11 @@ Gem::Specification.new do |spec|
   spec.version       = '4.2.2'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
+  spec.homepage      = 'https://github.com/puppetlabs/facter'
 
   spec.summary       = 'Facter, a system inventory tool'
   spec.description   = 'You can prove anything with facts!'
+  spec.license       = 'MIT'
 
   # ruby 2.3 doesn't support `base` keyword arg
   dirs =

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 


### PR DESCRIPTION
Using `gem build facter.gemspec` failed because `pathname` was not loaded
Using `gem build agent/facter-ng.gemspec` failed because the paths were not taking into consideration that the build is relative to the `agent` folder.

```
~/Workspace/facter  pl/main ⇡                                                                                                                                                                                                                                                       2.7.2
❯ gem build agent/facter-ng.gemspec
  Successfully built RubyGem
  Name: facter-ng
  Version: 4.2.2
  File: facter-ng-4.2.2.gem

~/Workspace/facter  pl/main ⇡                                                                                                                                                                                                                                                       2.7.2
❯ gem build facter.gemspec
  Successfully built RubyGem
  Name: facter
  Version: 4.2.2
  File: facter-4.2.2.gem

~/Workspace/facter  pl/main ⇡
```

Fixed a couple of warnings in `.gemspec`