### PR TITLE
(FACT-3427) Fix logger arguments

### DIFF
--- a/lib/facter/custom_facts/util/fact.rb
+++ b/lib/facter/custom_facts/util/fact.rb
@@ -85,7 +85,9 @@ module Facter
 
         resolve
       rescue StandardError => e
-        log.log_exception("Unable to add resolve #{resolution_name.inspect} for fact #{@name}: #{e.message}")
+        msg = "Unable to add resolve #{resolution_name.inspect} for fact '#{@name}': #{e.message}"
+        msg += "\n" + e.backtrace.join("\n") if Options[:trace]
+        log.error(msg, true)
         nil
       end
 

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -107,12 +107,15 @@ describe Facter::Util::Fact do
       expect(fact.resolution('named')).to be_a_kind_of Facter::Core::Aggregate
     end
 
-    # it "raises an error if there is an existing resolution with a different type" do
-    #   pending "We need to stop rescuing all errors when instantiating resolutions"
-    #   fact.define_resolution('named')
-    #   expect(fact.define_resolution('named', :type => :aggregate))
-    #     .to raise_error(ArgumentError, /Cannot return resolution.*already defined as simple/)
-    # end
+    it 'raises an error if there is an existing resolution with a different type' do
+      expect(logger).to receive(:error).with(
+        "Unable to add resolve \"named\" for fact 'yay': Cannot return resolution named with type aggregate; already "\
+          'defined as simple', true
+      )
+
+      fact.define_resolution('named', type: :simple)
+      fact.define_resolution('named', type: :aggregate)
+    end
 
     it 'returns existing resolutions by name' do
       allow(Facter::Util::Resolution).to receive(:new).once.with('named', fact).and_return(res)


### PR DESCRIPTION
Prior to this commit, the define_resolution method was incorrectly passing two arguments to Facter::Log#log_exception when raising. This commit updates the call to log_exception to no longer pass a string and instead only pass an exception.

Additionally, this enables a test that was pending.