### PR TITLE
(FACT-3119) RFC2863 operational state for network interfaces

### DIFF
--- a/lib/facter/resolvers/linux/networking.rb
+++ b/lib/facter/resolvers/linux/networking.rb
@@ -31,6 +31,7 @@ module Facter
             @fact_list[:interfaces].keys.each do |interface_name|
               mtu(interface_name, mtu_and_indexes)
               dhcp(interface_name, mtu_and_indexes)
+              operstate(interface_name)
               physical(interface_name)
 
               @log.debug("Found interface #{interface_name} with #{@fact_list[:interfaces][interface_name]}")
@@ -46,6 +47,11 @@ module Facter
               parse_ip_command_line(line, mtu_and_indexes)
             end
             mtu_and_indexes
+          end
+
+          def operstate(interface_name)
+            state = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/operstate", nil)
+            @fact_list[:interfaces][interface_name][:operational_state] = state.strip if state
           end
 
           def physical(ifname)

--- a/spec/facter/resolvers/linux/networking_spec.rb
+++ b/spec/facter/resolvers/linux/networking_spec.rb
@@ -23,6 +23,10 @@ describe Facter::Resolvers::Linux::Networking do
         .with('/proc/net/if_inet6', nil).and_return(load_fixture('proc_net_if_inet6').read)
       allow(File).to receive(:exist?).with('/sys/class/net/lo/device').and_return(false)
       allow(File).to receive(:exist?).with('/sys/class/net/ens160/device').and_return(true)
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/lo/operstate', nil).and_return('unknown')
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/ens160/operstate', nil).and_return('up')
     end
 
     after do
@@ -70,6 +74,7 @@ describe Facter::Resolvers::Linux::Networking do
           netmask6: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
           network: '127.0.0.0',
           network6: '::1',
+          operational_state: 'unknown',
           physical: false,
           scope6: 'host'
         },
@@ -91,6 +96,7 @@ describe Facter::Resolvers::Linux::Networking do
           netmask6: 'ffff:ffff:ffff:ffff::',
           network: '10.16.112.0',
           network6: 'fe80::',
+          operational_state: 'up',
           physical: true,
           scope6: 'link'
         }
@@ -162,6 +168,7 @@ describe Facter::Resolvers::Linux::Networking do
           netmask6: 'ffff:ffff:ffff:ffff::',
           network: '10.16.112.0',
           network6: 'fe80::',
+          operational_state: 'up',
           physical: true,
           scope6: 'link'
         }
@@ -213,6 +220,7 @@ describe Facter::Resolvers::Linux::Networking do
           mtu: 1500,
           netmask: '255.255.240.0',
           network: '10.16.112.0',
+          operational_state: 'up',
           physical: true
         }
 
@@ -276,6 +284,7 @@ describe Facter::Resolvers::Linux::Networking do
             mtu: 65_536,
             netmask6: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
             network6: '::1',
+            operational_state: 'unknown',
             physical: false,
             scope6: 'host'
           },
@@ -289,6 +298,7 @@ describe Facter::Resolvers::Linux::Networking do
             mtu: 1500,
             netmask6: 'ffff:ffff:ffff:ffff::',
             network6: 'fe80::',
+            operational_state: 'up',
             physical: true,
             scope6: 'link'
           }


### PR DESCRIPTION
This adds RFC2863 operational state information for Linux.

I confess I'll need help with the tests....