### PR TITLE
(FACT-2955) Only use the available processors (4.x)

### DIFF
--- a/lib/facter/resolvers/aix/processors.rb
+++ b/lib/facter/resolvers/aix/processors.rb
@@ -42,8 +42,9 @@ module Facter
             return unless result
 
             names = retrieve_from_array(result.scan(/name\s=\s.*/), 1)
+            status = retrieve_from_array(result.scan(/\s+status\s=\s.*/), 1)
 
-            names.each { |elem| query_cuat(elem) }
+            names.each_with_index { |elem, idx| query_cuat(elem) if status[idx] == '1' }
           end
 
           def query_cuat(name)

--- a/spec/facter/resolvers/aix/processors_spec.rb
+++ b/spec/facter/resolvers/aix/processors_spec.rb
@@ -6,11 +6,15 @@ describe Facter::Resolvers::Aix::Processors do
   let(:odm_query_spy) { instance_spy(Facter::Util::Aix::ODMQuery) }
   let(:odm_query_spy2) { instance_spy(Facter::Util::Aix::ODMQuery) }
   let(:odm_query_spy3) { instance_spy(Facter::Util::Aix::ODMQuery) }
+  let(:odm_query_spy4) { instance_spy(Facter::Util::Aix::ODMQuery) }
   let(:logger_spy) { instance_spy(Facter::Log) }
 
   before do
     resolver.instance_variable_set(:@log, logger_spy)
-    allow(Facter::Util::Aix::ODMQuery).to receive(:new).and_return(odm_query_spy, odm_query_spy2, odm_query_spy3)
+    allow(Facter::Util::Aix::ODMQuery).to receive(:new).and_return(odm_query_spy,
+                                                                   odm_query_spy2,
+                                                                   odm_query_spy3,
+                                                                   odm_query_spy4)
     allow(odm_query_spy).to receive(:equals).with('class', 'processor')
     allow(odm_query_spy).to receive(:execute).and_return(result)
   end
@@ -69,6 +73,9 @@ describe Facter::Resolvers::Aix::Processors do
 
       allow(odm_query_spy3).to receive(:equals).with('name', 'proc0')
       allow(odm_query_spy3).to receive(:execute).and_return(load_fixture('processors_cuat').read)
+
+      allow(odm_query_spy4).to receive(:equals).with('name', 'proc8')
+      allow(odm_query_spy4).to receive(:execute).and_return(load_fixture('processors_cuat').read)
     end
 
     it 'returns speed fact' do

--- a/spec/fixtures/processors_cudv
+++ b/spec/fixtures/processors_cudv
@@ -1,4 +1,11 @@
 CuDv:
-        name = "proc0"
-        status = 1
-        PdDvLn = "processor/sys/proc_rspc"
+		name = "proc0"
+		status = 1
+		chgstatus = 2
+		PdDvLn = "processor/sys/proc_rspc"
+
+CuDv:
+		name = "proc8"
+		status = 0
+		chgstatus = 2
+		PdDvLn = "processor/sys/proc_rspc"


### PR DESCRIPTION
Previously, after querying for CuDv, facter added all the procs found in the
said query, without checking the proc's status. This commit adds a check for
the each proc's status, and if the status is different from available, we skip
the processor.