### PR TITLE
Fix FACT-3151

### DIFF
--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -49,7 +49,7 @@ module Facter
 
           pairs = []
           content.each do |line|
-            pairs << line.strip.delete('"').split('=', 2)
+            pairs << line.strip.delete('"').split('=', 2) unless line.start_with?('#')
           end
 
           pairs


### PR DESCRIPTION
Fix for https://tickets.puppetlabs.com/browse/FACT-3151. Allows comments on /etc/os-release file.