### PR TITLE
(FACT-3155) Remove timecop from spec tests

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 1.38'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sys-filesystem', '~> 1.3'
-  spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'webmock', '~> 3.12'
   spec.add_development_dependency 'yard', '~> 0.9'
 

--- a/spec/custom_facts/util/parser_spec.rb
+++ b/spec/custom_facts/util/parser_spec.rb
@@ -354,9 +354,6 @@ describe LegacyFacter::Util::Parser do
         let(:yaml_content) { load_fixture('external_fact_yaml_date').read }
 
         it 'loads date' do
-          if RUBY_VERSION.to_f == 3.2 && Gem::Version.new(Timecop::VERSION) < Gem::Version.new('0.9.6')
-            pending 'There is a bug in newer versions of Psych and timecop'
-          end
           expected_result = { 'testsfact' => { 'date' => Date.parse('2020-04-28') } }
 
           expect(yaml_parser.parse_results).to eq(expected_result)

--- a/spec/facter/util/resolvers/aws_token_spec.rb
+++ b/spec/facter/util/resolvers/aws_token_spec.rb
@@ -28,7 +28,8 @@ describe 'Facter::Util::Resolvers::Http' do
     it 'makes a second request if token is expired' do
       allow(Facter::Util::Resolvers::Http).to receive(:put_request).and_return('token')
       aws_token.get(1)
-      Timecop.travel(Time.now + 2)
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now + 2)
       aws_token.get(1)
       expect(Facter::Util::Resolvers::Http).to have_received(:put_request).twice
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ end
 require 'open3'
 require 'thor'
 require 'fileutils'
-require 'timecop'
 
 require_relative '../lib/facter/resolvers/base_resolver'
 


### PR DESCRIPTION
Intiailly, timecop was added for an AWS rspec test. When testing with Ruby 3.2.0, we ran into an issue due to how timecop and Psych interact. Due to this, we are removing timecop.