### PR TITLE
(maint) Update os.macosx.version.full fact

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -276,7 +276,11 @@ module Facter
           expected_facts['os.macosx.version.full'] = /#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}/
         else
           expected_facts['os.macosx.version.patch'] = /\d+/
-          expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.#{expected_facts['os.macosx.version.patch']}$/
+          if agent['platform'] =~ /arm64/
+            expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}$/
+          else
+            expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.#{expected_facts['os.macosx.version\.patch']}$/
+          end
         end
 
         expected_facts


### PR DESCRIPTION
MacOS M1 full version is only major and minor version, the patch version is
dropped. This PR fixes the acceptance test for that.