### PR TITLE
(FACT-3187) Rescue Solaris mountpoint errors

### DIFF
--- a/lib/facter/resolvers/solaris/mountpoints.rb
+++ b/lib/facter/resolvers/solaris/mountpoints.rb
@@ -33,32 +33,51 @@ module Facter
 
               next if fs.mount_type == 'autofs'
 
+              mounts = {}
               device = fs.name
               filesystem = fs.mount_type
               path = fs.mount_point
               options = fs.options.split(',').map(&:strip)
 
-              stats = Facter::Util::Resolvers::FilesystemHelper.read_mountpoint_stats(path)
-              size_bytes = stats.bytes_total.abs
-              available_bytes = stats.bytes_available.abs
-
-              used_bytes = stats.bytes_used.abs
-              total_bytes = used_bytes + available_bytes
-              capacity = Facter::Util::Resolvers::FilesystemHelper.compute_capacity(used_bytes, total_bytes)
-
-              size = Facter::Util::Facts::UnitConverter.bytes_to_human_readable(size_bytes)
-              available = Facter::Util::Facts::UnitConverter.bytes_to_human_readable(available_bytes)
-              used = Facter::Util::Facts::UnitConverter.bytes_to_human_readable(used_bytes)
+              mounts = read_stats(path).tap do |hash|
+                hash[:device] = device
+                hash[:filesystem] = filesystem
+                hash[:path] = path
+                hash[:options] = options if options.any?
+              end
 
               @mounts << Hash[Facter::Util::Resolvers::FilesystemHelper::MOUNT_KEYS
                               .zip(Facter::Util::Resolvers::FilesystemHelper::MOUNT_KEYS
-                .map { |v| binding.local_variable_get(v) })]
+                .map { |v| mounts[v] })]
             end
 
             exclude_auto_home_mounts!
 
             @fact_list[:mountpoints] = @mounts
             @fact_list[fact_name]
+          end
+
+          def read_stats(path)
+            begin
+              stats = Facter::Util::Resolvers::FilesystemHelper.read_mountpoint_stats(path)
+              size_bytes = stats.bytes_total.abs
+              available_bytes = stats.bytes_available.abs
+              used_bytes = stats.bytes_used.abs
+              total_bytes = used_bytes + available_bytes
+            rescue Sys::Filesystem::Error
+              size_bytes = used_bytes = available_bytes = 0
+            end
+
+            {
+              size_bytes: size_bytes,
+              available_bytes: available_bytes,
+              used_bytes: used_bytes,
+              total_bytes: total_bytes,
+              capacity: Facter::Util::Resolvers::FilesystemHelper.compute_capacity(used_bytes, total_bytes),
+              size: Facter::Util::Facts::UnitConverter.bytes_to_human_readable(size_bytes),
+              available: Facter::Util::Facts::UnitConverter.bytes_to_human_readable(available_bytes),
+              used: Facter::Util::Facts::UnitConverter.bytes_to_human_readable(used_bytes)
+            }
           end
         end
       end


### PR DESCRIPTION
This commit updates the Solaris mountpoint resolver to rescue Sys::Filesystem::Error to set available, size, and used bytes to 0 and otherwise proceed as normal.