### PR TITLE
(FACT-3422) Fix SLES SAP use of os distro

### DIFF
--- a/lib/facter/resolvers/os_release.rb
+++ b/lib/facter/resolvers/os_release.rb
@@ -69,6 +69,7 @@ module Facter
         def process_id
           return unless @fact_list[:id]
 
+          @fact_list[:id] = 'sles' if /sles_sap/i.match?(@fact_list[:id])
           @fact_list[:id] = 'opensuse' if /opensuse/i.match?(@fact_list[:id])
         end
 

--- a/spec/facter/resolvers/os_release_spec.rb
+++ b/spec/facter/resolvers/os_release_spec.rb
@@ -156,6 +156,12 @@ describe Facter::Resolvers::OsRelease do
 
       expect(result).to eq('SLES')
     end
+
+    it 'returns os ID' do
+      result = Facter::Resolvers::OsRelease.resolve(:id)
+
+      expect(result).to eq('sles')
+    end
   end
 
   context 'when on Manjarolinux' do


### PR DESCRIPTION
In facter 3.x when determining the distro of an OS we looked at the os-release file's description. The regex we used was good enogugh to capture multiple versions of SUSE Enterprise Server.
In facter 4.x we switched from reading the description setting to reading the 'id' setting. This PR adds a bit of logic to that to take sles_sap into account.

Prior to this PR if a user as on SLES SAP, the `os.distro` fact would fail to resolve, this fixes that.