### PR TITLE
(maint) Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,6 +21,7 @@ jobs:
           - '2.3'
           - '2.7'
           - '3.0'
+          - '3.1'
           - 'jruby'
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This is used by modern distributions so I think it's a good idea to test
against it.