### PR TITLE
(FACT-3146) Updates Ubuntu runners to latest

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -31,9 +31,7 @@ end
 
 def beaker_platform
   {
-    'ubuntu-18.04' => 'ubuntu1804-64a',
-    'ubuntu-16.04' => 'ubuntu1604-64a',
-    'ubuntu-20.04' => 'ubuntu2004-64a',
+    'ubuntu-latest' => 'ubuntu2004-64a',
     'macos-10.15' => 'osx1015-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        os: [ windows-2019, ubuntu-latest, macos-10.15]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rubocop_checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: RuboCop
     steps:
       - name: Checkout current PR
@@ -38,7 +38,7 @@ jobs:
           FORCE_ERROR_EXIT: true
 
   commit_checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: commit message
     steps:
       - name: Checkout current PR

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   coverage_checks:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: coverage
     steps:
       - name: Checkout current PR

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
-          - 'jruby'
+          - 'jruby-9.3.7.0'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.0'
           - '3.1'
           - 'jruby'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 used in GitHub Actions to `ubuntu-latest` (currently Ubuntu 20.04).