### PR TITLE
(FACT-3083) add disks serial number and wwid to the disks fact

### DIFF
--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -7,6 +7,7 @@ module Facter
     module Execution
       class Base
         STDERR_MESSAGE = 'Command %s completed with the following stderr message: %s'
+        VALID_OPTIONS = %i[on_fail expand logger timeout].freeze
 
         def initialize
           @log = Log.new(self)
@@ -117,9 +118,10 @@ module Facter
           timeout = (options[:timeout] || options[:time_limit] || options[:limit]).to_i
           timeout = timeout.positive? ? timeout : nil
 
-          extra_keys = options.keys - %i[on_fail expand logger timeout]
+          extra_keys = options.keys - VALID_OPTIONS
           unless extra_keys.empty?
-            @log.warn("Unexpected key passed to Facter::Core::Execution.execute option: #{options.keys.join(',')}")
+            @log.warn("Unexpected key passed to Facter::Core::Execution.execute option: #{extra_keys.join(',')}" \
+                      " - valid keys: #{VALID_OPTIONS.join(',')}")
           end
 
           [on_fail, expand, logger, timeout]

--- a/lib/facter/facts/linux/disks.rb
+++ b/lib/facter/facts/linux/disks.rb
@@ -8,7 +8,7 @@ module Facts
 
       def call_the_resolver
         facts = []
-        disks = Facter::Resolvers::Linux::Disk.resolve(:disks)
+        disks = Facter::Resolvers::Linux::Disks.resolve(:disks)
 
         return Facter::ResolvedFact.new(FACT_NAME, nil) if disks.nil? || disks.empty?
 

--- a/lib/facter/resolvers/disk.rb
+++ b/lib/facter/resolvers/disk.rb
@@ -9,7 +9,13 @@ module Facter
         init_resolver
 
         DIR = '/sys/block'
-        FILE_PATHS = { model: 'device/model', size: 'size', vendor: 'device/vendor', type: 'queue/rotational' }.freeze
+        FILE_PATHS = { model: 'device/model',
+                       size: 'size',
+                       vendor: 'device/vendor',
+                       type: 'queue/rotational',
+                       sn: 'false',
+                       wwid: 'false'
+                     }.freeze
 
         class << self
           private
@@ -25,7 +31,19 @@ module Facter
               @fact_list[:disks].each do |disk, value|
                 file_path = File.join(DIR, disk, file)
 
-                result = Facter::Util::FileHelper.safe_read(file_path).strip
+                if file == 'false'
+                  value[key] = case key
+                               when :sn
+                                 result = Facter::Core::Execution.execute("/usr/bin/lsblk -dn -o serial /dev/#{disk}", {on_fail: "", time_limit: 1}).strip
+                                 next if result.empty?
+                               when :wwid
+                                 result = Facter::Core::Execution.execute("/us/bin/lsblk -dn -o wwn /dev/#{disk}", {on_fail: "", time_limit: 1}).strip
+                                 next if result.empty?
+                               end
+                else
+                  result = Facter::Util::FileHelper.safe_read(file_path).strip
+                end
+
                 next if result.empty?
 
                 value[key] = case key

--- a/lib/facter/resolvers/disks.rb
+++ b/lib/facter/resolvers/disks.rb
@@ -3,7 +3,7 @@
 module Facter
   module Resolvers
     module Linux
-      class Disk < BaseResolver
+      class Disks < BaseResolver
         @log = Facter::Log.new(self)
 
         init_resolver

--- a/lib/facter/util/file_helper.rb
+++ b/lib/facter/util/file_helper.rb
@@ -22,6 +22,16 @@ module Facter
           default_return
         end
 
+        def dir_children(path)
+          children = if RUBY_VERSION.to_f < 2.5
+                       Dir.entries(path).reject { |dir| ['.', '..'].include?(dir) }
+                     else
+                       Dir.children(path)
+                     end
+
+          children
+        end
+
         private
 
         def log_failed_to_read(path)

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -54,42 +54,32 @@ describe Facter::Core::Execution do
     end
 
     context 'with default parameters' do
-      it 'execute the found command' do
+      it 'executes the found command' do
         execution.execute('waffles')
         expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, nil)
       end
     end
 
     context 'with a timeout' do
-      it 'execute the found command with a timeout' do
+      it 'executes the found command with a timeout' do
         execution.execute('waffles', timeout: 90)
         expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
       end
     end
 
-    context 'with a deprecated time_limit' do
-      it 'execute the found command with a timeout' do
-        execution.execute('waffles', time_limit: 90)
-        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
+    context 'when passing deprecated arguments' do
+      %i[time_limit limit].each do |option|
+        it 'executes the found command with a timeout' do
+          execution.execute('waffles', option => 90)
+          expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
+        end
       end
 
       it 'emits a warning' do
-        execution.execute('waffles', time_limit: 90)
+        execution.execute('waffles', time_limit: 90, bad_opt: true)
         expect(logger).to have_received(:warn)
-          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit')
-      end
-    end
-
-    context 'with a deprecated limit' do
-      it 'execute the found command with a timeout' do
-        execution.execute('waffles', limit: 90)
-        expect(impl).to have_received(:execute_command).with('/under/the/honey/are/the/waffles', :raise, nil, 90)
-      end
-
-      it 'emits a warning' do
-        execution.execute('waffles', limit: 90)
-        expect(logger).to have_received(:warn)
-          .with('Unexpected key passed to Facter::Core::Execution.execute option: limit')
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit,bad_opt' \
+                ' - valid keys: on_fail,expand,logger,timeout')
       end
     end
   end

--- a/spec/facter/facts/linux/disks_spec.rb
+++ b/spec/facter/facts/linux/disks_spec.rb
@@ -27,12 +27,12 @@ describe Facts::Linux::Disks do
 
   describe '#call_the_resolver' do
     before do
-      allow(Facter::Resolvers::Linux::Disk).to receive(:resolve).with(:disks).and_return(disk)
+      allow(Facter::Resolvers::Linux::Disks).to receive(:resolve).with(:disks).and_return(disk)
     end
 
-    it 'calls Facter::Resolvers::Linux::Disk' do
+    it 'calls Facter::Resolvers::Linux::Disks' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::Linux::Disk).to have_received(:resolve).with(:disks)
+      expect(Facter::Resolvers::Linux::Disks).to have_received(:resolve).with(:disks)
     end
 
     it 'returns resolved fact with name disk and value' do

--- a/spec/facter/resolvers/disk_spec.rb
+++ b/spec/facter/resolvers/disk_spec.rb
@@ -5,15 +5,41 @@ describe Facter::Resolvers::Linux::Disk do
     subject(:resolver) { Facter::Resolvers::Linux::Disk }
 
     let(:disk_files) { %w[sr0/device sr0/size sda/device sda/size] }
-    let(:paths) { { model: '/device/model', size: '/size', vendor: '/device/vendor', type: '/queue/rotational' } }
-    let(:disks) { %w[sr0 sda] }
-    let(:size) { '12' }
-    let(:model) { 'test' }
-    let(:rotational) { '1' }
-    let(:nonrotational) { '0' }
+
+    let(:paths) do
+      {
+        model: '/device/model',
+        size: '/size',
+        vendor: '/device/vendor',
+        type: '/queue/rotational',
+        serial: 'false',
+        wwn: 'false'
+      }
+    end
+
+    let(:disks) do
+      {
+        sr0: {
+          size: '12',
+          rotational: '0',
+          model: 'model1',
+          vendor: 'vendor1',
+          serial: 'AJDI2491AK',
+          wwn: '239090190.0'
+        },
+        sda: {
+          size: '231',
+          rotational: '1',
+          model: 'model2',
+          vendor: 'vendor2',
+          serial: 'B2EI34F1AL',
+          wwn: '29429191.0'
+        }
+      }
+    end
 
     before do
-      allow(Dir).to receive(:entries).with('/sys/block').and_return(['.', '..', 'sr0', 'sda'])
+      allow(Facter::Util::FileHelper).to receive(:dir_children).with('/sys/block').and_return(%w[sda sr0])
     end
 
     after do
@@ -22,25 +48,36 @@ describe Facter::Resolvers::Linux::Disk do
 
     context 'when device dir for blocks exists' do
       let(:expected_output) do
-        { 'sda' => { model: 'test', size: '6.00 KiB', size_bytes: 6144, vendor: 'test', type: 'hdd' },
-          'sr0' => { model: 'test', size: '6.00 KiB', size_bytes: 6144, vendor: 'test', type: 'hdd' } }
+        { 'sr0' => { model: 'model1', serial: 'AJDI2491AK', wwn: '239090190.0',
+                     size: '6.00 KiB', size_bytes: 6144, vendor: 'vendor1', type: 'ssd' },
+          'sda' => { model: 'model2', serial: 'B2EI34F1AL', wwn: '29429191.0',
+                     size: '115.50 KiB', size_bytes: 118_272, vendor: 'vendor2', type: 'hdd' } }
       end
 
       before do
         disk_files.each do |disk_file|
           allow(File).to receive(:readable?).with("/sys/block/#{disk_file}").and_return(true)
         end
-        paths.each do |_key, value|
-          disks.each do |disk|
-            if value == '/size'
+
+        paths.each do |fact, value|
+          disks.each do |disk, values|
+            case value
+            when '/size'
               allow(Facter::Util::FileHelper).to receive(:safe_read)
-                .with("/sys/block/#{disk}#{value}").and_return(size)
-            elsif value == 'queue/rotational'
+                .with("/sys/block/#{disk}#{value}", nil).and_return(values[:size])
+            when '/queue/rotational'
               allow(Facter::Util::FileHelper).to receive(:safe_read)
-                .with("/sys/block/#{disk}#{value}").and_return(rotational)
-            else
+                .with("/sys/block/#{disk}#{value}", nil).and_return(values[:rotational])
+            when '/device/model'
               allow(Facter::Util::FileHelper).to receive(:safe_read)
-                .with("/sys/block/#{disk}#{value}").and_return(model)
+                .with("/sys/block/#{disk}#{value}", nil).and_return(values[:model])
+            when '/device/vendor'
+              allow(Facter::Util::FileHelper).to receive(:safe_read)
+                .with("/sys/block/#{disk}#{value}", nil).and_return(values[:vendor])
+            when 'false'
+              allow(Facter::Core::Execution).to receive(:execute)
+                .with("/usr/bin/lsblk -dn -o #{fact} /dev/#{disk}", on_fail: '', timeout: 1)
+                .and_return(values[fact])
             end
           end
         end
@@ -52,40 +89,18 @@ describe Facter::Resolvers::Linux::Disk do
         end
       end
 
-      context 'when disk are non-rotational' do
-        let(:expected_output) do
-          { 'sda' => { model: 'test', size: '6.00 KiB', size_bytes: 6144, vendor: 'test', type: 'ssd' },
-            'sr0' => { model: 'test', size: '6.00 KiB', size_bytes: 6144, vendor: 'test', type: 'ssd' } }
-        end
-
-        before do
-          paths.each do |_key, value|
-            disks.each do |disk|
-              if value == '/queue/rotational'
-                allow(Facter::Util::FileHelper).to receive(:safe_read)
-                  .with("/sys/block/#{disk}#{value}").and_return(nonrotational)
-              end
-            end
-          end
-        end
-
-        it 'returns disks fact' do
-          expect(resolver.resolve(:disks)).to eql(expected_output)
-        end
-      end
-
       context 'when size files are not readable' do
         let(:expected_output) do
-          { 'sda' => { model: 'test', vendor: 'test', type: 'hdd' },
-            'sr0' => { model: 'test', vendor: 'test', type: 'hdd' } }
+          { 'sr0' => { model: 'model1', vendor: 'vendor1', type: 'ssd', serial: 'AJDI2491AK', wwn: '239090190.0' },
+            'sda' => { model: 'model2', vendor: 'vendor2', type: 'hdd', serial: 'B2EI34F1AL', wwn: '29429191.0' } }
         end
 
         before do
           paths.each do |_key, value|
-            disks.each do |disk|
+            disks.each do |disk, _values|
               if value == '/size'
                 allow(Facter::Util::FileHelper).to receive(:safe_read)
-                  .with("/sys/block/#{disk}#{value}").and_return('')
+                  .with("/sys/block/#{disk}#{value}", nil).and_return(nil)
               end
             end
           end
@@ -98,17 +113,40 @@ describe Facter::Resolvers::Linux::Disk do
 
       context 'when device vendor and model files are not readable' do
         let(:expected_output) do
-          { 'sda' => { size: '6.00 KiB', size_bytes: 6144 },
-            'sr0' => { size: '6.00 KiB', size_bytes: 6144 } }
+          { 'sr0' => { size: '6.00 KiB', size_bytes: 6144, serial: 'AJDI2491AK', wwn: '239090190.0' },
+            'sda' => { size: '115.50 KiB', size_bytes: 118_272, serial: 'B2EI34F1AL', wwn: '29429191.0' } }
         end
 
         before do
           paths.each do |_key, value|
-            disks.each do |disk|
+            disks.each do |disk, _values|
               if value != '/size'
                 allow(Facter::Util::FileHelper).to receive(:safe_read)
-                  .with("/sys/block/#{disk}#{value}").and_return('')
+                  .with("/sys/block/#{disk}#{value}", nil).and_return(nil)
               end
+            end
+          end
+        end
+
+        it 'returns disks fact' do
+          expect(resolver.resolve(:disks)).to eql(expected_output)
+        end
+      end
+
+      context 'when serial and wwn are not returned by lsblk' do
+        let(:expected_output) do
+          { 'sr0' => { size: '6.00 KiB', size_bytes: 6144, model: 'model1', vendor: 'vendor1', type: 'ssd' },
+            'sda' => { size: '115.50 KiB', size_bytes: 118_272, model: 'model2', vendor: 'vendor2', type: 'hdd' } }
+        end
+
+        before do
+          paths.each do |fact, value|
+            disks.each do |disk, _values|
+              next unless value == 'false'
+
+              allow(Facter::Core::Execution).to receive(:execute)
+                .with("/usr/bin/lsblk -dn -o #{fact} /dev/#{disk}", on_fail: '', timeout: 1)
+                .and_return('')
             end
           end
         end

--- a/spec/facter/resolvers/disks_spec.rb
+++ b/spec/facter/resolvers/disks_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-describe Facter::Resolvers::Linux::Disk do
+describe Facter::Resolvers::Linux::Disks do
   describe '#resolve' do
-    subject(:resolver) { Facter::Resolvers::Linux::Disk }
+    subject(:resolver) { Facter::Resolvers::Linux::Disks }
 
     let(:disk_files) { %w[sr0/device sr0/size sda/device sda/size] }
 
@@ -43,7 +43,7 @@ describe Facter::Resolvers::Linux::Disk do
     end
 
     after do
-      Facter::Resolvers::Linux::Disk.invalidate_cache
+      Facter::Resolvers::Linux::Disks.invalidate_cache
     end
 
     context 'when device dir for blocks exists' do


### PR DESCRIPTION
Integrated https://github.com/puppetlabs/facter/pull/2297, did some refactoring of the disk resolver class, fixed a misleading execution API warning, and renamed the disk resolver.