### PR TITLE
(FACT-3058) Add windows_display_version legacy fact

### DIFF
--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -167,6 +167,7 @@ module Facter
           macosx_productversion_major
           macosx_productversion_minor
           macosx_productversion_patch
+          windows_display_version
           windows_edition_id
           windows_installation_type
           windows_product_name

--- a/lib/facter/facts/windows/os/windows/display_version.rb
+++ b/lib/facter/facts/windows/os/windows/display_version.rb
@@ -6,11 +6,12 @@ module Facts
       module Windows
         class DisplayVersion
           FACT_NAME = 'os.windows.display_version'
+          ALIASES = 'windows_display_version'
 
           def call_the_resolver
             fact_value = Facter::Resolvers::ProductRelease.resolve(:display_version)
 
-            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
           end
         end
       end

--- a/spec/facter/facts/windows/os/windows/display_version_spec.rb
+++ b/spec/facter/facts/windows/os/windows/display_version_spec.rb
@@ -16,8 +16,9 @@ describe Facts::Windows::Os::Windows::DisplayVersion do
     end
 
     it 'returns os release id fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-        have_attributes(name: 'os.windows.display_version', value: value)
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.windows.display_version', value: value),
+                        an_object_having_attributes(name: 'windows_display_version', value: value, type: :legacy))
     end
   end
 end


### PR DESCRIPTION
Add windows_display_version legacy fact to maintain
backward compatibility with Facter 3