### PR TITLE
(FACT-3433) Log error if external fact is invalid

### DIFF
--- a/lib/facter/custom_facts/util/directory_loader.rb
+++ b/lib/facter/custom_facts/util/directory_loader.rb
@@ -93,7 +93,12 @@ module LegacyFacter
           if data == false
             log.warn "Could not interpret fact file #{fact.file}"
           elsif (data == {}) || data.nil?
-            log.debug("Fact file #{fact.file} was parsed but no key=>value data was returned")
+            log.debug(
+              "Structured data fact file #{fact.file} was parsed but was either empty or an invalid filetype "\
+                '(valid filetypes are .yaml, .json, and .txt).'
+            )
+          elsif !data.is_a?(Hash)
+            log.error("Structured data fact file #{fact.file} was parsed but no key=>value data was returned.")
           else
             add_data(data, collection, fact, weight)
           end

--- a/spec/custom_facts/util/directory_loader_spec.rb
+++ b/spec/custom_facts/util/directory_loader_spec.rb
@@ -46,6 +46,31 @@ describe LegacyFacter::Util::DirectoryLoader do
       expect(collection_double).to have_received(:add).with('f1', value: 'one', fact_type: :external, file: file)
     end
 
+    it 'ignores when a structured data fact contains empty hash' do
+      data = {}
+      write_to_file('data.yaml', YAML.dump(data))
+      file = File.join(dir_loader.directories[0], 'data.yaml')
+
+      expect(log_spy).to receive(:debug).with(
+        "Structured data fact file #{file} was parsed but was either empty or an invalid filetype (valid filetypes "\
+          'are .yaml, .json, and .txt).'
+      )
+
+      dir_loader.load(collection)
+    end
+
+    it 'ignores when fact with external type contains invalid data type' do
+      data = 'foo'
+      write_to_file('data.yaml', YAML.dump(data))
+      file = File.join(dir_loader.directories[0], 'data.yaml')
+
+      expect(log_spy).to receive(:error).with(
+        "Structured data fact file #{file} was parsed but no key=>value data was returned."
+      )
+
+      dir_loader.load(collection)
+    end
+
     it "ignores files that begin with '.'" do
       not_to_be_used_collection = double('collection should not be used')
       expect(not_to_be_used_collection).not_to receive(:add)


### PR DESCRIPTION
Prior to this commit, when Facter attempted to load an external fact that used a non-hash data type, it would cause a fatal exception.

This commit updates Facter to validate whether an external fact is a non-empty hash and, if it isn't, logs an error. This brings Facter 4 behavior more in line with Facter 3.

This commit also updates the debug message for structured data facts that are the wrong filetype or empty to provide more useful debug information.