### PR TITLE
(FACT-3195) Fix inconsistency in disks serial number reporting

### DIFF
--- a/lib/facter/resolvers/disks.rb
+++ b/lib/facter/resolvers/disks.rb
@@ -52,18 +52,26 @@ module Facter
 
                 next unless result
 
-                value[key] = case key
-                             when :size
-                               # Linux always considers sectors to be 512 bytes long
-                               # independently of the devices real block size.
-                               construct_size(value, result)
-                             when :type
-                               result == '0' ? 'ssd' : 'hdd'
-                             else
-                               result
-                             end
+                result = case key
+                         when :size
+                           # Linux always considers sectors to be 512 bytes long
+                           # independently of the devices real block size.
+                           construct_size(value, result)
+                         when :type
+                           result == '0' ? 'ssd' : 'hdd'
+                         else
+                           result
+                         end
+
+                add_fact(value, key, result)
               end
             end
+          end
+
+          def add_fact(disk_info, fact, value)
+            fact = :serial_number if fact == :serial
+
+            disk_info[fact] = value
           end
 
           def build_disks_hash

--- a/lib/schema/facter.yaml
+++ b/lib/schema/facter.yaml
@@ -226,6 +226,7 @@ disks:
     description: Return the disk (block) devices attached to the system.
     resolution: |
         AIX: query the ODM for all disk devices
+        FreeBSD: rely on GEOM to get devices
         Linux: parse the contents of `/sys/block/<device>/`.
         Solaris: use the `kstat` function to query disk information.
     caveats: |
@@ -252,12 +253,15 @@ disks:
                 size_bytes:
                     type: integer
                     description: The size of the disk or block device, in bytes.
-                vendor:
-                    type: string
-                    description: The vendor of the disk or block device.
                 type:
                     type: string
                     description: The type of disk or block device (sshd or hdd). This fact is available only on Linux.
+                vendor:
+                    type: string
+                    description: The vendor of the disk or block device.
+                wwn:
+                    type: string
+                    description: The World Wide Name of the disk or block device. This fact is available only on Linux.
 
 dmi:
     type: map
@@ -1275,6 +1279,7 @@ partitions:
     description: Return the disk partitions of the system.
     resolution: |
         AIX: use the ODM to retrieve list of logical volumes; use `lvm_querylv` function to get details
+        FreeBSD: rely on GEOM to get devices
         Linux: use `libblkid` to retrieve the disk partitions.
     caveats: |
         Linux: `libfacter` must be built with `libblkid` support.

--- a/spec/facter/resolvers/disks_spec.rb
+++ b/spec/facter/resolvers/disks_spec.rb
@@ -48,9 +48,9 @@ describe Facter::Resolvers::Linux::Disks do
 
     context 'when device dir for blocks exists' do
       let(:expected_output) do
-        { 'sr0' => { model: 'model1', serial: 'AJDI2491AK', wwn: '239090190.0',
+        { 'sr0' => { model: 'model1', serial_number: 'AJDI2491AK', wwn: '239090190.0',
                      size: '6.00 KiB', size_bytes: 6144, vendor: 'vendor1', type: 'ssd' },
-          'sda' => { model: 'model2', serial: 'B2EI34F1AL', wwn: '29429191.0',
+          'sda' => { model: 'model2', serial_number: 'B2EI34F1AL', wwn: '29429191.0',
                      size: '115.50 KiB', size_bytes: 118_272, vendor: 'vendor2', type: 'hdd' } }
       end
 
@@ -91,8 +91,10 @@ describe Facter::Resolvers::Linux::Disks do
 
       context 'when size files are not readable' do
         let(:expected_output) do
-          { 'sr0' => { model: 'model1', vendor: 'vendor1', type: 'ssd', serial: 'AJDI2491AK', wwn: '239090190.0' },
-            'sda' => { model: 'model2', vendor: 'vendor2', type: 'hdd', serial: 'B2EI34F1AL', wwn: '29429191.0' } }
+          { 'sr0' => { model: 'model1', vendor: 'vendor1', type: 'ssd', serial_number: 'AJDI2491AK',
+                       wwn: '239090190.0' },
+            'sda' => { model: 'model2', vendor: 'vendor2', type: 'hdd', serial_number: 'B2EI34F1AL',
+                       wwn: '29429191.0' } }
         end
 
         before do
@@ -113,8 +115,8 @@ describe Facter::Resolvers::Linux::Disks do
 
       context 'when device vendor and model files are not readable' do
         let(:expected_output) do
-          { 'sr0' => { size: '6.00 KiB', size_bytes: 6144, serial: 'AJDI2491AK', wwn: '239090190.0' },
-            'sda' => { size: '115.50 KiB', size_bytes: 118_272, serial: 'B2EI34F1AL', wwn: '29429191.0' } }
+          { 'sr0' => { size: '6.00 KiB', size_bytes: 6144, serial_number: 'AJDI2491AK', wwn: '239090190.0' },
+            'sda' => { size: '115.50 KiB', size_bytes: 118_272, serial_number: 'B2EI34F1AL', wwn: '29429191.0' } }
         end
 
         before do


### PR DESCRIPTION
When support for serial numbers of disks was added in Facter in a676bbd727ed1ba40a70df27147a0f37bdf55e61, the key was named `serial_number` and documented in `lib/schema/facter.yaml`.

When a similar feature was added for Linux, the key was initially named `sn` (57dbe34e0e9682b7ae98d05abf1630c5a532eac1) then renamed to `serial` (006f4fbd1f4cb6bc32e20328e27c322c52f148c8).

Align disks serial number reporting to match the schema on Linux.