### PR TITLE
(FACT-1592) A key/value pair for Interface Speed/Duplex

### DIFF
--- a/lib/facter/resolvers/linux/networking.rb
+++ b/lib/facter/resolvers/linux/networking.rb
@@ -33,6 +33,8 @@ module Facter
               dhcp(interface_name, mtu_and_indexes)
               operstate(interface_name)
               physical(interface_name)
+              linkspeed(interface_name)
+              duplex(interface_name)
 
               @log.debug("Found interface #{interface_name} with #{@fact_list[:interfaces][interface_name]}")
             end
@@ -60,6 +62,30 @@ module Facter
                                                          else
                                                            false
                                                          end
+          end
+
+          def duplex(interface_name)
+            return unless @fact_list[:interfaces][interface_name][:physical]
+
+            # not all interfaces support this, wifi for example causes an EINVAL (Invalid argument)
+            begin
+              plex = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/duplex", nil)
+              @fact_list[:interfaces][interface_name][:duplex] = plex.strip if plex
+            rescue StandardError => e
+              @log.debug("Failed to read '/sys/class/net/#{interface_name}/duplex': #{e.message}")
+            end
+          end
+
+          def linkspeed(interface_name)
+            return unless @fact_list[:interfaces][interface_name][:physical]
+
+            # not all interfaces support this, wifi for example causes an EINVAL (Invalid argument)
+            begin
+              speed = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/speed", nil)
+              @fact_list[:interfaces][interface_name][:speed] = speed.strip if speed
+            rescue StandardError => e
+              @log.debug("Failed to read '/sys/class/net/#{interface_name}/speed': #{e.message}")
+            end
           end
 
           def parse_ip_command_line(line, mtu_and_indexes)

--- a/spec/facter/resolvers/linux/networking_spec.rb
+++ b/spec/facter/resolvers/linux/networking_spec.rb
@@ -27,6 +27,10 @@ describe Facter::Resolvers::Linux::Networking do
         .with('/sys/class/net/lo/operstate', nil).and_return('unknown')
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/class/net/ens160/operstate', nil).and_return('up')
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/ens160/speed', nil).and_return(1000)
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/ens160/duplex', nil).and_return('full')
     end
 
     after do
@@ -293,6 +297,7 @@ describe Facter::Resolvers::Linux::Networking do
               { address: 'fe80::250:56ff:fe9a:8481', netmask: 'ffff:ffff:ffff:ffff::',
                 network: 'fe80::', scope6: 'link', flags: ['permanent'] }
             ],
+            duplex: 'full',
             ip6: 'fe80::250:56ff:fe9a:8481',
             mac: '00:50:56:9a:61:46',
             mtu: 1500,
@@ -300,7 +305,8 @@ describe Facter::Resolvers::Linux::Networking do
             network6: 'fe80::',
             operational_state: 'up',
             physical: true,
-            scope6: 'link'
+            scope6: 'link',
+            speed: 1000
           }
         }
       end


### PR DESCRIPTION
I'll confess, I'll need help with the tests....

This partially resolves the issue for Linux systems.

Facter will have a `speed` fact equal to the link speed determined by the kernel for each supported interface.
Facter will have a `duplex` fact equal to the duplex determined by the kernel for each supported interface.

For wired networks this should report the speed/duplex even if the interface is not assigned an address.