### PR TITLE
Revert "(maint) Temporary fix for Minitest capitalization"

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -132,9 +132,7 @@ def run(command, dir = './', env = {})
   output
 end
 
-# temporary workaround for change in minitest: https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6
 ENV['DEBIAN_DISABLE_RUBYGEMS_INTEGRATION'] = 'no_warnings'
-ENV['MT_COMPAT'] = 'true'
 if_no_env_vars_set_defaults
 ACCEPTANCE_PATH = File.join(ENV['FACTER_ROOT'], 'acceptance')
 HOST_PLATFORM = ARGV[0]


### PR DESCRIPTION
This commit reverts 4809fdc because beaker [5.3.1](https://github.com/voxpupuli/beaker/releases/tag/5.3.1) and [4.40.2](https://github.com/voxpupuli/beaker/releases/tag/4.40.2) were released with the Minitest fix.