### PR TITLE
(FACT-3151) Ensure /etc/os-release can contain comments without raising

### DIFF
--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -49,7 +49,7 @@ module Facter
 
           pairs = []
           content.each do |line|
-            pairs << line.strip.delete('"').split('=', 2)
+            pairs << line.strip.delete('"').split('=', 2) unless line.start_with?('#')
           end
 
           pairs

--- a/spec/facter/resolvers/os_release_spec.rb
+++ b/spec/facter/resolvers/os_release_spec.rb
@@ -56,6 +56,14 @@ describe Facter::Resolvers::OsRelease do
     end
   end
 
+  context 'when /etc/os-release file has comment' do
+    let(:os_release_content) { load_fixture('os_release_redhat_linux_with_comment').readlines }
+
+    it 'does not raise an exception' do
+      expect { Facter::Resolvers::OsRelease.resolve(:name) }.not_to raise_error
+    end
+  end
+
   context 'when on Debian' do
     let(:os_release_content) { load_fixture('os_release_debian').readlines }
 

--- a/spec/fixtures/os_release_redhat_linux_with_comment
+++ b/spec/fixtures/os_release_redhat_linux_with_comment
@@ -1,0 +1,19 @@
+# This is a comment
+NAME="Red Hat Enterprise Linux"
+VERSION="8.6 (Ootpa)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="8.6"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Red Hat Enterprise Linux 8.6 (Ootpa)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:8::baseos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/8/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+# Whoa, this is another comment!
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
+REDHAT_BUGZILLA_PRODUCT_VERSION=8.6
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="8.6"


### PR DESCRIPTION
Comments are allowed in the /etc/os-release files (see this link for more
information: https://www.man7.org/linux/man-pages/man5/os-release.5.html). This
commit enables comments in /etc/os-releases files without raising an exception
and adds a spec test to ensure Facter is behaving as expected.

Fabiano Pires (fxpires) wrote the commit (#2527) that allows comments in
/etc/os-release files without raising an exception. Previously, Facter would
raise an exception if there was a comment in the /etc/os-release files.