### PR TITLE
(maint) Disable DHCP test on EL 8 platforms - 3.x

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -9,8 +9,9 @@ test_name 'C59029: networking facts should be fully populated' do
   @ip_regex       = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
   @netmask_regex  = /^(((128|192|224|240|248|252|254)\.0\.0\.0)|(255\.(0|128|192|224|240|248|252|254)\.0\.0)|(255\.255\.(0|128|192|224|240|248|252|254)\.0)|(255\.255\.255\.(0|128|192|224|240|248|252|254)))$/
 
-  expected_networking = {
-      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|el-8-aarch64|el-8-ppc64le/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+  agents.each do |agent|
+    expected_networking = {
+      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|el-8-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       "networking.ip"       => @ip_regex,
       "networking.ip6"      => /[a-f0-9]+:+/,
       "networking.mac"      => /[a-f0-9]{2}:/,
@@ -19,9 +20,8 @@ test_name 'C59029: networking facts should be fully populated' do
       "networking.netmask6" => /[a-f0-9]+:/,
       "networking.network"  => @ip_regex,
       "networking.network6" => /([a-f0-9]+)?:([a-f0-9]+)?/
-  }
+    }
 
-  agents.each do |agent|
     primary_interface = fact_on(agent, 'networking.primary')
     refute_empty(primary_interface)
 


### PR DESCRIPTION
AlmaLinux and Rocky come with newer versions of NetworkManager which
don't provide the necessary DHCP options for us to resolve the dhcp
fact, see https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426.

It looks like some of the options were added, but they are not available
in the NetworkManager version found on Alma and Rocky.

As Alma/Rocky/RHEL/CentOS are the same platform, the simplest way is to
disable the test on all el-8 platforms. We will probably encounter this
again when we migrate to GCP and the RedHat templates there have newer
NetworkManager versions anyway.