### PR TITLE
(PUP-11370) Github workflow now uses windows 2019

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'windows-2016', 'ubuntu-18.04' ]
+        os: [ 'windows-2019', 'ubuntu-18.04' ]
     
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Upgraded github actions to use windows 2019 instead of windows 2016 as
it will be removed on March 15, 2022.