### PR TITLE
Resolve DMI ChassisType for Windows too

### DIFF
--- a/lib/facter/facts/windows/dmi/chassis/type.rb
+++ b/lib/facter/facts/windows/dmi/chassis/type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facts
+  module Windows
+    module Dmi
+      module Chassis
+        class Type
+          FACT_NAME = 'dmi.chassis.type'
+          ALIASES = 'chassistype'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::DMISystemEnclosure.resolve(:chassis_type)
+
+            [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/windows/dmi_systemenclosure.rb
+++ b/lib/facter/resolvers/windows/dmi_systemenclosure.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    class DMISystemEnclosure < BaseResolver
+      @log = Facter::Log.new(self)
+      init_resolver
+
+      class << self
+        # ChassisType
+
+        private
+
+        def post_resolve(fact_name, _options)
+          @fact_list.fetch(fact_name) { read_facts(fact_name) }
+        end
+
+        def read_facts(fact_name)
+          win = Facter::Util::Windows::Win32Ole.new
+          systemenclosure = win.return_first('SELECT ChassisTypes FROM Win32_SystemEnclosure')
+          unless systemenclosure
+            @log.debug 'WMI query returned no results for Win32_SystemEnclosure with values ChassisTypes.'
+            return
+          end
+
+          build_fact_list(systemenclosure)
+
+          # ChassisTypes is an Array on Windows - Convert the first one to a name
+          chassis_to_name(@fact_list[fact_name][0]) if fact_name == :chassis_type
+
+          @fact_list[fact_name]
+        end
+
+        def build_fact_list(systemenclosure)
+          @fact_list[:chassis_type] = systemenclosure.ChassisTypes
+        end
+
+        def chassis_to_name(chassis_type)
+          types = ['Other', nil, 'Desktop', 'Low Profile Desktop', 'Pizza Box', 'Mini Tower', 'Tower',
+                   'Portable', 'Laptop', 'Notebook', 'Hand Held', 'Docking Station', 'All in One', 'Sub Notebook',
+                   'Space-Saving', 'Lunch Box', 'Main System Chassis', 'Expansion Chassis', 'SubChassis',
+                   'Bus Expansion Chassis', 'Peripheral Chassis', 'Storage Chassis', 'Rack Mount Chassis',
+                   'Sealed-Case PC', 'Multi-system', 'CompactPCI', 'AdvancedTCA', 'Blade', 'Blade Enclosure',
+                   'Tablet', 'Convertible', 'Detachable']
+          @fact_list[:chassis_type] = types[chassis_type.to_i - 1]
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/windows/dmi/chassis/type_spec.rb
+++ b/spec/facter/facts/windows/dmi/chassis/type_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Windows::Dmi::Chassis::Type do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Windows::Dmi::Chassis::Type.new }
+
+    let(:type) { 'Low Profile Desktop' }
+
+    before do
+      allow(Facter::Resolvers::DMISystemEnclosure).to receive(:resolve).with(:chassis_type).and_return(type)
+    end
+
+    it 'calls Facter::Resolvers::Windows::DMISystemEnclosure' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::DMISystemEnclosure).to have_received(:resolve).with(:chassis_type)
+    end
+
+    it 'returns chassis type fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'dmi.chassis.type', value: type),
+                        an_object_having_attributes(name: 'chassistype', value: type, type: :legacy))
+    end
+  end
+end


### PR DESCRIPTION
We use the `dmi.chassis.type` fact (as a poor way) to determine whether a system in compatible with Dell server management tools. No reason it shouldn't be available on Windows.