### PR TITLE
/etc/os-release parsing: strip comments and blank lines

### DIFF
--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -48,7 +48,11 @@ module Facter
           return nil if content.empty?
 
           pairs = []
-          content.each do |line|
+          content.map {
+                | line | line.strip
+              }.select {
+                | line | ! line.start_with?('#') and line.size > 0
+              }.each do |line|
             pairs << line.strip.delete('"').split('=', 2)
           end
 


### PR DESCRIPTION
In the function "read_and_parse_os_release_file" the "pairs" variable is constructed with a very simple parse of the file. This patch will cleanup the content of os-release by: stripping white space from either side of each line string; discarding lines that are either empty or start with a '#'.

This is required as Arista EOS is based on CentOS 7 with customisations. In /etc/os-release there are comments that cause facter to throw an error.