### PR TITLE
(FACT-3073) Fix timeout option processing for Facter::Core::Execution.execute

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,7 @@ Metrics/CyclomaticComplexity:
 Metrics/ClassLength:
   Exclude:
     - 'lib/facter/resolvers/partitions.rb'
+    - 'lib/facter/custom_facts/core/execution/base.rb'
     - 'lib/facter/custom_facts/util/fact.rb'
     - 'lib/facter/resolvers/windows/networking.rb'
     - 'lib/facter/custom_facts/util/collection.rb'

--- a/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
+++ b/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
@@ -4,7 +4,7 @@ test_name 'Facter::Core::Execution accepts and correctly sets a time limit optio
   first_file_content = <<-EOM
     Facter.add(:foo) do
       setcode do
-        Facter::Core::Execution.execute("sleep 3", {:limit => 2, :on_fail => :not_raise})
+        Facter::Core::Execution.execute("sleep 3", {:timeout => 2, :on_fail => :not_raise})
       end
     end
   EOM
@@ -12,7 +12,7 @@ test_name 'Facter::Core::Execution accepts and correctly sets a time limit optio
   second_file_content = <<-EOM
     Facter.add(:custom_fact) do
       setcode do
-         Facter::Core::Execution.execute("sleep 2", {:limit => 1})
+         Facter::Core::Execution.execute("sleep 2", {:timeout => 1})
       end
     end
   EOM

--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -15,9 +15,9 @@ module Facter
 
       module_function
 
-      # Returns the locations to be searched when looking for a binary. This
-      #   is currently determined by the +PATH+ environment variable plus
-      #   `/sbin` and `/usr/sbin` when run on unix
+      # Returns the locations to be searched when looking for a binary. This is
+      # currently determined by the +PATH+ environment variable plus `/sbin`
+      # and `/usr/sbin` when run on unix
       #
       # @return [Array<String>] The paths to be searched for binaries
       #
@@ -27,8 +27,9 @@ module Facter
       end
 
       # Determines the full path to a binary. If the supplied filename does not
-      #   already describe an absolute path then different locations (determined
-      #   by {search_paths}) will be searched for a match.
+      # already describe an absolute path then different locations (determined
+      # by {search_paths}) will be searched for a match.
+      #
       # @param bin [String] The executable to locate
       #
       # @return [String/nil] The full path to the executable or nil if not
@@ -40,7 +41,8 @@ module Facter
       end
 
       # Determine in a platform-specific way whether a path is absolute. This
-      #   defaults to the local platform if none is specified.
+      # defaults to the local platform if none is specified.
+      #
       # @param path [String] The path to check
 
       # @param platform [:posix/:windows/nil] The platform logic to use
@@ -58,8 +60,9 @@ module Facter
       end
 
       # Given a command line, this returns the command line with the
-      #   executable written as an absolute path. If the executable contains
-      #   spaces, it has to be put in double quotes to be properly recognized.
+      # executable written as an absolute path. If the executable contains
+      # spaces, it has to be put in double quotes to be properly recognized.
+      #
       # @param command [String] the command line
       #
       # @return [String/nil] The command line with the executable's path
@@ -71,8 +74,9 @@ module Facter
       end
 
       # Overrides environment variables within a block of code.  The
-      #   specified values will be set for the duration of the block, after
-      #   which the original values (if any) will be restored.
+      # specified values will be set for the duration of the block, after
+      # which the original values (if any) will be restored.
+      #
       # @param values [Hash<String=>String>] A hash of the environment
       #   variables to override
       #
@@ -84,6 +88,7 @@ module Facter
       end
 
       # Try to execute a command and return the output.
+      #
       # @param command [String] Command to run
       #
       # @return [String/nil] Output of the program, or nil if the command does
@@ -96,16 +101,18 @@ module Facter
       end
 
       # Execute a command and return the output of that program.
+      #
       # @param command [String] Command to run
       #
-      # @param options [Hash<Symbol=>Any>] Hash with options for the command
+      # @param options [Hash] Hash with options for the command
       #
-      # Options accepted values :on_fail How to behave when the command could
+      # @option options [Object] :on_fail How to behave when the command could
       #   not be run. Specifying :raise will raise an error, anything else will
       #   return that object on failure. Default is :raise.
-      #   :logger Optional logger used to log the command's stderr.
-      #   :timeout Optional time out for the specified command. If no timeout is passed,
-      #   a default of 300 seconds is used.
+      # @option options [Object] :logger Optional logger used to log the
+      #   command's stderr.
+      # @option options :timeout Optional time out for the specified
+      #   command. If no timeout is passed, a default of 300 seconds is used.
       #
       # @raise [Facter::Core::Execution::ExecutionFailure] If the command does
       #   not exist or could not be executed and :on_fail is set to :raise
@@ -119,6 +126,7 @@ module Facter
       end
 
       # Execute a command and return the stdout and stderr of that program.
+      #
       # @param command [String] Command to run
       #
       # @param on_fail[Object] How to behave when the command could

--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -98,13 +98,13 @@ module Facter
       # Execute a command and return the output of that program.
       # @param command [String] Command to run
       #
-      # @param options [Hash] Hash with options for the command
+      # @param options [Hash<Symbol=>Any>] Hash with options for the command
       #
       # Options accepted values :on_fail How to behave when the command could
       #   not be run. Specifying :raise will raise an error, anything else will
       #   return that object on failure. Default is :raise.
       #   :logger Optional logger used to log the command's stderr.
-      #   :time_limit Optional time out for the specified command. If no time_limit is passed,
+      #   :timeout Optional time out for the specified command. If no timeout is passed,
       #   a default of 300 seconds is used.
       #
       # @raise [Facter::Core::Execution::ExecutionFailure] If the command does
@@ -125,7 +125,7 @@ module Facter
       #   not be run. Specifying :raise will raise an error, anything else will
       #   return that object on failure. Default is :raise.
       # @param logger Optional logger used to log the command's stderr.
-      # @param time_limit Optional time out for the specified command. If no time_limit is passed,
+      # @param timeout Optional time out for the specified command. If no timeout is passed,
       #   a default of 300 seconds is used.
       #
       # @raise [Facter::Core::Execution::ExecutionFailure] If the command does
@@ -135,8 +135,8 @@ module Facter
       #   :on_fail if command execution failed and :on_fail was specified.
       #
       # @api private
-      def execute_command(command, on_fail = nil, logger = nil, time_limit = nil)
-        @@impl.execute_command(command, on_fail, logger, time_limit)
+      def execute_command(command, on_fail = nil, logger = nil, timeout = nil)
+        @@impl.execute_command(command, on_fail, logger, timeout)
       end
 
       class ExecutionFailure < StandardError; end

--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -117,6 +117,11 @@ module Facter
           timeout = (options[:timeout] || options[:time_limit] || options[:limit]).to_i
           timeout = timeout.positive? ? timeout : nil
 
+          extra_keys = options.keys - %i[on_fail expand logger timeout]
+          unless extra_keys.empty?
+            @log.warn("Unexpected key passed to Facter::Core::Execution.execute option: #{options.keys.join(',')}")
+          end
+
           [on_fail, expand, logger, timeout]
         end
 

--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -42,7 +42,7 @@ module Facter
         end
 
         def execute(command, options = {})
-          on_fail, expand, logger, time_limit = extract_options(options)
+          on_fail, expand, logger, timeout = extract_options(options)
 
           expanded_command = if !expand && builtin_command?(command) || logger
                                command
@@ -59,12 +59,12 @@ module Facter
             return on_fail
           end
 
-          out, = execute_command(expanded_command, on_fail, logger, time_limit)
+          out, = execute_command(expanded_command, on_fail, logger, timeout)
           out
         end
 
-        def execute_command(command, on_fail = nil, logger = nil, time_limit = nil)
-          time_limit ||= 300
+        def execute_command(command, on_fail = nil, logger = nil, timeout = nil)
+          timeout ||= 300
           begin
             # Set LC_ALL and LANG to force i18n to C for the duration of this exec;
             # this ensures that any code that parses the
@@ -78,12 +78,12 @@ module Facter
               out_reader = Thread.new { stdout.read }
               err_reader = Thread.new { stderr.read }
               begin
-                Timeout.timeout(time_limit) do
+                Timeout.timeout(timeout) do
                   stdout_messages << out_reader.value
                   stderr_messages << err_reader.value
                 end
               rescue Timeout::Error
-                message = "Timeout encounter after #{time_limit}s, killing process with pid: #{pid}"
+                message = "Timeout encounter after #{timeout}s, killing process with pid: #{pid}"
                 Process.kill('KILL', pid)
                 on_fail == :raise ? (raise StandardError, message) : @log.debug(message)
               ensure
@@ -114,10 +114,10 @@ module Facter
           on_fail = options.fetch(:on_fail, :raise)
           expand = options.fetch(:expand, true)
           logger = options[:logger]
-          time_limit = options[:limit].to_i
-          time_limit = time_limit.positive? ? time_limit : nil
+          timeout = (options[:timeout] || options[:time_limit] || options[:limit]).to_i
+          timeout = timeout.positive? ? timeout : nil
 
-          [on_fail, expand, logger, time_limit]
+          [on_fail, expand, logger, timeout]
         end
 
         def log_stderr(msg, command, logger)

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -5,6 +5,7 @@ describe Facter::Core::Execution do
 
   let(:windows_impl) { instance_spy(Facter::Core::Execution::Windows) }
   let(:impl) { Facter::Core::Execution.impl }
+  let(:logger) { impl.instance_variable_get(:@log) }
 
   before do
     allow(Facter::Core::Execution::Windows).to receive(:new).and_return(windows_impl)
@@ -43,5 +44,53 @@ describe Facter::Core::Execution do
   it 'delegates #execute to the implementation' do
     expect(impl).to receive(:execute).with('waffles', {})
     execution.execute('waffles')
+  end
+
+  context 'when running an actual command' do
+    before do
+      allow(impl).to receive(:which).with('waffles').and_return('/under/the/honey/are/the/waffles')
+      allow(impl).to receive(:execute_command)
+      allow(logger).to receive(:warn)
+    end
+
+    context 'with default parameters' do
+      it 'execute the found command' do
+        execution.execute('waffles')
+        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, nil)
+      end
+    end
+
+    context 'with a timeout' do
+      it 'execute the found command with a timeout' do
+        execution.execute('waffles', timeout: 90)
+        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
+      end
+    end
+
+    context 'with a deprecated time_limit' do
+      it 'execute the found command with a timeout' do
+        execution.execute('waffles', time_limit: 90)
+        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
+      end
+
+      it 'emits a warning' do
+        execution.execute('waffles', time_limit: 90)
+        expect(logger).to have_received(:warn)
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit')
+      end
+    end
+
+    context 'with a deprecated limit' do
+      it 'execute the found command with a timeout' do
+        execution.execute('waffles', limit: 90)
+        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
+      end
+
+      it 'emits a warning' do
+        execution.execute('waffles', limit: 90)
+        expect(logger).to have_received(:warn)
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: limit')
+      end
+    end
   end
 end


### PR DESCRIPTION
The documentation of Facter::Core::Execution.execute indicate that the
options hash accept 3 values (`expand` is not documented):
  - `on_fail`
  - `logger`
  - `time_limit`

However, when options are extracted by the extract_options method, the
key `limit` is checked instead of `time_limit` as documented.

Finally, previous versions of facter used a `timeout` parameter.

Fix these inconsistencies by using a single name `timeout` consistently.

Adjust the logic so that the documented name that was previously not
working (:time_limit) and the actual name which was working (:time) also
work the same way.