### PR TITLE
(FACT-3094) Aix mountpoint resolver couldn't resolve nfs

### DIFF
--- a/lib/facter/resolvers/aix/mountpoints.rb
+++ b/lib/facter/resolvers/aix/mountpoints.rb
@@ -30,8 +30,11 @@ module Facter
 
           def add_mount_points_fact(line)
             elem = line.split("\s")
+
+            elem.shift unless line[0] == ' '
+
             @fact_list[:mountpoints][elem[1]] = { device: elem[0], filesystem: elem[2],
-                                                  options: elem.last.split(',') }
+                                                  options: elem.last.include?(':') ? [] : elem.last.split(',') }
           end
 
           def retrieve_sizes_for_mounts

--- a/spec/facter/resolvers/aix/mountpoints_spec.rb
+++ b/spec/facter/resolvers/aix/mountpoints_spec.rb
@@ -11,7 +11,10 @@ describe Facter::Resolvers::Aix::Mountpoints do
                   used: '2.16 GiB', used_bytes: 2_319_687_680 },
       '/var' => { available: '205.06 MiB', available_bytes: 215_023_616, capacity: '0.76%', device: '/dev/hd3',
                   filesystem: 'x', options: ['rw', 'nodev', 'log=/dev/hd3'], size: '206.64 MiB',
-                  size_bytes: 216_678_912, used: '1.58 MiB', used_bytes: 1_655_296 } }
+                  size_bytes: 216_678_912, used: '1.58 MiB', used_bytes: 1_655_296 },
+      '/tmp/salam' => { available: '63.57 GiB', available_bytes: 68_253_413_376, capacity: '7.20%',
+                        device: '/var/share', filesystem: 'nfs3', options: [], size: '68.50 GiB',
+                        size_bytes: 73_549_217_792, used: '4.93 GiB', used_bytes: 5_295_804_416 } }
   end
   let(:log_spy) { instance_spy(Facter::Log) }
 

--- a/spec/fixtures/df
+++ b/spec/fixtures/df
@@ -3,3 +3,4 @@ Filesystem    512-blocks      Used Available Capacity Mounted on
 /dev/hd2        10485760   4530640   5955120      44% /usr
 /dev/hd3          423201      3233    419968      1%  /var
 /proc                  -         -         -       - /proc
+joe:/var/share   143650816  10343368 133307448       8% /tmp/salam

--- a/spec/fixtures/mount
+++ b/spec/fixtures/mount
@@ -5,3 +5,4 @@
          /proc            /proc            procfs Mar 22 08:05 rw
          /dev/hd10opt     /opt             jfs2   Mar 22 08:05 rw,log=/dev/hd8
          /dev/hd3         /var             x      Mar 22 08:05 rw,nodev,log=/dev/hd3
+joe      /var/share       /tmp/salam       nfs3   Nov 12 04:40


### PR DESCRIPTION
This commit fixes NFS mounts being resolved incorrectly by facter. This
happened because the node from where the remote directory is mounted
would be under the `node` header of the mount output. To fix this, we
shift the array by removing the first element, so that every other
column falls into place

Previously, the AIX mountpoint resolver would check each line of the
`mount` command output to check if it matches the header of the table,
so it can be skipped.

This is not efficient and it can cause many problems, such as not
skipping the first line of the output if spaces are not present before
`node`, therefore considering the header of the table as a mountpoint.

```
  node       mounted        mounted over    vfs       date        options
-------- ---------------  ---------------  ------ ------------ ---------------
         /dev/hd4         /                jfs2   Mar 22 08:05 rw,log=/dev/hd8
         /dev/hd2         /usr             jfs2   Mar 22 08:05 rw,log=/dev/hd8
         /proc            /proc            procfs Mar 22 08:05 rw
         /dev/hd10opt     /opt             jfs2   Mar 22 08:05 rw,log=/dev/hd8
         /dev/hd3         /var             x      Mar 22 08:05 rw,nodev,log=/dev/hd3
```

To fix this, instead of checking a line matches the header, we just
simply skip the first 2 lines of the output, removing unnecessary regex
expressions and improving performance
