### PR TITLE
(maint) Update acceptance test for Win11

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -534,6 +534,9 @@ module Facter
           os_version = agent['platform'] =~ /R2/ ? '2012 R2' : '2012'
         elsif agent['platform'] =~ /-10/
           os_version = '10'
+        elsif agent['platform'] =~ /-11/
+          # FACT-3090 was only fixed in facter#main
+          os_version = '10'
         elsif agent['platform'] =~ /2016/
           os_version = '2016'
         elsif agent['platform'] =~ /2019/


### PR DESCRIPTION
https://github.com/voxpupuli/beaker/pull/1744, https://github.com/voxpupuli/beaker/pull/1745 must be merged first in order to test Windows 11.

Passed using

```
$ grep ' platform:' hosts.yaml 
    platform: windows-11ent-64
    platform: windows-10ent-64
    platform: windows-10ent-32
$ SHA=d3a3c70edc4316d30c1ddebde37359baa95e2bfc bundle exec beaker init --hosts hosts.yaml
$ SHA=d3a3c70edc4316d30c1ddebde37359baa95e2bfc bundle exec beaker provision                                   
$ SHA=d3a3c70edc4316d30c1ddebde37359baa95e2bfc bundle exec beaker exec pre-suite --pre-suite /home/josh/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/beaker-puppet-1.26.2/setup/aio/010_Install_Puppet_Agent.rb
$ SHA=d3a3c70edc4316d30c1ddebde37359baa95e2bfc bundle exec beaker exec tests                          
```
