### PR TITLE
(maint) Revert RuboCop changes for install.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,6 +127,10 @@ Naming/FileName:
     - 'lib/facter.rb'
     - 'agent/lib/facter-ng.rb'
 
+Performance/RegexpMatch:
+  Exclude:
+    - 'install.rb'
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/install.rb
+++ b/install.rb
@@ -153,7 +153,7 @@ class Installer
     # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin
     # which is not generally where people expect executables to be installed
     # These settings are appropriate defaults for all OS X versions.
-    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM.match?(/^universal-darwin[\d\.]+$/)
+    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM =~ /^universal-darwin[\d\.]+$/
 
     # if InstallOptions.configdir
     #   configdir = InstallOptions.configdir
@@ -176,7 +176,7 @@ class Installer
         sitelibdir = $LOAD_PATH.find { |x| x =~ /site_ruby/ }
         if sitelibdir.nil?
           sitelibdir = File.join(libdir, 'site_ruby')
-        elsif !sitelibdir&.match?(Regexp.quote(version))
+        elsif sitelibdir !~ Regexp.quote(version)
           sitelibdir = File.join(sitelibdir, version)
         end
       end
@@ -232,7 +232,7 @@ class Installer
       File.open(tmp_file.path, 'w') do |op|
         op.puts "#!#{ruby}"
         contents = ip.readlines
-        contents.shift if /^#!/.match?(contents[0])
+        contents.shift if contents[0] =~ /^#!/
         op.write contents.join
       end
     end


### PR DESCRIPTION
Because we use an old version of Ruby (2.1.9) via the pl-ruby package on older and esoteric platforms (such as RHEL 7 AARCH64 and Solaris) to build puppet-agent, newer Ruby language features such as the safe navigation operator (&.) do not work during installation.

This commit reverts RuboCop-related changes to install.rb introduced in 0330d22 that use newer Ruby language features.