### PR TITLE
(FACT-3121) Detect Illumos (SmartOS/OmniOS) LX virtualization

### DIFF
--- a/lib/facter/util/facts/posix/virtual_detector.rb
+++ b/lib/facter/util/facts/posix/virtual_detector.rb
@@ -8,9 +8,9 @@ module Facter
           class << self
             def platform
               @fact_value ||= # rubocop:disable Naming/MemoizedInstanceVariableName
-                check_docker_lxc || check_freebsd || check_gce || retrieve_from_virt_what || \
-                check_vmware || check_open_vz || check_vserver || check_xen || check_other_facts || \
-                check_lspci || 'physical'
+                check_docker_lxc || check_freebsd || check_gce || check_illumos_lx || \
+                retrieve_from_virt_what || check_vmware || check_open_vz || check_vserver || \
+                check_xen || check_other_facts || check_lspci || 'physical'
             end
 
             private
@@ -22,6 +22,10 @@ module Facter
             def check_gce
               bios_vendor = Facter::Resolvers::Linux::DmiBios.resolve(:bios_vendor)
               'gce' if bios_vendor&.include?('Google')
+            end
+
+            def check_illumos_lx
+              'illumos-lx' if Facter::Resolvers::Uname.resolve(:kernelversion) == 'BrandZ virtual linux'
             end
 
             def check_vmware

--- a/spec/facter/util/facts/posix/virtual_detector_spec.rb
+++ b/spec/facter/util/facts/posix/virtual_detector_spec.rb
@@ -74,6 +74,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(value)
       end
 
@@ -96,6 +97,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(value)
       end
 
@@ -119,6 +121,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(value)
       end
 
@@ -143,6 +146,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(value)
       end
 
@@ -168,6 +172,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Vmware).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(value)
       end
 
@@ -193,6 +198,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::OpenVz).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
         allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('Bochs Machine')
       end
@@ -227,6 +233,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(value)
       end
 
@@ -237,6 +244,23 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
       end
 
       it 'returns hyper-v' do
+        expect(detector.platform).to eq(value)
+      end
+    end
+
+    context 'when illumos-lx' do
+      let(:value) { 'illumos-lx' }
+
+      before do
+        allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
+        allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
+        allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('lxc')
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return('BrandZ virtual linux')
+      end
+
+      it 'returns illumos-lx' do
         expect(detector.platform).to eq(value)
       end
     end
@@ -255,6 +279,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
       end
 
       it 'returns physical' do
@@ -274,6 +299,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vserver).and_return(nil)
         allow(Facter::Resolvers::Xen).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Lspci).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelversion).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return('unknown')
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return('unknown')
       end


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/FACT-3121.

Facter uses `virt-what`'s output which is `lxc` (on `virt-what` 1.20) or null (on `virt-what` 1.21+), so I added `check_illumos_lx` prior to `retrieve_from_virt_what`.