### PR TITLE
(maint) prefer /usr/bin/true for spec test

### DIFF
--- a/spec/custom_facts/core/execution/posix_spec.rb
+++ b/spec/custom_facts/core/execution/posix_spec.rb
@@ -108,7 +108,7 @@ describe Facter::Core::Execution::Posix, unless: LegacyFacter::Util::Config.wind
     let(:logger) { instance_spy(Logger) }
 
     it 'executes a command' do
-      expect(posix_executor.execute_command('/bin/true', nil, logger)).to eq(['', ''])
+      expect(posix_executor.execute_command('/usr/bin/true', nil, logger)).to eq(['', ''])
     end
 
     it "raises if 'on_fail' argument is specified" do


### PR DESCRIPTION
The path /bin/true is not available on macos 12; this just changes the path to location available on both macos and ubuntu 20.04.