### PR TITLE
(FACT-3058) Fix `os.windows.release_id` fact and add `os.windows.display_version` fact

### DIFF
--- a/lib/inc/facter/facts/fact.hpp
+++ b/lib/inc/facter/facts/fact.hpp
@@ -451,6 +451,11 @@ namespace facter { namespace facts {
         constexpr static char const* windows_release_id = "windows_release_id";
 
         /**
+         * The fact for Windows Display Version.
+         */
+        constexpr static char const* windows_display_version = "windows_display_version";
+
+        /**
          * The fact for Windows native system32 directory.
          */
         constexpr static char const* windows_system32 = "system32";

--- a/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
+++ b/lib/inc/internal/facts/resolvers/operating_system_resolver.hpp
@@ -113,6 +113,10 @@ namespace facter { namespace facts { namespace resolvers {
              */
             std::string product_name;
             /**
+             * Stores the Windows Display Version.
+             */
+            std::string display_version;
+            /**
              * Stores the Windows Build Version.
              */
             std::string release_id;

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -1238,6 +1238,9 @@ os:
                 product_name:
                     type: string
                     description: Specify the textual product name.
+                display_version:
+                    type: string
+                    description: Windows Display Version of the form YYMM.
                 release_id:
                     type: string
                     description: Windows Build Version of the form YYMM.
@@ -1719,6 +1722,13 @@ windows_release_id:
     description: Return Windows Build Version of the form YYMM.
     resolution: |
         Windows: query the registry to retrieve the build version number.
+
+windows_display_version:
+    type: string
+    hidden: true
+    description: Return Windows Display Version.
+    resolution: |
+        Windows: query the registry to retrieve the display version.
 
 system32:
     type: string

--- a/lib/src/facts/resolvers/operating_system_resolver.cc
+++ b/lib/src/facts/resolvers/operating_system_resolver.cc
@@ -39,6 +39,7 @@ namespace facter { namespace facts { namespace resolvers {
                 fact::windows_edition_id,
                 fact::windows_installation_type,
                 fact::windows_product_name,
+                fact::windows_display_version,
                 fact::windows_release_id,
                 fact::windows_system32,
                 fact::selinux,
@@ -217,6 +218,11 @@ namespace facter { namespace facts { namespace resolvers {
         if (!data.win.release_id.empty()) {
             facts.add(fact::windows_release_id, make_value<string_value>(data.win.release_id, true));
             windows->add("release_id", make_value<string_value>(move(data.win.release_id)));
+        }
+
+        if (!data.win.display_version.empty()) {
+            facts.add(fact::windows_display_version, make_value<string_value>(data.win.display_version, true));
+            windows->add("display_version", make_value<string_value>(move(data.win.display_version)));
         }
 
         if (!data.win.system32.empty()) {

--- a/lib/src/facts/windows/operating_system_resolver.cc
+++ b/lib/src/facts/windows/operating_system_resolver.cc
@@ -79,14 +79,29 @@ namespace facter { namespace facts { namespace windows {
         }
     }
 
+    static string get_display_version()
+    {
+        string displayVersion;
+        try {
+            displayVersion = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "DisplayVersion");
+        } catch (registry_exception &e) {
+            LOG_DEBUG("failure getting DisplayVersion: {1}", e.what());
+        }
+        return displayVersion;
+    }
+
     static string get_release_id()
     {
         string releaseID;
-        try {
-            releaseID = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
-                "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "ReleaseId");
-        } catch (registry_exception &e) {
-            LOG_DEBUG("failure getting ReleaseId: {1}", e.what());
+        releaseID = get_display_version();
+        if (releaseID.empty()) {
+            try {
+                releaseID = registry::get_registry_string(registry::HKEY::LOCAL_MACHINE,
+                    "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\", "ReleaseId");
+            } catch (registry_exception &e) {
+                LOG_DEBUG("failure getting ReleaseId: {1}", e.what());
+            }
         }
         return releaseID;
     }
@@ -144,6 +159,7 @@ namespace facter { namespace facts { namespace windows {
         result.architecture = get_architecture(result.hardware);
         result.win.system32 = get_system32();
         result.win.release_id = get_release_id();
+        result.win.display_version = get_display_version();
         result.win.edition_id = get_edition_id();
         result.win.installation_type = get_installation_type();
         result.win.product_name = get_product_name();

--- a/lib/tests/facts/resolvers/operating_system_resolver.cc
+++ b/lib/tests/facts/resolvers/operating_system_resolver.cc
@@ -37,6 +37,7 @@ struct test_os_resolver : operating_system_resolver
         result.osx.product = "Mac OS X";
         result.osx.build = "14A388b";
         result.osx.version = "10.10";
+        result.win.display_version = "21H2";
         result.win.release_id = "1904";
         result.win.edition_id = "ServerStandard";
         result.win.installation_type = "Server";
@@ -65,7 +66,7 @@ SCENARIO("using the operating system resolver") {
     }
     WHEN("data is present") {
         facts.add(make_shared<test_os_resolver>());
-        REQUIRE(facts.size() == 30u);
+        REQUIRE(facts.size() == 31u);
         THEN("a structured fact is added") {
             auto os = facts.get<map_value>(fact::os);
             REQUIRE(os);
@@ -144,7 +145,7 @@ SCENARIO("using the operating system resolver") {
             REQUIRE(minor->value() == "0");
             auto windows = os->get<map_value>("windows");
             REQUIRE(windows);
-            REQUIRE(windows->size() == 5u);
+            REQUIRE(windows->size() == 6u);
             auto edition_id = facts.get<string_value>(fact::windows_edition_id);
             REQUIRE(edition_id);
             REQUIRE(edition_id->value() == "ServerStandard");
@@ -157,6 +158,9 @@ SCENARIO("using the operating system resolver") {
             auto release_id = facts.get<string_value>(fact::windows_release_id);
             REQUIRE(release_id);
             REQUIRE(release_id->value() == "1904");
+            auto display_version = facts.get<string_value>(fact::windows_display_version);
+            REQUIRE(display_version);
+            REQUIRE(display_version->value() == "21H2");
             auto system32 = windows->get<string_value>("system32");
             REQUIRE(system32);
             REQUIRE(system32->value() == "C:\\WINDOWS\\sysnative");
@@ -249,6 +253,9 @@ SCENARIO("using the operating system resolver") {
             auto release_id = facts.get<string_value>(fact::windows_release_id);
             REQUIRE(release_id);
             REQUIRE(release_id->value() == "1904");
+            auto display_version = facts.get<string_value>(fact::windows_display_version);
+            REQUIRE(display_version);
+            REQUIRE(display_version->value() == "21H2");
             auto system32 = facts.get<string_value>(fact::windows_system32);
             REQUIRE(system32);
             REQUIRE(system32->value() == "C:\\WINDOWS\\sysnative");

--- a/lib/tests/facts/schema.cc
+++ b/lib/tests/facts/schema.cc
@@ -283,6 +283,7 @@ struct operating_system_resolver : resolvers::operating_system_resolver
         result.osx.product = "product";
         result.osx.build = "build";
         result.osx.version = "10.10";
+        result.win.display_version = "21H2";
         result.win.release_id = "1904";
         result.win.edition_id = "ServerStandard";
         result.win.installation_type = "Server";


### PR DESCRIPTION
This commit fixes `os.windows.release_id` fact on Windows 2022 by retrieving the information from the correct registry key. The `ReleaseId` registry key from `SOFTWARE\Microsoft\Windows NT\CurrentVersion` seems to be abandoned since build `2009` (is still kept on newer builds and versions of Windows but not updated anymore) and replaced by the `DisplayVersion` registry key from the same location.

This commit also adds a new fact, `os.windows.release_id`, with above information. For backwards compatibility reasons, when `DisplayVersion` is available, both facts will be populated from this registry key. When `DisplayVersion` is not available, only `os.windows.release_id` will be populated but from `ReleaseId` registry key instead (same as before this fix). 

TODO in Facter 5: remove `os.windows.release_id` fact to avoid duplicated information

See https://github.com/puppetlabs/facter/pull/2439 for same implementation in Facter 4