### PR TITLE
(FACT-3075) Fix the `os.release` fact on Windows 2022

### DIFF
--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -23,9 +23,11 @@ module Facter
           private
 
           def check_version_10(consumerrel, kernel_version)
+            return '10' if consumerrel
+
             build_number = kernel_version[/([^.]*)$/].to_i
-            if consumerrel
-              '10'
+            if build_number >= 20_348
+              '2022'
             elsif build_number >= 17_623
               '2019'
             else

--- a/spec/facter/util/facts/windows_release_finder_spec.rb
+++ b/spec/facter/util/facts/windows_release_finder_spec.rb
@@ -25,6 +25,17 @@ describe Facter::Util::Facts::WindowsReleaseFinder do
     end
   end
 
+  describe '#find windows release when version is 2022' do
+    let(:cons) { false }
+    let(:desc) {}
+    let(:k_version) { '10.0.20348' }
+    let(:version) { '10.0' }
+
+    it 'returns 2022' do
+      expect(Facter::Util::Facts::WindowsReleaseFinder.find_release(input)).to eql('2022')
+    end
+  end
+
   describe '#find windows release when version is 2019' do
     let(:cons) { false }
     let(:desc) {}


### PR DESCRIPTION
This commit allows the `os.release.full` and `os.release.major` to correctly detect and output Windows 2022 instead of '2019' as previously.