### PR TITLE
(FACT-3147) Updates minimum Ruby version to 2.5

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -31,7 +31,7 @@ end
 
 def beaker_platform
   {
-    'ubuntu-latest' => 'ubuntu2004-64a',
+    'ubuntu-20.04' => 'ubuntu2004-64a',
     'macos-latest' => 'osx11-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-latest, macos-latest ]
+        os: [ windows-2019, ubuntu-20.04, macos-latest ]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rubocop_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: RuboCop
     steps:
       - name: Checkout current PR
@@ -25,7 +25,7 @@ jobs:
       - run: bundle exec rubocop --parallel
 
   rtc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: RuboCop TODO
     steps:
       - uses: actions/checkout@v1
@@ -38,7 +38,7 @@ jobs:
           FORCE_ERROR_EXIT: true
 
   commit_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: commit message
     steps:
       - name: Checkout current PR

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   coverage_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: coverage
     steps:
       - name: Checkout current PR

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   snyk_monitor:
     if: ${{ github.repository_owner == 'puppetlabs' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Snyk Monitor
     steps:
       - name: Checkout current PR

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.3'
+          - '2.5'
           - '2.7'
           - '3.0'
           - '3.2.0-preview2'

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.0'
           - '3.2.0-preview2'
           - 'jruby-9.3.7.0'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ site](https://puppet.com/docs/puppet/latest/facter.html).
 * AIX
 
 ## Requirements
-* Ruby 2.3+
+* Ruby 2.5+
 * FFI (for facts like `mountpoints` which are resolved using C API calls)
 
 ## Basic concepts

--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter-ng'
-  spec.version       = '4.2.15'
+  spec.version       = '4.3.0'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.files = dirs.map { |path| path.sub(base, '') }
 
-  spec.required_ruby_version = '>= 2.3', '< 4.0'
+  spec.required_ruby_version = '>= 2.5', '< 4.0'
 
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -12,7 +12,7 @@ gem_require_path: 'lib'
 gem_executables: 'facter'
 gem_license: 'Apache-2.0'
 gem_default_executables: 'facter'
-gem_required_ruby_version: ['>= 2.3', '< 4.0']
+gem_required_ruby_version: ['>= 2.5', '< 4.0']
 gem_runtime_dependencies:
   hocon: ~> 1.3
   thor: ['>= 1.0.1', '< 2.0']

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter'
-  spec.version       = '4.2.15'
+  spec.version       = '4.3.0'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   base = "#{__dir__}#{File::SEPARATOR}"
   spec.files = dirs.map { |path| path.sub(base, '') }
 
-  spec.required_ruby_version = '>= 2.3', '< 4.0'
+  spec.required_ruby_version = '>= 2.5', '< 4.0'
   spec.bindir = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Facter
-  VERSION = '4.2.15' unless defined?(VERSION)
+  VERSION = '4.3.0' unless defined?(VERSION)
 end

--- a/spec/custom_facts/util/parser_spec.rb
+++ b/spec/custom_facts/util/parser_spec.rb
@@ -354,7 +354,9 @@ describe LegacyFacter::Util::Parser do
         let(:yaml_content) { load_fixture('external_fact_yaml_date').read }
 
         it 'loads date' do
-          pending 'There is a bug in newer versions of Psych and Timecop' if RUBY_VERSION =~ /^3\.2/
+          if RUBY_VERSION.to_f == 3.2 && Gem::Version.new(Timecop::VERSION) < Gem::Version.new('0.9.6')
+            pending 'There is a bug in newer versions of Psych and timecop'
+          end
           expected_result = { 'testsfact' => { 'date' => Date.parse('2020-04-28') } }
 
           expect(yaml_parser.parse_results).to eq(expected_result)

--- a/spec/facter/facts/aix/ruby/version_spec.rb
+++ b/spec/facter/facts/aix/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Aix::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Aix::Ruby::Version.new }
 
-    let(:value) { '2.4.5' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/facts/freebsd/ruby/version_spec.rb
+++ b/spec/facter/facts/freebsd/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Freebsd::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Freebsd::Ruby::Version.new }
 
-    let(:value) { '2.4.5' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/facts/linux/ruby/version_spec.rb
+++ b/spec/facter/facts/linux/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Linux::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::Ruby::Version.new }
 
-    let(:value) { '2.4.5' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/facts/macosx/ruby/version_spec.rb
+++ b/spec/facter/facts/macosx/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Macosx::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Macosx::Ruby::Version.new }
 
-    let(:value) { '2.4.5' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/facts/solaris/ruby/version_spec.rb
+++ b/spec/facter/facts/solaris/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Solaris::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Solaris::Ruby::Version.new }
 
-    let(:value) { '2.4.5' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/facts/windows/ruby/version_spec.rb
+++ b/spec/facter/facts/windows/ruby/version_spec.rb
@@ -4,7 +4,7 @@ describe Facts::Windows::Ruby::Version do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Windows::Ruby::Version.new }
 
-    let(:value) { '2.5.7' }
+    let(:value) { '2.5.9' }
 
     before do
       allow(Facter::Resolvers::Ruby).to receive(:resolve).with(:version).and_return(value)

--- a/spec/facter/util/file_helper_spec.rb
+++ b/spec/facter/util/file_helper_spec.rb
@@ -98,36 +98,18 @@ describe Facter::Util::FileHelper do
   end
 
   describe '#dir_children' do
-    context 'with ruby < 2.5' do
-      before do
-        allow(Dir).to receive(:entries).with(File.dirname(path)).and_return(entries + ['.', '..'])
-        stub_const('RUBY_VERSION', '2.4.5')
-      end
-
-      it 'delegates to Dir.entries' do
-        file_helper.dir_children(File.dirname(path))
-        expect(Dir).to have_received(:entries)
-      end
-
-      it 'correctly resolves entries' do
-        expect(file_helper.dir_children(File.dirname(path))).to eq(entries)
-      end
+    before do
+      allow(Dir).to receive(:children).with(File.dirname(path)).and_return(entries)
+      stub_const('RUBY_VERSION', '2.5.9')
     end
 
-    context 'with ruby >= 2.5', if: RUBY_VERSION.to_f >= 2.5 do
-      before do
-        allow(Dir).to receive(:children).with(File.dirname(path)).and_return(entries)
-        stub_const('RUBY_VERSION', '2.5.1')
-      end
+    it 'delegates to Dir.children' do
+      file_helper.dir_children(File.dirname(path))
+      expect(Dir).to have_received(:children)
+    end
 
-      it 'delegates to Dir.children' do
-        file_helper.dir_children(File.dirname(path))
-        expect(Dir).to have_received(:children)
-      end
-
-      it 'correctly resolves entries' do
-        expect(file_helper.dir_children(File.dirname(path))).to eq(entries)
-      end
+    it 'correctly resolves entries' do
+      expect(file_helper.dir_children(File.dirname(path))).to eq(entries)
     end
   end
 


### PR DESCRIPTION
This PR both updates the minimum Ruby version for Facter to Ruby 2.5 (removing all instances of Ruby 2.3 and 2.4 in the codebase) and increments the next Facter version to 4.3.0.