### PR TITLE
(FACT-3179) Fix the Facter.resolve method to always return a Hash

### DIFF
--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -18,7 +18,7 @@ module Facter
     # Method used by puppet-agent to retrieve facts
     # @param args_as_string [string] facter cli arguments
     #
-    # @return query result
+    # @return [Hash<String, Object>]
     #
     # @api private
     def resolve(args_as_string)
@@ -42,7 +42,7 @@ module Facter
       cli_options[:show_legacy] ||= false
       Facter::Options.store(cli_options)
 
-      queried_facts(cli.args)
+      Hash[queried_facts(cli.args)]
     end
 
     # Method used by cli to set puppet paths
@@ -370,7 +370,7 @@ module Facter
     # Retrieves a fact's value. Returns `nil` if no such fact exists.
     #
     # @param user_query [String] the fact name
-    # @return [String] the value of the fact, or nil if no fact is found
+    # @return [Hash<String, Object>]
     #
     # @api public
     def to_hash

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -63,7 +63,11 @@ describe Facter do
     let(:cli_double) { instance_spy(Facter::Cli) }
 
     before do
-      allow(Facter).to receive(:queried_facts)
+      allow(Facter).to receive(:queried_facts).and_return({})
+    end
+
+    it 'returns hash object when API called' do
+      expect(Facter.resolve('').class).to eq(Hash)
     end
 
     context 'when user query and options in arguments' do


### PR DESCRIPTION
Updated doc tags for the change, and added in a spec test.