### PR TITLE
(maint) Disable DHCP test on EL 8 platforms

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -120,6 +120,11 @@ module Facter
                      end
         release_string = on(agent, 'cat /etc/*-release').stdout.downcase
         case release_string
+        when /almalinux/
+          os_name = 'AlmaLinux'
+          os_distro_description = /AlmaLinux release #{os_version}\.\d+ \(.+\)/
+          os_distro_id = 'AlmaLinux'
+          os_distro_release_full = /#{os_version}\.\d+/
         when /amazon/
           os_name = 'Amazon'
           # This parses: VERSION_ID="2017.09"
@@ -127,6 +132,11 @@ module Facter
           os_distro_description = /Amazon Linux( AMI)? release (\d )?(\()?#{os_version}(\))?/
           os_distro_id = /^Amazon(AMI)?$/
           os_distro_release_full = /#{os_version}(\.\d+)?/
+        when /rocky/
+          os_name = 'Rocky'
+          os_distro_description = /Rocky Linux release #{os_version}\.\d+ \(.+\)/
+          os_distro_id = 'Rocky'
+          os_distro_release_full = /#{os_version}\.\d+/
         when /centos/
           os_name = 'CentOS'
           os_distro_description = /CentOS( Linux)? release #{os_version}\.\d+(\.\d+)? \(\w+\)/

--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -9,20 +9,20 @@ test_name 'C59029: networking facts should be fully populated' do
   @ip_regex       = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
   @netmask_regex  = /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/
 
-  expected_networking = {
-    %w[networking dhcp] => agent['platform'] =~ /fedora-32|fedora-34|el-8-aarch64|el-8-ppc64le/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
-    %w[networking ip] => @ip_regex,
-    %w[networking ip6] => /[a-f0-9]+:+/,
-    %w[networking mac] => /[a-f0-9]{2}:/,
-    %w[networking mtu] => /\d+/,
-    %w[networking netmask] => @netmask_regex,
-    %w[networking netmask6] => /[a-f0-9]+:/,
-    %w[networking network] => @ip_regex,
-    %w[networking network6] => /([a-f0-9]+)?:([a-f0-9]+)?/,
-    %w[networking scope6] => /link|host|site|global|compat/
-  }
-
   agents.each do |agent|
+    expected_networking = {
+      %w[networking dhcp] => agent['platform'] =~ /fedora-32|fedora-34|el-8-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+      %w[networking ip] => @ip_regex,
+      %w[networking ip6] => /[a-f0-9]+:+/,
+      %w[networking mac] => /[a-f0-9]{2}:/,
+      %w[networking mtu] => /\d+/,
+      %w[networking netmask] => @netmask_regex,
+      %w[networking netmask6] => /[a-f0-9]+:/,
+      %w[networking network] => @ip_regex,
+      %w[networking network6] => /([a-f0-9]+)?:([a-f0-9]+)?/,
+      %w[networking scope6] => /link|host|site|global|compat/
+    }
+
     primary_interface = fact_on(agent, 'networking.primary')
     refute_empty(primary_interface)
 


### PR DESCRIPTION
AlmaLinux and Rocky come with newer versions of NetworkManager which
don't provide the necessary DHCP options for us to resolve the dhcp
fact, see https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426.

It looks like some of the options were added, but they are not available
in the NetworkManager version found on Alma and Rocky.

As Alma/Rocky/RHEL/CentOS are the same platform, the simplest way is to
disable the test on all el-8 platforms. We will probably encounter this
again when we migrate to GCP and the RedHat templates there have newer
NetworkManager versions anyway.