### PR TITLE
(FACT-3178) Ensure Facter escapes metacharacters when searching for fact

### DIFF
--- a/lib/facter/framework/parsers/query_parser.rb
+++ b/lib/facter/framework/parsers/query_parser.rb
@@ -85,7 +85,8 @@ module Facter
 
         return false if fact_with_wildcard && !query_fact.match("^#{fact_name}$")
 
-        return false unless fact_with_wildcard || fact_name.match("^#{processed_equery_fact}($|\\.)")
+        # Must escape metacharacters (like dots) to ensure the correct fact is found
+        return false unless fact_with_wildcard || fact_name.match("^#{Regexp.escape(processed_equery_fact)}($|\\.)")
 
         true
       end

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -79,6 +79,25 @@ describe Facter::QueryParser do
         contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: path_class)))
     end
 
+    context 'when user query contains metacharacters (like dots)' do
+      it 'finds the structured fact and not the alias' do
+        query_list = ['ldom.domainrole.impl']
+        ldom_class = 'Facter::Solaris::Ldom'
+
+        loaded_fact_ldom = double(Facter::LoadedFact, name: 'ldom', klass: ldom_class, type: :core, file: nil)
+        ldom_fact_ldom_alias = double(Facter::LoadedFact, name: 'ldom_domainrole_impl', klass: ldom_class,
+                                                          type: :legacy, file: nil)
+        loaded_facts = [loaded_fact_ldom, ldom_fact_ldom_alias]
+
+        matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
+
+        expect(matched_facts).to be_an_instance_of(Array).and \
+          contain_exactly(an_instance_of(Facter::SearchedFact)
+          .and(having_attributes(name: 'ldom', user_query: 'ldom.domainrole.impl', fact_class: ldom_class,
+                                 type: :core)))
+      end
+    end
+
     context 'when fact does not exist' do
       let(:query_list) { ['non_existing_fact'] }
       let(:loaded_facts) { [] }


### PR DESCRIPTION
Previously, when searching for a fact that matches the user query, if the fact name contains any metacharacters like dots (.) then the regex comparing the fact_name and processed_equery_fact would incorrectly match and result in the wrong fact being resolved. 

For example, when running `facter ldom.domainrole.impl`, the legacy alias fact, ldom_domainrole_impl is returned instead of the ldom structured core fact. This leads to issues later when extracting the fact value because you cannot dig into ldom_domainrole_impl and nil would be returned as its value. 

This commit ensures any special meta characters are escaped in the regex so the correct fact is found and resolved.