### PR TITLE
Revert "(maint) Skip os facts in acceptance on Debian 11"

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -173,12 +173,7 @@ module Facter
             'kernelrelease'            => /\d+\.\d+\.\d+/,
             'kernelversion'            => /\d+\.\d+/,
             'kernelmajversion'         => /\d+\.\d+/
-        }.reject do |fact, value|
-          # Skip os fact matching on Debian 11 as it does not report the stable
-          # version until its official release
-          fact.start_with?('os.') if os_version == /11/
-        end
-
+        }
         expected_facts
       end
 


### PR DESCRIPTION
This reverts commit 2a685624dfe9ec2c8a10afe4f12d1bc14f25efe2.

We updated our Debian 11 templates to the released version, so this can
be reverted.