### PR TITLE
(FACT-3027) Fix: Allow facter to be used with Ruby 3

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   base = "#{__dir__}#{File::SEPARATOR}"
   spec.files = dirs.map { |path| path.sub(base, '') }
 
-  spec.required_ruby_version = '>= 2.3', '< 4.0'
+  spec.required_ruby_version = '>= 2.3', '< 4'
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
Without this change it's not possible to install the gem on Ruby 3:

I tested this on the facterdb project.
```
$ bundle install --path .vendor/ --jobs "$(nproc)"
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path '.vendor/'`, and stop using this flag
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
facter-4.0.47 requires ruby version ~> 2.3, which is incompatible with the current version, ruby 3.0.2p107
```

And after pointing the Gemfile to my fix:

```
$ git diff
diff --git a/Gemfile b/Gemfile
index 84d5627..007e6b6 100644
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
 else
-  gem 'facter', :require => false
+  gem 'facter', git: 'https://github.com/bastelfreak/facter.git', branch: 'ruby3', :require => false
 end

 group :development do
```

```
$ bundle update
...
Using facter 4.2.4 (was 2.5.7) from https://github.com/bastelfreak/facter.git (at ruby3@e9872fa)
...
```