### PR TITLE
(FACT-3082) EC2 facts timeout of 2 minutes on non EC2 machines

### DIFF
--- a/lib/inc/facter/util/aws_token.hpp
+++ b/lib/inc/facter/util/aws_token.hpp
@@ -16,6 +16,7 @@ namespace facter { namespace util {
      * @param cli the client used to make the request
      * @param lifetime the lifetime of the token
      */
-   std::string get_token(std::string const& url, leatherman::curl::client& cli, int const& lifetime);
+   std::string get_token(std::string const& url, leatherman::curl::client& cli, int const& lifetime,
+                         unsigned int ec2_connection_timeout, unsigned int ec2_session_timeout);
 }}  // namespace facter::util
 #endif  // USE_CURL

--- a/lib/src/facts/resolvers/ec2_resolver.cc
+++ b/lib/src/facts/resolvers/ec2_resolver.cc
@@ -138,7 +138,7 @@ namespace facter { namespace facts { namespace resolvers {
 
         try
         {
-            token = facter::util::get_token(AWS_API_TOKEN_URL, cli, AWS_API_TOKEN_LIFETIME);
+            token = facter::util::get_token(AWS_API_TOKEN_URL, cli, AWS_API_TOKEN_LIFETIME, EC2_CONNECTION_TIMEOUT, EC2_SESSION_TIMEOUT);
         }
         catch (lth_curl::http_request_exception& ex) {
             LOG_DEBUG("EC2 IMDSv2 endpoint is unavailable");

--- a/lib/src/util/aws_token.cc
+++ b/lib/src/util/aws_token.cc
@@ -9,8 +9,11 @@ using namespace std;
 
 namespace facter { namespace util {
 
-    string get_token(string const& url, lth_curl::client& cli, int const& lifetime){
+    string get_token(string const& url, lth_curl::client& cli, int const& lifetime,
+                     unsigned int ec2_connection_timeout, unsigned int ec2_session_timeout){
         lth_curl::request req(url);
+        req.connection_timeout(ec2_connection_timeout);
+        req.timeout(ec2_session_timeout);
         req.add_header("X-aws-ec2-metadata-token-ttl-seconds", to_string(lifetime));
         auto response = cli.put(req);
 


### PR DESCRIPTION
steps to reproduce:
1. run `tables -I OUTPUT -d 169.254.169.254 -j DROP`
2. run `export FACTER_virtual=kvm`
3. run facter