### PR TITLE
Add is_virtual and virtual support for Nutanix AHV

### DIFF
--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -13,7 +13,7 @@ module Facter
           # Is_Virtual
 
           MODEL_HASH = { 'VirtualBox' => 'virtualbox', 'VMware' => 'vmware', 'KVM' => 'kvm',
-                         'Bochs' => 'bochs', 'Google' => 'gce', 'OpenStack' => 'openstack' }.freeze
+                         'Bochs' => 'bochs', 'Google' => 'gce', 'OpenStack' => 'openstack', 'AHV' => 'ahv' }.freeze
 
           private
 


### PR DESCRIPTION
Prior to this change facter returned:

    $ facter is_virtual
    false
    $ facter virtual
    physical

After this change facter returns:

    $ facter is_virtual
    true
    $ facter virtual
    ahv

Systems running on Nutanix AHV are correctly recognized now.