### PR TITLE
resolvers/freebsd/virtual.rb: Adding kenv check for bhyve

### DIFF
--- a/lib/facter/resolvers/freebsd/virtual.rb
+++ b/lib/facter/resolvers/freebsd/virtual.rb
@@ -31,6 +31,11 @@ module Facter
 
               vm = VM_GUEST_SYSCTL_NAMES[vm] if VM_GUEST_SYSCTL_NAMES.key?(vm)
 
+              if (vm == 'generic')
+                ## may be bhyve
+                vm = Facter::Freebsd::FfiHelper.kenv(:get, 'smbios.bios.vendor').downcase
+              end
+
               @fact_list[:vm] = vm
             else
               @fact_list[:vm] = 'jail'


### PR DESCRIPTION
This changeset adds a test for bhyve virtualization. 

Presently, bhyve VMs would be reported as 'generic' under  the 'virtual' key in facter. This would match the value of the `kern.vm_guest` sysctl under bhyve.

This changeset detects the generic case, then providing a string-downcase translation of the `smbios.bios.vendor` field under FreeBSD kenv. This might typically be the string, 'bhyve'. 

This more specialized representation for a bhyve vm might be easier to interpret for its relevance, in Puppet manifest code, contrated to the string, 'generic'.

Candidly, this may have an impact on any existing code that would assume that the value 'generic' will be produced for that key. If this patch was adopted, perhaps the updated behavior could be annotated in the release notes or in documentation?

(cherry picked from commit 98ca8d7d229f2df8e22f6bf32808448ca5aec330)