### PR TITLE
(maint) Temporary fix for Minitest capitalization

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -132,7 +132,9 @@ def run(command, dir = './', env = {})
   output
 end
 
+# temporary workaround for change in minitest: https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6
 ENV['DEBIAN_DISABLE_RUBYGEMS_INTEGRATION'] = 'no_warnings'
+ENV['MT_COMPAT'] = 'true'
 if_no_env_vars_set_defaults
 ACCEPTANCE_PATH = File.join(ENV['FACTER_ROOT'], 'acceptance')
 HOST_PLATFORM = ARGV[0]


### PR DESCRIPTION
Minitest v5.19.0, released today, includes a commit[1] that only calls its compatibility layer when using an environment variable ("MT_COMPAT"). See minitest/minitest@a2c6c18 for more info.

This means that calling "MiniTest" (with a capital "T") instead of "Minitest" (with all lowercase "T"s) no longer works.

This commit adds the MT_COMPAT environment variable as a temporary fix while we are waiting for upstream beaker to to put in a fix & release.