### PR TITLE
(FACT-3062) Remove snyk test on PR 

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -52,22 +52,3 @@ jobs:
           ruby-version: 2.6
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rake commits
-
-  snyk_test:
-    runs-on: ubuntu-latest
-    name: Snyk vulnerabilities
-    steps:
-      - name: Checkout current PR
-        uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - name: Install dependencies
-        run: bundle install --jobs 3 --retry 3
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/ruby@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          command: test

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -3,9 +3,12 @@ name: Snyk Monitor
 on:
   schedule:
     - cron: '0 5 * * 1-5'
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 jobs:
   snyk_monitor:
+    if: github.repository_owner = 'puppetlabs'
     runs-on: ubuntu-latest
     name: Snyk Monitor
     steps:


### PR DESCRIPTION
Since PRs from forks do not have access to secrets we don't have a (simple) way to run the snyk test check. Remove it for now, and just run the daily monitor check on main.

