### PR TITLE
(FACT-1902) Ensure Facter validates that facts output proper UTF-8

### DIFF
--- a/spec/custom_facts/core/resolvable_spec.rb
+++ b/spec/custom_facts/core/resolvable_spec.rb
@@ -41,6 +41,26 @@ describe LegacyFacter::Core::Resolvable do
           "resolution='resolvable': kaboom!")
       expect { resolvable.value }.to raise_error(Facter::ResolveCustomFactError)
     end
+
+    context 'with a fact whose value is invalid UTF-8 string' do
+      let(:logger) { instance_spy(Facter::Log) }
+
+      before do
+        allow(Facter::Log).to receive(:new).and_return(logger)
+      end
+
+      after do
+        Facter.instance_variable_set(:@logger, nil)
+      end
+
+      it 'cannot resolve and logs error with fact name' do
+        resolvable.resolve_value = "\xc3\x28"
+        resolvable.value
+        expect(logger).to have_received(:error).with("Fact resolution fact='stub fact', resolution='resolvable' "\
+                                                     "resolved to an invalid value: String \"\\xC3(\" doesn't match "\
+                                                     'the reported encoding UTF-8')
+      end
+    end
   end
 
   describe 'timing out' do

--- a/spec/custom_facts/util/normalization_spec.rb
+++ b/spec/custom_facts/util/normalization_spec.rb
@@ -56,6 +56,23 @@ describe LegacyFacter::Util::Normalization do
         expect do
           normalization.normalize(str)
         end.to raise_error(LegacyFacter::Util::Normalization::NormalizationError,
+                           /String \"\\xADay!\" doesn't match the reported encoding UTF-8/)
+      end
+
+      it 'rejects strings that only have the start of a valid UTF-8 sequence' do
+        str = "\xc3\x28"
+        expect do
+          normalization.normalize(str)
+        end.to raise_error(LegacyFacter::Util::Normalization::NormalizationError,
+                           /String \"\\xC3\(\" doesn't match the reported encoding UTF-8/)
+      end
+
+      it 'rejects valid non-UTF-8 encoded strings that claim to be UTF-8 encoded' do
+        str = 'Mitteleuropäische Zeit'.encode(Encoding::UTF_16LE)
+        str.force_encoding(Encoding::UTF_8)
+        expect do
+          normalization.normalize(str)
+        end.to raise_error(LegacyFacter::Util::Normalization::NormalizationError,
                            /String.*doesn't match the reported encoding UTF-8/)
       end
     end


### PR DESCRIPTION
This commit adds spec tests to ensure that all fact types output proper UTF-8 and if unable to, an exception will be raised with a message that specifies which fact has invalid data.