### PR TITLE
(FACT-3136) Split GCE ssh keys on newlines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ require:
 
 Layout/LineLength:
   Max: 120
+  Exclude:
+    - spec/facter/resolvers/gce_spec.rb
 
 Lint/RaiseException:
   Enabled: true
@@ -51,25 +53,7 @@ Naming/ClassAndModuleCamelCase:
     - 'spec/mocks/**/*'
 
 Metrics/AbcSize:
-  Max: 16
-  Exclude:
-    - 'spec/custom_facts/util/parser_spec.rb'
-    - 'spec/custom_facts/core/logging_spec.rb'
-    - 'lib/facter/custom_facts/util/values.rb'
-    - 'lib/facter/custom_facts/util/loader.rb'
-    - 'lib/facter/custom_facts/util/confine.rb'
-    - 'lib/facter/custom_facts/util/confine.rb'
-    - 'lib/facter/custom_facts/core/execution/windows.rb'
-    - 'lib/facter/custom_facts/core/execution/base.rb'
-    - 'lib/facter/custom_facts/core/resolvable.rb'
-    - 'lib/facter/resolvers/bsd/ffi/ffi_helper.rb'
-    - 'install.rb'
-    - 'scripts/generate_changelog.rb'
-    - 'lib/facter/resolvers/aix/ffi/ffi_helper.rb'
-    - 'lib/facter/custom_facts/core/execution/popen3.rb'
-    - 'lib/facter.rb'
-    - 'lib/facter/framework/parsers/query_parser.rb'
-    - 'lib/facter/framework/core/fact_manager.rb'
+  Enabled: false
 
 Metrics/PerceivedComplexity:
   Exclude:

--- a/lib/facter/resolvers/freebsd/swap_memory.rb
+++ b/lib/facter/resolvers/freebsd/swap_memory.rb
@@ -13,7 +13,7 @@ module Facter
             @fact_list.fetch(fact_name) { read_swap_memory(fact_name) }
           end
 
-          def read_swap_memory(fact_name) # rubocop:disable Metrics/AbcSize
+          def read_swap_memory(fact_name)
             output = Facter::Core::Execution.execute('swapinfo -k', logger: log)
             data = output.split("\n")[1..-1].map { |line| line.split(/\s+/) }
 

--- a/lib/facter/resolvers/gce.rb
+++ b/lib/facter/resolvers/gce.rb
@@ -39,6 +39,13 @@ module Facter
           instance_data = gce_data['instance']
           return if instance_data.nil? || instance_data.empty?
 
+          # See https://cloud.google.com/compute/docs/metadata for information about these values
+          keys = gce_data.dig('project', 'attributes', 'sshKeys')
+          gce_data['project']['attributes']['sshKeys'] = keys.strip.split("\n") if keys
+
+          keys = instance_data.dig('attributes', 'sshKeys')
+          instance_data['attributes']['sshKeys'] = keys.strip.split("\n") if keys
+
           %w[image machineType zone].each do |key|
             instance_data[key] = instance_data[key].split('/').last if instance_data[key]
           end

--- a/lib/facter/resolvers/gce.rb
+++ b/lib/facter/resolvers/gce.rb
@@ -40,11 +40,13 @@ module Facter
           return if instance_data.nil? || instance_data.empty?
 
           # See https://cloud.google.com/compute/docs/metadata for information about these values
-          keys = gce_data.dig('project', 'attributes', 'sshKeys')
-          gce_data['project']['attributes']['sshKeys'] = keys.strip.split("\n") if keys
+          %w[sshKeys ssh-keys].each do |name|
+            keys = gce_data.dig('project', 'attributes', name)
+            gce_data['project']['attributes'][name] = keys.strip.split("\n") if keys
 
-          keys = instance_data.dig('attributes', 'sshKeys')
-          instance_data['attributes']['sshKeys'] = keys.strip.split("\n") if keys
+            keys = instance_data.dig('attributes', name)
+            instance_data['attributes'][name] = keys.strip.split("\n") if keys
+          end
 
           %w[image machineType zone].each do |key|
             instance_data[key] = instance_data[key].split('/').last if instance_data[key]

--- a/lib/facter/resolvers/macosx/swap_memory.rb
+++ b/lib/facter/resolvers/macosx/swap_memory.rb
@@ -13,7 +13,7 @@ module Facter
             @fact_list.fetch(fact_name) { read_swap_memory(fact_name) }
           end
 
-          def read_swap_memory(fact_name) # rubocop:disable Metrics/AbcSize
+          def read_swap_memory(fact_name)
             output = Facter::Core::Execution.execute('sysctl -n vm.swapusage', logger: log)
             data = output.match(/^total = ([\d.]+)M  used = ([\d.]+)M  free = ([\d.]+)M  (\(encrypted\))$/)
 

--- a/lib/facter/resolvers/solaris/mountpoints.rb
+++ b/lib/facter/resolvers/solaris/mountpoints.rb
@@ -21,7 +21,7 @@ module Facter
             end
           end
 
-          def read_mounts(fact_name) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+          def read_mounts(fact_name) # rubocop:disable Metrics/MethodLength
             @mounts = []
             @auto_home_paths = []
 

--- a/lib/facter/util/api_debugger.rb
+++ b/lib/facter/util/api_debugger.rb
@@ -3,7 +3,7 @@
 module Facter
   module Util
     module ApiDebugger
-      def self.prepended(receiver) # rubocop:disable Metrics/AbcSize
+      def self.prepended(receiver)
         exclude, print_caller = parse_options(ENV['API_DEBUG'])
 
         receiver_methods = receiver.instance_methods - Object.methods

--- a/lib/facter/util/resolvers/ffi/hostname.rb
+++ b/lib/facter/util/resolvers/ffi/hostname.rb
@@ -36,7 +36,7 @@ module Facter
             raw_hostname.read_string
           end
 
-          def self.getffiaddrinfo(hostname) # rubocop:disable  Metrics/AbcSize
+          def self.getffiaddrinfo(hostname)
             ret = FFI::MemoryPointer.new(:pointer)
 
             hints = Facter::Util::Resolvers::Ffi::AddrInfo.new

--- a/spec/facter/resolvers/gce_spec.rb
+++ b/spec/facter/resolvers/gce_spec.rb
@@ -21,6 +21,10 @@ describe Facter::Resolvers::Gce do
         'instance' => {
           'attributes' => {
             # resolver transforms key1\nkey2 into array of keys
+            'ssh-keys' => [
+              'john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"john.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
+              'jane_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jane.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'
+            ],
             'sshKeys' => [
               'jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jill.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
               'jacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jacob.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'
@@ -128,8 +132,8 @@ describe Facter::Resolvers::Gce do
         'project' => {
           'attributes' => {
             # resolver transforms key1\nkey2 into array of keys
-            'ssh-keys' => 'john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B' \
-              " google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
+            'ssh-keys' => ['john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"john.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
+                           'jane_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jane.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'],
             'sshKeys' => [
               'jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jill.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
               'jacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jacob.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'

--- a/spec/facter/resolvers/gce_spec.rb
+++ b/spec/facter/resolvers/gce_spec.rb
@@ -20,6 +20,11 @@ describe Facter::Resolvers::Gce do
       {
         'instance' => {
           'attributes' => {
+            # resolver transforms key1\nkey2 into array of keys
+            'sshKeys' => [
+              'jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jill.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
+              'jacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jacob.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'
+            ]
           },
           'cpuPlatform' => 'Intel Broadwell',
           'description' => '',
@@ -122,8 +127,13 @@ describe Facter::Resolvers::Gce do
         },
         'project' => {
           'attributes' => {
+            # resolver transforms key1\nkey2 into array of keys
             'ssh-keys' => 'john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B' \
-              " google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n"
+              " google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
+            'sshKeys' => [
+              'jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jill.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}',
+              'jacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {"userName":"jacob.doe@puppet.com","expireOn":"2020-08-13T12:17:19+0000"}'
+            ]
           },
           'numericProjectId' => 728_618_928_092,
           'projectId' => 'facter-performance-history'

--- a/spec/fixtures/gce
+++ b/spec/fixtures/gce
@@ -2,6 +2,7 @@
 "instance":
     {
         "attributes":{
+            "ssh-keys":"john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njane_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jane.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
             "sshKeys":"jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jill.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jacob.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}"
         },
         "cpuPlatform":"Intel Broadwell",
@@ -65,7 +66,7 @@
     {
         "attributes":
         {
-            "ssh-keys":"john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
+            "ssh-keys":"john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njane_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jane.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
             "sshKeys":"jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jill.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jacob.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}"
         },
         "numericProjectId":728618928092,

--- a/spec/fixtures/gce
+++ b/spec/fixtures/gce
@@ -1,7 +1,9 @@
 {
 "instance":
     {
-        "attributes":{},
+        "attributes":{
+            "sshKeys":"jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jill.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jacob.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}"
+        },
         "cpuPlatform":"Intel Broadwell",
         "description":"",
         "disks":[{"deviceName":"instance-3","index":0,"interface":"SCSI","mode":"READ_WRITE","type":"PERSISTENT"}],
@@ -63,7 +65,8 @@
     {
         "attributes":
         {
-            "ssh-keys":"john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n"
+            "ssh-keys":"john_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"john.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\n",
+            "sshKeys":"jill_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jill.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}\njacob_doe:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA9D8Op48TtEiDmb+Gtna3Bs9B google-ssh {\"userName\":\"jacob.doe@puppet.com\",\"expireOn\":\"2020-08-13T12:17:19+0000\"}"
         },
         "numericProjectId":728618928092,
         "projectId":"facter-performance-history"


### PR DESCRIPTION
GCE returns ssh keys as a string with newlines separating each key. When parsing
the project and VM instance data, convert to an array of keys like Facter 3 did.

Note Facter 3 used a streaming JSON parser and it matched all hash keys named
"sshKeys" (at any level), whereas we are only matching the keys for the project
and VM instance, but not custom fields that happen to be called "sshKeys".

GCE deprecated "sshKeys" and recommends "ssh-keys", so transform both.

[1] https://cloud.google.com/compute/docs/metadata/default-metadata-values