### PR TITLE
(FACT-3115) Correctly detect KVM in RHEL hypervisors

### DIFF
--- a/lib/facter/resolvers/virt_what.rb
+++ b/lib/facter/resolvers/virt_what.rb
@@ -34,11 +34,13 @@ module Facter
         end
 
         def determine_other(output)
-          other_vm = output.split("\n").first
+          values = output.split("\n")
+          other_vm = values.first
           return unless other_vm
 
           return 'zlinux' if other_vm =~ /ibm_systemz/
           return retrieve_vserver if other_vm =~ /linux_vserver/
+          return (values - ['redhat']).first if values.include?('redhat')
 
           other_vm
         end

--- a/spec/facter/resolvers/virt_what_spec.rb
+++ b/spec/facter/resolvers/virt_what_spec.rb
@@ -54,4 +54,22 @@ describe Facter::Resolvers::VirtWhat do
       expect(virt_what_resolver.resolve(:vm)).to eq(result)
     end
   end
+
+  context 'when virt-what detects kvm in RHEL hypervisors redhat first' do
+    let(:content) { "redhat\nkvm" }
+    let(:result) { 'kvm' }
+
+    it 'returns virtual fact' do
+      expect(virt_what_resolver.resolve(:vm)).to eq(result)
+    end
+  end
+
+  context 'when virt-what detects kvm in RHEL hypervisors redhat last' do
+    let(:content) { "kvm\nredhat" }
+    let(:result) { 'kvm' }
+
+    it 'returns virtual fact' do
+      expect(virt_what_resolver.resolve(:vm)).to eq(result)
+    end
+  end
 end


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2074476 and https://tickets.puppetlabs.com/browse/FACT-3115

Before:

``` 1c-enterprise
[/]@ndev9.cern.ch
λ virt-what
redhat
kvm
[/]@ndev9.cern.ch
λ facter virtual
redhat
```

After:

``` 1c-enterprise
[/]@ndev9.cern.ch
λ facter virtual
kvm
```

Versions of `virt-what` that break Facter:

* `virt-what-1.22-1.el9`
* `virt-what-1.18-14.el8`