### PR TITLE
(FACT-3435) Guard against non-global zones in DMI

### DIFF
--- a/lib/facter/resolvers/solaris/dmi_sparc.rb
+++ b/lib/facter/resolvers/solaris/dmi_sparc.rb
@@ -19,6 +19,12 @@ module Facter
 
             matches = output.match(/System Configuration:\s+(.+?)\s+sun\d+\S+\s+(.+)/)&.captures
 
+            # There are circumstances (e.g. in non-global zones) when prtdiag
+            # will return text, but it's an error message or some other string
+            # that isn't parsed by the above match/capture. In that case, we
+            # simply return.
+            return if matches.nil?
+
             @fact_list[:manufacturer] = matches[0]&.strip
             @fact_list[:product_name] = matches[1]&.strip
 

--- a/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
+++ b/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
@@ -33,4 +33,34 @@ describe Facter::Resolvers::Solaris::DmiSparc do
       expect(resolver.resolve(:serial_number)).to eq('random_string')
     end
   end
+
+  describe '#reolve under a non-global zone' do
+    subject(:resolver) { Facter::Resolvers::Solaris::DmiSparc }
+
+    let(:log_spy) { instance_spy(Facter::Log) }
+
+    before do
+      resolver.instance_variable_set(:@log, log_spy)
+      allow(File).to receive(:executable?).with('/usr/sbin/prtdiag').and_return(true)
+      allow(Facter::Core::Execution).to receive(:execute)
+        .with('/usr/sbin/prtdiag', { logger: log_spy })
+        .and_return('prtdiag can only be run in the global zone')
+    end
+
+    after do
+      Facter::Resolvers::Solaris::DmiSparc.invalidate_cache
+    end
+
+    it 'does not return manufacturer' do
+      expect(resolver.resolve(:manufacturer)).to eq(nil)
+    end
+
+    it 'does not return product_name' do
+      expect(resolver.resolve(:product_name)).to eq(nil)
+    end
+
+    it 'does not return serial_number' do
+      expect(resolver.resolve(:serial_number)).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
Solaris non-global zones have limited access to system information and aren't able to perform all of the operations of a global zone.

Because of that when the Solaris SPARC DMI resolver ran in a non-global zone, it wasn't able to access system information via `prtdiag`, resulting in unexpected text output that caused the resolver to error.

This commit updates the Solaris SPARC DMI resolver to return if it receives unexpected text as a result of prtdiag.