### PR TITLE
(FACT-3172) Fix IPv6 unique-local unicast address filtering

### DIFF
--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -65,7 +65,7 @@ module Facter
           end
 
           IPV4_LINK_LOCAL_ADDR = IPAddr.new('169.254.0.0/16').freeze # RFC5735
-          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/16').freeze # RFC4291
+          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/10').freeze # RFC4291
 
           def ignored_ip_address(addr)
             return true if addr.empty?

--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -64,8 +64,23 @@ module Facter
             bindings.empty? ? nil : bindings.first
           end
 
+          IPV4_LINK_LOCAL_ADDR = IPAddr.new('169.254.0.0/16').freeze # RFC5735
+          IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/16').freeze # RFC4291
+
           def ignored_ip_address(addr)
-            addr.empty? || addr.start_with?('127.', '169.254.') || addr.start_with?('fe80') || addr.eql?('::1')
+            return true if addr.empty?
+
+            ip = IPAddr.new(addr)
+            return true if ip.loopback?
+
+            [
+              IPV4_LINK_LOCAL_ADDR,
+              IPV6_LINK_LOCAL_ADDR
+            ].each do |range|
+              return true if range.include?(ip)
+            end
+
+            false
           end
 
           def calculate_mask_length(netmask)

--- a/lib/facter/util/resolvers/networking/networking.rb
+++ b/lib/facter/util/resolvers/networking/networking.rb
@@ -66,6 +66,7 @@ module Facter
 
           IPV4_LINK_LOCAL_ADDR = IPAddr.new('169.254.0.0/16').freeze # RFC5735
           IPV6_LINK_LOCAL_ADDR = IPAddr.new('fe80::/10').freeze # RFC4291
+          IPV6_UNIQUE_LOCAL_ADDR = IPAddr.new('fc00::/7').freeze # RFC4193
 
           def ignored_ip_address(addr)
             return true if addr.empty?
@@ -75,7 +76,8 @@ module Facter
 
             [
               IPV4_LINK_LOCAL_ADDR,
-              IPV6_LINK_LOCAL_ADDR
+              IPV6_LINK_LOCAL_ADDR,
+              IPV6_UNIQUE_LOCAL_ADDR
             ].each do |range|
               return true if range.include?(ip)
             end

--- a/spec/facter/util/resolvers/networking/networking_spec.rb
+++ b/spec/facter/util/resolvers/networking/networking_spec.rb
@@ -233,7 +233,7 @@ describe Facter::Util::Resolvers::Networking do
       expect(networking_facts).to include(expected)
     end
 
-    context 'when there is a global ip address' do
+    context 'when there is a link-local ip address' do
       let(:networking_facts) do
         {
           interfaces:
@@ -251,10 +251,40 @@ describe Facter::Util::Resolvers::Networking do
 
       it 'expands the correct binding' do
         expected = {
-          ip6: 'fe87::1',
+          ip6: '::1',
+          netmask6: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          network6: '::1',
+          scope6: 'host'
+        }
+
+        networking_helper.expand_main_bindings(networking_facts)
+
+        expect(networking_facts[:interfaces]['lo0']).to include(expected)
+      end
+    end
+
+    context 'when there is a global ip address' do
+      let(:networking_facts) do
+        {
+          interfaces:
+            { 'lo0' =>
+              { mtu: 16_384,
+                bindings6:
+                  [{ address: '::1',
+                     netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+                     network: '::1' },
+                   { address: '2001:0DB8::1',
+                     netmask: 'ffff:ffff:ffff:ffff::',
+                     network: '2001:0DB8::' }] } }
+        }
+      end
+
+      it 'expands the correct binding' do
+        expected = {
+          ip6: '2001:0DB8::1',
           netmask6: 'ffff:ffff:ffff:ffff::',
-          network6: 'fe87::',
-          scope6: 'link'
+          network6: '2001:0DB8::',
+          scope6: 'global'
         }
 
         networking_helper.expand_main_bindings(networking_facts)

--- a/spec/facter/util/resolvers/networking/networking_spec.rb
+++ b/spec/facter/util/resolvers/networking/networking_spec.rb
@@ -263,6 +263,36 @@ describe Facter::Util::Resolvers::Networking do
       end
     end
 
+    context 'when there is a unique local ip address' do
+      let(:networking_facts) do
+        {
+          interfaces:
+            { 'lo0' =>
+              { mtu: 16_384,
+                bindings6:
+                  [{ address: '::1',
+                     netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+                     network: '::1' },
+                   { address: 'fdfc:f496:4c6f:0:b0e3:7bff:fe3a:6baf',
+                     netmask: 'ffff:ffff:ffff:ffff::',
+                     network: 'fdfc:f496:4c6f:0::' }] } }
+        }
+      end
+
+      it 'expands the correct binding' do
+        expected = {
+          ip6: '::1',
+          netmask6: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+          network6: '::1',
+          scope6: 'host'
+        }
+
+        networking_helper.expand_main_bindings(networking_facts)
+
+        expect(networking_facts[:interfaces]['lo0']).to include(expected)
+      end
+    end
+
     context 'when there is a global ip address' do
       let(:networking_facts) do
         {


### PR DESCRIPTION
We do not want these addresses to be reported as the default IPv6 address in `networking.ip6`.  Quoting RFC4193:

> This document defines an IPv6 unicast address format that is globally
> unique and is intended for local communications, usually inside of a
> site.  These addresses are not expected to be routable on the global
> Internet.

This PR also include:
* #2539
