### PR TITLE
(packaging) Bump to version '4.2.10' [no-promote]

### DIFF
--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter-ng'
-  spec.version       = '4.2.9'
+  spec.version       = '4.2.10'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter'
-  spec.version       = '4.2.9'
+  spec.version       = '4.2.10'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Facter
-  VERSION = '4.2.9' unless defined?(VERSION)
+  VERSION = '4.2.10' unless defined?(VERSION)
 end


### PR DESCRIPTION
We have already tagged and released Facter 4.2.9 in April 2022, so we need to manually increment all of the version files prior to the release of Facter 4.2.10 (which should correspond with the upcoming Puppet 7.17.0 release).

We've had some great community contributions since the last release:
```
$ git log 4.2.9..HEAD --oneline
38f053030 (HEAD -> maint/main/version_4_2_10, origin/maint/main/version_4_2_10) (packaging) Bump to version '4.2.10' [no-promote]
41475dd9f (upstream/main, main) Merge pull request #2486 from kajinamit/FACT-3116
54933dc8a Merge pull request #2477 from smortex/windows-11
034fbc0e5 Merge pull request #2485 from nbarrientos/fact3115
c7e3f55b6 (FACT-3116) Ignore EROFS when deleting fact cache
31bfd9ac9 (fact3115) (FACT-3115) Correctly detect KVM in RHEL hypervisors
75ea27751 (FACT-3090) Fix windows 11 detection
```