### PR TITLE
(FACT-3090) Fix windows 11 detection

### DIFF
--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -14,7 +14,7 @@ module Facter
             kernel_version = input[:kernel_version]
 
             if version =~ /10.0/
-              check_version_10(consumerrel, kernel_version)
+              check_version_10_11(consumerrel, kernel_version)
             else
               check_version_6(version, consumerrel) || check_version_5(version, consumerrel, description) || version
             end
@@ -22,10 +22,12 @@ module Facter
 
           private
 
-          def check_version_10(consumerrel, kernel_version)
+          def check_version_10_11(consumerrel, kernel_version)
+            build_number = kernel_version[/([^.]*)$/].to_i
+
+            return '11' if build_number >= 22_000
             return '10' if consumerrel
 
-            build_number = kernel_version[/([^.]*)$/].to_i
             if build_number >= 20_348
               '2022'
             elsif build_number >= 17_623

--- a/spec/facter/util/facts/windows_release_finder_spec.rb
+++ b/spec/facter/util/facts/windows_release_finder_spec.rb
@@ -25,6 +25,17 @@ describe Facter::Util::Facts::WindowsReleaseFinder do
     end
   end
 
+  describe '#find windows release when version is 11' do
+    let(:cons) { true }
+    let(:desc) {}
+    let(:k_version) { '10.0.22000' }
+    let(:version) { '10.0' }
+
+    it 'returns 11' do
+      expect(Facter::Util::Facts::WindowsReleaseFinder.find_release(input)).to eql('11')
+    end
+  end
+
   describe '#find windows release when version is 2022' do
     let(:cons) { false }
     let(:desc) {}


### PR DESCRIPTION
Windows 11 has version 10.0.22000 (yeah, versioning is **hard** at microsoft):

https://docs.microsoft.com/en-us/windows/release-health/windows11-release-information

Adjust the logic so that os.release.full is set to 11, not 10.
