### PR TITLE
(FACT-3116) Ignore EROFS when deleting fact cache

### DIFF
--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -227,7 +227,7 @@ cache_format_version is incorrect!")
 
       begin
         File.delete(cache_file_name) if File.readable?(cache_file_name)
-      rescue Errno::EACCES => e
+      rescue Errno::EACCES, Errno::EROFS => e
         @log.warn("Could not delete cache: #{e.message}")
       end
     end


### PR DESCRIPTION
When fact cache is placed in read only file system, deleting a file
fails with EROFS instead of EACCES .