### PR TITLE
(packaging) Bump to version '4.5.1' [no-promote]

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter'
-  spec.version       = '4.5.0'
+  spec.version       = '4.5.1'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Facter
-  VERSION = '4.5.0' unless defined?(VERSION)
+  VERSION = '4.5.1' unless defined?(VERSION)
 end


### PR DESCRIPTION
Currently, Facter's verion is set to 4.5.0 but 4.5.1 will be used for puppet-agent 7.27.0 & 8.3.0 release so Facter's version needs to be bumped.