### PR TITLE
(FACT-3097) Kvm returns nil on OpenStack

### DIFF
--- a/lib/facter/facts/linux/hypervisors/kvm.rb
+++ b/lib/facter/facts/linux/hypervisors/kvm.rb
@@ -35,13 +35,15 @@ module Facts
         end
 
         def kvm?
+          product_name = discover_hypervisor
           bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
           @log.debug("Detected bios vendor: #{bios_vendor}")
 
           Facter::Resolvers::VirtWhat.resolve(:vm) == 'kvm' ||
             Facter::Resolvers::Lspci.resolve(:vm) == 'kvm' ||
             bios_vendor&.include?('Amazon EC2') ||
-            bios_vendor&.include?('Google')
+            bios_vendor&.include?('Google') ||
+            product_name&.include?('OpenStack')
         end
 
         def discover_provider

--- a/spec/facter/facts/linux/hypervisors/kvm_spec.rb
+++ b/spec/facter/facts/linux/hypervisors/kvm_spec.rb
@@ -122,6 +122,13 @@ describe Facts::Linux::Hypervisors::Kvm do
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact)
           .and have_attributes(name: 'hypervisors.kvm', value: { 'openstack' => true })
       end
+
+      it 'returns open stack when Lspci return nil' do
+        allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return('unknown')
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('OpenStack')
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact)
+          .and have_attributes(name: 'hypervisors.kvm', value: { 'openstack' => true })
+      end
     end
   end
 end


### PR DESCRIPTION
This commit adds the dmi `product_name` fact to the `kvm?` check to allow OpenStack instances to be detected when `VirtWhat` and `Lscpi` won't work.
This was inspired from https://github.com/puppetlabs/libwhereami/blob/c9666110a1bdec1c7034e4a607710c704603cbf9/lib/src/detectors/kvm_detector.cc#L28-L29

Before fix: 
```
DEBUG Facts::Linux::Hypervisors::Kvm - Detected product name: OpenStack Nova
DEBUG Facts::Linux::Hypervisors::Kvm - Detected hypervisor OpenStack Nova
DEBUG Facts::Linux::Hypervisors::Kvm - Detected bios vendor: SeaBIOS


```
It would detect the correct system information, but since the `bios_vendor` fact, and the `virtwhat` `lspci` commands sometimes won't work, it didn't have the appropriate checks to resolve the fact.

After fix:
```
DEBUG Facts::Linux::Hypervisors::Kvm - Detected product name: OpenStack Nova
DEBUG Facts::Linux::Hypervisors::Kvm - Detected hypervisor OpenStack Nova
DEBUG Facts::Linux::Hypervisors::Kvm - Detected bios vendor: SeaBIOS
DEBUG Facts::Linux::Hypervisors::Kvm - Detected manufacturer: OpenStack Foundation
DEBUG Facter::FactManager - fact "hypervisors.kvm" has resolved to: {"openstack"=>true}
DEBUG Facter::LegacyFactFormatter - Formatting for single user query
DEBUG Facter::LegacyFactFormatter - Converting hash to pretty json
DEBUG Facter::LegacyFactFormatter - Change key value delimiter from : to =>
DEBUG Facter::LegacyFactFormatter - Remove quotes from parent nodes
DEBUG Facter::LegacyFactFormatter - Remove double backslashes from paths
DEBUG Facter::LegacyFactFormatter - Remove quotes from value if it is a simple string
{
  kvm => {
    openstack => true
  }
}
```


