### PR TITLE
(maint) Update networking_facts test

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -11,7 +11,7 @@ test_name 'C59029: networking facts should be fully populated' do
 
   agents.each do |agent|
     expected_networking = {
-      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|el-8-|el-9-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+      "networking.dhcp"     => agent['platform'] =~ /fedora-32|fedora-34|fedora-36|el-8-|el-9-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       "networking.ip"       => @ip_regex,
       "networking.ip6"      => /[a-f0-9]+:+/,
       "networking.mac"      => /[a-f0-9]{2}:/,


### PR DESCRIPTION
Acceptance test is failing currently on fedora-36 with:
```
  * Ensure the Networking fact resolves with reasonable values for at least one interface
    
    cute-outpatient.vmpooler-prod.puppet.net (cute-outpatient.vmpooler-prod.puppet.net) 19:50:18$ facter --json "networking.dhcp"
      {
        "networking.dhcp": ""
      }
    
    cute-outpatient.vmpooler-prod.puppet.net (cute-outpatient.vmpooler-prod.puppet.net) executed in 0.17 seconds
Minitest::Assertion: Expected /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/ to match "".
```