### PR TITLE
Revert "(maint) Pin jruby version in GitHub Actions workflow"

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           - 2.3
           - 2.7
           - 3.0
-          - 'jruby-9.2.19.0'
+          - jruby
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout current PR


### PR DESCRIPTION
Reverts puppetlabs/facter#2440

JRuby 9.3.1.0 was [released](https://www.jruby.org/2021/10/13/jruby-9-3-1-0.html) and this removes the need of pinning jRuby to specific version in our GitHub Actions workflows.

Kudos to @GabrielNagy for https://github.com/jruby/jruby/pull/6861 🎉 