### PR TITLE
(FACT-3196) Ensure file descriptors are closed

### DIFF
--- a/lib/facter/custom_facts/core/execution.rb
+++ b/lib/facter/custom_facts/core/execution.rb
@@ -131,7 +131,7 @@ module Facter
       #
       # @param on_fail[Object] How to behave when the command could
       #   not be run. Specifying :raise will raise an error, anything else will
-      #   return that object on failure. Default is :raise.
+      #   return that object on failure. Default is to not raise.
       # @param logger Optional logger used to log the command's stderr.
       # @param timeout Optional time out for the specified command. If no timeout is passed,
       #   a default of 300 seconds is used.

--- a/lib/facter/custom_facts/core/execution/base.rb
+++ b/lib/facter/custom_facts/core/execution/base.rb
@@ -98,7 +98,7 @@ module Facter
             message = "Failed while executing '#{command}': #{e.message}"
             if logger
               @log.debug(message)
-              return ''
+              return +''
             end
 
             return on_fail unless on_fail == :raise

--- a/lib/facter/resolvers/solaris/ffi/functions.rb
+++ b/lib/facter/resolvers/solaris/ffi/functions.rb
@@ -15,9 +15,11 @@ module Facter
 
           def self.ioctl(call_const, pointer, address_family = AF_INET)
             fd = Ioctl.open_socket(address_family, SOCK_DGRAM, 0)
-            result = ioctl_base(fd, call_const, pointer)
-            Ioctl.close_socket(fd, 2)
-            result
+            begin
+              ioctl_base(fd, call_const, pointer)
+            ensure
+              Ioctl.close_socket(fd, 2)
+            end
           end
         end
       end

--- a/spec/custom_facts/core/execution/posix_spec.rb
+++ b/spec/custom_facts/core/execution/posix_spec.rb
@@ -126,7 +126,6 @@ describe Facter::Core::Execution::Posix, unless: LegacyFacter::Util::Config.wind
     end
 
     it 'returns a mutable stdout string' do
-      pending
       expect(posix_executor.execute_command('/bin/notgoingtofindit', nil, logger)).not_to be_frozen
     end
   end

--- a/spec/custom_facts/core/execution/posix_spec.rb
+++ b/spec/custom_facts/core/execution/posix_spec.rb
@@ -103,4 +103,31 @@ describe Facter::Core::Execution::Posix, unless: LegacyFacter::Util::Config.wind
       end
     end
   end
+
+  context 'when calling execute_command' do
+    let(:logger) { instance_spy(Logger) }
+
+    it 'executes a command' do
+      expect(posix_executor.execute_command('/bin/true', nil, logger)).to eq(['', ''])
+    end
+
+    it "raises if 'on_fail' argument is specified" do
+      expect do
+        posix_executor.execute_command('/bin/notgoingtofindit', :raise)
+      end.to raise_error(Facter::Core::Execution::ExecutionFailure, %r{Failed while executing '/bin/notgoingtofindit'})
+    end
+
+    it 'returns nil if the command fails by default' do
+      expect(posix_executor.execute_command('/bin/notgoingtofindit')).to be_nil
+    end
+
+    it 'returns stdout string if the command fails and a logger was specified (!?)' do
+      expect(posix_executor.execute_command('/bin/notgoingtofindit', nil, logger)).to eq('')
+    end
+
+    it 'returns a mutable stdout string' do
+      pending
+      expect(posix_executor.execute_command('/bin/notgoingtofindit', nil, logger)).not_to be_frozen
+    end
+  end
 end


### PR DESCRIPTION
If ioctl returns non-zero then we were leaking file descriptors.

Always return a mutable string from `Facter::Core::Execution::Base.execute_command`