### PR TITLE
(FACT-3446) Call close(2) with Solaris FFI

### DIFF
--- a/lib/facter/resolvers/solaris/ffi/functions.rb
+++ b/lib/facter/resolvers/solaris/ffi/functions.rb
@@ -10,7 +10,7 @@ module Facter
 
           attach_function :ioctl_base, :ioctl, %i[int int pointer], :int
           attach_function :open_socket, :socket, %i[int int int], :int
-          attach_function :close_socket, :shutdown, %i[int int], :int
+          attach_function :close_socket, :close, %i[int], :int
           attach_function :inet_ntop, %i[int pointer pointer uint], :string
 
           def self.ioctl(call_const, pointer, address_family = AF_INET)
@@ -18,7 +18,7 @@ module Facter
             begin
               ioctl_base(fd, call_const, pointer)
             ensure
-              Ioctl.close_socket(fd, 2)
+              Ioctl.close_socket(fd)
             end
           end
         end

--- a/lib/facter/resolvers/solaris/networking.rb
+++ b/lib/facter/resolvers/solaris/networking.rb
@@ -79,7 +79,7 @@ module Facter
             ioctl = FFI::Ioctl.ioctl(FFI::SIOCGLIFMTU, lifreq, lifreq.ss_family)
 
             if ioctl == -1
-              @log.error("Cold not read MTU, error code is #{::FFI::LastError.error}")
+              @log.error("Could not read MTU, error code is: #{::FFI::LastError.error}")
               return
             end
 


### PR DESCRIPTION
Previously, when Facter ran on Solaris it would use shutdown(2) to attempt to close open sockets. However, this would leak file descriptors and occasionally cause an issue where the system would hit its maximum open files.

This commit updates Facter to instead use close(2) on Solaris to ensure that file descriptors are not leaked.