### PR TITLE
(FACT-3192) facter -p --no-external-facts should not raise

### DIFF
--- a/lib/facter/framework/core/options/options_validator.rb
+++ b/lib/facter/framework/core/options/options_validator.rb
@@ -55,8 +55,15 @@ module Facter
       no_custom_facts = !options[:custom_facts]
       puppet = options[:puppet]
       custom_dir = options[:custom_dir].nil? ? false : options[:custom_dir].any?
-      external_dir = options[:external_dir].nil? ? false : options[:external_dir].any?
-
+      default_external_dir = Facter::OptionStore.default_external_dir
+      # --puppet/-p option adds an external directory and is not an explicitly
+      # set external_dir from cli or config file
+      default_external_dir += [Puppet[:pluginfactdest]] if puppet && const_defined?('Puppet')
+      external_dir = if options[:external_dir].nil? || options[:external_dir].none?
+                       false
+                     else
+                       options[:external_dir] != default_external_dir
+                     end
       [
         { 'no-ruby' => no_ruby, 'custom-dir' => custom_dir },
         { 'no-external-facts' => !options[:external_facts], 'external-dir' => external_dir },

--- a/spec/fixtures/invalid_option_pairs.conf
+++ b/spec/fixtures/invalid_option_pairs.conf
@@ -1,0 +1,4 @@
+global : {
+    external-dir : ""
+    no-external-facts : true,
+}


### PR DESCRIPTION
Facter will raise an error saying `no-external-facts and external-dir options conflict: please specify only one` if the -p/--puppet and --no-external-facts options are used together. The -p option adds another directory to external-dir which causes Facter to think the --external-dir option was also passed in. This commit ensures -p and --no-external-facts can be used together without raising and --external-dir is either set to false or any explicitely passed in external directories and adds a spec test to test this behavior.