### PR TITLE
(maint) Pin jruby version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           - 2.3
           - 2.7
           - 3.0
-          - jruby
+          - 'jruby-9.2.19.0'
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout current PR


### PR DESCRIPTION
This commit pins jruby in GitHub Actions unit tests workflow to `9.2.19.0` since the latest version `9.3.0.0` introduced a non-backwards compatible change which breaks Facter (https://github.com/jruby/jruby/issues/6860). This is a temporary change until a fixed version will be released.

See https://github.com/puppetlabs/facter/pull/2438/checks?check_run_id=3719821972 for example of failing unit tests.