### PR TITLE
(FACT-3067) Fix resolution of custom facts that partial match legacy fact names

### DIFF
--- a/lib/facter/framework/core/fact_manager.rb
+++ b/lib/facter/framework/core/fact_manager.rb
@@ -51,7 +51,9 @@ module Facter
       core_and_external_facts = core_or_external_fact(user_query) || []
       resolved_facts = core_and_external_facts + custom_facts
 
-      resolved_facts = all_custom_facts(user_query) if resolved_facts.empty?
+      if resolved_facts.empty? || resolved_facts.none? { |rf| rf.resolves?(user_query) }
+        resolved_facts.concat(all_custom_facts(user_query))
+      end
 
       @cache_manager.cache_facts(resolved_facts)
 

--- a/lib/facter/models/resolved_fact.rb
+++ b/lib/facter/models/resolved_fact.rb
@@ -23,5 +23,9 @@ module Facter
     def to_s
       @value.to_s
     end
+
+    def resolves?(user_query)
+      @name == user_query
+    end
   end
 end

--- a/spec/framework/core/fact_manager_spec.rb
+++ b/spec/framework/core/fact_manager_spec.rb
@@ -61,7 +61,7 @@ describe Facter::FactManager do
       ]
     end
 
-    let(:resolved_fact) { mock_resolved_fact(os, 'Ubuntu', '') }
+    let(:resolved_fact) { mock_resolved_fact(os, 'Ubuntu', os) }
 
     before do
       allow(Facter::FactLoader.instance).to receive(:load).and_return(loaded_facts)
@@ -95,8 +95,8 @@ describe Facter::FactManager do
         ]
       end
 
-      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', '', :custom) }
-      let(:cached_fact) { mock_resolved_fact(fact_name, 'cached_custom', '', :custom) }
+      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', fact_name, :custom) }
+      let(:cached_fact) { mock_resolved_fact(fact_name, 'cached_custom', fact_name, :custom) }
 
       context 'when is found in custom_dir/fact_name.rb' do
         before do
@@ -251,7 +251,7 @@ describe Facter::FactManager do
         ]
       end
 
-      let(:resolved_fact) { mock_resolved_fact('os.name', 'darwin', '', :core) }
+      let(:resolved_fact) { mock_resolved_fact('os.name', 'darwin', 'os.name', :core) }
 
       before do
         # mock custom_fact_by_filename to return nil
@@ -298,7 +298,7 @@ describe Facter::FactManager do
 
       context 'when nil' do
         let(:user_query) { 'virtual' }
-        let(:resolved_fact) { mock_resolved_fact('virtual', nil, '', :core) }
+        let(:resolved_fact) { mock_resolved_fact('virtual', nil, 'virtual', :core) }
 
         before do
           # mock all custom facts to return []
@@ -313,7 +313,7 @@ describe Facter::FactManager do
 
       context 'when boolean false' do
         let(:user_query) { 'fips_enabled' }
-        let(:resolved_fact) { mock_resolved_fact('fips_enabled', false, '', :core) }
+        let(:resolved_fact) { mock_resolved_fact('fips_enabled', false, 'fips_enabled', :core) }
 
         it 'resolves fact to false' do
           resolved_facts = Facter::FactManager.instance.resolve_fact(user_query)
@@ -328,7 +328,7 @@ describe Facter::FactManager do
       let(:custom_fact) { instance_double(Facter::LoadedFact, name: 'custom_fact', klass: nil, type: :custom) }
       let(:loaded_facts) { [custom_fact] }
 
-      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', '', :custom) }
+      let(:resolved_fact) { mock_resolved_fact(fact_name, 'custom', fact_name, :custom) }
 
       before do
         # mock custom_fact_by_filename to return nil
@@ -394,7 +394,7 @@ describe Facter::FactManager do
         user_query: '', type: :core
       )
     end
-    let(:resolved_fact) { mock_resolved_fact('os', 'Ubuntu', '') }
+    let(:resolved_fact) { mock_resolved_fact('os', 'Ubuntu', 'os') }
 
     it 'resolves all core facts' do
       allow(fact_loader).to receive(:load_internal_facts).and_return(loaded_facts)

--- a/spec/mocks/util.rb
+++ b/spec/mocks/util.rb
@@ -43,7 +43,8 @@ end
 def mock_resolved_fact(fact_name, fact_value, user_query = nil, type = :core)
   resolved_fact_mock = double(Facter::ResolvedFact, name: fact_name, value: fact_value,
                                                     user_query: user_query, type: type,
-                                                    legacy?: type == :legacy, core?: type == :core, file: nil)
+                                                    legacy?: type == :legacy, core?: type == :core, file: nil,
+                                                    resolves?: fact_name == user_query)
 
   allow_attr_change(resolved_fact_mock, fact_name, fact_value)
   resolved_fact_mock

--- a/spec_integration/facter_spec.rb
+++ b/spec_integration/facter_spec.rb
@@ -78,6 +78,24 @@ describe 'Facter' do
           expect(Facter.value('arr_fact.-1')).to be_nil
         end
       end
+
+      context 'when having name collision with a core legacy fact' do
+        # core legacy fact -> network_.*
+        before do
+          Facter.search(custom_facts_dir)
+          data = <<-RUBY
+            Facter.add(:network_nexthop_ip) do
+              setcode { 'network_nexthop_ip' }
+            end
+          RUBY
+
+          write_to_file(tmp_filename('custom_fact.rb'), data, custom_facts_dir)
+        end
+
+        it 'resolves the custom fact' do
+          expect(Facter.value(:network_nexthop_ip)).to eql('network_nexthop_ip')
+        end
+      end
     end
 
     context 'with external facts' do


### PR DESCRIPTION
Before this commit, custom facts that had names which partially matched core legacy facts were being resolved as expected in CLI but not with the API. Due to the nature of how legacy facts are defined in Facter 4, with the regular expression used in `FACT_NAME`, `Facter::FactManager` was not resolving custom facts if core or external facts had any results.

This fix adds a new method to check if the user query matches the name of already resolved facts to decide whether or not we should also resolve custom facts.