### PR TITLE
(FACT-3180) Correct Oracle Linux OS behavior

### DIFF
--- a/lib/facter/facts/ol/lsbdistdescription.rb
+++ b/lib/facter/facts/ol/lsbdistdescription.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ol
+    class Lsbdistdescription
+      FACT_NAME = 'lsbdistdescription'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/ol/lsbdistid.rb
+++ b/lib/facter/facts/ol/lsbdistid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ol
+    class Lsbdistid
+      FACT_NAME = 'lsbdistid'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facter/facts/ol/os/distro/description.rb
+++ b/lib/facter/facts/ol/os/distro/description.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ol
+    module Os
+      module Distro
+        class Description
+          FACT_NAME = 'os.distro.description'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::OsRelease.resolve(:pretty_name)
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/facts/ol/os/distro/id.rb
+++ b/lib/facter/facts/ol/os/distro/id.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Facts
+  module Ol
+    module Os
+      module Distro
+        class Id
+          FACT_NAME = 'os.distro.id'
+
+          def call_the_resolver
+            fact_value = Facter::Resolvers::OsRelease.resolve(:id).capitalize
+
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -642,6 +642,10 @@ os_hierarchy.each do |os|
 
   when 'ol'
     require_relative '../../facts/ol/os/release.rb'
+    require_relative '../../facts/ol/lsbdistdescription.rb'
+    require_relative '../../facts/ol/lsbdistid.rb'
+    require_relative '../../facts/ol/os/distro/description.rb'
+    require_relative '../../facts/ol/os/distro/id.rb'
 
   when 'openwrt'
     require_relative '../../facts/openwrt/os/release.rb'


### PR DESCRIPTION
Previously, Facter misidentified os.distro.description and os.distro.id on Oracle Linux with information from Red Hat Linux (information was being pulled from /etc/redhat-release file).

This commit correctly identifies os.distro description and id facts on Oracle Linux (now pulls information from /etc/os-release).