### PR TITLE
(FACT-3077) Fix inconsistencies in Facter output

### DIFF
--- a/lib/facter/custom_facts/util/fact.rb
+++ b/lib/facter/custom_facts/util/fact.rb
@@ -117,7 +117,7 @@ module Facter
       #
       # @api public
       def value
-        return @value if @value
+        return @value unless @value.nil?
 
         if @resolves.empty?
           log.debug format('No resolves for %<name>s', name: @name)

--- a/lib/facter/custom_facts/util/resolution.rb
+++ b/lib/facter/custom_facts/util/resolution.rb
@@ -188,7 +188,7 @@ module Facter
       end
 
       def resolve_value
-        if @value
+        if !@value.nil?
           @value
         elsif @code.nil?
           nil

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -61,6 +61,11 @@ describe Facter::Util::Resolution do
       expect(resolution.value).to eq 'foo'
     end
 
+    it 'returns a value that is equal to false' do
+      resolution.value = false
+      expect(resolution.value).to eq false
+    end
+
     describe 'and setcode has not been called' do
       it 'returns nil' do
         expect(resolution.value).to be_nil


### PR DESCRIPTION
Previously, facter 4 wouldn't resolve custom facts that had the value equal
to `false`. For example the custom fact `custom.yaml` with the content
of:
```
---
key1: true
key2: false
```
Would output:
```
key1 => true
key2 =>
```

This commit fixes this issue by checking for `value.nil?` instead of
`value`, to avoid having boolean values skipped when they are set to
`false`