### PR TITLE
(maint) Remove `Ubunutu 16.04` os from GitHub Actions workflow

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [windows-2016, windows-2019, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        os: [windows-2016, windows-2019, ubuntu-18.04, ubuntu-20.04, macos-10.15]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true


### PR DESCRIPTION
The `Ubuntu 16.04` os environment has been removed on September 20 2021 from https://github.com/actions/virtual-environments, so this commit removes it from our GitHub Actions workflow.

See https://github.com/actions/virtual-environments/issues/3287 for more information.