### PR TITLE
(FACT-3099) ec2_userdata fails if it contains ASCII-8BIT chars

### DIFF
--- a/lib/facter/resolvers/ec2.rb
+++ b/lib/facter/resolvers/ec2.rb
@@ -20,7 +20,7 @@ module Facter
         def read_facts(fact_name)
           @fact_list[:metadata] = {}
           query_for_metadata(EC2_METADATA_ROOT_URL, @fact_list[:metadata])
-          @fact_list[:userdata] = get_data_from(EC2_USERDATA_ROOT_URL).strip
+          @fact_list[:userdata] = get_data_from(EC2_USERDATA_ROOT_URL).strip.force_encoding('UTF-8')
           @fact_list[fact_name]
         end
 


### PR DESCRIPTION
When using facter to get ec2_userdata that contains some ASCII-8Bit values, a
conversion error would be thrown.

The error is caused by amazon ec2 instances return base64-encoded userdata strings,
so it can contain non UTF-8 data.

Forcing a UTF-8 encoding seems to fix the problem, but not sure if there are
cases when we would want to have non UTF-8 data.