### PR TITLE
(FACT-3423) sys-filesystem updates

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -29,16 +29,20 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  # While we require sys-filesystem in filesystem_helpers we leave it as a
+  # development, not runtime, dependency. We do this so we do not also pull in
+  # sys-filesystem's dependency ffi, which contains native extensions which in
+  # turn would mean Facter would require a compiler to install as a gem.
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.38'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'sys-filesystem', '~> 1.4'
   spec.add_development_dependency 'webmock', '~> 3.12'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   spec.add_runtime_dependency 'hocon', '~> 1.3'
-  spec.add_runtime_dependency 'sys-filesystem', '~> 1.4'
   spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2.0']
 end

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -29,10 +29,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # While we require sys-filesystem in filesystem_helpers we leave it as a
-  # development, not runtime, dependency. We do this so we do not also pull in
-  # sys-filesystem's dependency ffi, which contains native extensions which in
-  # turn would mean Facter would require a compiler to install as a gem.
+  # While we require both ffi and sys-filesystem in parts of Facter, we specify
+  # them as development, not runtime, dependencies. Both gems either directly
+  # or indirectly contain native extensions. The intent behind excluding these
+  # gems from runtime dependencies is to allow users to be able to install
+  # Facter without a compiler.
+  spec.add_development_dependency 'ffi'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'

--- a/lib/facter/custom_facts/util/windows_root.rb
+++ b/lib/facter/custom_facts/util/windows_root.rb
@@ -6,6 +6,9 @@ module LegacyFacter
       def self.root?
         require_relative '../../../facter/resolvers/windows/ffi/identity_ffi'
         IdentityFFI.privileged?
+      rescue LoadError => e
+        log = Facter::Log.new(self)
+        log.debug("The ffi gem has not been installed: #{e}")
       end
     end
   end

--- a/lib/facter/resolvers/macosx/mountpoints.rb
+++ b/lib/facter/resolvers/macosx/mountpoints.rb
@@ -7,6 +7,8 @@ module Facter
         include Facter::Util::Resolvers::FilesystemHelper
         init_resolver
 
+        @log = Facter::Log.new(self)
+
         class << self
           private
 
@@ -16,18 +18,21 @@ module Facter
 
           def read_mounts
             mounts = {}
+            begin
+              Facter::Util::Resolvers::FilesystemHelper.read_mountpoints.each do |fs|
+                device = fs.name
+                filesystem = fs.mount_type
+                path = fs.mount_point
+                options = read_options(fs.options)
 
-            Facter::Util::Resolvers::FilesystemHelper.read_mountpoints.each do |fs|
-              device = fs.name
-              filesystem = fs.mount_type
-              path = fs.mount_point
-              options = read_options(fs.options)
-
-              mounts[path] = read_stats(path).tap do |hash|
-                hash[:device] = device
-                hash[:filesystem] = filesystem
-                hash[:options] = options if options.any?
+                mounts[path] = read_stats(path).tap do |hash|
+                  hash[:device] = device
+                  hash[:filesystem] = filesystem
+                  hash[:options] = options if options.any?
+                end
               end
+            rescue LoadError => e
+              @log.debug("Could not read mounts: #{e}")
             end
 
             @fact_list[:mountpoints] = mounts
@@ -39,7 +44,7 @@ module Facter
               size_bytes = stats.bytes_total
               available_bytes = stats.bytes_available
               used_bytes = size_bytes - available_bytes
-            rescue Sys::Filesystem::Error
+            rescue Sys::Filesystem::Error, LoadError
               size_bytes = used_bytes = available_bytes = 0
             end
 

--- a/lib/facter/resolvers/mountpoints.rb
+++ b/lib/facter/resolvers/mountpoints.rb
@@ -50,7 +50,9 @@ module Facter
               mount = {}
               get_mount_data(file_system, mount)
 
-              next if mount[:path] =~ %r{^/(proc|sys)} && mount[:filesystem] != 'tmpfs' || mount[:filesystem] == 'autofs'
+              if mount[:path] =~ %r{^/(proc|sys)} && mount[:filesystem] != 'tmpfs' || mount[:filesystem] == 'autofs'
+                next
+              end
 
               get_mount_sizes(mount)
               mounts << mount

--- a/lib/facter/resolvers/windows/hardware_architecture.rb
+++ b/lib/facter/resolvers/windows/hardware_architecture.rb
@@ -23,6 +23,9 @@ module Facter
           arch = determine_architecture(hard)
           build_facts_list(hardware: hard, architecture: arch)
           @fact_list[fact_name]
+        rescue LoadError => e
+          log = Facter::Log.new(self)
+          log.debug("The ffi gem has not been installed: #{e}")
         end
 
         def determine_hardware(sys_info)

--- a/lib/facter/resolvers/windows/identity.rb
+++ b/lib/facter/resolvers/windows/identity.rb
@@ -32,6 +32,8 @@ module Facter
           end
 
           { user: name_ptr.read_wide_string_with_length(size_ptr.read_uint32), privileged: IdentityFFI.privileged? }
+        rescue LoadError => e
+          @log.debug("Could not find username: #{e}")
         end
 
         def retrieve_facts(fact_name)

--- a/lib/facter/resolvers/windows/kernel.rb
+++ b/lib/facter/resolvers/windows/kernel.rb
@@ -30,6 +30,8 @@ module Facter
           build_facts_list(result)
 
           @fact_list[fact_name]
+        rescue LoadError => e
+          @log.debug("Could not get OS version information: #{e}")
         end
 
         def build_facts_list(result)

--- a/lib/facter/resolvers/windows/memory.rb
+++ b/lib/facter/resolvers/windows/memory.rb
@@ -28,6 +28,8 @@ module Facter
           @long_living_pointer = state_ptr
 
           PerformanceInformation.new(state_ptr)
+        rescue LoadError => e
+          @log.debug("Could not resolve memory facts: #{e}")
         end
 
         def calculate_memory

--- a/lib/facter/resolvers/windows/networking.rb
+++ b/lib/facter/resolvers/windows/networking.rb
@@ -31,6 +31,8 @@ module Facter
             Facter::Util::Resolvers::Networking.expand_main_bindings(@fact_list)
 
             @fact_list[fact_name]
+          rescue LoadError => e
+            @log.debug("The ffi gem has not been installed: #{e}")
           end
 
           def get_adapter_addresses(size_ptr, adapter_addresses, flags)

--- a/lib/facter/resolvers/windows/system32.rb
+++ b/lib/facter/resolvers/windows/system32.rb
@@ -31,6 +31,8 @@ module Facter
           end
 
           @fact_list[:system32] = construct_path(bool_ptr, windows_path)
+        rescue LoadError => e
+          @log.debug("Could not retrieve: #{e}")
         end
 
         def construct_path(bool_ptr, windows)

--- a/lib/facter/resolvers/windows/timezone.rb
+++ b/lib/facter/resolvers/windows/timezone.rb
@@ -33,6 +33,9 @@ module Facter
           def codepage_from_api
             require_relative '../../../facter/resolvers/windows/ffi/winnls_ffi'
             WinnlsFFI.GetACP.to_s
+          rescue LoadError => e
+            log = Facter::Log.new(self)
+            log.debug("Could not retrieve codepage: #{e}")
           end
         end
       end


### PR DESCRIPTION
This PR:

- Moves sys-filesystem back from a runtime dependency to a development dependency.
- Rescues LoadError in resolvers that depend on sys-filesystem.
- Adds ffi as a development dependency, as some resolvers depend on ffi but it's only implicitly required through sys-filesystem.
- Updates resolvers that depend on ffi to log a debug message when ffi is not present.
- Fixes a minor Rubocop issue