### PR TITLE
(FACT-3201) Report ProductVersionExtra on macOS 13 and later

### DIFF
--- a/lib/facter/facts/macosx/os/macosx/version.rb
+++ b/lib/facter/facts/macosx/os/macosx/version.rb
@@ -10,23 +10,27 @@ module Facts
                        macosx_productversion_patch].freeze
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::SwVers.resolve(:productversion)
-            ver = version_hash(fact_value)
+            version_value = Facter::Resolvers::SwVers.resolve(:productversion)
+            extra_value = Facter::Resolvers::SwVers.resolve(:productversionextra)
+            ver = version_hash(version_value, extra_value)
 
             [Facter::ResolvedFact.new(FACT_NAME, ver),
-             Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
+             Facter::ResolvedFact.new(ALIASES[0], version_value, :legacy),
              Facter::ResolvedFact.new(ALIASES[1], ver['major'], :legacy),
              Facter::ResolvedFact.new(ALIASES[2], ver['minor'], :legacy),
              Facter::ResolvedFact.new(ALIASES[3], ver['patch'], :legacy)]
           end
 
-          def version_hash(fact_value)
-            versions = fact_value.split('.')
+          def version_hash(version_value, extra_value)
+            versions = version_value.split('.')
             if versions[0] == '10'
-              { 'full' => fact_value, 'major' => "#{versions[0]}.#{versions[1]}", 'minor' => versions[-1] }
-            else
-              { 'full' => fact_value, 'major' => versions[0], 'minor' => versions.fetch(1, '0'),
+              { 'full' => version_value, 'major' => "#{versions[0]}.#{versions[1]}", 'minor' => versions[-1] }
+            elsif /11|12/.match?(versions[0]) || extra_value.nil?
+              { 'full' => version_value, 'major' => versions[0], 'minor' => versions.fetch(1, '0'),
                 'patch' => versions.fetch(2, '0') }
+            else
+              { 'full' => version_value, 'major' => versions[0], 'minor' => versions.fetch(1, '0'),
+                'patch' => versions.fetch(2, '0'), 'extra' => extra_value }
             end
           end
         end

--- a/lib/facter/resolvers/sw_vers.rb
+++ b/lib/facter/resolvers/sw_vers.rb
@@ -5,6 +5,7 @@ module Facter
     class SwVers < BaseResolver
       # :productname
       # :productversion
+      # :productversionextra
       # :buildversion
 
       init_resolver

--- a/spec/facter/facts/macosx/os/macosx/version_spec.rb
+++ b/spec/facter/facts/macosx/os/macosx/version_spec.rb
@@ -6,11 +6,14 @@ describe Facts::Macosx::Os::Macosx::Version do
 
     context 'when macOS version < 11' do
       let(:resolver_output) { '10.9.8' }
+      let(:resolver_extra_output) { nil }
       let(:version) { { 'full' => '10.9.8', 'major' => '10.9', 'minor' => '8' } }
 
       before do
         allow(Facter::Resolvers::SwVers).to \
           receive(:resolve).with(:productversion).and_return(resolver_output)
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversionextra).and_return(resolver_extra_output)
       end
 
       it 'calls Facter::Resolvers::SwVers' do
@@ -30,33 +33,100 @@ describe Facts::Macosx::Os::Macosx::Version do
                           an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
                                                       type: :legacy))
       end
+    end
 
-      context 'when macOS version >= 11' do
-        let(:resolver_output) { '11.2.1' }
-        let(:version) { { 'full' => '11.2.1', 'major' => '11', 'minor' => '2', 'patch' => '1' } }
+    context 'when macOS version >= 11 and < 13' do
+      let(:resolver_output) { '11.2.1' }
+      let(:resolver_extra_output) { nil }
+      let(:version) { { 'full' => '11.2.1', 'major' => '11', 'minor' => '2', 'patch' => '1' } }
 
-        before do
-          allow(Facter::Resolvers::SwVers).to \
-            receive(:resolve).with(:productversion).and_return(resolver_output)
-        end
+      before do
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversion).and_return(resolver_output)
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversionextra).and_return(resolver_extra_output)
+      end
 
-        it 'calls Facter::Resolvers::SwVers' do
-          fact.call_the_resolver
-          expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
-        end
+      it 'calls Facter::Resolvers::SwVers' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
+      end
 
-        it 'returns a resolved fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
-                            an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
-                                                        type: :legacy),
-                            an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
-                                                        type: :legacy),
-                            an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
-                                                        type: :legacy),
-                            an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
-                                                        type: :legacy))
-        end
+      it 'returns a resolved fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
+                          an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
+                                                      type: :legacy))
+      end
+    end
+
+    context 'when macOS version >= 13' do
+      let(:resolver_output) { '13.3.1' }
+      let(:resolver_extra_output) { nil }
+      let(:version) { { 'full' => '13.3.1', 'major' => '13', 'minor' => '3', 'patch' => '1' } }
+
+      before do
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversion).and_return(resolver_output)
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversionextra).and_return(resolver_extra_output)
+      end
+
+      it 'calls Facter::Resolvers::SwVers' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversionextra)
+      end
+
+      it 'returns a resolved fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
+                          an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
+                                                      type: :legacy))
+      end
+    end
+
+    context 'when macOS version >= 13 with RSR' do
+      let(:resolver_output) { '13.3.1' }
+      let(:resolver_extra_output) { '(a)' }
+      let(:version) { { 'full' => '13.3.1', 'major' => '13', 'minor' => '3', 'patch' => '1', 'extra' => '(a)' } }
+
+      before do
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversion).and_return(resolver_output)
+        allow(Facter::Resolvers::SwVers).to \
+          receive(:resolve).with(:productversionextra).and_return(resolver_extra_output)
+      end
+
+      it 'calls Facter::Resolvers::SwVers' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversion)
+        expect(Facter::Resolvers::SwVers).to have_received(:resolve).with(:productversionextra)
+      end
+
+      it 'returns a resolved fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.macosx.version', value: version),
+                          an_object_having_attributes(name: 'macosx_productversion', value: resolver_output,
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_major', value: version['major'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_minor', value: version['minor'],
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'macosx_productversion_patch', value: version['patch'],
+                                                      type: :legacy))
       end
     end
   end

--- a/spec/facter/resolvers/sw_vers_spec.rb
+++ b/spec/facter/resolvers/sw_vers_spec.rb
@@ -5,22 +5,57 @@ describe Facter::Resolvers::SwVers do
 
   let(:log_spy) { instance_spy(Facter::Log) }
 
-  before do
-    sw_vers.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute)
-      .with('sw_vers', { logger: log_spy })
-      .and_return("ProductName:\tMac OS X\nProductVersion:\t10.14.1\nBuildVersion:\t18B75\n")
+  context 'with ProductVersionExtra' do
+    before do
+      Facter::Resolvers::SwVers.invalidate_cache
+      sw_vers.instance_variable_set(:@log, log_spy)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('sw_vers', { logger: log_spy })
+        .and_return("ProductName:\tmacOS\nProductVersion:\t13.3.1\n"\
+          "ProductVersionExtra:\t(a)\nBuildVersion:\t22E772610a\n")
+    end
+
+    it 'returns os ProductName' do
+      expect(sw_vers.resolve(:productname)).to eq('macOS')
+    end
+
+    it 'returns os ProductVersion' do
+      expect(sw_vers.resolve(:productversion)).to eq('13.3.1')
+    end
+
+    it 'returns os ProductVersionExtra' do
+      expect(sw_vers.resolve(:productversionextra)).to eq('(a)')
+    end
+
+    it 'returns os BuildVersion' do
+      expect(sw_vers.resolve(:buildversion)).to eq('22E772610a')
+    end
   end
 
-  it 'returns os ProductName' do
-    expect(sw_vers.resolve(:productname)).to eq('Mac OS X')
-  end
+  context 'without ProductVersionExtra' do
+    before do
+      Facter::Resolvers::SwVers.invalidate_cache
+      sw_vers.instance_variable_set(:@log, log_spy)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('sw_vers', { logger: log_spy })
+        .and_return("ProductName:\tMac OS X\nProductVersion:\t10.14.1\n"\
+          "BuildVersion:\t18B75\n")
+    end
 
-  it 'returns os ProductVersion' do
-    expect(sw_vers.resolve(:productversion)).to eq('10.14.1')
-  end
+    it 'returns os ProductName' do
+      expect(sw_vers.resolve(:productname)).to eq('Mac OS X')
+    end
 
-  it 'returns os BuildVersion' do
-    expect(sw_vers.resolve(:buildversion)).to eq('18B75')
+    it 'returns os ProductVersion' do
+      expect(sw_vers.resolve(:productversion)).to eq('10.14.1')
+    end
+
+    it 'returns os BuildVersion' do
+      expect(sw_vers.resolve(:buildversion)).to eq('18B75')
+    end
+
+    it 'does not return os ProductVersionExtra' do
+      expect(sw_vers.resolve(:productversionextra)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
Starting with macOS 13, Apple can use a "Rapid Security Response" process to push small system updates out. When one of these is applied, a new `ProductVersionExtra` field is output from the `sw_vers` command:

```
$ sw_vers
ProductName:        macOS
ProductVersion:        13.3.1
ProductVersionExtra:    (a)
BuildVersion:        22E772610a
```

If no Rapid Security Response update is installed, the `ProductVersionExtra` field does not appear:

```
$ sw_vers
ProductName:        macOS
ProductVersion:        13.4
BuildVersion:        22F5049e
```

The `os.macosx.version` fact should report this. Currently it only reports `full`, `major`, `minor`, and `patch` fields.

This change adds an additional `extra` field for macOS 13 and later, if `ProductVersionExtra` is reported.

With this patch, on a 13.3.1 machine with the recent RSR installed, `facter os.macosx.version` returns:

```
{
  extra => "(a)",
  full => "13.3.1",
  major => "13",
  minor => "3",
  patch => "1"
}
```