### PR TITLE
(FACT-1557) Extend the cloud.provider fact to Google Compute Engine

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,8 @@ Metrics/CyclomaticComplexity:
     - 'lib/facter/custom_facts/util/confine.rb'
     - 'lib/facter/custom_facts/core/execution/windows.rb'
     - 'lib/facter/custom_facts/core/execution/posix.rb'
+    - 'lib/facter/facts/linux/cloud/provider.rb'
+    - 'lib/facter/facts/windows/cloud/provider.rb'
     - 'lib/facter/framework/detector/os_detector.rb'
     - 'install.rb'
     - 'scripts/generate_changelog.rb'

--- a/lib/facter/facts/linux/cloud/provider.rb
+++ b/lib/facter/facts/linux/cloud/provider.rb
@@ -12,6 +12,8 @@ module Facts
                        'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
                      when 'kvm', 'xen'
                        'aws' unless Facter::Resolvers::Ec2.resolve(:metadata).empty?
+                     when 'gce'
+                       'gce' unless Facter::Resolvers::Gce.resolve(:metadata).empty?
                      end
 
           Facter::ResolvedFact.new(FACT_NAME, provider)

--- a/lib/facter/facts/windows/cloud/provider.rb
+++ b/lib/facter/facts/windows/cloud/provider.rb
@@ -13,6 +13,8 @@ module Facts
                        'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
                      when 'kvm', 'xen'
                        'aws' unless Facter::Resolvers::Ec2.resolve(:metadata).empty?
+                     when 'gce'
+                       'gce' unless Facter::Resolvers::Gce.resolve(:metadata).empty?
                      end
 
           Facter::ResolvedFact.new(FACT_NAME, provider)

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -197,7 +197,7 @@ chassistype:
 
 cloud:
     type: map
-    description: Information about the cloud instance of the node. This is currently only populated on nodes running in Microsoft Azure and Amazon Web Service.
+    description: Information about the cloud instance of the node. This is currently only populated on nodes running in Microsoft Azure, Amazon Web Services, and Google Compute Engine.
     elements:
         provider:
             type: string

--- a/spec/facter/facts/linux/cloud/provider_spec.rb
+++ b/spec/facter/facts/linux/cloud/provider_spec.rb
@@ -89,5 +89,30 @@ describe Facts::Linux::Cloud::Provider do
         end
       end
     end
+
+    describe 'when on gce' do
+      before do
+        allow(Facter::Resolvers::Gce).to receive(:resolve).with(:metadata).and_return(value)
+        allow(Facter::Util::Facts::Posix::VirtualDetector).to receive(:platform).and_return('gce')
+      end
+
+      describe 'and the "gce" fact has content' do
+        let(:value) { { 'some' => 'metadata' } }
+
+        it 'resolves a provider of "gce"' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: 'gce')
+        end
+      end
+
+      context 'when the "gce" fact has no content' do
+        let(:value) { {} }
+
+        it 'resolves to nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: nil)
+        end
+      end
+    end
   end
 end

--- a/spec/facter/facts/windows/cloud/provider_spec.rb
+++ b/spec/facter/facts/windows/cloud/provider_spec.rb
@@ -79,6 +79,31 @@ describe Facts::Windows::Cloud::Provider do
       end
     end
 
+    context 'when on gce' do
+      before do
+        allow(Facter::Resolvers::Gce).to receive(:resolve).with(:metadata).and_return(value)
+        allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return('gce')
+      end
+
+      describe 'with the "gce" fact having data' do
+        let(:value) { { 'some' => 'metadata' } }
+
+        it 'resolves a provider of "gce"' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: 'gce')
+        end
+      end
+
+      context 'with the "gce" fact being empty' do
+        let(:value) { {} }
+
+        it 'resolves to nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'cloud.provider', value: nil)
+        end
+      end
+    end
+
     context 'when on a physical machine' do
       before do
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return(nil)


### PR DESCRIPTION
Similar to #2475 , this allows the `cloud.provider` fact to resolve on Google Compute Engine nodes to `gce`.

For example:
```
[user@a_gce_node]> facter cloud.provider
gce
```

This partially resolves https://tickets.puppetlabs.com/browse/FACT-1557

Note that I chose to have this resolve to the string "`gce`" because that's what the current `virtual` fact resolves to, so Facter/Puppet users are probably most familiar with "gce" meaning Google Compute Engine.