### PR TITLE
(maint) Update assert_not_match to refute_match

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
           - '2.5'
           - '2.7'
           - '3.0'
-          - '3.2.0'
+          - '3.2'
           - 'jruby-9.3.7.0'
     runs-on: ubuntu-20.04
     steps:
@@ -42,7 +42,7 @@ jobs:
       matrix:
         ruby:
           - '2.7'
-          - '3.2.0'
+          - '3.2'
     runs-on: windows-2019
     steps:
       - name: Checkout current PR

--- a/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
+++ b/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
@@ -52,7 +52,7 @@ EOM
       on(agent, facter("--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" --debug #{fact1} #{fact2}"), :acceptable_exit_codes => 1) do |facter_output|
         assert_match(/ERROR.*Caching is enabled for group "#{external_filename}" while there are at least two external facts files with the same filename/, stderr, 'Expected error message')
         assert_match(/#{fact1} => #{fact1_value}/, stdout, 'Expected fact to match first fact')
-        assert_not_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact not to match second fact')
+        refute_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact not to match second fact')
       end
     end
 

--- a/acceptance/tests/options/config_file/ttls_cached_fact_in_multiple_groups.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_fact_in_multiple_groups.rb
@@ -50,7 +50,7 @@ EOM
         first_cat_output = agent.cat(first_cached_fact_file)
         assert_match(/#{cached_fact_name}/, first_cat_output.strip, "Expected cached fact file to contain fact information")
         second_cat_output = agent.cat(second_cached_fact_file)
-        assert_not_match(/#{cached_fact_name}/, second_cat_output.strip, "Expected cached fact file to not contain fact information")
+        refute_match(/#{cached_fact_name}/, second_cat_output.strip, "Expected cached fact file to not contain fact information")
       end
     end
   end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_do_not_read_the_old_cached_value.rb
@@ -50,7 +50,7 @@ EOM
         agent.modified_at(cached_fact_file, '198001010000')
 
         on(agent, facter("#{cached_factname}")) do |facter_output|
-          assert_not_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to not match the cached fact file")
+          refute_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to not match the cached fact file")
         end
       end
     end


### PR DESCRIPTION
In Beaker, the assert_not_match method was removed in commit voxpupuli/beaker@6282311 in favor of MiniTest::Assertions#refute_match. This change was released in Beaker 5.0.0.

This commit updates all instances of the assert_not_match with refute_match in preparation for a future switch to Beaker 5.