### PR TITLE
Revert "(maint) Skip os facts in acceptance on Debian 11 - 4.x"

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -106,12 +106,7 @@ module Facter
           'kernelrelease' => /\d+\.\d+\.\d+/,
           'kernelversion' => /\d+\.\d+/,
           'kernelmajversion' => /\d+\.\d+/
-        }.reject do |fact, value|
-          # Skip os fact matching on Debian 11 as it does not report the stable
-          # version until its official release
-          fact.start_with?('os.') if os_version == /11/
-        end
-
+        }
         expected_facts
       end
 


### PR DESCRIPTION
This reverts commit 4286604e52615cb9d1759c16a6567f5e4d9541a5.

We updated our Debian 11 templates to the released version, so this can
be reverted.