### PR TITLE
(maint) Skip facter caching test on solaris 10

### DIFF
--- a/acceptance/tests/options/config_file/ttls_cache_missing_facts.rb
+++ b/acceptance/tests/options/config_file/ttls_cache_missing_facts.rb
@@ -2,6 +2,7 @@ test_name 'missing facts should not invalidate cache' do
   tag 'risk:high'
 
   confine :except, :platform => 'aix-7.2-power' # FACT-3209
+  confine :except, :platform => /^solaris-10-/ # FACT-3209
 
   require 'facter/acceptance/user_fact_utils'
   extend Facter::Acceptance::UserFactUtils


### PR DESCRIPTION
Due to FACT-3209, any host that lacks IPv6 will cause the networking fact cache to be updated. And the test will fail if the before and after times cross the minute boundary. Neither Solaris 10 Intel or SPARC have IPv6 enabled, so skip.