### PR TITLE
(FACT-3177) Update facter tests to expect Ruby 3

### DIFF
--- a/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
+++ b/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
@@ -47,6 +47,7 @@ test_name "C64580: Non-root default user external facts directory is searched fo
   #
   def get_home_dir(host, user_name)
     home_dir = nil
+    pending_test("PA-4843: ruby-shadow taint")
     on host, puppet_resource('user', user_name) do |result|
       home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
     end

--- a/acceptance/tests/facts/ruby.rb
+++ b/acceptance/tests/facts/ruby.rb
@@ -40,7 +40,12 @@ test_name "C100305: The Ruby fact should resolve as expected in AIO" do
 
       has_sitedir = !on(agent, 'ruby -e"puts RbConfig::CONFIG[\'sitedir\']"').output.chomp.empty?
 
-      ruby_version   = /2\.\d+\.\d+/
+      puppet_version = on(agent, puppet("--version")).stdout.chomp
+      ruby_version   = if puppet_version =~ /^(6|7)\./
+                         /2\.\d+\.\d+/
+                       else
+                         /3\.\d+\.\d+/
+                       end
       expected_facts = {
           'ruby.platform' => ruby_platform,
           'ruby.version'  => ruby_version


### PR DESCRIPTION
Assume ruby 3, unless `puppet --version` starts with 6 or 7. This should also
work when the github action runs facter tests against nightly puppet-agent 7 or
8 builds.