### PR TITLE
(FACT-3081) Replace invalid UTF characters in dmi.rb

### DIFF
--- a/lib/facter/resolvers/dmi.rb
+++ b/lib/facter/resolvers/dmi.rb
@@ -36,6 +36,7 @@ module Facter
             return unless File.directory?('/sys/class/dmi')
 
             file_content = Facter::Util::FileHelper.safe_read("/sys/class/dmi/id/#{fact_name}", nil)
+                                                   .encode('UTF-8', invalid: :replace)
             if files.include?(fact_name.to_s) && file_content
               file_content = file_content.strip
               @fact_list[fact_name] = file_content unless file_content.empty?

--- a/spec/facter/resolvers/dmi_spec.rb
+++ b/spec/facter/resolvers/dmi_spec.rb
@@ -159,5 +159,14 @@ describe Facter::Resolvers::Linux::DmiBios do
         expect(resolver.resolve(:product_uuid)).to be(nil)
       end
     end
+
+    context 'when product_name contains garbled information' do
+      let(:file_content) { "Supermicro^L\x8DD$Pptal0\n" }
+      let(:file) { 'sys_vendor' }
+
+      it 'returns product_name with the invalid characters replaced' do
+        expect(resolver.resolve(:sys_vendor)).to eq('Supermicro^L�D$Pptal0')
+      end
+    end
   end
 end


### PR DESCRIPTION
One server has some invalid (looks like binary data/corruption) in the DMI-data. Productname and -manufacturer are garbled. On one hand this should not happen, on the other hand puppet(facter) should not break over it.
This change should just replace the invalid characters with a questionmark-gliph-thingy, and continue not burning down.