### PR TITLE
(FACT-3171) Fix IPv6 link-local unicast address filtering

### DIFF
--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -65,7 +65,7 @@ module Facter
           end
 
           IPV4_LINK_LOCAL_ADDR = IPAddr.new('169.254.0.0/16').freeze # RFC5735
-          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/16').freeze # RFC4291
+          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/10').freeze # RFC4291
 
           def ignored_ip_address(addr)
             return true if addr.empty?

--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -64,8 +64,23 @@ module Facter
             bindings.empty? ? nil : bindings.first
           end
 
+          IPV4_LINK_LOCAL_ADDR = IPAddr.new('169.254.0.0/16').freeze # RFC5735
+          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/16').freeze # RFC4291
+
           def ignored_ip_address(addr)
-            addr.empty? || addr.start_with?('127.', '169.254.') || addr.start_with?('fe80') || addr.eql?('::1')
+            return true if addr.empty?
+
+            ip = IPAddr.new(addr)
+            return true if ip.loopback?
+
+            [
+              IPV4_LINK_LOCAL_ADDR,
+              IPV6_LINK_LOCAL_ADDR
+            ].each do |range|
+              return true if range.include?(ip)
+            end
+
+            false
           end
 
           def calculate_mask_length(netmask)

--- a/spec/facter/util/resolvers/networking/networking_spec.rb
+++ b/spec/facter/util/resolvers/networking/networking_spec.rb
@@ -233,7 +233,7 @@ describe Facter::Util::Resolvers::Networking do
       expect(networking_facts).to include(expected)
     end
 
-    context 'when there is a global ip address' do
+    context 'when there is a link-local ip address' do
       let(:networking_facts) do
         {
           interfaces:
@@ -251,10 +251,40 @@ describe Facter::Util::Resolvers::Networking do
 
       it 'expands the correct binding' do
         expected = {
-          ip6: 'fe87::1',
+          ip6: '::1',
+          netmask6: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          network6: '::1',
+          scope6: 'host'
+        }
+
+        networking_helper.expand_main_bindings(networking_facts)
+
+        expect(networking_facts[:interfaces]['lo0']).to include(expected)
+      end
+    end
+
+    context 'when there is a global ip address' do
+      let(:networking_facts) do
+        {
+          interfaces:
+            { 'lo0' =>
+              { mtu: 16_384,
+                bindings6:
+                  [{ address: '::1',
+                     netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+                     network: '::1' },
+                   { address: '2001:0DB8::1',
+                     netmask: 'ffff:ffff:ffff:ffff::',
+                     network: '2001:0DB8::' }] } }
+        }
+      end
+
+      it 'expands the correct binding' do
+        expected = {
+          ip6: '2001:0DB8::1',
           netmask6: 'ffff:ffff:ffff:ffff::',
-          network6: 'fe87::',
-          scope6: 'link'
+          network6: '2001:0DB8::',
+          scope6: 'global'
         }
 
         networking_helper.expand_main_bindings(networking_facts)


### PR DESCRIPTION
RFC4291 define the Link-local unicast range as `fe80::/10`, not `fe80::/16` (what we compared against because of the String comparison). As a consequence, some Link-local unicast addresses where not correctly filtered, e.g. `fe87::`.

While here, add a "working" example with an actual global IPv6 address from the `2001:0DB8::/32` range reserved for documentation (RFC3849).
