### PR TITLE
(maint) Bump JRuby version in unit tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.2'
-          - 'jruby-9.3.7.0'
+          - 'jruby-9.3.9.0'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR


### PR DESCRIPTION
This commit updates JRuby in our GitHub Actions unit tests to match the version of the most recent version of puppetserver 7.