### PR TITLE
(FACT-3059) Fix AIX reporting odd number of arguments for Hash 

### DIFF
--- a/lib/facter/resolvers/aix/disks.rb
+++ b/lib/facter/resolvers/aix/disks.rb
@@ -34,7 +34,7 @@ module Facter
 
             return if stdout.empty?
 
-            info_size = Facter::Util::Aix::InfoExtractor.extract(stdout, /PP SIZE:|TOTAL PPs:|FREE PPs:|PV STATE:/)
+            info_size = Facter::Util::Aix::InfoExtractor.extract(stdout, :lspv)
 
             return unless info_size['PV STATE']
 

--- a/lib/facter/resolvers/aix/partitions.rb
+++ b/lib/facter/resolvers/aix/partitions.rb
@@ -40,7 +40,7 @@ module Facter
 
             return if stdout.empty?
 
-            info_hash =  Facter::Util::Aix::InfoExtractor.extract(stdout, /PPs:|PP SIZE|TYPE:|LABEL:|MOUNT/)
+            info_hash =  Facter::Util::Aix::InfoExtractor.extract(stdout, :lslv)
             size_bytes = compute_size(info_hash)
 
             part_info = {

--- a/lib/facter/util/aix/info_extractor.rb
+++ b/lib/facter/util/aix/info_extractor.rb
@@ -6,17 +6,68 @@ module Facter
       module InfoExtractor
         MEGABYTES_EXPONENT = 1024**2
         GIGABYTES_EXPONENT = 1024**3
+        PROPERTIES = {
+          lslv: [
+            'LOGICAL VOLUME:',
+            'VOLUME GROUP:',
+            'LV IDENTIFIER:',
+            'PERMISSION:',
+            'VG STATE:',
+            'LV STATE:',
+            'TYPE:',
+            'WRITE VERIFY:',
+            'MAX LPs:',
+            'PP SIZE:',
+            'COPIES:',
+            'SCHED POLICY:',
+            'LPs:',
+            'PPs:',
+            'STALE PPs:',
+            'BB POLICY:',
+            'INTER-POLICY:',
+            'RELOCATABLE:',
+            'INTRA-POLICY:',
+            'UPPER BOUND:',
+            'MOUNT POINT:',
+            'LABEL:',
+            'MIRROR WRITE CONSISTENCY:',
+            'EACH LP COPY ON A SEPARATE PV ?:',
+            'Serialize IO ?:'
+          ],
+          lspv: [
+            'PHYSICAL VOLUME:',
+            'VOLUME GROUP:',
+            'PV IDENTIFIER:',
+            'VG IDENTIFIER',
+            'PV STATE:',
+            'STALE PARTITIONS:',
+            'ALLOCATABLE:',
+            'PP SIZE:',
+            'LOGICAL VOLUMES:',
+            'TOTAL PPs:',
+            'VG DESCRIPTORS:',
+            'FREE PPs:',
+            'HOT SPARE:',
+            'USED PPs:',
+            'MAX REQUEST:',
+            'FREE DISTRIBUTION:',
+            'USED DISTRIBUTION:',
+            'MIRROR POOL:'
+          ]
+        }.freeze
 
-        def self.extract(content, regex)
-          content = content.each_line.map do |line|
-            next unless regex =~ line
-
-            line.split(/:\s*|\s{2,}/)
+        def self.extract(content, cmd)
+          property_hash = {}
+          properties = PROPERTIES[cmd]
+          properties.each do |property|
+            str = (properties - [property]).join('|')
+            matcher = content.match(/#{Regexp.escape(property)}([^\n]*?)(#{str}|\n|$)/s)
+            if matcher
+              value = matcher[1].strip
+              property_hash[property.split(':').first] = value
+            end
           end
-
-          content.flatten!.reject!(&:nil?)
-
-          Hash[*content]
+          property_hash
         end
       end
     end

--- a/spec/facter/resolvers/aix/mountpoints_spec.rb
+++ b/spec/facter/resolvers/aix/mountpoints_spec.rb
@@ -9,9 +9,9 @@ describe Facter::Resolvers::Aix::Mountpoints do
       '/usr' => { available: '2.84 GiB', available_bytes: 3_049_021_440, capacity: '43.21%', device: '/dev/hd2',
                   filesystem: 'jfs2', options: ['rw', 'log=/dev/hd8'], size: '5.00 GiB', size_bytes: 5_368_709_120,
                   used: '2.16 GiB', used_bytes: 2_319_687_680 },
-      '/var' => { available: '205.06 MiB', available_bytes: 215023616, capacity: '0.76%', device: '/dev/hd3', 
-                  filesystem: 'x', options: ['rw', 'nodev', 'log=/dev/hd3'], size: '206.64 MiB', size_bytes: 216678912, 
-                  used: '1.58 MiB', used_bytes: 1655296}}
+      '/var' => { available: '205.06 MiB', available_bytes: 215_023_616, capacity: '0.76%', device: '/dev/hd3',
+                  filesystem: 'x', options: ['rw', 'nodev', 'log=/dev/hd3'], size: '206.64 MiB',
+                  size_bytes: 216_678_912, used: '1.58 MiB', used_bytes: 1_655_296 } }
   end
   let(:log_spy) { instance_spy(Facter::Log) }
 

--- a/spec/fixtures/lslv_output
+++ b/spec/fixtures/lslv_output
@@ -8,6 +8,6 @@ LPs:                1                      PPs:            1
 STALE PPs:          0                      BB POLICY:      non-relocatable
 INTER-POLICY:       minimum                RELOCATABLE:    no
 INTRA-POLICY:       edge                   UPPER BOUND:    32
-MOUNT POINT:        N/A                    LABEL:          primary_bootlv
+MOUNT POINT:        N/A LABEL:          primary_bootlv
 MIRROR WRITE CONSISTENCY: on/ACTIVE
 EACH LP COPY ON A SEPARATE PV ?: yes


### PR DESCRIPTION
Previously, the aix `info_extractor` would make the assumption that keys are
separated from values with multiple spaces, but in some instances there would be
only one space.

This commit fixes this issue by searching for each known key
(from the `PROPERTIES` variable), and finds the value, then ignores the rest of
the line. The algorithm repeats for each key.