### PR TITLE
(FACT-3057) Downcase environment facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/3bd4be86f4b0b49bc0ca/maintainability)](https://codeclimate.com/github/puppetlabs/facter/maintainability)
 
 
-Facter is a command-line tool that gathers basic facts about nodes (systems) such as hardware details, network settings, OS type and version, and more. These facts are made available as variables in your Puppet manifests and can be used to inform conditional expressions in Puppet.
+Facter is a command-line tool that gathers basic facts about nodes (systems)
+such as hardware details, network settings, OS type and version, and more.
+These facts are made available as variables in your Puppet manifests and can be
+used to inform conditional expressions in Puppet.
+
+## Documentation
+
+Documentation for the Facter project can be found on the [Puppet Docs
+site](https://puppet.com/docs/puppet/latest/facter.html).
 
 ## Supported platforms
 * Linux
@@ -21,6 +29,7 @@ Facter is a command-line tool that gathers basic facts about nodes (systems) suc
 
 ## Requirements
 * Ruby 2.3+
+* FFI (for facts like `mountpoints` which are resolved using C API calls)
 
 ## Basic concepts
 The project has three main parts, the framework, facts and resolvers.
@@ -29,7 +38,7 @@ In the framework we implement functionality that is agnostic of specific facts l
 Facts are the nuggets of information that will be provided by facter e.g. `os.name`, `networking.interfaces`, etc.
 
 Resolvers have the role of gathering data from the system.
-For example a resolver can execute a command on the system, can read a file or any operation that retries some data from a single source on the system.
+For example a resolver can execute a command on the system, can read a file or any operation that retrieves some data from a single source on the system.
 
 ![Facter user interaction](docs/diagrams/facter_user_interaction.png?raw=true)
 
@@ -37,7 +46,7 @@ For example a resolver can execute a command on the system, can read a file or a
 After cloning the project, run `bundle install` to install all dependencies.
 
 You can run facter by executing `./bin/facter`.
-The command will output all the facts that facter detected for the current os.
+The command will output all the facts that facter detected for the current OS.
 
 The implementation can be validated locally by running `bundle exec rake check`.
 

--- a/acceptance/tests/api/value/env_fact.rb
+++ b/acceptance/tests/api/value/env_fact.rb
@@ -22,5 +22,15 @@ test_name 'Facter.value(env_fact)' do
         assert_match(fact_value, result.stdout.chomp, 'Incorrect fact value for env fact')
       end
     end
+
+    step 'resolves the fact with the correct value if the env fact is upcased' do
+      facter_rb = facter_value_rb(agent, fact_name)
+
+      env = { "FACTER_#{fact_name.upcase}" => fact_value }
+
+      on(agent, "#{ruby_command(agent)} #{facter_rb}", environment: env) do |result|
+        assert_match(fact_value, result.stdout.chomp, 'Incorrect fact value for env fact')
+      end
+    end
   end
 end

--- a/acceptance/tests/env_fact.rb
+++ b/acceptance/tests/env_fact.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
 test_name 'Can use environment facts' do
-  step 'FACTER_ env fact correctly is resolved' do
+  step 'FACTER_ env fact is correctly resolved' do
     fact_name = 'env_name'
     fact_value = 'env_value'
 
     on(agent, facter(fact_name, environment: { "FACTER_#{fact_name}" => fact_value })) do |facter_output|
+      assert_equal(
+        fact_value,
+        facter_output.stdout.chomp,
+        'Expected `FACTER_` to be resolved from environment'
+      )
+    end
+  end
+
+  step 'FACTER_ env fact is correctly resolved when the fact name is upcased' do
+    fact_name = 'env_name'
+    fact_value = 'env_value'
+
+    on(agent, facter(fact_name, environment: { "FACTER_#{fact_name.upcase}" => fact_value })) do |facter_output|
       assert_equal(
         fact_value,
         facter_output.stdout.chomp,

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -390,7 +390,7 @@ module Facter
     #
     # @api public
     def value(user_query)
-      user_query = user_query.to_s
+      user_query = user_query.to_s.downcase
       resolve_fact(user_query)
 
       @already_searched[user_query]&.value
@@ -407,7 +407,7 @@ module Facter
     #
     # @api public
     def fact(user_query)
-      user_query = user_query.to_s
+      user_query = user_query.to_s.downcase
       resolve_fact(user_query)
 
       @already_searched[user_query]

--- a/lib/facter/custom_facts/util/loader.rb
+++ b/lib/facter/custom_facts/util/loader.rb
@@ -141,13 +141,13 @@ module LegacyFacter
           # Skip anything that doesn't match our regex.
           next unless name =~ /^facter_?(\w+)$/i
 
-          env_name = Regexp.last_match(1)
+          env_name = Regexp.last_match(1).downcase
 
           # If a fact name was specified, skip anything that doesn't
           # match it.
           next if fact && (env_name != fact)
 
-          LegacyFacter.add(Regexp.last_match(1), fact_type: :external, is_env: true) do
+          LegacyFacter.add(env_name, fact_type: :external, is_env: true) do
             has_weight 1_000_000
             setcode { value }
           end

--- a/spec/custom_facts/util/loader_spec.rb
+++ b/spec/custom_facts/util/loader_spec.rb
@@ -263,7 +263,7 @@ describe LegacyFacter::Util::Loader do
 
     context 'when loads all facts from the environment' do
       before do
-        Facter::Util::Resolution.with_env 'facter_one' => 'yayness', 'facter_two' => 'boo' do
+        Facter::Util::Resolution.with_env 'FACTER_one' => 'yayness', 'FACTER_TWO' => 'boo' do
           loader.load_all
         end
       end
@@ -277,7 +277,7 @@ describe LegacyFacter::Util::Loader do
       end
     end
 
-    it 'onlies load all facts one time' do
+    it 'only load all facts once' do
       loader = loader_from(env: {})
       expect(loader).to receive(:load_env).once
 

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -198,6 +198,13 @@ describe Facter do
   end
 
   describe '#value' do
+    it 'downcases the user query' do
+      mock_fact_manager(:resolve_fact, [os_fact])
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
+
+      expect(Facter.value('OS.NAME')).to eq('Ubuntu')
+    end
+
     it 'returns a value' do
       mock_fact_manager(:resolve_fact, [os_fact])
       allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
@@ -212,7 +219,7 @@ describe Facter do
       expect(Facter.value('os.name')).to be nil
     end
 
-    context 'when custom fact with nill value' do
+    context 'when custom fact with nil value' do
       let(:type) { :custom }
       let(:fact_value) { nil }
       let(:fact_user_query) { '' }
@@ -227,6 +234,13 @@ describe Facter do
   end
 
   describe '#fact' do
+    it 'downcases the user query' do
+      mock_fact_manager(:resolve_fact, [os_fact])
+      allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')
+
+      expect(Facter.fact('OS.NAME')).to be_instance_of(Facter::ResolvedFact).and have_attributes(value: 'Ubuntu')
+    end
+
     it 'returns a fact' do
       mock_fact_manager(:resolve_fact, [os_fact])
       allow(fact_collection_spy).to receive(:value).with('os.name').and_return('Ubuntu')


### PR DESCRIPTION
Previously, environment facts were not downcased prior to being added to the fact collection. This contradicts the Facter 3 [behavior](https://github.com/puppetlabs/facter/blob/f123fc0c371114e4c6bc61ab245cdb3a32cf5ebb/lib/src/facts/collection.cc#L257), and breaks some use cases where the fact name is upcased when added to the collection and downcased when resolved via the CLI/Ruby API.

Downcase environment facts before adding them to the collection, and downcase the user queries passed to `Facter.fact` and `Facter.value`, which matches the [behavior of Facter 3](https://github.com/puppetlabs/facter/blob/f123fc0c371114e4c6bc61ab245cdb3a32cf5ebb/lib/src/ruby/module.cc#L483).

Link to the Facter documentation in the README, where this behavior will also be documented.