### PR TITLE
(FACT-3089) Retain full uname output for ISA

### DIFF
--- a/lib/facter/facts/linux/processors/isa.rb
+++ b/lib/facter/facts/linux/processors/isa.rb
@@ -9,16 +9,7 @@ module Facts
 
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:processor)
-          isa = get_isa(fact_value)
-
-          [Facter::ResolvedFact.new(FACT_NAME, isa), Facter::ResolvedFact.new(ALIASES, isa, :legacy)]
-        end
-
-        private
-
-        def get_isa(fact_value)
-          value_split = fact_value.split('.')
-          value_split.last
+          [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end
       end
     end


### PR DESCRIPTION
Previous to this commit, the processor instruction set architecture (ISA) fact on Linux would split the output for `uname -p` on periods and return only the last value. Depending on the Linux distribution and hardware, this could result in unexpected output.

This commit changes the ISA fact on Linux to return the full output from `uname -p`, which is in line with how this fact is handled on other *nix operating systems (i.e. macOS, AIX, Solaris).