### PR TITLE
(maint) Expect `with` hash arguments instead of kwargs

### DIFF
--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -37,7 +37,7 @@ describe Facter::Core::Execution do
   end
 
   it 'delegates #exec to #execute' do
-    expect(impl).to receive(:execute).with('waffles', on_fail: nil)
+    expect(impl).to receive(:execute).with('waffles', { on_fail: nil })
     execution.exec('waffles')
   end
 

--- a/spec/custom_facts/util/collection_spec.rb
+++ b/spec/custom_facts/util/collection_spec.rb
@@ -41,9 +41,9 @@ describe LegacyFacter::Util::Collection do
 
     it 'passes resolution specific options to the fact' do
       fact = Facter::Util::Fact.new(:myname)
-      allow(Facter::Util::Fact).to receive(:new).with(:myname, timeout: 'myval').and_return(fact)
+      allow(Facter::Util::Fact).to receive(:new).with(:myname, { timeout: 'myval' }).and_return(fact)
 
-      expect(fact).to receive(:add).with(timeout: 'myval')
+      expect(fact).to receive(:add).with({ timeout: 'myval' })
 
       collection.add(:myname, timeout: 'myval') {}
     end

--- a/spec/facter/facts/alpine/os/release_spec.rb
+++ b/spec/facter/facts/alpine/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Alpine::Os::Release do
 
     before do
       allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-        .with(:release, release_file: '/etc/alpine-release')
+        .with(:release, { release_file: '/etc/alpine-release' })
         .and_return(value)
     end
 
@@ -17,7 +17,7 @@ describe Facts::Alpine::Os::Release do
       it 'calls Facter::Resolvers::SpecificReleaseFile with version' do
         fact.call_the_resolver
         expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
-          .with(:release, release_file: '/etc/alpine-release')
+          .with(:release, { release_file: '/etc/alpine-release' })
       end
 
       it 'returns operating system name fact' do

--- a/spec/facter/facts/amzn/os/distro/codename_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/codename_spec.rb
@@ -4,19 +4,19 @@ describe Facts::Amzn::Os::Distro::Codename do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Amzn::Os::Distro::Codename.new }
 
+    before do
+      allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
+        .with(:release, { release_file: '/etc/system-release' }).and_return(value)
+    end
+
     context 'when codename is not in system-release' do
       let(:value) { 'Amazon Linux AMI release 2017.03' }
       let(:expected_value) { 'n/a' }
 
-      before do
-        allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-          .with(:release, release_file: '/etc/system-release').and_return(value)
-      end
-
       it 'calls Facter::Resolvers::SpecificReleaseFile' do
         fact.call_the_resolver
         expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
-          .with(:release, release_file: '/etc/system-release')
+          .with(:release, { release_file: '/etc/system-release' })
       end
 
       it "returns 'n/a' fact value" do
@@ -29,15 +29,10 @@ describe Facts::Amzn::Os::Distro::Codename do
       let(:value) { 'Amazon Linux release 2 (2017.12) LTS Release Candidate' }
       let(:expected_value) { '2017.12' }
 
-      before do
-        allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-          .with(:release, release_file: '/etc/system-release').and_return(value)
-      end
-
       it 'calls Facter::Resolvers::SpecificReleaseFile' do
         fact.call_the_resolver
         expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
-          .with(:release, release_file: '/etc/system-release')
+          .with(:release, { release_file: '/etc/system-release' })
       end
 
       it 'returns release fact' do

--- a/spec/facter/facts/amzn/os/distro/description_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/description_spec.rb
@@ -8,13 +8,13 @@ describe Facts::Amzn::Os::Distro::Description do
 
     before do
       allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-        .with(:release, release_file: '/etc/system-release').and_return(value)
+        .with(:release, { release_file: '/etc/system-release' }).and_return(value)
     end
 
     it 'calls Facter::Resolvers::SpecificReleaseFile' do
       fact.call_the_resolver
       expect(Facter::Resolvers::SpecificReleaseFile).to have_received(:resolve)
-        .with(:release, release_file: '/etc/system-release')
+        .with(:release, { release_file: '/etc/system-release' })
     end
 
     it 'returns release fact' do

--- a/spec/facter/facts/amzn/os/distro/id_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/id_spec.rb
@@ -9,7 +9,7 @@ describe Facts::Amzn::Os::Distro::Id do
 
     before do
       allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-        .with(:release, release_file: '/etc/system-release').and_return(value)
+        .with(:release, { release_file: '/etc/system-release' }).and_return(value)
     end
 
     it 'calls Facter::Resolvers::SpecificReleaseFile' do

--- a/spec/facter/facts/amzn/os/distro/release_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Amzn::Os::Distro::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/system-release')
+        .with(:release, { release_file: '/etc/system-release' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/amzn/os/release_spec.rb
+++ b/spec/facter/facts/amzn/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Amzn::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/system-release')
+        .with(:release, { release_file: '/etc/system-release' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/devuan/os/release_spec.rb
+++ b/spec/facter/facts/devuan/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Devuan::Os::Release do
 
     before do
       allow(Facter::Resolvers::SpecificReleaseFile).to receive(:resolve)
-        .with(:release, release_file: '/etc/devuan_version')
+        .with(:release, { release_file: '/etc/devuan_version' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/gentoo/os/release_spec.rb
+++ b/spec/facter/facts/gentoo/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Gentoo::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/gentoo-release')
+        .with(:release, { release_file: '/etc/gentoo-release' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/meego/os/release_spec.rb
+++ b/spec/facter/facts/meego/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Meego::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/meego-release')
+        .with(:release, { release_file: '/etc/meego-release' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/oel/os/release_spec.rb
+++ b/spec/facter/facts/oel/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Oel::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/enterprise-release')
+        .with(:release, { release_file: '/etc/enterprise-release' })
         .and_return(value)
     end
 

--- a/spec/facter/facts/ol/os/release_spec.rb
+++ b/spec/facter/facts/ol/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Ol::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/oracle-release')
+        .with(:release, { release_file: '/etc/oracle-release' })
         .and_return(value)
     end
 
@@ -17,7 +17,7 @@ describe Facts::Ol::Os::Release do
       it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
         fact.call_the_resolver
         expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
-          .with(:release, release_file: '/etc/oracle-release')
+          .with(:release, { release_file: '/etc/oracle-release' })
       end
 
       it 'returns operating system name fact' do

--- a/spec/facter/facts/ovs/os/release_spec.rb
+++ b/spec/facter/facts/ovs/os/release_spec.rb
@@ -6,7 +6,7 @@ describe Facts::Ovs::Os::Release do
 
     before do
       allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, release_file: '/etc/ovs-release')
+        .with(:release, { release_file: '/etc/ovs-release' })
         .and_return(value)
     end
 
@@ -17,7 +17,7 @@ describe Facts::Ovs::Os::Release do
       it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
         fact.call_the_resolver
         expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
-          .with(:release, release_file: '/etc/ovs-release')
+          .with(:release, { release_file: '/etc/ovs-release' })
       end
 
       it 'returns operating system name fact' do

--- a/spec/facter/facts/windows/hypervisors/kvm_spec.rb
+++ b/spec/facter/facts/windows/hypervisors/kvm_spec.rb
@@ -33,7 +33,9 @@ describe Facts::Windows::Hypervisors::Kvm do
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return('kvm')
         allow(Facter::Resolvers::DMIComputerSystem).to receive(:resolve).with(:name).and_return('OpenStack')
         allow(Facter::Resolvers::DMIBios).to receive(:resolve).with(:manufacturer).and_return('value')
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.kvm', openstack: true).and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new)
+          .with('hypervisors.kvm', { openstack: true })
+          .and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Kvm.new
         expect(fact.call_the_resolver).to eq(expected_fact)
@@ -47,7 +49,7 @@ describe Facts::Windows::Hypervisors::Kvm do
         allow(Facter::Resolvers::NetKVM).to receive(:resolve).with(:kvm).and_return(true)
         allow(Facter::Resolvers::DMIComputerSystem).to receive(:resolve).with(:name).and_return('value')
         allow(Facter::Resolvers::DMIBios).to receive(:resolve).with(:manufacturer).and_return('Google')
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.kvm', google: true).and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.kvm', { google: true }).and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Kvm.new
         expect(fact.call_the_resolver).to eq(expected_fact)

--- a/spec/facter/facts/windows/hypervisors/virtualbox_spec.rb
+++ b/spec/facter/facts/windows/hypervisors/virtualbox_spec.rb
@@ -22,8 +22,9 @@ describe Facts::Windows::Hypervisors::Virtualbox do
         allow(Facter::Resolvers::Windows::Virtualization)
           .to receive(:resolve).with(:oem_strings)
                                .and_return(['vboxVer_ 13.4', 'vboxRev_ 13.4'])
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.virtualbox', revision: ' 13.4', version: ' 13.4')
-                                                    .and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new)
+          .with('hypervisors.virtualbox', { revision: ' 13.4', version: ' 13.4' })
+          .and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Virtualbox.new
         expect(fact.call_the_resolver).to eq(expected_fact)
@@ -37,8 +38,9 @@ describe Facts::Windows::Hypervisors::Virtualbox do
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return('value')
         allow(Facter::Resolvers::DMIComputerSystem).to receive(:resolve).with(:name).and_return('VirtualBox')
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:oem_strings).and_return(['', ''])
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.virtualbox', revision: '', version: '')
-                                                    .and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new)
+          .with('hypervisors.virtualbox', { revision: '', version: '' })
+          .and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Virtualbox.new
         expect(fact.call_the_resolver).to eq(expected_fact)

--- a/spec/facter/facts/windows/hypervisors/xen_spec.rb
+++ b/spec/facter/facts/windows/hypervisors/xen_spec.rb
@@ -18,7 +18,8 @@ describe Facts::Windows::Hypervisors::Xen do
         expected_fact = double(Facter::ResolvedFact, name: 'hypervisors.xen', value: { context: 'pv' })
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return('xen')
         allow(Facter::Resolvers::DMIComputerSystem).to receive(:resolve).with(:name).and_return('PV domU')
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.xen', context: 'pv').and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new)
+          .with('hypervisors.xen', { context: 'pv' }).and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Xen.new
         expect(fact.call_the_resolver).to eq(expected_fact)
@@ -30,7 +31,8 @@ describe Facts::Windows::Hypervisors::Xen do
         expected_fact = double(Facter::ResolvedFact, name: 'hypervisors.xen', value: { context: 'hvm' })
         allow(Facter::Resolvers::Windows::Virtualization).to receive(:resolve).with(:virtual).and_return('xen')
         allow(Facter::Resolvers::DMIComputerSystem).to receive(:resolve).with(:name).and_return('HVM domU')
-        allow(Facter::ResolvedFact).to receive(:new).with('hypervisors.xen', context: 'hvm').and_return(expected_fact)
+        allow(Facter::ResolvedFact).to receive(:new)
+          .with('hypervisors.xen', { context: 'hvm' }).and_return(expected_fact)
 
         fact = Facts::Windows::Hypervisors::Xen.new
         expect(fact.call_the_resolver).to eq(expected_fact)

--- a/spec/facter/resolvers/aix/disks_spec.rb
+++ b/spec/facter/resolvers/aix/disks_spec.rb
@@ -7,8 +7,9 @@ describe Facter::Resolvers::Aix::Disks do
 
   before do
     resolver.instance_variable_set(:@log, logger_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('lspv', logger: logger_spy)
-                                                       .and_return(result)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('lspv', { logger: logger_spy })
+      .and_return(result)
   end
 
   after do
@@ -31,8 +32,9 @@ describe Facter::Resolvers::Aix::Disks do
     end
 
     before do
-      allow(Facter::Core::Execution).to receive(:execute).with('lspv hdisk0', logger: logger_spy)
-                                                         .and_return(load_fixture('lspv_disk_output').read)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('lspv hdisk0', { logger: logger_spy })
+        .and_return(load_fixture('lspv_disk_output').read)
     end
 
     it 'returns disks informations' do
@@ -41,8 +43,9 @@ describe Facter::Resolvers::Aix::Disks do
 
     context 'when second lspv call fails' do
       before do
-        allow(Facter::Core::Execution).to receive(:execute).with('lspv hdisk0', logger: logger_spy)
-                                                           .and_return('')
+        allow(Facter::Core::Execution).to receive(:execute)
+          .with('lspv hdisk0', { logger: logger_spy })
+          .and_return('')
       end
 
       it 'returns disks informations' do

--- a/spec/facter/resolvers/aix/memory_spec.rb
+++ b/spec/facter/resolvers/aix/memory_spec.rb
@@ -7,10 +7,12 @@ describe Facter::Resolvers::Aix::Memory do
 
   before do
     resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('svmon', logger: log_spy)
-                                                       .and_return(svmon_content)
-    allow(Facter::Core::Execution).to receive(:execute).with('pagesize', logger: log_spy)
-                                                       .and_return(pagesize_content)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('svmon', { logger: log_spy })
+      .and_return(svmon_content)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('pagesize', { logger: log_spy })
+      .and_return(pagesize_content)
   end
 
   after do

--- a/spec/facter/resolvers/aix/mountpoints_spec.rb
+++ b/spec/facter/resolvers/aix/mountpoints_spec.rb
@@ -20,10 +20,12 @@ describe Facter::Resolvers::Aix::Mountpoints do
 
   before do
     Facter::Resolvers::Aix::Mountpoints.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('mount', logger: log_spy)
-                                                       .and_return(load_fixture('mount').read)
-    allow(Facter::Core::Execution).to receive(:execute).with('df -P', logger: log_spy)
-                                                       .and_return(load_fixture('df').read)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('mount', { logger: log_spy })
+      .and_return(load_fixture('mount').read)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('df -P', { logger: log_spy })
+      .and_return(load_fixture('df').read)
   end
 
   it "only skips lines containing the string 'node'" do

--- a/spec/facter/resolvers/aix/networking_spec.rb
+++ b/spec/facter/resolvers/aix/networking_spec.rb
@@ -15,11 +15,11 @@ describe Facter::Resolvers::Aix::Networking do
   before do
     networking_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('netstat -rn', logger: log_spy)
+      .with('netstat -rn', { logger: log_spy })
       .and_return(netstat_rn)
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('netstat -in', logger: log_spy)
+      .with('netstat -in', { logger: log_spy })
       .and_return(netstat_in)
 
     allow(Facter::Resolvers::Aix::FfiHelper).to receive(:read_interfaces).and_return(ffi_interfaces)

--- a/spec/facter/resolvers/aix/partitions_spec.rb
+++ b/spec/facter/resolvers/aix/partitions_spec.rb
@@ -37,10 +37,12 @@ describe Facter::Resolvers::Aix::Partitions do
     end
 
     before do
-      allow(Facter::Core::Execution).to receive(:execute).with('lslv -L hd5', logger: logger_spy)
-                                                         .and_return(load_fixture('lslv_output').read)
-      allow(Facter::Core::Execution).to receive(:execute).with('lslv -L hd6', logger: logger_spy)
-                                                         .and_return('')
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('lslv -L hd5', { logger: logger_spy })
+        .and_return(load_fixture('lslv_output').read)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('lslv -L hd6', { logger: logger_spy })
+        .and_return('')
     end
 
     it 'returns partitions informations' do

--- a/spec/facter/resolvers/augeas_spec.rb
+++ b/spec/facter/resolvers/augeas_spec.rb
@@ -18,7 +18,7 @@ describe Facter::Resolvers::Augeas do
   context 'when augparse is installed' do
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('augparse --version 2>&1', logger: log_spy)
+        .with('augparse --version 2>&1', { logger: log_spy })
         .and_return('augparse 1.12.0 <http://augeas.net/>')
     end
 
@@ -32,7 +32,7 @@ describe Facter::Resolvers::Augeas do
 
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/opt/puppetlabs/puppet/bin/augparse --version 2>&1', logger: log_spy)
+        .with('/opt/puppetlabs/puppet/bin/augparse --version 2>&1', { logger: log_spy })
         .and_return('augparse 1.12.0 <http://augeas.net/>')
     end
 
@@ -44,7 +44,7 @@ describe Facter::Resolvers::Augeas do
   context 'when augparse is not installed' do
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('augparse --version 2>&1', logger: log_spy)
+        .with('augparse --version 2>&1', { logger: log_spy })
         .and_return('sh: augparse: command not found')
     end
 

--- a/spec/facter/resolvers/disks_spec.rb
+++ b/spec/facter/resolvers/disks_spec.rb
@@ -76,7 +76,7 @@ describe Facter::Resolvers::Linux::Disks do
                 .with("/sys/block/#{disk}#{value}", nil).and_return(values[:vendor])
             when 'false'
               allow(Facter::Core::Execution).to receive(:execute)
-                .with("lsblk -dn -o #{fact} /dev/#{disk}", on_fail: '', timeout: 1)
+                .with("lsblk -dn -o #{fact} /dev/#{disk}", { on_fail: '', timeout: 1 })
                 .and_return(values[fact])
             end
           end
@@ -145,7 +145,7 @@ describe Facter::Resolvers::Linux::Disks do
               next unless value == 'false'
 
               allow(Facter::Core::Execution).to receive(:execute)
-                .with("lsblk -dn -o #{fact} /dev/#{disk}", on_fail: '', timeout: 1)
+                .with("lsblk -dn -o #{fact} /dev/#{disk}", { on_fail: '', timeout: 1 })
                 .and_return('')
             end
           end

--- a/spec/facter/resolvers/dmi_decode_spec.rb
+++ b/spec/facter/resolvers/dmi_decode_spec.rb
@@ -6,7 +6,7 @@ describe Facter::Resolvers::DmiDecode do
 
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('dmidecode', logger: instance_of(Facter::Log)).and_return(command_output)
+        .with('dmidecode', { logger: instance_of(Facter::Log) }).and_return(command_output)
     end
 
     after { dmidecode.invalidate_cache }

--- a/spec/facter/resolvers/freebsd/freebsd_version_spec.rb
+++ b/spec/facter/resolvers/freebsd/freebsd_version_spec.rb
@@ -5,10 +5,10 @@ describe Facter::Resolvers::Freebsd::FreebsdVersion do
 
   before do
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/bin/freebsd-version -k', logger: freebsd_version.log)
+      .with('/bin/freebsd-version -k', { logger: freebsd_version.log })
       .and_return("13.0-CURRENT\n")
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/bin/freebsd-version -ru', logger: freebsd_version.log)
+      .with('/bin/freebsd-version -ru', { logger: freebsd_version.log })
       .and_return("12.1-RELEASE-p3\n12.0-STABLE\n")
   end
 

--- a/spec/facter/resolvers/freebsd/swap_memory_spec.rb
+++ b/spec/facter/resolvers/freebsd/swap_memory_spec.rb
@@ -13,7 +13,7 @@ describe Facter::Resolvers::Freebsd::SwapMemory do
   before do
     swap_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('swapinfo -k', logger: log_spy)
+      .with('swapinfo -k', { logger: log_spy })
       .and_return(load_fixture('freebsd_swapinfo').read)
   end
 

--- a/spec/facter/resolvers/freebsd/system_memory_spec.rb
+++ b/spec/facter/resolvers/freebsd/system_memory_spec.rb
@@ -16,7 +16,7 @@ describe Facter::Resolvers::Freebsd::SystemMemory do
       .and_return(17_043_554_304)
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('vmstat -H --libxo json', logger: log_spy)
+      .with('vmstat -H --libxo json', { logger: log_spy })
       .and_return(load_fixture('freebsd_vmstat').read)
   end
 

--- a/spec/facter/resolvers/linux/docker_uptime_spec.rb
+++ b/spec/facter/resolvers/linux/docker_uptime_spec.rb
@@ -15,7 +15,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', logger: log_spy)
+        .with('ps -o etime= -p "1"', { logger: log_spy })
         .and_return('20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -45,7 +45,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', logger: log_spy)
+        .with('ps -o etime= -p "1"', { logger: log_spy })
         .and_return('10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -75,7 +75,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', logger: log_spy)
+        .with('ps -o etime= -p "1"', { logger: log_spy })
         .and_return('3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -105,7 +105,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', logger: log_spy)
+        .with('ps -o etime= -p "1"', { logger: log_spy })
         .and_return('1-3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -135,7 +135,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', logger: log_spy)
+        .with('ps -o etime= -p "1"', { logger: log_spy })
         .and_return('2-3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)

--- a/spec/facter/resolvers/linux/lscpu_spec.rb
+++ b/spec/facter/resolvers/linux/lscpu_spec.rb
@@ -5,7 +5,7 @@ describe Facter::Resolvers::Linux::Lscpu do
     Facter::Resolvers::Linux::Lscpu.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with("lscpu | grep -e 'Thread(s)' -e 'Core(s)'", logger: log_spy)
+      .with("lscpu | grep -e 'Thread(s)' -e 'Core(s)'", { logger: log_spy })
       .and_return(lscpu_output)
   end
 

--- a/spec/facter/resolvers/linux/networking_spec.rb
+++ b/spec/facter/resolvers/linux/networking_spec.rb
@@ -9,7 +9,7 @@ describe Facter::Resolvers::Linux::Networking do
     before do
       networking_linux.instance_variable_set(:@log, log_spy)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('ip link show', logger: log_spy).and_return(load_fixture('ip_link_show').read)
+        .with('ip link show', { logger: log_spy }).and_return(load_fixture('ip_link_show').read)
       allow(Facter::Util::Linux::SocketParser).to receive(:retrieve_interfaces)
         .with(log_spy).and_return(socket_interfaces)
       allow(Facter::Util::Linux::Dhcp).to receive(:dhcp).with('lo', '1', log_spy).and_return('10.32.22.9')

--- a/spec/facter/resolvers/lpar_spec.rb
+++ b/spec/facter/resolvers/lpar_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Lpar do
   before do
     lpar_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/lparstat -i', logger: log_spy)
+      .with('/usr/bin/lparstat -i', { logger: log_spy })
       .and_return(load_fixture('lparstat_i').read)
     lpar_resolver.invalidate_cache
   end

--- a/spec/facter/resolvers/lspci_spec.rb
+++ b/spec/facter/resolvers/lspci_spec.rb
@@ -7,7 +7,8 @@ describe Facter::Resolvers::Lspci do
 
   before do
     lspci_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('lspci', logger: log_spy).and_return(output)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('lspci', { logger: log_spy }).and_return(output)
   end
 
   after do

--- a/spec/facter/resolvers/macosx/dmi_spec.rb
+++ b/spec/facter/resolvers/macosx/dmi_spec.rb
@@ -9,7 +9,7 @@ describe Facter::Resolvers::Macosx::DmiBios do
   before do
     dmi_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n hw.model', logger: log_spy)
+      .with('sysctl -n hw.model', { logger: log_spy })
       .and_return(macosx_model)
   end
 

--- a/spec/facter/resolvers/macosx/filesystems_spec.rb
+++ b/spec/facter/resolvers/macosx/filesystems_spec.rb
@@ -7,8 +7,9 @@ describe Facter::Resolvers::Macosx::Filesystems do
 
   before do
     filesystems_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('mount', logger: log_spy)
-                                                       .and_return(load_fixture('macosx_filesystems').read)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('mount', { logger: log_spy })
+      .and_return(load_fixture('macosx_filesystems').read)
   end
 
   describe '#call_the_resolver' do

--- a/spec/facter/resolvers/macosx/load_averages_spec.rb
+++ b/spec/facter/resolvers/macosx/load_averages_spec.rb
@@ -9,7 +9,7 @@ describe Facter::Resolvers::Macosx::LoadAverages do
   before do
     load_averages.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n vm.loadavg', logger: log_spy)
+      .with('sysctl -n vm.loadavg', { logger: log_spy })
       .and_return('{ 0.00 0.03 0.03 }')
   end
 

--- a/spec/facter/resolvers/macosx/processors_spec.rb
+++ b/spec/facter/resolvers/macosx/processors_spec.rb
@@ -19,7 +19,7 @@ describe Facter::Resolvers::Macosx::Processors do
 
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with(query_string, logger: log_spy)
+      .with(query_string, { logger: log_spy })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/macosx/swap_memory_spec.rb
+++ b/spec/facter/resolvers/macosx/swap_memory_spec.rb
@@ -13,7 +13,7 @@ describe Facter::Resolvers::Macosx::SwapMemory do
   before do
     swap_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n vm.swapusage', logger: log_spy)
+      .with('sysctl -n vm.swapusage', { logger: log_spy })
       .and_return('total = 3072.00M  used = 1422.75M  free = 1649.25M  (encrypted)')
   end
 

--- a/spec/facter/resolvers/macosx/system_memory_spec.rb
+++ b/spec/facter/resolvers/macosx/system_memory_spec.rb
@@ -12,11 +12,11 @@ describe Facter::Resolvers::Macosx::SystemMemory do
   before do
     system_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n hw.memsize', logger: log_spy)
+      .with('sysctl -n hw.memsize', { logger: log_spy })
       .and_return('34359738368')
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('vm_stat', logger: log_spy)
+      .with('vm_stat', { logger: log_spy })
       .and_return(load_fixture('vm_stat').read)
   end
 

--- a/spec/facter/resolvers/mountpoints_spec.rb
+++ b/spec/facter/resolvers/mountpoints_spec.rb
@@ -140,7 +140,7 @@ describe Facter::Resolvers::Mountpoints do
           .with('/proc/cmdline')
           .and_return(load_fixture('cmdline_root_device_partuuid').read)
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('blkid', logger: log)
+          .with('blkid', { logger: log })
           .and_return(load_fixture('blkid_output_root_has_partuuid').read)
         Facter::Resolvers::Mountpoints.instance_variable_set(:@log, log)
       end
@@ -154,7 +154,7 @@ describe Facter::Resolvers::Mountpoints do
       context 'when blkid command is not available' do
         before do
           allow(Facter::Core::Execution).to receive(:execute)
-            .with('blkid', logger: log)
+            .with('blkid', { logger: log })
             .and_return('blkid: command not found')
           Facter::Resolvers::Mountpoints.instance_variable_set(:@log, log)
         end

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -11,15 +11,16 @@ describe Facter::Resolvers::Networking do
       allow(Facter::Util::Resolvers::Networking::PrimaryInterface)
         .to receive(:read_from_route)
         .and_return(primary)
-      allow(Facter::Core::Execution).to receive(:execute).with('ifconfig -a', logger: log_spy).and_return(interfaces)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption en0 server_identifier', logger: log_spy).and_return(dhcp)
+        .to receive(:execute).with('ifconfig -a', { logger: log_spy }).and_return(interfaces)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption en0.1 server_identifier', logger: log_spy).and_return(dhcp)
+        .to receive(:execute).with('ipconfig getoption en0 server_identifier', { logger: log_spy }).and_return(dhcp)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption llw0 server_identifier', logger: log_spy).and_return('')
+        .to receive(:execute).with('ipconfig getoption en0.1 server_identifier', { logger: log_spy }).and_return(dhcp)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', logger: log_spy).and_return(dhcp)
+        .to receive(:execute).with('ipconfig getoption llw0 server_identifier', { logger: log_spy }).and_return('')
+      allow(Facter::Core::Execution)
+        .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', { logger: log_spy }).and_return(dhcp)
     end
 
     after do

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -40,11 +40,11 @@ describe Facter::Resolvers::Partitions do
       allow(Facter::Core::Execution).to receive(:which)
         .with('blkid').and_return('/usr/bin/blkid')
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('blkid', logger: logger).and_return(load_fixture('blkid_output').read)
+        .with('blkid', { logger: logger }).and_return(load_fixture('blkid_output').read)
       allow(Facter::Core::Execution).to receive(:which)
         .with('lsblk').and_return('/usr/bin/lsblk')
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('lsblk -fp', logger: logger).and_return(load_fixture('lsblk_output').read)
+        .with('lsblk -fp', { logger: logger }).and_return(load_fixture('lsblk_output').read)
     end
 
     context 'when block has a device subdir' do

--- a/spec/facter/resolvers/selinux_spec.rb
+++ b/spec/facter/resolvers/selinux_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Resolvers::SELinux do
   before do
     selinux_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('cat /proc/self/mounts', logger: log_spy)
+      .with('cat /proc/self/mounts', { logger: log_spy })
       .and_return(load_fixture(file).read)
   end
 

--- a/spec/facter/resolvers/solaris/disks_spec.rb
+++ b/spec/facter/resolvers/solaris/disks_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Resolvers::Solaris::Disks do
     allow(File).to receive(:executable?).with('/usr/bin/kstat').and_return(status)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/bin/kstat sderr', logger: resolver.log)
+      .with('/usr/bin/kstat sderr', { logger: resolver.log })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
+++ b/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
@@ -10,11 +10,11 @@ describe Facter::Resolvers::Solaris::DmiSparc do
       resolver.instance_variable_set(:@log, log_spy)
       allow(File).to receive(:executable?).with('/usr/sbin/prtdiag').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/prtdiag', logger: log_spy)
+        .with('/usr/sbin/prtdiag', { logger: log_spy })
         .and_return(load_fixture('prtdiag').read)
       allow(File).to receive(:executable?).with('/usr/sbin/sneep').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/sneep', logger: log_spy).and_return('random_string')
+        .with('/usr/sbin/sneep', { logger: log_spy }).and_return('random_string')
     end
 
     after do

--- a/spec/facter/resolvers/solaris/dmi_spec.rb
+++ b/spec/facter/resolvers/solaris/dmi_spec.rb
@@ -10,13 +10,13 @@ describe Facter::Resolvers::Solaris::Dmi do
       resolver.instance_variable_set(:@log, log_spy)
       allow(File).to receive(:executable?).with('/usr/sbin/smbios').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_BIOS', logger: log_spy)
+        .with('/usr/sbin/smbios -t SMB_TYPE_BIOS', { logger: log_spy })
         .and_return(load_fixture('smbios_bios').read)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_SYSTEM', logger: log_spy)
+        .with('/usr/sbin/smbios -t SMB_TYPE_SYSTEM', { logger: log_spy })
         .and_return(load_fixture('smbios_system').read)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_CHASSIS', logger: log_spy)
+        .with('/usr/sbin/smbios -t SMB_TYPE_CHASSIS', { logger: log_spy })
         .and_return(load_fixture('smbios_chassis').read)
     end
 

--- a/spec/facter/resolvers/solaris/filesystem_spec.rb
+++ b/spec/facter/resolvers/solaris/filesystem_spec.rb
@@ -10,7 +10,7 @@ describe Facter::Resolvers::Solaris::Filesystem do
     filesystems_resolver.instance_variable_set(:@log, log_spy)
     allow(File).to receive(:executable?).with('/usr/sbin/sysdef').and_return(true)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/sbin/sysdef', logger: log_spy)
+      .with('/usr/sbin/sysdef', { logger: log_spy })
       .and_return(load_fixture('solaris_filesystems').read)
   end
 

--- a/spec/facter/resolvers/solaris/ipaddress_spec.rb
+++ b/spec/facter/resolvers/solaris/ipaddress_spec.rb
@@ -12,8 +12,9 @@ describe Facter::Resolvers::Solaris::Ipaddress do
 
     before do
       ipaddress.instance_variable_set(:@log, log)
-      allow(Facter::Core::Execution).to receive(:execute).with('route -n get default | grep interface',
-                                                               logger: log).and_return(route)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('route -n get default | grep interface', { logger: log })
+        .and_return(route)
     end
 
     context 'when returns ip' do
@@ -21,7 +22,9 @@ describe Facter::Resolvers::Solaris::Ipaddress do
       let(:ifconfig) { load_fixture('solaris_ifconfig').read }
 
       before do
-        allow(Facter::Core::Execution).to receive(:execute).with('ifconfig net0', logger: log).and_return(ifconfig)
+        allow(Facter::Core::Execution).to receive(:execute)
+          .with('ifconfig net0', { logger: log })
+          .and_return(ifconfig)
       end
 
       it 'detects ipadress' do

--- a/spec/facter/resolvers/solaris/ldom_spec.rb
+++ b/spec/facter/resolvers/solaris/ldom_spec.rb
@@ -9,7 +9,7 @@ describe Facter::Resolvers::Solaris::Ldom do
     resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/sbin/virtinfo  -a  -p', logger: log_spy)
+      .with('/usr/sbin/virtinfo  -a  -p', { logger: log_spy })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/solaris/memory_spec.rb
+++ b/spec/facter/resolvers/solaris/memory_spec.rb
@@ -9,15 +9,15 @@ describe Facter::Resolvers::Solaris::Memory do
     resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/bin/kstat -m unix -n system_pages', logger: log_spy)
+      .with('/usr/bin/kstat -m unix -n system_pages', { logger: log_spy })
       .and_return(kstat_output)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('pagesize', logger: log_spy)
+      .with('pagesize', { logger: log_spy })
       .and_return(pagesize)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/sbin/swap -l', logger: log_spy)
+      .with('/usr/sbin/swap -l', { logger: log_spy })
       .and_return(swap_output)
   end
 

--- a/spec/facter/resolvers/solaris/processors_spec.rb
+++ b/spec/facter/resolvers/solaris/processors_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Resolvers::Solaris::Processors do
     allow(File).to receive(:executable?).with('/usr/bin/kstat').and_return(status)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/bin/kstat -m cpu_info', logger: resolver.log)
+      .with('/usr/bin/kstat -m cpu_info', { logger: resolver.log })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/solaris/zone_name_spec.rb
+++ b/spec/facter/resolvers/solaris/zone_name_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Resolvers::Solaris::ZoneName do
       .with('/bin/zonename')
       .and_return(true)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/bin/zonename', logger: log_spy)
+      .with('/bin/zonename', { logger: log_spy })
       .and_return(zone_name_output)
   end
 

--- a/spec/facter/resolvers/solaris/zone_spec.rb
+++ b/spec/facter/resolvers/solaris/zone_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Solaris::Zone do
   before do
     solaris_zone.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/sbin/zoneadm list -cp', logger: log_spy)
+      .with('/usr/sbin/zoneadm list -cp', { logger: log_spy })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/sw_vers_spec.rb
+++ b/spec/facter/resolvers/sw_vers_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::SwVers do
   before do
     sw_vers.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sw_vers', logger: log_spy)
+      .with('sw_vers', { logger: log_spy })
       .and_return("ProductName:\tMac OS X\nProductVersion:\t10.14.1\nBuildVersion:\t18B75\n")
   end
 

--- a/spec/facter/resolvers/uname_spec.rb
+++ b/spec/facter/resolvers/uname_spec.rb
@@ -13,7 +13,7 @@ describe Facter::Resolvers::Uname do
             uname -p &&
             uname -r &&
             uname -s &&
-            uname -v', logger: log_spy)
+            uname -v', { logger: log_spy })
       .and_return('x86_64
         wifi.tsr.corp.puppet.net
         i386

--- a/spec/facter/resolvers/virt_what_spec.rb
+++ b/spec/facter/resolvers/virt_what_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Resolvers::VirtWhat do
 
   before do
     virt_what_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('virt-what', logger: log_spy).and_return(content)
+    allow(Facter::Core::Execution).to receive(:execute).with('virt-what', { logger: log_spy }).and_return(content)
   end
 
   context 'when virt-what fails' do

--- a/spec/facter/resolvers/vmware_spec.rb
+++ b/spec/facter/resolvers/vmware_spec.rb
@@ -7,7 +7,7 @@ describe Facter::Resolvers::Vmware do
 
   before do
     vmware_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('vmware -v', logger: log_spy).and_return(output)
+    allow(Facter::Core::Execution).to receive(:execute).with('vmware -v', { logger: log_spy }).and_return(output)
   end
 
   after do

--- a/spec/facter/resolvers/wpar_spec.rb
+++ b/spec/facter/resolvers/wpar_spec.rb
@@ -6,7 +6,7 @@ describe Facter::Resolvers::Wpar do
   before do
     Facter::Resolvers::Wpar.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/lparstat -W', logger: log_spy)
+      .with('/usr/bin/lparstat -W', { logger: log_spy })
       .and_return(open3_result)
   end
 

--- a/spec/facter/resolvers/xen_spec.rb
+++ b/spec/facter/resolvers/xen_spec.rb
@@ -16,7 +16,8 @@ describe Facter::Resolvers::Xen do
     allow(File).to receive(:exist?).with('/usr/lib/xen-common/bin/xen-toolstack').and_return(false)
     allow(File).to receive(:exist?).with('/usr/sbin/xl').and_return(false)
     allow(File).to receive(:exist?).with('/usr/sbin/xm').and_return(true)
-    allow(Facter::Core::Execution).to receive(:execute).with('/usr/sbin/xm list', logger: log_spy).and_return(domains)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with('/usr/sbin/xm list', { logger: log_spy }).and_return(domains)
 
     xen_resolver.invalidate_cache
   end

--- a/spec/facter/resolvers/zfs_spec.rb
+++ b/spec/facter/resolvers/zfs_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::ZFS do
   before do
     zfs_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('zfs upgrade -v', logger: log_spy)
+      .with('zfs upgrade -v', { logger: log_spy })
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/zpool_spec.rb
+++ b/spec/facter/resolvers/zpool_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Zpool do
   before do
     zpool_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('zpool upgrade -v', logger: log_spy)
+      .with('zpool upgrade -v', { logger: log_spy })
       .and_return(output)
   end
 

--- a/spec/facter/util/aix/odm_query_spec.rb
+++ b/spec/facter/util/aix/odm_query_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Util::Aix::ODMQuery do
   it 'creates a query' do
     odm_query.equals('name', '12345')
 
-    expect(Facter::Core::Execution).to receive(:execute).with("odmget -q \"name='12345'\" CuAt", logger: log_spy)
+    expect(Facter::Core::Execution).to receive(:execute).with("odmget -q \"name='12345'\" CuAt", { logger: log_spy })
     odm_query.execute
   end
 
@@ -20,7 +20,7 @@ describe Facter::Util::Aix::ODMQuery do
     odm_query.equals('field1', 'value').like('field2', 'value*')
 
     expect(Facter::Core::Execution).to receive(:execute)
-      .with("odmget -q \"field1='value' AND field2 like 'value*'\" CuAt", logger: log_spy)
+      .with("odmget -q \"field1='value' AND field2 like 'value*'\" CuAt", { logger: log_spy })
     odm_query.execute
   end
 end

--- a/spec/facter/util/facts/uptime_parser_spec.rb
+++ b/spec/facter/util/facts/uptime_parser_spec.rb
@@ -17,7 +17,7 @@ describe Facter::Util::Facts::UptimeParser do
       it 'returns the correct result' do
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, logger: log_spy)
+          .with(uptime_proc_file_cmd, { logger: log_spy })
           .and_return(proc_uptime_value)
 
         expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(2672)
@@ -36,12 +36,12 @@ describe Facter::Util::Facts::UptimeParser do
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, logger: log_spy)
+          .with(uptime_proc_file_cmd, { logger: log_spy })
           .and_return('')
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(kern_boottime_cmd, logger: log_spy)
+          .with(kern_boottime_cmd, { logger: log_spy })
           .and_return(kern_boottime_value)
 
         expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(60)
@@ -52,12 +52,12 @@ describe Facter::Util::Facts::UptimeParser do
       before do
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, logger: log_spy)
+          .with(uptime_proc_file_cmd, { logger: log_spy })
           .and_return('')
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(kern_boottime_cmd, logger: log_spy)
+          .with(kern_boottime_cmd, { logger: log_spy })
           .and_return('')
       end
 
@@ -65,7 +65,7 @@ describe Facter::Util::Facts::UptimeParser do
         it 'returns the correct result' do
           allow(Facter::Core::Execution)
             .to receive(:execute)
-            .with(uptime_cmd, logger: log_spy)
+            .with(uptime_cmd, { logger: log_spy })
             .and_return(cmd_output)
 
           expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(result)

--- a/spec/facter/util/linux/dhcp_spec.rb
+++ b/spec/facter/util/linux/dhcp_spec.rb
@@ -71,7 +71,7 @@ describe Facter::Util::Linux::Dhcp do
         allow(Facter::Core::Execution).to receive(:which)
           .with('dhcpcd').and_return('/usr/bin/dhcpcd')
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('/usr/bin/dhcpcd -U ens160', logger: log_spy).and_return(load_fixture('dhcpcd').read)
+          .with('/usr/bin/dhcpcd -U ens160', { logger: log_spy }).and_return(load_fixture('dhcpcd').read)
 
         dhcp_search.instance_eval { @dhcpcd_command = nil }
       end

--- a/spec/facter/util/linux/routing_table_spec.rb
+++ b/spec/facter/util/linux/routing_table_spec.rb
@@ -9,9 +9,9 @@ describe Facter::Util::Linux::RoutingTable do
     context 'when ip route show finds an IP, Socket lib did not retrieve' do
       before do
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ip route show', logger: log_spy).and_return(load_fixture('ip_route_show').read)
+          .with('ip route show', { logger: log_spy }).and_return(load_fixture('ip_route_show').read)
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ip -6 route show', logger: log_spy).and_return(load_fixture('ip_-6_route_show').read)
+          .with('ip -6 route show', { logger: log_spy }).and_return(load_fixture('ip_-6_route_show').read)
       end
 
       it 'returns the ipv4 info' do

--- a/spec/facter/util/linux/socket_parser_spec.rb
+++ b/spec/facter/util/linux/socket_parser_spec.rb
@@ -27,7 +27,7 @@ describe Facter::Util::Linux::SocketParser do
       allow(Socket).to receive(:getifaddrs).and_return(ifaddrs)
       allow(Socket).to receive(:const_defined?).with(:PF_LINK).and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('ip -o link show', logger: log_spy).and_return(load_fixture('ip_link_show_all').read)
+        .with('ip -o link show', { logger: log_spy }).and_return(load_fixture('ip_link_show_all').read)
     end
 
     let(:result) do


### PR DESCRIPTION
Facter verifies partial doubles so arguments are checked against the original method and to ensure methods that don't exist can't be stubbed. RSpec 3.11.2 changes how keyword arguments are verified[1].

So previously you could write `expect(:m).with(a: true)` and it would pass if the method was called with a hash or keyword arguments. But now the expectation must expect a hash, not keyword arguments.

[1] https://github.com/rspec/rspec-mocks/commit/bc1a68725d57e167c885763e7f3edc236f92b7b5