### PR TITLE
(maint) Update test for Solaris 10

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -338,6 +338,10 @@ module Facter
                        /#{version[1]}/
                      end
         case agent[:platform]
+        when /solaris-10/
+          os_release_full = /#{os_version}_u\d+/
+          os_kernel       = /Generic_\d+-\d+/
+          os_kernel_major = os_kernel
         when /solaris-11/
           os_release_full = /#{os_version}\.\d+/
           os_kernel       = os_release_full


### PR DESCRIPTION
Copied expected Solaris 10 os facts from facter#3.x, see https://github.com/puppetlabs/facter/blob/3.14.24/acceptance/lib/facter/acceptance/base_fact_utils.rb#L442-L445