### PR TITLE
(maint) improve and regenerate manpage

### DIFF
--- a/lib/facter/templates/man.erb
+++ b/lib/facter/templates/man.erb
@@ -1,11 +1,14 @@
 <%# encoding: UTF-8%>
+facter - collect and display facts about the current system
+===========================================================
+
 SYNOPSIS
 --------
-  facter [options] [query] [query] [...]
+<b>facter</b> [options] [query] [query] [...]
 
 DESCRIPTION
 -----------
-Collect and display facts about the current system. The library behind Facter is easy to extend, making Facter an easy way to collect information about a system.
+<b>facter</b> is a command-line tool that gathers basic facts about nodes (systems) such as hardware details, network settings, OS type and version, and more. These facts are made available as variables in your Puppet manifests and can be used to inform conditional expressions in Puppet.
 
 If no queries are given, then all facts will be returned.
 

--- a/man/man8/facter.8
+++ b/man/man8/facter.8
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FACTER" "8" "July 2021" "Puppet, Inc." "Facter manual"
+.TH "FACTER" "8" "March 2024" "Puppet, Inc." "Facter manual"
 .
 .SH "NAME"
-\fBfacter\fR
+\fBfacter\fR \- collect and display facts about the current system
 .
 .SH "SYNOPSIS"
-facter [options] [query] [query] [\.\.\.]
+\fBfacter\fR [options] [query] [query] [\.\.\.]
 .
 .SH "DESCRIPTION"
-Collect and display facts about the current system\. The library behind Facter is easy to extend, making Facter an easy way to collect information about a system\.
+\fBfacter\fR is a command\-line tool that gathers basic facts about nodes (systems) such as hardware details, network settings, OS type and version, and more\. These facts are made available as variables in your Puppet manifests and can be used to inform conditional expressions in Puppet\.
 .
 .P
 If no queries are given, then all facts will be returned\.
@@ -145,6 +145,12 @@ Show how much time it took to resolve each fact
 .
 .IP
 Resolve facts sequentially
+.
+.TP
+\fB\-\-http\-debug\fR:
+.
+.IP
+Whether to write HTTP request and responses to stderr\. This should never be used in production\.
 .
 .TP
 \fB\-p\fR, \fB\-\-puppet\fR:


### PR DESCRIPTION
This improves the facter manpage to fix parsing errors due to the missing short description in the NAME section, makes the formatting consistent with most other manpages, and updates the DESCRIPTION section using the one in the project's README, which is more useful this context.