### PR TITLE
(FACT-3114) Arch Linux: Implement os version facts

### DIFF
--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -34,6 +34,7 @@ module Facter
                 Sled
               ]
             },
+            'Archlinux',
             'Gentoo',
             'Alpine',
             'Photon',

--- a/lib/facter/facts/archlinux/os/release.rb
+++ b/lib/facter/facts/archlinux/os/release.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Facts
+  module Archlinux
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+
+        def call_the_resolver
+          # Arch Linux is rolling release and has no version numbers
+          # For historical reasons facter used the kernel version as OS version on Arch Linux
+          kernelrelease = Facter::Resolvers::Uname.resolve(:kernelrelease)
+          versions = kernelrelease.split('.')
+          hash = { full: kernelrelease, major: versions[0], minor: versions[1] }
+
+          Facter::ResolvedFact.new(FACT_NAME, hash)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -246,6 +246,9 @@ os_hierarchy.each do |os|
 
     require_relative '../../resolvers/amzn/os_release_rpm'
 
+  when 'archlinux'
+    require_relative '../../facts/archlinux/os/release'
+
   when 'bsd'
     require_relative '../../facts/bsd/kernelmajversion'
     require_relative '../../facts/bsd/kernelversion'

--- a/lib/facter/framework/detector/os_detector.rb
+++ b/lib/facter/framework/detector/os_detector.rb
@@ -68,6 +68,7 @@ class OsDetector
 
   def detect_based_on_release_file
     @identifier = :devuan if File.readable?('/etc/devuan_version')
+    @identifier = :archlinux if File.readable?('/etc/arch-release')
   end
 
   def detect_distro


### PR DESCRIPTION
From this branch:
```
$ bundle exec facter os
{
  architecture => "x86_64",
  distro => {
    codename => "n/a",
    description => "Arch Linux",
    id => "Arch",
    release => {
      full => "rolling",
      major => "rolling",
      minor => null
    },
    specification => "n/a"
  },
  family => "Archlinux",
  hardware => "x86_64",
  name => "Archlinux",
  release => {
    full => "6.9.3-arch1-1",
    major => "6",
    minor => "9"
  },
  selinux => {
    enabled => false
  }
}
```

Facter 3 on Archlinux:
```
$ facter os
{
  architecture => "x86_64",
  distro => {
    codename => "n/a",
    description => "Arch Linux",
    id => "Arch",
    release => {
      full => "rolling",
      major => "rolling"
    },
    specification => "n/a"
  },
  family => "Archlinux",
  hardware => "x86_64",
  name => "Archlinux",
  release => {
    full => "6.9.3-arch1-1",
    major => "6",
    minor => "9"
  },
  selinux => {
    enabled => false
  }
}
```