### PR TITLE
(FACT-3137) add ec2_metadata to FreeBSD

### DIFF
--- a/lib/facter/facts/freebsd/ec2_metadata.rb
+++ b/lib/facter/facts/freebsd/ec2_metadata.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    class Ec2Metadata
+      FACT_NAME = 'ec2_metadata'
+
+      def call_the_resolver
+        return Facter::ResolvedFact.new(FACT_NAME, nil) unless aws_hypervisors?
+
+        fact_value = Facter::Resolvers::Ec2.resolve(:metadata)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value&.empty? ? nil : fact_value)
+      end
+
+      private
+
+      def aws_hypervisors?
+        Facter::Util::Facts::Posix::VirtualDetector.platform =~ /kvm|xen|aws/
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves FACT-3137 for ec2_metadata on FreeBSD.

This was present for this platform in Facter 3.x, but is not in 4.x.  This broke our manifests that depend on the EC2 metadata in order to determine an instance's public IP address.