### PR TITLE
(FACT-3142) Add support for Mariner to Facter 4.x

### DIFF
--- a/lib/facter/config.rb
+++ b/lib/facter/config.rb
@@ -39,7 +39,8 @@ module Facter
             'Photon',
             'Slackware',
             'Mageia',
-            'Openwrt'
+            'Openwrt',
+            'Mariner'
           ]
         },
         {

--- a/lib/facter/facts/mariner/os/release.rb
+++ b/lib/facter/facts/mariner/os/release.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Facts
+  module Mariner
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = from_specific_file || from_os_release
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def from_specific_file
+          version = Facter::Resolvers::SpecificReleaseFile.resolve(:release,
+                                                                   { release_file: '/etc/mariner-release',
+                                                                     regex: /CBL\-Mariner ([0-9.]+)/ })
+          Facter::Util::Facts.release_hash_from_matchdata(version)
+        end
+
+        def from_os_release
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+
+          Facter::Util::Facts.release_hash_from_string(version)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -85,6 +85,8 @@ module Facter
           @fact_list[:name] = if os_name.downcase.start_with?('red', 'oracle', 'arch', 'manjaro')
                                 os_name = os_name.split(' ')[0..1].join
                                 os_name
+                              elsif os_name.downcase.end_with?('mariner')
+                                os_name.split(' ')[-1].strip
                               else
                                 os_name.split(' ')[0].strip
                               end

--- a/lib/facter/util/facts/facts_utils.rb
+++ b/lib/facter/util/facts/facts_utils.rb
@@ -10,7 +10,7 @@ module Facter
 
       PHYSICAL_HYPERVISORS = %w[physical xen0 vmware_server vmware_workstation openvzhn vserver_host].freeze
       REDHAT_FAMILY = %w[redhat rhel fedora centos scientific ascendos cloudlinux psbm
-                         oraclelinux ovs oel amazon xenserver xcp-ng virtuozzo photon].freeze
+                         oraclelinux ovs oel amazon xenserver xcp-ng virtuozzo photon mariner].freeze
       DEBIAN_FAMILY = %w[debian ubuntu huaweios linuxmint devuan kde].freeze
       SUSE_FAMILY = %w[sles sled suse].freeze
       GENTOO_FAMILY = ['gentoo'].freeze

--- a/spec/facter/facts/mariner/os/release_spec.rb
+++ b/spec/facter/facts/mariner/os/release_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe Facts::Mariner::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Mariner::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/mariner-release',
+                          regex: /CBL\-Mariner ([0-9.]+)/ })
+        .and_return(value)
+    end
+
+    context 'when version is retrieved from specific file' do
+      let(:value) { /CBL\-Mariner ([0-9.]+)/.match('CBL-Mariner 2.0.20220824') }
+      let(:release) { { 'full' => '2.0.20220824', 'major' => '2', 'minor' => '0' } }
+
+      it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
+        receive(:resolve)
+          .with(:release, { release_file: '/etc/mariner-release',
+                            regex: /CBL\-Mariner ([0-9.]+)/ })
+          .and_return(value)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file' do
+      let(:value) { nil }
+      let(:os_release) { '2.0.20220824' }
+      let(:release) { { 'full' => '2.0.20220824', 'major' => '2', 'minor' => '0' } }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+
+      context 'when release can\'t be received' do
+        let(:os_release) { nil }
+
+        it 'returns operating system name fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.release', value: nil)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for CBL-Mariner, Microsoft's Linux distribution for
cloud infrastructure and edge products and services.