### PR TITLE
(maint) Don't stub integration tests

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,38 @@
+---
+name: Integration tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CI: true
+
+jobs:
+  integration_tests:
+    name: integration ${{ matrix.cfg.os }} (ruby ${{ matrix.cfg.ruby }})
+    strategy:
+      matrix:
+        cfg:
+          - {os: ubuntu-latest, ruby: '2.7'}
+          - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
+          - {os: ubuntu-22.04, ruby: 'jruby-9.3.7.0'}
+          - {os: windows-2019, ruby: '2.7'}
+          - {os: windows-2019, ruby: '3.2'} # with openssl 3
+    runs-on: ${{ matrix.cfg.os }}
+    steps:
+      - name: Checkout current PR
+        uses: actions/checkout@v3
+
+      - name: Rspec checks
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.cfg.ruby }}
+      - run: gem update bundler
+      - run: bundle config set --local with integration
+      - run: bundle install --jobs 3 --retry 3
+      - run: bundle exec rake spec_integration

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -35,7 +35,6 @@ jobs:
       - run: gem update bundler
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rake spec_random
-      - run: bundle exec rake spec_integration
 
   windows_unit_tests:
     name: Windows tests with Ruby ${{ matrix.ruby }}
@@ -56,4 +55,3 @@ jobs:
       - run: gem update bundler
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rake spec_random
-      - run: bundle exec rake spec_integration

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ gem 'packaging', require: false
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)
 
+group(:integration, optional: true) do
+  gem 'ffi', '~> 1.15', require: false
+end
+
 group(:documentation) do
   gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,16 +22,20 @@ require 'fileutils'
 
 require_relative '../lib/facter/resolvers/base_resolver'
 
-Dir[ROOT_DIR.join('spec/mocks/*.rb')].sort.each { |file| require file }
+unit_tests = ARGV.grep(/spec_integration/).empty?
+Dir[ROOT_DIR.join('spec/mocks/*.rb')].sort.each { |file| require file } if unit_tests
+
 require_relative 'custom_facts/puppetlabs_spec/files'
 
 require 'facter'
 require 'facter/framework/cli/cli'
 require 'facter/framework/cli/cli_launcher'
 
-Dir.glob(File.join('./lib/facter/util', '/**/*/', '*.rb'), &method(:require))
-Dir.glob(File.join('./lib/facter/facts', '/**/*/', '*.rb'), &method(:require))
-Dir.glob(File.join('./lib/facter/resolvers', '/**/*/', '*.rb'), &method(:require))
+if unit_tests
+  Dir.glob(File.join('./lib/facter/util', '/**/*/', '*.rb'), &method(:require))
+  Dir.glob(File.join('./lib/facter/facts', '/**/*/', '*.rb'), &method(:require))
+  Dir.glob(File.join('./lib/facter/resolvers', '/**/*/', '*.rb'), &method(:require))
+end
 
 default_coverage = 90
 SimpleCov.minimum_coverage ENV['COVERAGE'] || default_coverage


### PR DESCRIPTION
Facter's spec_integration tests sometimes fail, because the ffi mocks don't implement all of the methods for the underlying ffi classes. For example, FFI::Struct#to_ptr is missing, yet that method is called by Facter::Util::Resolvers::Ffi::Hostname.getffihostname.

This commit moves the integration tests to a separate GH action. The test doesn't stub anything, unlike the unit tests. The integration test matrix is restricted to ruby versions that we currently use on agent and server.

The `ffi` gem is added as an optional dependency to the `integration` group. This way it remains a soft dependency/feature as not all hosts have compilers.