### PR TITLE
(PA-4994) Check for valid encoding from spawned process

### DIFF
--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -106,6 +106,7 @@ module Facter
             raise Facter::Core::Execution::ExecutionFailure.new, message
           end
 
+          out.force_encoding(Encoding.default_external) unless out.valid_encoding?
           [out.strip, stderr]
         end
 


### PR DESCRIPTION
When facter spawns a new process, it is possible that the encoding for the output will come back as a non-UTF8 string; for instance, when the locale is set to CP932 for Japanese. This can occur when the shell injects a string into the output, such as for a command- not-found type of error. In these cases, we should fall back to the external default encoding, otherwise ruby will error on string manipulations of strings that re not UTF-8.