### PR TITLE
(maint) fix gemspec stack level too deep

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pathname'
-
 lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -16,22 +14,17 @@ Gem::Specification.new do |spec|
   spec.description   = 'You can prove anything with facts!'
   spec.license       = 'MIT'
 
-  # ruby 2.3 doesn't support `base` keyword arg
-  # we are building from `facter/agent` so we need to move
-  # one level up in the `facter` folder.
-  root_dir = Pathname.new(File.expand_path('..', __dir__))
+  root_dir = File.join(__dir__, '..')
   dirs =
     Dir[File.join(root_dir, 'bin/facter-ng')] +
     Dir[File.join(root_dir, 'LICENSE')] +
     Dir[File.join(root_dir, 'lib/**/*.rb')] +
     Dir[File.join(root_dir, 'lib/**/*.json')] +
     Dir[File.join(root_dir, 'lib/**/*.conf')] +
-    Dir[File.join(root_dir, 'agent/**/*')] +
     Dir[File.join(root_dir, 'lib/**/*.erb')]
-  base = Pathname.new(root_dir)
-  spec.files = dirs.map do |path|
-    Pathname.new(path).relative_path_from(base).to_path
-  end
+  base = "#{root_dir}#{File::SEPARATOR}"
+
+  spec.files = dirs.map { |path| path.sub(base, '') }
 
   spec.required_ruby_version = '>= 2.3', '< 4.0'
 

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pathname'
-
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -16,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.description   = 'You can prove anything with facts!'
   spec.license       = 'MIT'
 
-  # ruby 2.3 doesn't support `base` keyword arg
   dirs =
     Dir[File.join(__dir__, 'bin/facter')] +
     Dir[File.join(__dir__, 'LICENSE')] +
@@ -24,10 +21,8 @@ Gem::Specification.new do |spec|
     Dir[File.join(__dir__, 'lib/**/*.json')] +
     Dir[File.join(__dir__, 'lib/**/*.conf')] +
     Dir[File.join(__dir__, 'lib/**/*.erb')]
-  base = Pathname.new(__dir__)
-  spec.files = dirs.map do |path|
-    Pathname.new(path).relative_path_from(base).to_path
-  end
+  base = "#{__dir__}#{File::SEPARATOR}"
+  spec.files = dirs.map { |path| path.sub(base, '') }
 
   spec.required_ruby_version = '>= 2.3', '< 4.0'
   spec.bindir = 'bin'


### PR DESCRIPTION
Because of an r10k issue(https://github.com/puppetlabs/r10k/issues/760#issuecomment-325825267)
we cannot use any require statemens inside `.gemspec`
files.

This commit updates `facter.gemspec` and `facter-ng.gemspec`
to build the file paths without using `pathname`