### PR TITLE
(FACT-3054) convert ip6 ranges into single ip as it does for ip4

### DIFF
--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -37,7 +37,9 @@ module Facter
 
         def clean_up_interfaces_response(response)
           # convert ip ranges into single ip. eg. 10.16.132.213 -->  10.16.132.213 is converted to 10.16.132.213
-          response.gsub!(/(\d+(\.\d+)*)\s+-->\s+\d+(\.\d+)*/, '\\1')
+          # convert ip6 ranges into single ip. eg. 2001:db8:cafe::132:213 -->
+          # 2001:db8:cafe::132:213 is converted to 2001:db8:cafe::132:213
+          response.gsub!(/([\da-fA-F]+([\.:]+[\da-fA-F]+)*)\s+-->\s+[\da-fA-F]+([\.:]+[\da-fA-F]+)*/, '\\1')
         end
 
         def parse_interfaces_response(response)

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -39,7 +39,7 @@ describe Facter::Resolvers::Networking do
     end
 
     it 'detects all interfaces' do
-      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 ib0 ib1]
+      expected = %w[lo0 gif0 stf0 en0 en0.1 en1 en2 bridge0 p2p0 awdl0 llw0 utun0 utun1 utun2 utun3 ib0 ib1]
       expect(networking.resolve(:interfaces).keys).to match_array(expected)
     end
 
@@ -127,6 +127,14 @@ describe Facter::Resolvers::Networking do
     it 'checks interface utun2' do
       expected = { bindings: [{ address: '10.16.132.213', netmask: '255.255.254.0', network: '10.16.132.0' }] }
       expect(networking.resolve(:interfaces)['utun2']).to include(expected)
+    end
+
+    it 'checks interface utun3' do
+      expected = { bindings6: [
+        { address: '2001:db8:cafe::132:213', netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          network: '2001:db8:cafe::132:213', scope6: 'global' }
+      ] }
+      expect(networking.resolve(:interfaces)['utun3']).to include(expected)
     end
 
     it 'checks interface ib0 has the expected mac' do

--- a/spec/fixtures/ifconfig_mac
+++ b/spec/fixtures/ifconfig_mac
@@ -72,6 +72,8 @@ utun1: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
 	nd6 options=201<PERFORMNUD,DAD>
 utun2: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500
 	inet 10.16.132.213 -->  10.16.132.213 netmask 0xfffffe00 
+utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1500
+	inet6 2001:db8:cafe::132:213 --> 2001:db8:cafe::132:213 prefixlen 128
 ib0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 4092
         infiniband 80:00:02:08:FA:81:00:00:00:00:00:00:00:00:00:00:00:00:00:00  txqueuelen 256  (InfiniBand)
         RX packets 0  bytes 0 (0.0 B)


### PR DESCRIPTION
Filed as https://tickets.puppetlabs.com/browse/FACT-3054

There might be some discussion on the regexp for mixed ipv4/ipv6 use, but then again this regexp would also work with invalid IPv4 addresses if presented to Facter somehow