### PR TITLE
(maint) Update testing to be aware of amd64 macos

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -348,11 +348,17 @@ module Facter
         else
           os_version = /#{version[1]}/
         end
-
+        if agent['platform'] =~ /x86_64/
+          os_arch                 = 'x86_64'
+          os_hardware             = 'x86_64'
+        elsif agent['platform'] =~ //
+          os_arch                 = 'arm64'
+          os_hardware             = 'arm64'
+        end
         expected_facts = {
-            'os.architecture'          => 'x86_64',
+            'os.architecture'          => os_arch,
             'os.family'                => 'Darwin',
-            'os.hardware'              => 'x86_64',
+            'os.hardware'              => os_hardware,
             'os.name'                  => 'Darwin',
             'os.macosx.build'          => /\d+[A-Z]\d{2,4}\w?/,
             'os.macosx.product'        => agent['platform'] =~ /osx-1[1-9]-/ ? 'macOS' : 'Mac OS X',

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -17,7 +17,7 @@ test_name "C100305: The Ruby fact should resolve as expected in AIO" do
         when /windows/
           ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
         when /osx/
-          ruby_platform = /x86_64-darwin[\d.]+/
+          ruby_platform = /(x86_64|aarch64)-darwin[\d.]+/
         when /aix/
           ruby_platform = /powerpc-aix[\d.]+/
         when /solaris/


### PR DESCRIPTION
Facter looks to be correctly picking up the facts, just our tests need updating:
```
pix-arm64-macos12-2:~ root# facter os.hardware
arm64
pix-arm64-macos12-2:~ root# facter os.architecture
arm64
pix-arm64-macos12-2:~ root# facter ruby
{
  platform => "aarch64-darwin",
  sitedir => "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
  version => "2.5.9"
}
```