### PR TITLE
(FACT-3432) Pin FFI to 1.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,10 @@ gem 'packaging', require: false
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)
 
+# ffi >= 1.16.0 introduces breaking changes, so we pin to the version prior
+# for now
 group(:integration, optional: true) do
-  gem 'ffi', '~> 1.15', require: false
+  gem 'ffi', '1.15.5', require: false
 end
 
 group(:documentation) do

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # or indirectly contain native extensions. The intent behind excluding these
   # gems from runtime dependencies is to allow users to be able to install
   # Facter without a compiler.
-  spec.add_development_dependency 'ffi'
+  spec.add_development_dependency 'ffi', '1.15.5'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'


### PR DESCRIPTION
FFI version 1.16.0 was released and introduced breaking changes to code that extends the FFI library. This causes Facter to fail on Windows.

This commit pins the FFI development dependency to 1.15.5 (the last version prior to 1.16.0) until we can resolve these issues.