### PR TITLE
(FACT-3102) Use non-deprecated YAML safe loading

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,6 +21,7 @@ jobs:
           - '2.3'
           - '2.7'
           - '3.0'
+          - '3.1'
           - 'jruby'
     runs-on: ubuntu-18.04
     steps:

--- a/lib/facter/custom_facts/util/parser.rb
+++ b/lib/facter/custom_facts/util/parser.rb
@@ -70,7 +70,11 @@ module LegacyFacter
         def parse_executable_output(output)
           res = nil
           begin
-            res = YAML.safe_load(output, [Symbol, Time])
+            res = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0') # Ruby 2.6+
+                    YAML.safe_load(output, permitted_classes: [Symbol, Time])
+                  else
+                    YAML.safe_load(output, [Symbol, Time])
+                  end
           rescue StandardError => e
             Facter.debug("Could not parse executable fact output as YAML or JSON (#{e.message})")
           end
@@ -114,7 +118,11 @@ module LegacyFacter
           # Add quotes to Yaml time
           cont = content.gsub(TIME, '"\1"')
 
-          YAML.safe_load(cont, [Date])
+          if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0') # Ruby 2.6+
+            YAML.safe_load(cont, permitted_classes: [Date])
+          else
+            YAML.safe_load(cont, [Date])
+          end
         end
       end
 


### PR DESCRIPTION
This PR suppresses the following `Psych.safe_load` args warn when using Psych 3.1.0 (Ruby 2.6+).

    Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.

This is needed because in Psych 4 (included in Ruby 3.1) it is no longer allowed to use the non-keyword style.

An alternative to https://github.com/puppetlabs/facter/pull/2484