### PR TITLE
(maint) Fix Thor::Command.new arguments

### DIFF
--- a/spec/framework/cli/cli_launcher_spec.rb
+++ b/spec/framework/cli/cli_launcher_spec.rb
@@ -9,11 +9,13 @@ describe CliLauncher do
 
   describe '#prepare_arguments' do
     let(:task_list) do
-      { 'help' => Thor::Command.new('help', 'description', 'long_description', 'usage'),
-        'query' => Thor::Command.new('query', 'description', 'long_description', 'usage'),
-        'version' => Thor::Command.new('version', 'description', 'long_description', 'usage'),
-        'list_block_groups' => Thor::Command.new('list_block_groups', 'description', 'long_description', 'usage'),
-        'list_cache_groups' => Thor::Command.new('list_cache_groups', 'description', 'long_description', 'usage') }
+      { 'help' => Thor::Command.new('help', 'description', 'long_description', 'wrap_long_description', 'usage'),
+        'query' => Thor::Command.new('query', 'description', 'long_description', 'wrap_long_description', 'usage'),
+        'version' => Thor::Command.new('version', 'description', 'long_description', 'wrap_long_description', 'usage'),
+        'list_block_groups' => Thor::Command.new('list_block_groups', 'description', 'wrap_long_description',
+                                                 'long_description', 'usage'),
+        'list_cache_groups' => Thor::Command.new('list_cache_groups', 'description', 'wrap_long_description',
+                                                 'long_description', 'usage') }
     end
 
     let(:map) do


### PR DESCRIPTION
In spec tests, we instantiate Thor::Command to stub command line arguments.

Thor 1.3.0 was recently released and is automatically pulled into Facter as it satisfies Facter's current gemspec requirements (>= 1.0.1, < 2.0).

Thor 1.3.0 includes rails/thor@190f19a, which adds a new wrap_long_description option to Thor::Command. This new option causes an ArgumentError in current tests because we pass the number of arguments previous to wrap_long_description being added.

This commit updates spec tests to use all of Thor::Command.new's arguments.