### PR TITLE
(maint) GitHub Actions maintenance

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -48,9 +48,19 @@ def install_puppet_agent
   message('INSTALL PUPPET AGENT')
 
   beaker_puppet_root = run('bundle info beaker-puppet --path')
-  presuite_file_path = File.join(beaker_puppet_root.chomp, 'setup', 'aio', '010_Install_Puppet_Agent.rb')
 
-  run("beaker exec pre-suite --pre-suite #{presuite_file_path} --preserve-state", './', env_path_var)
+  # Bundler/Rubygems can sometimes give output other than the filepath (deprecation warnings, etc.)
+  begin
+    if File.exist?(beaker_puppet_root.chomp)
+      presuite_file_path = File.join(beaker_puppet_root.chomp, 'setup', 'aio', '010_Install_Puppet_Agent.rb')
+
+      run("beaker exec pre-suite --pre-suite #{presuite_file_path} --preserve-state", './', env_path_var)
+    else
+      exit
+    end
+  rescue SystemExit
+    puts "`bundle info beaker-puppet --path` produced unexpected output, please address this."
+  end
 end
 
 def puppet_puppet_bin_dir

--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -32,7 +32,7 @@ end
 def beaker_platform
   {
     'ubuntu-20.04' => 'ubuntu2004-64a',
-    'macos-latest' => 'osx11-64a',
+    'macos-11' => 'osx11-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'
   }[HOST_PLATFORM]

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macos-latest ]
+        os: [ windows-2019, ubuntu-20.04, macos-11 ]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
+          rubygems: '3.3.26'
 
       - name: Fix common Linux and macOS permissions
         if: runner.os != 'Windows'

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           path: facter
 
-      - name: Install Ruby 2.6
+      - name: Install Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
 
       - name: Fix common Linux and macOS permissions
         if: runner.os != 'Windows'

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: facter
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Rubocop checks
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: '2.7'
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rubocop --parallel
 
@@ -49,6 +49,6 @@ jobs:
       - name: Commit message checks
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: '2.7'
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rake commits

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,7 +15,7 @@ jobs:
     name: RuboCop
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Rubocop checks
         uses: ruby/setup-ruby@v1
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: RuboCop TODO
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: gimmyxd/rtc-action@0.3.1
         env:
           RTC_TOKEN: ${{ secrets.RTC_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
     name: commit message
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     name: coverage
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Code Climate test-reporter
         run: |

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate coverage
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: '2.7'
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rake spec
 

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Snyk Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '2.7'
       - name: Install dependencies
         run: bundle install --jobs 3 --retry 3
       - name: Run Snyk to check for vulnerabilities

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Rspec checks
         uses: ruby/setup-ruby@v1
@@ -47,7 +47,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Rspec checks
         uses: ruby/setup-ruby@v1

--- a/spec/mocks/win32.rb
+++ b/spec/mocks/win32.rb
@@ -6,6 +6,9 @@ module Win32
 
     def close; end
 
+    module API
+    end
+
     class HKEY_LOCAL_MACHINE
       def self.open(*); end
 


### PR DESCRIPTION
This PR does the following:

- Updates the Checkout Action to v3 everywhere to address the upcoming Node12 deprecation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Updates the Ruby versions used in GitHub Actions to a minimum of 2.7 (except in our unit tests, where we still need to support 2.5).
- Adds error handling to the presuite action, which started failing because of a deprecation warning for Rubygems: https://github.com/puppetlabs/facter/actions/runs/3832413911/jobs/6525131161
- Updates Rubygems to get rid of the deprecation warning