### PR TITLE
(FACT-3032) skip ipv6 tests outside of CI

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  CI: true
+
 jobs:
   linux_unit_tests:
     name: Ruby version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,11 @@ top of things.
 
 * Make sure you have added the necessary tests for your changes.
 * Run _all_ the tests to assure nothing else was accidentally broken.
-  * We recommend running `./check.sh` to have the same checks run as on github
+* We recommend running the follwing rake tasks:
+  * `bundle exec rake rubocop` - runs rubocop cheks
+  * `bundle exec rake spec_random` - runs unit tests
+  * `bundle exec rake spec_integration` - runs integration tests. Note that tests with the `skip_outside_ci` tag are excluded outside of CI, you can run them with `CI=true bundle exec rake spec_integration`
+* Or you can use `bundle exec rake check` to run all the above tasks in one command
 
 ## Making Trivial Changes
 

--- a/spec_integration/facter_to_hash_spec.rb
+++ b/spec_integration/facter_to_hash_spec.rb
@@ -92,7 +92,7 @@ describe Facter do
         expect(out).to match(/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/)
       end
 
-      it 'returns ipaddress6' do
+      it 'returns ipaddress6', :skip_outside_ci do
         out, = IntegrationHelper.exec_facter('ipaddress6')
 
         expect(out).to match(/([a-z0-9]{1,4}:{1,2})+[a-z0-9]{1,4}/)
@@ -131,7 +131,7 @@ describe Facter do
       expect(fact_hash['ipaddress']).to match(/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/)
     end
 
-    it 'contains ipaddress6' do
+    it 'contains ipaddress6', :skip_outside_ci do
       fact_hash = Facter.to_hash
 
       expect(fact_hash['ipaddress6']).to match(/([a-z0-9]{1,4}:{1,2})+[a-z0-9]{1,4}/)

--- a/spec_integration/spec_helper.rb
+++ b/spec_integration/spec_helper.rb
@@ -12,6 +12,9 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
+  # exclude `skip_outside_ci` tests if not running on CI
+  config.filter_run_excluding :skip_outside_ci unless ENV['CI']
+
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
   config.expose_dsl_globally = true


### PR DESCRIPTION
Because ipv6 tests usually fail when running locally,
updated the RSpec configuration to skip them by
default. These tests will be run only when setting
the environment variable `CI`.

The `skip_outside_ci` tag can be used for future tests that
need to be excluded when running locally.