### PR TITLE
(FACT-3186) Handle partitions fact when none exist

### DIFF
--- a/lib/facter/facts/linux/partitions.rb
+++ b/lib/facter/facts/linux/partitions.rb
@@ -11,6 +11,10 @@ module Facts
 
       def partitions
         parts = Facter::Resolvers::Partitions.resolve(:partitions)
+        # We should exit early if we are running on a node with no partitions
+        # (e.g. a diskless, netbooted VM)
+        return nil unless parts
+
         mountpoints = Facter::Resolvers::Mountpoints.resolve(:mountpoints)
         return parts unless mountpoints
 


### PR DESCRIPTION
Prior to this commit, when a diskless machine used Facter the partitions fact errored out with an undefined method error. This was because the machine did not have any partitions and Facter was unable to dig into the partitions hash because the hash didn't exist.

This commit updates Linux's partition fact to return nil early in the partitions method if the partitions resolver returns nothing.