### PR TITLE
resolvers/networking.rb: avoid calling ipconfig unless Windows

### DIFF
--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -71,7 +71,8 @@ module Facter
         end
 
         def extract_dhcp(interface_name, raw_data, parsed_interface_data)
-          return unless raw_data =~ /status:\s+active/
+          return unless ((raw_data =~ /status:\s+active/) &&
+                         (OsDetector.instance.identifier == :windows))
 
           result = Facter::Core::Execution.execute("ipconfig getoption #{interface_name} " \
                                                      'server_identifier', logger: log)


### PR DESCRIPTION
The following message was observed when running **`puppet catalog compile`** under `RUBYOPT=--debug` with Puppet 7 and Facter 4.2.9 on FreeBSD 12.3

~~~~
Exception `Errno::ENOENT' at /opt/puppet/puppet_wk/puppet_ctl/tools/bundle/ruby/3.0/gems/facter-4.2.9/lib/facter/custom_facts/core/execution/popen3.rb:17 - No such file or directory - ipconfig
~~~~

In order to prevent the call to the Microsoft Windows **ipconfig** tool, this changeset adds an additional test under the method **Facter::Resolvers::Networking.extract_dhcp**

The patched networking.rb has been tested with Puppet 7 from a local installation of Puppet, using Ruby 3.0 from FreeBSD ports, on a FreeBSD 12.3 platform

(cherry picked from commit 614213a104971ffb89c1728d58081f60d7f65af2)