### PR TITLE
(FACT-3047) --http_debug cli shows HTTP debug logs in Facter 4

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -205,6 +205,25 @@ module Facter
       Facter::Options[:debug] = debug_bool
     end
 
+    # Check whether http debugging is enabled
+    #
+    # @return [bool]
+    #
+    # @api public
+    def http_debug?
+      Options[:http_debug]
+    end
+
+    # Enable or disable http debugging
+    # @param debug_bool [bool] State which http debugging should have
+    #
+    # @return [type] [description]
+    #
+    # @api public
+    def http_debug(http_debug_bool)
+      Facter::Options[:http_debug] = http_debug_bool
+    end
+
     # Enable sequential resolving of facts
     #
     # @return [bool]

--- a/lib/facter/framework/cli/cli.rb
+++ b/lib/facter/framework/cli/cli.rb
@@ -97,6 +97,10 @@ module Facter
                  type: :boolean,
                  desc: 'Resolve facts sequentially'
 
+    class_option :http_debug,
+                 type: :boolean,
+                 desc: 'Whether to write HTTP request and responses to stderr. This should never be used in production.'
+
     class_option :puppet,
                  type: :boolean,
                  aliases: '-p',

--- a/lib/facter/framework/core/options/option_store.rb
+++ b/lib/facter/framework/core/options/option_store.rb
@@ -36,6 +36,7 @@ module Facter
     @hocon = false
     @allow_external_loggers = true
     @force_dot_resolution = false
+    @http_debug = false
 
     class << self
       attr_reader :debug, :verbose, :log_level, :show_legacy,
@@ -44,7 +45,7 @@ module Facter
       attr_accessor :config, :strict, :json,
                     :cache, :yaml, :puppet, :ttls, :block, :cli, :config_file_custom_dir,
                     :config_file_external_dir, :default_external_dir, :fact_groups, :force_dot_resolution,
-                    :block_list, :color, :trace, :sequential, :timing, :hocon, :allow_external_loggers
+                    :block_list, :color, :trace, :sequential, :timing, :hocon, :allow_external_loggers, :http_debug
 
       attr_writer :external_dir
 
@@ -179,6 +180,7 @@ module Facter
         @ttls = []
         @block = true
         @cli = nil
+        @http_debug = false
         reset_config
       end
 

--- a/lib/facter/util/resolvers/http.rb
+++ b/lib/facter/util/resolvers/http.rb
@@ -60,6 +60,9 @@ module Facter
             http = Net::HTTP.new(parsed_url.host)
             http.read_timeout = timeouts[:session] || SESSION_TIMEOUT
             http.open_timeout = timeouts[:connection] || CONNECTION_TIMEOUT
+
+            http.set_debug_output($stderr) if Options[:http_debug]
+
             http
           end
 

--- a/spec/facter/util/resolvers/http_spec.rb
+++ b/spec/facter/util/resolvers/http_spec.rb
@@ -79,6 +79,22 @@ describe Facter::Util::Resolvers::Http do
         expect(log_spy).to have_received(:debug).with("Trying to connect to #{url} but got: some error")
       end
     end
+
+    context 'when options[:http_debug] is set to true' do
+      let(:net_http_class) { class_spy(Net::HTTP) }
+      let(:net_http_instance) { instance_spy(Net::HTTP) }
+
+      before do
+        stub_const('Net::HTTP', net_http_class)
+        Facter::Options[:http_debug] = true
+      end
+
+      it 'sets Net::Http to write request and responses to stderr' do
+        allow(net_http_class).to receive(:new).and_return(net_http_instance)
+        http.send(client_method, url)
+        expect(net_http_instance).to have_received(:set_debug_output).with($stderr)
+      end
+    end
   end
 
   RSpec.shared_examples 'a http request on windows' do

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -44,7 +44,8 @@ describe Facter::OptionStore do
         external_dir: [],
         custom_dir: [],
         allow_external_loggers: true,
-        force_dot_resolution: false
+        force_dot_resolution: false,
+        http_debug: false
       )
     end
   end


### PR DESCRIPTION
`--http_debug` option was added to Facter 4 cli to show HTTP debug.