### PR TITLE
(FACT-1644) Facter 4 does not resolve `physical_count` on AIX

### DIFF
--- a/lib/facter/facts/aix/processors/physicalcount.rb
+++ b/lib/facter/facts/aix/processors/physicalcount.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Aix
+    module Processors
+      class Physicalcount
+        FACT_NAME = 'processors.physicalcount'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::Aix::Processors.resolve(:physical_count)
+          Facter::ResolvedFact.new(FACT_NAME, fact_value)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/aix/processors.rb
+++ b/lib/facter/resolvers/aix/processors.rb
@@ -18,6 +18,7 @@ module Facter
             @fact_list[:logical_count] = 0
             @fact_list[:cores_per_socket] = 0
             @fact_list[:threads_per_core] = 0
+            @fact_list[:physical_count] = 0
 
             odmquery = Facter::Util::Aix::ODMQuery.new
             odmquery.equals('class', 'processor')
@@ -42,9 +43,11 @@ module Facter
             return unless result
 
             names = retrieve_from_array(result.scan(/name\s=\s.*/), 1)
+
             status = retrieve_from_array(result.scan(/\s+status\s=\s.*/), 1)
 
             names.each_with_index { |elem, idx| query_cuat(elem) if status[idx] == '1' }
+            @fact_list[:physical_count] = status.count('1')
           end
 
           def query_cuat(name)

--- a/spec/facter/facts/aix/processors/physicalcount_spec.rb
+++ b/spec/facter/facts/aix/processors/physicalcount_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Aix::Processors::Physicalcount do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Aix::Processors::Physicalcount.new }
+
+    let(:physical_count) { '2' }
+
+    before do
+      allow(Facter::Resolvers::Aix::Processors).to \
+        receive(:resolve).with(:physical_count).and_return(physical_count)
+    end
+
+    it 'calls Facter::Resolvers::Aix::Processors' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Aix::Processors).to have_received(:resolve).with(:physical_count)
+    end
+
+    it 'returns processors physical count fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'processors.physicalcount', value: physical_count)
+    end
+  end
+end

--- a/spec/facter/resolvers/aix/processors_spec.rb
+++ b/spec/facter/resolvers/aix/processors_spec.rb
@@ -97,5 +97,9 @@ describe Facter::Resolvers::Aix::Processors do
     it 'returns threads fact' do
       expect(resolver.resolve(:threads_per_core)).to eq(8)
     end
+
+    it 'returns physical_count fact' do
+      expect(resolver.resolve(:physical_count)).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Previously, in Facter 3, e73ea8d removed the
physical_count fact for AIX systems.  This commit adds the said fact back, and
sets the `physical_count` fact to the number of `CuDv` query results, that have
the `status` equal to 1 (see cf0eb1bc6db428d8e4cf5ba754659e9b30d56f38). This makes sense since each proc is a different
processor.
 To verify this, one can check the number of procs with the output from
`prtconf`

```
[AIX] # prtconf
System Model: IBM,8284-22A
Machine Serial Number: 21684EW
Processor Type: PowerPC_POWER8
Processor Implementation Mode: POWER 8
Processor Version: PV_8_Compat
Number Of Processors: 4 <--
```
And the `CuDv` query result:
```
[AIX] # odmget -q 'PdDvLn=processor/sys/proc_rspc' CuDv

CuDv:
        name = "proc0"
	...
CuDv:
        name = "proc8"
	...
CuDv:
        name = "proc16"
	...
CuDv:
        name = "proc24"
	...
```

Output before fix:
```
[0] [AIX] # facter processors
{
  cores => 4,
  count => 32,
  isa => "powerpc",
  models => [
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8"
  ],
  speed => "3.43 GHz",
  threads => 8
}
```
Output after fix:
```
{
  cores => 4,
  count => 32,
  isa => "powerpc",
  models => [
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8",
    "PowerPC_POWER8"
  ],
  physicalcount => 4,
  speed => "3.43 GHz",
  threads => 8
}
```