### PR TITLE
(maint) Hardcodes Ubuntu 20.04 GHA runners

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -31,7 +31,7 @@ end
 
 def beaker_platform
   {
-    'ubuntu-latest' => 'ubuntu2004-64a',
+    'ubuntu-20.04' => 'ubuntu2004-64a',
     'macos-latest' => 'osx11-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rubocop_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: RuboCop
     steps:
       - name: Checkout current PR
@@ -25,7 +25,7 @@ jobs:
       - run: bundle exec rubocop --parallel
 
   rtc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: RuboCop TODO
     steps:
       - uses: actions/checkout@v1
@@ -38,7 +38,7 @@ jobs:
           FORCE_ERROR_EXIT: true
 
   commit_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: commit message
     steps:
       - name: Checkout current PR

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   coverage_checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: coverage
     steps:
       - name: Checkout current PR

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   snyk_monitor:
     if: ${{ github.repository_owner == 'puppetlabs' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Snyk Monitor
     steps:
       - name: Checkout current PR

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.0'
           - '3.2.0-preview2'
           - 'jruby-9.3.7.0'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-latest GitHub Actions runner currently translates to Ubuntu 20.04, but will migrate to 22.04 next year: https://github.com/actions/runner-images/issues/6399

Because platform translation is necessary in the presuit.rb file, this commit changes all instances of "ubuntu-latest" in our GitHub Actions configuration to "ubuntu-20.04".