### PR TITLE
(maint) Pin jaro_winkler to 1.5.4

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'jaro_winkler', '= 1.5.4'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'


### PR DESCRIPTION
1.5.5 is missing a java version and native C extensions aren't supported in JRuby, so pin back to 1.5.4.

When https://github.com/tonytonyjan/jaro_winkler/issues/54 is resolved, this can be reverted.