### PR TITLE
(maint) Two more macos 12 arm64 testing updates

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -351,9 +351,13 @@ module Facter
         if agent['platform'] =~ /x86_64/
           os_arch                 = 'x86_64'
           os_hardware             = 'x86_64'
+          processors_isa          = 'i386'
+          processors_models       = /"Intel\(R\).*"/
         elsif agent['platform'] =~ /arm64/
           os_arch                 = 'arm64'
           os_hardware             = 'arm64'
+          processors_isa          = 'arm'
+          processors_models       = /"Apple M1.*"/
         end
         expected_facts = {
             'os.architecture'          => os_arch,
@@ -370,8 +374,8 @@ module Facter
             'os.release.minor'         => /\d+/,
             'processors.count'         => /[1-9]/,
             'processors.physicalcount' => /[1-9]/,
-            'processors.isa'           => 'i386',
-            'processors.models'        => /"Intel\(R\).*"/,
+            'processors.isa'           => processors_isa,
+            'processors.models'        => processors_models,
             'kernel'                   => 'Darwin',
             'kernelrelease'            => /\d+\.\d+\.\d+/,
             'kernelversion'            => /\d+\.\d+\.\d+/,

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -17,7 +17,7 @@ test_name "C100305: The Ruby fact should resolve as expected in AIO" do
         when /windows/
           ruby_platform = agent['ruby_arch'] == 'x64' ? 'x64-mingw32' : 'i386-mingw32'
         when /osx/
-          ruby_platform = /(x86_64|aarch64)-darwin[\d.]+/
+          ruby_platform = /(x86_64-darwin[\d.]+|aarch64-darwin)/
         when /aix/
           ruby_platform = /powerpc-aix[\d.]+/
         when /solaris/


### PR DESCRIPTION
The ruby test assumed there was a version number, but that isn't the case.
Also the base_fact_utils had a few more intel hard coded settings that need
to be updated.