### PR TITLE
(FACT-3436) Standardize Debian architecture fact

### DIFF
--- a/lib/facter/facts/debian/architecture.rb
+++ b/lib/facter/facts/debian/architecture.rb
@@ -8,9 +8,7 @@ module Facts
         ALIASES = 'architecture'
 
         def call_the_resolver
-          fact_value = Facter::Resolvers::Uname.resolve(:machine)
-          fact_value = 'amd64' if fact_value == 'x86_64'
-          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
+          fact_value = Facter::Core::Execution.execute('dpkg --print-architecture')
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/spec/facter/facts/debian/os/architecture_spec.rb
+++ b/spec/facter/facts/debian/os/architecture_spec.rb
@@ -4,61 +4,16 @@ describe Facts::Debian::Os::Architecture do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Debian::Os::Architecture.new }
 
-    context 'when resolver does not return x86_64' do
-      let(:value) { 'i86pc' }
+    %w[amd64 arm64 i386].each do |arch|
+      it 'calls Facter::Core::Execution and returns architecture fact' do
+        allow(Facter::Core::Execution).to receive(:execute).and_return(arch)
 
-      before do
-        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
-      end
-
-      it 'calls Facter::Resolvers::Uname' do
         fact.call_the_resolver
-        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
-      end
+        expect(Facter::Core::Execution).to have_received(:execute).with('dpkg --print-architecture')
 
-      it 'returns architecture fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
-                          an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
-      end
-    end
-
-    context 'when os is 32-bit' do
-      let(:value) { 'i586' }
-      let(:fact_value) { 'i386' }
-
-      before do
-        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
-      end
-
-      it 'calls Facter::Resolvers::Uname' do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
-      end
-
-      it 'returns architecture fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: fact_value),
-                          an_object_having_attributes(name: 'architecture', value: fact_value, type: :legacy))
-      end
-    end
-
-    context 'when resolver returns x86_64' do
-      let(:value) { 'x86_64' }
-
-      before do
-        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
-      end
-
-      it 'calls Facter::Resolvers::Uname' do
-        fact.call_the_resolver
-        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
-      end
-
-      it 'returns architecture fact' do
-        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: 'amd64'),
-                          an_object_having_attributes(name: 'architecture', value: 'amd64', type: :legacy))
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: arch),
+                          an_object_having_attributes(name: 'architecture', value: arch, type: :legacy))
       end
     end
   end


### PR DESCRIPTION
Prior to this commit the os.architecture fact on Debian and Debian-based distrubitions resolved inconsistently. The fact used Debian's architecture naming scheme for some platforms (i386 and amd64) but not others.

This commit updates the os.architecture fact on Debian and Debian-based distrubitions to consistently use Debian's naming convention by relying on the output of `dpkg --print-architecture`.