### PR TITLE
(maint) RuboCop housekeeping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
     - acceptance/**/*
     - vendor/**/*

--- a/install.rb
+++ b/install.rb
@@ -153,7 +153,7 @@ class Installer
     # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin
     # which is not generally where people expect executables to be installed
     # These settings are appropriate defaults for all OS X versions.
-    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM =~ /^universal-darwin[\d\.]+$/
+    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM.match?(/^universal-darwin[\d\.]+$/)
 
     # if InstallOptions.configdir
     #   configdir = InstallOptions.configdir
@@ -176,7 +176,7 @@ class Installer
         sitelibdir = $LOAD_PATH.find { |x| x =~ /site_ruby/ }
         if sitelibdir.nil?
           sitelibdir = File.join(libdir, 'site_ruby')
-        elsif sitelibdir !~ Regexp.quote(version)
+        elsif !sitelibdir&.match?(Regexp.quote(version))
           sitelibdir = File.join(sitelibdir, version)
         end
       end
@@ -232,7 +232,7 @@ class Installer
       File.open(tmp_file.path, 'w') do |op|
         op.puts "#!#{ruby}"
         contents = ip.readlines
-        contents.shift if contents[0] =~ /^#!/
+        contents.shift if /^#!/.match?(contents[0])
         op.write contents.join
       end
     end

--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -140,7 +140,7 @@ module Facter
 
         def builtin_command?(command)
           output, _status = Open3.capture2("type #{command}")
-          output.chomp =~ /builtin/ ? true : false
+          /builtin/.match?(output.chomp) ? true : false
         end
       end
     end

--- a/lib/facter/custom_facts/core/execution/posix.rb
+++ b/lib/facter/custom_facts/core/execution/posix.rb
@@ -44,7 +44,7 @@ module Facter
 
           return unless exe && (expanded = which(exe))
 
-          expanded = "'#{expanded}'" if expanded =~ /\s/
+          expanded = "'#{expanded}'" if /\s/.match?(expanded)
           expanded << " #{args}" if args
 
           expanded

--- a/lib/facter/custom_facts/core/execution/windows.rb
+++ b/lib/facter/custom_facts/core/execution/windows.rb
@@ -11,7 +11,7 @@ module Facter
         def which(bin)
           # `echo` is allowed for facter 3.x compatibility, otherwise
           # all commands much be found on the PATH or absolute.
-          return bin if /^echo$/i =~ bin
+          return bin if /^echo$/i.match?(bin)
 
           if absolute_path?(bin)
             return bin if File.executable?(bin)
@@ -56,7 +56,7 @@ module Facter
 
           return unless exe && (expanded = which(exe))
 
-          expanded = "\"#{expanded}\"" if expanded =~ /\s+/
+          expanded = "\"#{expanded}\"" if /\s+/.match?(expanded)
           expanded << " #{args}" if args
 
           expanded

--- a/lib/facter/custom_facts/util/normalization.rb
+++ b/lib/facter/custom_facts/util/normalization.rb
@@ -51,7 +51,7 @@ module LegacyFacter
       # @param value [String]
       # @return [void]
 
-      if RUBY_VERSION =~ /^1\.8/
+      if RUBY_VERSION.match?(/^1\.8/)
         require 'iconv'
 
         def normalize_string(value)

--- a/lib/facter/custom_facts/util/normalization.rb
+++ b/lib/facter/custom_facts/util/normalization.rb
@@ -38,11 +38,7 @@ module LegacyFacter
       #
       # Attempt to normalize and validate the given string.
       #
-      # On Ruby 1.8 the string is checked by stripping out all non UTF-8
-      # characters and comparing the converted string to the original. If they
-      # do not match then the string is considered invalid.
-      #
-      # On Ruby 1.9+, the string is validate by checking that the string encoding
+      # The string is validated by checking that the string encoding
       # is UTF-8 and that the string content matches the encoding. If the string
       # is not an expected encoding then it is converted to UTF-8.
       #
@@ -51,27 +47,16 @@ module LegacyFacter
       # @param value [String]
       # @return [void]
 
-      if RUBY_VERSION.match?(/^1\.8/)
-        require 'iconv'
+      def normalize_string(value)
+        value = value.encode(Encoding::UTF_8)
 
-        def normalize_string(value)
-          converted = Iconv.conv('UTF-8//IGNORE', 'UTF-8', value)
-          raise NormalizationError, "String #{value.inspect} is not valid UTF-8" if converted != value
-
-          value
+        unless value.valid_encoding?
+          raise NormalizationError, "String #{value.inspect} doesn't match the reported encoding #{value.encoding}"
         end
-      else
-        def normalize_string(value)
-          value = value.encode(Encoding::UTF_8)
 
-          unless value.valid_encoding?
-            raise NormalizationError, "String #{value.inspect} doesn't match the reported encoding #{value.encoding}"
-          end
-
-          value
-        rescue EncodingError
-          raise NormalizationError, "String encoding #{value.encoding} is not UTF-8 and could not be converted to UTF-8"
-        end
+        value
+      rescue EncodingError
+        raise NormalizationError, "String encoding #{value.encoding} is not UTF-8 and could not be converted to UTF-8"
       end
 
       # Validate all elements of the array.

--- a/lib/facter/facts/debian/architecture.rb
+++ b/lib/facter/facts/debian/architecture.rb
@@ -10,7 +10,7 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
           fact_value = 'amd64' if fact_value == 'x86_64'
-          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
+          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/facts/linux/hypervisors/kvm.rb
+++ b/lib/facter/facts/linux/hypervisors/kvm.rb
@@ -52,9 +52,9 @@ module Facts
 
           return { google: true } if manufacturer == 'Google'
 
-          return { openstack: true } if manufacturer =~ /^OpenStack/
+          return { openstack: true } if /^OpenStack/.match?(manufacturer)
 
-          return { amazon: true } if manufacturer =~ /^Amazon/
+          return { amazon: true } if /^Amazon/.match?(manufacturer)
 
           {}
         end

--- a/lib/facter/facts/linux/os/architecture.rb
+++ b/lib/facter/facts/linux/os/architecture.rb
@@ -10,7 +10,7 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
 
-          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
+          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/facts/windows/hypervisors/kvm.rb
+++ b/lib/facter/facts/windows/hypervisors/kvm.rb
@@ -27,9 +27,9 @@ module Facts
 
           return { google: true } if manufacturer == 'Google'
 
-          return { openstack: true } if Facter::Resolvers::DMIComputerSystem.resolve(:name) =~ /^OpenStack/
+          return { openstack: true } if /^OpenStack/.match?(Facter::Resolvers::DMIComputerSystem.resolve(:name))
 
-          return { amazon: true } if manufacturer =~ /^Amazon/
+          return { amazon: true } if /^Amazon/.match?(manufacturer)
         end
       end
     end

--- a/lib/facter/framework/config/fact_groups.rb
+++ b/lib/facter/framework/config/fact_groups.rb
@@ -64,7 +64,7 @@ module Facter
     def get_fact(fact_name)
       return @facts_ttls[fact_name] if @facts_ttls[fact_name]
 
-      result = @facts_ttls.select { |name, fact| break fact if fact_name =~ /^#{name}\..*/ }
+      result = @facts_ttls.select { |name, fact| break fact if /^#{name}\..*/.match?(fact_name) }
       return nil if result == {}
 
       result

--- a/lib/facter/framework/core/fact_loaders/fact_loader.rb
+++ b/lib/facter/framework/core/fact_loaders/fact_loader.rb
@@ -103,7 +103,7 @@ module Facter
 
       blocked_facts.each do |blocked|
         facts.each do |fact|
-          next unless fact.name =~ /^#{blocked}\..*|^#{blocked}$/
+          next unless /^#{blocked}\..*|^#{blocked}$/.match?(fact.name)
 
           if fact.type == :core
             reject_list_core << fact

--- a/lib/facter/framework/formatters/legacy_fact_formatter.rb
+++ b/lib/facter/framework/formatters/legacy_fact_formatter.rb
@@ -95,7 +95,7 @@ module Facter
       # quotation marks that come after \ are not removed
       @log.debug('Remove unnecessary comma and quotation marks on root facts')
       output.split("\n")
-            .map! { |line| line =~ /^[\s]+/ ? line : line.gsub(/,$|(?<!\\)\"/, '').gsub('\\"', '"') }.join("\n")
+            .map! { |line| /^[\s]+/.match?(line) ? line : line.gsub(/,$|(?<!\\)\"/, '').gsub('\\"', '"') }.join("\n")
     end
   end
 end

--- a/lib/facter/framework/formatters/yaml_fact_formatter.rb
+++ b/lib/facter/framework/formatters/yaml_fact_formatter.rb
@@ -52,9 +52,9 @@ module Facter
     end
 
     def needs_quote?(value)
-      return false if value =~ /true|false/
+      return false if /true|false/.match?(value)
       return false if value[/^[0-9]+$/]
-      return true if value =~ /y|Y|yes|Yes|YES|n|N|no|No|NO|True|TRUE|False|FALSE|on|On|ON|off|Off|OFF|:/
+      return true if /y|Y|yes|Yes|YES|n|N|no|No|NO|True|TRUE|False|FALSE|on|On|ON|off|Off|OFF|:/.match?(value)
       return false if value[/[a-zA-Z]/]
       return false if value[/[0-9]+\.[0-9]+/]
 

--- a/lib/facter/patches/sysfilesystem/sys/statvfs.rb
+++ b/lib/facter/patches/sysfilesystem/sys/statvfs.rb
@@ -10,7 +10,7 @@ module Sys
         # it the second time will make FFI log a warning message.
         remove_instance_variable(:@layout) if @layout
 
-        if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
+        if /darwin|osx|mach/i.match?(RbConfig::CONFIG['host_os'])
           layout(
             :f_bsize, :ulong,
             :f_frsize, :ulong,
@@ -24,7 +24,7 @@ module Sys
             :f_flag, :ulong,
             :f_namemax, :ulong
           )
-        elsif RbConfig::CONFIG['host'] =~ /bsd/i
+        elsif /bsd/i.match?(RbConfig::CONFIG['host'])
           layout(
             :f_bavail, :uint64,
             :f_bfree, :uint64,
@@ -38,7 +38,7 @@ module Sys
             :f_fsid, :ulong,
             :f_namemax, :ulong
           )
-        elsif RbConfig::CONFIG['host'] =~ /sunos|solaris/i
+        elsif /sunos|solaris/i.match?(RbConfig::CONFIG['host'])
           layout(
             :f_bsize, :ulong,
             :f_frsize, :ulong,
@@ -55,7 +55,7 @@ module Sys
             :f_fstr, [:char, 32],
             :f_filler, [:ulong, 16]
           )
-        elsif RbConfig::CONFIG['host'] =~ /i686/i
+        elsif /i686/i.match?(RbConfig::CONFIG['host'])
           layout(
             :f_bsize, :ulong,
             :f_frsize, :ulong,

--- a/lib/facter/resolvers/aix/filesystem.rb
+++ b/lib/facter/resolvers/aix/filesystem.rb
@@ -18,7 +18,7 @@ module Facter
             return if file_content.empty?
 
             file_content = file_content.map do |line|
-              next if line =~ /#|%/ # skip lines that are comments or defaultvfs line
+              next if /#|%/.match?(line) # skip lines that are comments or defaultvfs line
 
               line.split(' ').first
             end

--- a/lib/facter/resolvers/aix/memory.rb
+++ b/lib/facter/resolvers/aix/memory.rb
@@ -25,7 +25,7 @@ module Facter
 
             result.each_line do |line|
               @fact_list[:system] = populate_system(line, pagesize) if line.include?('memory')
-              @fact_list[:swap] = populate_swap(line, pagesize) if line =~ /pg\sspace/
+              @fact_list[:swap] = populate_swap(line, pagesize) if /pg\sspace/.match?(line)
             end
 
             @fact_list[fact_name]

--- a/lib/facter/resolvers/aix/mountpoints.rb
+++ b/lib/facter/resolvers/aix/mountpoints.rb
@@ -19,7 +19,7 @@ module Facter
             @fact_list[:mountpoints] = {}
             output = Facter::Core::Execution.execute('mount', logger: log)
             output.split("\n").drop(2).map do |line|
-              next if line =~ /procfs|ahafs/
+              next if /procfs|ahafs/.match?(line)
 
               add_mount_points_fact(line)
             end
@@ -40,7 +40,7 @@ module Facter
           def retrieve_sizes_for_mounts
             output = Facter::Core::Execution.execute('df -P', logger: log)
             output.split("\n").drop(1).map do |line|
-              next if line =~ /-\s+-\s+-/
+              next if /-\s+-\s+-/.match?(line)
 
               mount_info = line.split("\s")
               mount_info[3] = translate_to_bytes(mount_info[3])

--- a/lib/facter/resolvers/aix/networking.rb
+++ b/lib/facter/resolvers/aix/networking.rb
@@ -43,7 +43,7 @@ module Facter
           def populate_with_mtu_and_mac!(interfaces)
             output = Facter::Core::Execution.execute('netstat -in', logger: log)
             output.each_line do |line|
-              next if line =~ /Name\s/
+              next if /Name\s/.match?(line)
 
               info = line.split("\s")
               interface_name = info[0]

--- a/lib/facter/resolvers/aix/partitions.rb
+++ b/lib/facter/resolvers/aix/partitions.rb
@@ -50,8 +50,8 @@ module Facter
             }
             mount = info_hash['MOUNT POINT']
             label = info_hash['LABEL']
-            part_info[:mount] = mount unless %r{N/A} =~ mount
-            part_info[:label] = label.strip unless /None/ =~ label
+            part_info[:mount] = mount unless %r{N/A}.match?(mount)
+            part_info[:label] = label.strip unless /None/.match?(label)
             part_info
           end
 

--- a/lib/facter/resolvers/lspci.rb
+++ b/lib/facter/resolvers/lspci.rb
@@ -26,7 +26,7 @@ module Facter
         end
 
         def retrieve_vm(output)
-          output.each_line { |line| REGEX_VALUES.each { |key, value| return value if line =~ /#{key}/ } }
+          output.each_line { |line| REGEX_VALUES.each { |key, value| return value if /#{key}/.match?(line) } }
 
           nil
         end

--- a/lib/facter/resolvers/networking.rb
+++ b/lib/facter/resolvers/networking.rb
@@ -71,7 +71,7 @@ module Facter
         end
 
         def extract_dhcp(interface_name, raw_data, parsed_interface_data)
-          return unless raw_data =~ /status:\s+active/
+          return unless /status:\s+active/.match?(raw_data)
 
           result = Facter::Core::Execution.execute("ipconfig getoption #{interface_name} " \
                                                      'server_identifier', logger: log)

--- a/lib/facter/resolvers/open_vz.rb
+++ b/lib/facter/resolvers/open_vz.rb
@@ -29,7 +29,7 @@ module Facter
             parts = line.split("\s")
             next unless parts.size.equal?(2)
 
-            next unless /^envID:/ =~ parts[0]
+            next unless /^envID:/.match?(parts[0])
 
             @fact_list[:id] = parts[1]
 

--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -63,13 +63,13 @@ module Facter
         def process_version_id
           return unless @fact_list[:version_id]
 
-          @fact_list[:version_id] = "#{@fact_list[:version_id]}.0" unless @fact_list[:version_id] =~ /\./
+          @fact_list[:version_id] = "#{@fact_list[:version_id]}.0" unless /\./.match?(@fact_list[:version_id])
         end
 
         def process_id
           return unless @fact_list[:id]
 
-          @fact_list[:id] = 'opensuse' if @fact_list[:id] =~ /opensuse/i
+          @fact_list[:id] = 'opensuse' if /opensuse/i.match?(@fact_list[:id])
         end
 
         def process_name

--- a/lib/facter/resolvers/selinux.rb
+++ b/lib/facter/resolvers/selinux.rb
@@ -26,7 +26,7 @@ module Facter
           mountpoint = ''
 
           output.each_line do |line|
-            next unless line =~ /selinuxfs/
+            next unless /selinuxfs/.match?(line)
 
             mountpoint = line.split("\s")[1]
             break
@@ -54,8 +54,8 @@ module Facter
           file_lines = Facter::Util::FileHelper.safe_readlines('/etc/selinux/config')
 
           file_lines.map do |line|
-            @fact_list[:config_mode] = line.split('=').last.strip if line =~ /^SELINUX=/
-            @fact_list[:config_policy] = line.split('=').last.strip if line =~ /^SELINUXTYPE=/
+            @fact_list[:config_mode] = line.split('=').last.strip if /^SELINUX=/.match?(line)
+            @fact_list[:config_policy] = line.split('=').last.strip if /^SELINUXTYPE=/.match?(line)
           end
 
           !file_lines.empty? ? true : false

--- a/lib/facter/resolvers/solaris/filesystems.rb
+++ b/lib/facter/resolvers/solaris/filesystems.rb
@@ -18,7 +18,7 @@ module Facter
 
             file_content = Facter::Core::Execution.execute('/usr/sbin/sysdef', logger: log)
             files = file_content.split("\n").map do |line|
-              line.split('/').last if line =~ /^fs\.*/
+              line.split('/').last if /^fs\.*/.match?(line)
             end
 
             @fact_list[:file_systems] = files.compact.sort.join(',')

--- a/lib/facter/resolvers/virt_what.rb
+++ b/lib/facter/resolvers/virt_what.rb
@@ -28,9 +28,9 @@ module Facter
           return unless xen_info
 
           xen_info = xen_info.to_s
-          return 'xenu' if xen_info =~ /xen-domu/
-          return 'xenhvm' if xen_info =~ /xen-hvm/
-          return 'xen0' if xen_info =~ /xen-dom0/
+          return 'xenu' if /xen-domu/.match?(xen_info)
+          return 'xenhvm' if /xen-hvm/.match?(xen_info)
+          return 'xen0' if /xen-dom0/.match?(xen_info)
         end
 
         def determine_other(output)
@@ -38,8 +38,8 @@ module Facter
           other_vm = values.first
           return unless other_vm
 
-          return 'zlinux' if other_vm =~ /ibm_systemz/
-          return retrieve_vserver if other_vm =~ /linux_vserver/
+          return 'zlinux' if /ibm_systemz/.match?(other_vm)
+          return retrieve_vserver if /linux_vserver/.match?(other_vm)
           return (values - ['redhat']).first if values.include?('redhat')
 
           other_vm
@@ -53,7 +53,7 @@ module Facter
             parts = line.split("\s")
             next unless parts.size.equal?(2)
 
-            next unless parts[0] =~ /^s_context:|^VxID:/
+            next unless /^s_context:|^VxID:/.match?(parts[0])
             return @fact_list[:vserver] = 'vserver_host' if parts[1] == '0'
 
             return @fact_list[:vserver] = 'vserver'

--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -42,9 +42,9 @@ module Facter
             manufacturer = comp.Manufacturer
             if comp.Model =~ /^Virtual Machine/ && manufacturer =~ /^Microsoft/
               'hyperv'
-            elsif manufacturer =~ /^Xen/
+            elsif /^Xen/.match?(manufacturer)
               'xen'
-            elsif manufacturer =~ /^Amazon EC2/
+            elsif /^Amazon EC2/.match?(manufacturer)
               'kvm'
             else
               'physical'

--- a/lib/facter/resolvers/xen.rb
+++ b/lib/facter/resolvers/xen.rb
@@ -45,7 +45,7 @@ module Facter
           return if output.empty?
 
           output.each_line do |line|
-            next if line =~ /Domain-0|Name/
+            next if /Domain-0|Name/.match?(line)
 
             domain = line.match(/^([^\s]*)\s/)
             domain = domain&.captures&.first

--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -13,7 +13,7 @@ module Facter
             description = input[:description]
             kernel_version = input[:kernel_version]
 
-            if version =~ /10.0/
+            if /10.0/.match?(version)
               check_version_10_11(consumerrel, kernel_version)
             else
               check_version_6(version, consumerrel) || check_version_5(version, consumerrel, description) || version
@@ -47,7 +47,7 @@ module Facter
           end
 
           def check_version_5(version, consumerrel, description)
-            return unless version =~ /5.2/
+            return unless /5.2/.match?(version)
             return 'XP' if consumerrel
 
             description == 'R2' ? '2003 R2' : '2003'

--- a/lib/facter/util/linux/dhcp.rb
+++ b/lib/facter/util/linux/dhcp.rb
@@ -45,7 +45,7 @@ module Facter
 
               lease_files.select do |file|
                 content = Facter::Util::FileHelper.safe_read("#{dir}#{file}", nil)
-                next unless content =~ /interface.*#{interface_name}/
+                next unless /interface.*#{interface_name}/.match?(content)
 
                 dhcp = content.match(/dhcp-server-identifier ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/)
                 return dhcp[1] if dhcp

--- a/lib/facter/util/utils.rb
+++ b/lib/facter/util/utils.rb
@@ -14,7 +14,7 @@ module Facter
 
     def self.split_user_query(user_query)
       queries = user_query.split('.')
-      queries.map! { |query| query =~ /^[0-9]+$/ ? query.to_i : query }
+      queries.map! { |query| /^[0-9]+$/.match?(query) ? query.to_i : query }
     end
 
     def self.deep_stringify_keys(object)


### PR DESCRIPTION
This PR:

- Updates the target Ruby version in .rubocop.yml from 2.3 to 2.5.
- Updates several files from using `~=` for regex comparison to the generally more performant `match?` method (RuboCop did not previously flag this because that `match?` method was introduced in Ruby 2.4).
- Removes a Ruby 1.8-specific method that I noticed from the update to `match?`, as Ruby 1.8 was end-of-life almost nine years ago. 