### PR TITLE
(maint) Reduce stubbing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,6 +133,9 @@ RSpec/ExampleLength:
 RSpec/DescribedClass:
   EnforcedStyle: explicit
 
+RSpec/MultipleExpectations:
+  Max: 2
+
 RSpec/NestedGroups:
   Max: 6
 


### PR DESCRIPTION
Only stub what `Facter::FactManager.instance` returns, not private methods in the Facter module that we're trying to test, such as:

    allow(Facter).to receive(:queried_facts).and_return({})

Remove stubbing of the JSON formatter and FactCollection.

Assert the return values for Facter API methods (behavior), not which private methods they call (implementation details).