### PR TITLE
(FACT-3199) Escape regex special characters for queries

### DIFF
--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -109,5 +109,17 @@ describe Facter::QueryParser do
         )
       end
     end
+
+    context 'when a fact name contains a regex special character' do
+      let(:query_list) { ['regex(string'] }
+      let(:loaded_facts) { [double(Facter::LoadedFact, name: 'a_loaded_fact', klass: nil, type: :custom, file: nil)] }
+
+      it 'is escaped correctly and does not result in an unexpected regex parse error' do
+        matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
+        expect(matched_facts).to be_an_instance_of(Array).and contain_exactly(
+          an_object_having_attributes(name: 'regex(string', user_query: 'regex(string', type: :nil)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
When looking up a query for a fact name, the fact name itself is plopped into a regular expression to determine if it was a matched correctly. This caused problems because invalid regex expressions would cause unexpected stack traces within Facter's evaluation. The change needed for this was introduced in 6854f6f, so this commit just adds an additional test to ensure that the invalid regex error just not occur.