### PR TITLE
(maint) Bump JRuby version in unit tests

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -20,7 +20,7 @@ jobs:
         cfg:
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
-          - {os: ubuntu-22.04, ruby: 'jruby-9.3.7.0'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.3.9.0'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}


### PR DESCRIPTION
This commit updates JRuby in our GitHub Actions integration tests to match the version of the most recent version of puppetserver 7.