### PR TITLE
(FACT-3109) Add handling for Windows NIC names

### DIFF
--- a/lib/facter/resolvers/windows/networking.rb
+++ b/lib/facter/resolvers/windows/networking.rb
@@ -71,12 +71,11 @@ module Facter
                 adapter_address = IpAdapterAddressesLh.new(adapter_address[:Next])
                 next
               end
-
               if !@fact_list[:domain] || @fact_list[:domain].empty?
-                @fact_list[:domain] = adapter_address[:DnsSuffix].read_wide_string_without_length
+                @fact_list[:domain] = adapter_address[:DnsSuffix]
+                                      .read_wide_string_without_length(replace_invalid_chars: true)
               end
-
-              name = adapter_address[:FriendlyName].read_wide_string_without_length
+              name = adapter_address[:FriendlyName].read_wide_string_without_length(replace_invalid_chars: true)
               net_interface[name] = build_interface_info(adapter_address, name)
             end
 

--- a/spec/facter/resolvers/windows/networking_spec.rb
+++ b/spec/facter/resolvers/windows/networking_spec.rb
@@ -261,6 +261,13 @@ describe Facter::Resolvers::Windows::Networking do
       it 'returns domain' do
         expect(resolver.resolve(:domain)).to eql(domain)
       end
+
+      it 'replaces invalid characters in the friendly name' do
+        stub_utf16le_bytes(friendly_name_ptr, invalid_chars)
+
+        resolved_interface = resolver.resolve(:interfaces).keys.first
+        expect(resolved_interface).to eq("\uFFFD")
+      end
     end
   end
 end

--- a/spec/facter/resolvers/windows/networking_spec.rb
+++ b/spec/facter/resolvers/windows/networking_spec.rb
@@ -11,6 +11,7 @@ describe Facter::Resolvers::Windows::Networking do
     let(:domain) { '' }
 
     before do
+      allow(FFI::MemoryPointer).to receive(:new).and_call_original
       allow(FFI::MemoryPointer).to receive(:new)
         .with(NetworkingFFI::BUFFER_LENGTH).and_return(size_ptr)
       allow(FFI::MemoryPointer).to receive(:new)

--- a/spec/mocks/ffi.rb
+++ b/spec/mocks/ffi.rb
@@ -65,6 +65,8 @@ module FFI
 
     def read_uint32(); end
 
+    def get_bytes(*); end
+
     def self.size; end
   end
 
@@ -82,8 +84,6 @@ module FFI
     def read_int; end
 
     def read_uint32(); end
-
-    def read_wide_string_with_length(*); end
 
     def self.size; end
   end


### PR DESCRIPTION
In Windows, a network interface's (NIC) "friendly name" is set by
the user and encoded in UTF-16LE. We currently convert these names
to UTF-8 and invalid characters can cause an error.

This commit replaces any invalid characters during the conversion to
UTF-8.