### PR TITLE
(FACT-1592) A key/value pair for Interface Speed/Duplex

### DIFF
--- a/lib/facter/resolvers/linux/networking.rb
+++ b/lib/facter/resolvers/linux/networking.rb
@@ -33,6 +33,8 @@ module Facter
               dhcp(interface_name, mtu_and_indexes)
               operstate(interface_name)
               physical(interface_name)
+              linkspeed(interface_name)
+              duplex(interface_name)
 
               @log.debug("Found interface #{interface_name} with #{@fact_list[:interfaces][interface_name]}")
             end
@@ -60,6 +62,30 @@ module Facter
                                                          else
                                                            false
                                                          end
+          end
+
+          def duplex(interface_name)
+            return unless @fact_list[:interfaces][interface_name][:physical]
+
+            # not all interfaces support this, wifi for example causes an EINVAL (Invalid argument)
+            begin
+              plex = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/duplex", nil)
+              @fact_list[:interfaces][interface_name][:duplex] = plex.strip if plex
+            rescue StandardError => e
+              @log.debug("Failed to read '/sys/class/net/#{interface_name}/duplex': #{e.message}")
+            end
+          end
+
+          def linkspeed(interface_name)
+            return unless @fact_list[:interfaces][interface_name][:physical]
+
+            # not all interfaces support this, wifi for example causes an EINVAL (Invalid argument)
+            begin
+              speed = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/speed", nil)
+              @fact_list[:interfaces][interface_name][:speed] = speed.strip if speed
+            rescue StandardError => e
+              @log.debug("Failed to read '/sys/class/net/#{interface_name}/speed': #{e.message}")
+            end
           end
 
           def parse_ip_command_line(line, mtu_and_indexes)

--- a/lib/facter/resolvers/linux/networking.rb
+++ b/lib/facter/resolvers/linux/networking.rb
@@ -82,7 +82,7 @@ module Facter
             # not all interfaces support this, wifi for example causes an EINVAL (Invalid argument)
             begin
               speed = Facter::Util::FileHelper.safe_read("/sys/class/net/#{interface_name}/speed", nil)
-              @fact_list[:interfaces][interface_name][:speed] = speed.strip if speed
+              @fact_list[:interfaces][interface_name][:speed] = speed.strip.to_i if speed
             rescue StandardError => e
               @log.debug("Failed to read '/sys/class/net/#{interface_name}/speed': #{e.message}")
             end

--- a/spec/facter/resolvers/linux/networking_spec.rb
+++ b/spec/facter/resolvers/linux/networking_spec.rb
@@ -27,6 +27,10 @@ describe Facter::Resolvers::Linux::Networking do
         .with('/sys/class/net/lo/operstate', nil).and_return('unknown')
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/class/net/ens160/operstate', nil).and_return('up')
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/ens160/speed', nil).and_return(1000)
+      allow(Facter::Util::FileHelper).to receive(:safe_read)
+        .with('/sys/class/net/ens160/duplex', nil).and_return('full')
     end
 
     after do
@@ -88,6 +92,7 @@ describe Facter::Resolvers::Linux::Networking do
               network: 'fe80::', scope6: 'link', flags: ['permanent'] }
           ],
           dhcp: '10.32.22.10',
+          duplex: 'full',
           ip: '10.16.119.155',
           ip6: 'fe80::250:56ff:fe9a:8481',
           mac: '00:50:56:9a:61:46',
@@ -160,6 +165,7 @@ describe Facter::Resolvers::Linux::Networking do
               scope6: 'link', flags: ['permanent'] }
           ],
           dhcp: '10.32.22.10',
+          duplex: 'full',
           ip: '10.16.127.70',
           ip6: 'fe80::250:56ff:fe9a:8481',
           mac: '00:50:56:9a:61:46',
@@ -215,6 +221,7 @@ describe Facter::Resolvers::Linux::Networking do
             { address: '10.16.125.217' }
           ],
           dhcp: '10.32.22.10',
+          duplex: 'full',
           ip: '10.16.119.155',
           mac: '00:50:56:9a:61:46',
           mtu: 1500,
@@ -293,6 +300,7 @@ describe Facter::Resolvers::Linux::Networking do
               { address: 'fe80::250:56ff:fe9a:8481', netmask: 'ffff:ffff:ffff:ffff::',
                 network: 'fe80::', scope6: 'link', flags: ['permanent'] }
             ],
+            duplex: 'full',
             ip6: 'fe80::250:56ff:fe9a:8481',
             mac: '00:50:56:9a:61:46',
             mtu: 1500,

--- a/spec/facter/resolvers/linux/networking_spec.rb
+++ b/spec/facter/resolvers/linux/networking_spec.rb
@@ -18,6 +18,7 @@ describe Facter::Resolvers::Linux::Networking do
         .with(log_spy).and_return([[{ interface: 'ens192', ip: '10.16.125.217' }], []])
       allow(Facter::Util::Resolvers::Networking::PrimaryInterface).to receive(:read_from_proc_route)
         .and_return('ens160')
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/proc/net/if_inet6').and_return(true)
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/proc/net/if_inet6', nil).and_return(load_fixture('proc_net_if_inet6').read)
@@ -28,7 +29,7 @@ describe Facter::Resolvers::Linux::Networking do
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/class/net/ens160/operstate', nil).and_return('up')
       allow(Facter::Util::FileHelper).to receive(:safe_read)
-        .with('/sys/class/net/ens160/speed', nil).and_return(1000)
+        .with('/sys/class/net/ens160/speed', nil).and_return('1000')
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/class/net/ens160/duplex', nil).and_return('full')
     end
@@ -103,7 +104,8 @@ describe Facter::Resolvers::Linux::Networking do
           network6: 'fe80::',
           operational_state: 'up',
           physical: true,
-          scope6: 'link'
+          scope6: 'link',
+          speed: 1000
         }
       }
     end
@@ -176,7 +178,8 @@ describe Facter::Resolvers::Linux::Networking do
           network6: 'fe80::',
           operational_state: 'up',
           physical: true,
-          scope6: 'link'
+          scope6: 'link',
+          speed: 1000
         }
       end
 
@@ -228,7 +231,8 @@ describe Facter::Resolvers::Linux::Networking do
           netmask: '255.255.240.0',
           network: '10.16.112.0',
           operational_state: 'up',
-          physical: true
+          physical: true,
+          speed: 1000
         }
 
         expect(networking_linux.resolve(:interfaces)['ens160']).to eq(expected)
@@ -308,7 +312,8 @@ describe Facter::Resolvers::Linux::Networking do
             network6: 'fe80::',
             operational_state: 'up',
             physical: true,
-            scope6: 'link'
+            scope6: 'link',
+            speed: 1000
           }
         }
       end


### PR DESCRIPTION
Collect the speed and duplex settings for physical network interfaces on Linux using `/sys/class/net`.

This supersedes https://github.com/puppetlabs/facter/pull/2480