### PR TITLE
Revert "(FACT-3177) Mark test as pending due to ruby-shadow"

### DIFF
--- a/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
+++ b/acceptance/tests/external_facts/non_root_users_default_external_fact_directory.rb
@@ -47,7 +47,6 @@ test_name "C64580: Non-root default user external facts directory is searched fo
   #
   def get_home_dir(host, user_name)
     home_dir = nil
-    pending_test("PA-4843: ruby-shadow taint")
     on host, puppet_resource('user', user_name) do |result|
       home_dir = result.stdout.match(/home\s*=>\s*'([^']+)'/m)[1]
     end


### PR DESCRIPTION
This reverts commit 2d5ea83dc7e01fce6ebc0aa94365a6033ddd8f7f.

Test now passes using puppet-agent built from puppet-agent#main

```
❯  bx rake ci:test:setup SHA=2ca95d5071b4ea3bf81aa7d2b8326e5558820dd5 HOSTS=redhat7-64a 
...
❯ bx beaker exec tests/external_facts/non_root_users_default_external_fact_directory.rb
...
tests/external_facts/non_root_users_default_external_fact_directory.rb passed in 8.39 seconds
```
