### PR TITLE
(FACT-3148) Updates macOS GitHub Actions runners

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -32,7 +32,7 @@ end
 def beaker_platform
   {
     'ubuntu-latest' => 'ubuntu2004-64a',
-    'macos-10.15' => 'osx1015-64a',
+    'macos-latest' => 'osx11-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'
   }[HOST_PLATFORM]

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-latest, macos-10.15]
+        os: [ windows-2019, ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true
@@ -33,7 +33,7 @@ jobs:
         with:
           ruby-version: '2.6'
 
-      - name: Fix common Linux and MacOs permissions
+      - name: Fix common Linux and macOS permissions
         if: runner.os != 'Windows'
         run: sudo chmod a-w /opt
 
@@ -49,17 +49,18 @@ jobs:
           sudo apt install dhcpcd5
           sudo dhclient
 
-      #Ipv6 is missing on the GitHub OSX machine and we need it for the networking facts tests
-      - name: Add ipv6 on OSX
+      # IPv6 is missing on the GitHub macOS image and we need it for the networking facts tests
+      # https://github.com/actions/runner-images/issues/668
+      - name: Add IPv6 on macOS
         if: runner.os == 'macOS'
         run: |
           primary_interface=`route -n get default | awk '/interface: */{print $NF}'`
           sudo ifconfig $primary_interface inet6 add ::1/64
 
-      - name: Run acceptance tests on Linux like platform
+      - name: Run acceptance tests on Linux-like platform
         if: runner.os != 'Windows'
         run: sudo -E "PATH=$PATH" ruby $FACTER_ROOT/.github/actions/presuite.rb ${{ matrix.os }}
 
-      - name: Run acceptance tests on Windows like platform
+      - name: Run acceptance tests on Windows-like platform
         if: runner.os == 'Windows'
         run: ruby $Env:FACTER_ROOT/.github/actions/presuite.rb ${{ matrix.os }}

--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -279,10 +279,9 @@ module Facter
           if agent['platform'] =~ /arm64/
             expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}$/
           else
-            expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.#{expected_facts['os.macosx.version.patch']}$/
+            expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.*#{expected_facts['os.macosx.version.patch']}*$/
           end
         end
-
         expected_facts
       end
 


### PR DESCRIPTION
GitHub Actions' macOS 10.15 runners are going end-of-life on December 1, 2022:
https://github.com/actions/runner-images/issues/5583

This commit updates the macOS runners in use to macos-latest, which is currently macOS 11 Big Sur.