### PR TITLE
(FACT-3145) Ignore unused registry values

### DIFF
--- a/lib/facter/resolvers/windows/networking.rb
+++ b/lib/facter/resolvers/windows/networking.rb
@@ -137,10 +137,11 @@ module Facter
           end
 
           def retrieve_domain_from_registry
-            ::Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters') do |rg|
-              rg.each do |name, _value|
-                @fact_list[:domain] = rg[name] if name == 'Domain'
-              end
+            ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
+              'SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters'
+            ) do |key|
+              domain = key['Domain']
+              @fact_list[:domain] = domain if domain
             end
           rescue Win32::Registry::Error
             @log.debug('Could not read TCPIP Parameters from registry')

--- a/spec/facter/resolvers/windows/networking_spec.rb
+++ b/spec/facter/resolvers/windows/networking_spec.rb
@@ -24,8 +24,6 @@ describe Facter::Resolvers::Windows::Networking do
       allow(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open)
         .with('SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters')
         .and_yield(reg)
-      allow(reg).to receive(:each)
-        .and_yield('Domain', domain)
       allow(reg).to receive(:[]).with('Domain').and_return(domain)
       allow(reg).to receive(:close)
 


### PR DESCRIPTION
Previously, we read all of the registry values for the "Parameters" key and then
only used the "Domain" registry value. However, if an unused value contained a
registry value whose string value could not be converted into the active code
page, then facter would fail to parse the "Domain".

This commit just looks up the "Domain" value directly, ignoring unused registry
values.