### PR TITLE
(FACT-2955) Only use the available processors

### DIFF
--- a/lib/src/facts/aix/processor_resolver.cc
+++ b/lib/src/facts/aix/processor_resolver.cc
@@ -56,8 +56,12 @@ namespace facter { namespace facts { namespace aix {
             string query = (boost::format("PdDvLn=%1%") % type).str();
             auto cu_dv_query = odm_class<CuDv>::open("CuDv").query(query);
             for (auto& cu_dv : cu_dv_query) {
-                LOG_DEBUG("got a processor: {1}", cu_dv.name);
-                processor_names.push_back(cu_dv.name);
+                if (cu_dv.status == 1) {
+                    LOG_DEBUG("got a processor: {1}", cu_dv.name);
+                    processor_names.push_back(cu_dv.name);
+                } else {
+                    LOG_DEBUG("processor: {1} is a defined or stopped device, skipping", cu_dv.name)
+                }
             }
         }
 


### PR DESCRIPTION
Previously, after querying for CuDv, facter added all the procs found in the
said query, without checking the proc's status.  This commit adds a check for
the each proc's status, and if the status is different from available, we skip
the processor.

Tested this PR manually by changing the logic in the CuDv logic to check for `status == 2`. By doing so, if all the processors were available, `facter processors` should only output the isa, without any processors details.
```
> ./facter processors
{
  isa => "powerpc"
}
```