### PR TITLE
(PUP-11370) Github workflow now uses windows 2019

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [windows-2016, windows-2019, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        os: [ windows-2019, ubuntu-18.04, ubuntu-20.04, macos-10.15]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true


### PR DESCRIPTION
Removed windows 2016 from github actions as
it will be removed on March 15, 2022.