### PR TITLE
(maint) Add RHEL9 support to networking_facts test

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -11,7 +11,7 @@ test_name 'C59029: networking facts should be fully populated' do
 
   agents.each do |agent|
     expected_networking = {
-      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|el-8-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|el-8-|el-9-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       "networking.ip"       => @ip_regex,
       "networking.ip6"      => /[a-f0-9]+:+/,
       "networking.mac"      => /[a-f0-9]{2}:/,


### PR DESCRIPTION
DHCP fact does not work properly due to NetworkManager issue

See also: PA-4121