### PR TITLE
(maint) Disable bad test on AIX

### DIFF
--- a/acceptance/tests/options/config_file/ttls_cache_missing_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_cache_missing_facts.rb
@@ -1,6 +1,8 @@
 test_name 'missing facts should not invalidate cache' do
   tag 'risk:high'
 
+  confine :except, :platform => 'aix-7.2-power' # FACT-3209
+
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils
 


### PR DESCRIPTION
This test fails on AIX because ipv6 is not enabled on all interfaces and gives a false positive if facter is run twice within the same minute (because `ls -ld` only provides resolution in hours and minutes).

Disable until FACT-3209 can be fixed.