### PR TITLE
(FACT-3431) Update Checkout GitHub Action

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: facter
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,7 +15,7 @@ jobs:
     name: RuboCop
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rubocop checks
         uses: ruby/setup-ruby@v1
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: RuboCop TODO
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gimmyxd/rtc-action@0.3.1
         env:
           RTC_TOKEN: ${{ secrets.RTC_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
     name: commit message
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,7 +12,7 @@ jobs:
     name: coverage
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Code Climate test-reporter
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rspec checks
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/mend.yaml
+++ b/.github/workflows/mend.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Mend Monitor
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rspec checks
         uses: ruby/setup-ruby@v1
@@ -46,7 +46,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Rspec checks
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The Checkout GitHub Action v3 uses Node 16, which hit end-of-life on September 11, 2023.

This commit updates all instances of the Checkout Action from v3 to v4.