### PR TITLE
(FACT-3162) Add 'normalize_os_name' to os release resolver

### DIFF
--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -75,9 +75,19 @@ module Facter
         def process_name
           return unless @fact_list[:name]
 
+          normalize_os_name
           join_os_name
           capitalize_os_name
           append_linux_to_os_name
+        end
+
+        def normalize_os_name
+          os_name = @fact_list[:name]
+          @fact_list[:name] = if os_name.downcase.start_with?('sles')
+                                'SLES'
+                              else
+                                os_name
+                              end
         end
 
         def join_os_name

--- a/spec/facter/resolvers/os_release_spec.rb
+++ b/spec/facter/resolvers/os_release_spec.rb
@@ -138,6 +138,26 @@ describe Facter::Resolvers::OsRelease do
     end
   end
 
+  context 'when on SLES' do
+    let(:os_release_content) { load_fixture('os_release_sles').readlines }
+
+    it 'returns os NAME' do
+      result = Facter::Resolvers::OsRelease.resolve(:name)
+
+      expect(result).to eq('SLES')
+    end
+  end
+
+  context 'when on SLES_SAP' do
+    let(:os_release_content) { load_fixture('os_release_sles_sap').readlines }
+
+    it 'returns os NAME' do
+      result = Facter::Resolvers::OsRelease.resolve(:name)
+
+      expect(result).to eq('SLES')
+    end
+  end
+
   context 'when on Manjarolinux' do
     let(:os_release_content) { load_fixture('os_release_manjarolinux').readlines }
 

--- a/spec/fixtures/os_release_sles
+++ b/spec/fixtures/os_release_sles
@@ -1,0 +1,8 @@
+NAME="SLES"
+VERSION="15"
+VERSION_ID="15"
+PRETTY_NAME="SUSE Linux Enterprise Server 15"
+ID="sles"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15"

--- a/spec/fixtures/os_release_sles_sap
+++ b/spec/fixtures/os_release_sles_sap
@@ -1,0 +1,7 @@
+NAME="SLES_SAP"
+VERSION="12-SP2"
+VERSION_ID="12.2"
+PRETTY_NAME="SUSE Linux Enterprise Server for SAP Applications 12 SP2"
+ID="sles_sap"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"


### PR DESCRIPTION
When facter resolves the os.name for 'SLES SAP' OS it would include the entire 'SLES_SAP' as the name.
This would break things further down stream like the zypper package provider. This PR fixes the os.name fact so SLES_SAP will correctly resolve as 'SLES'.