### PR TITLE
(FACT-3160) Fix size calculations for AIX blockdevice and partitions

### DIFF
--- a/lib/facter/resolvers/aix/disks.rb
+++ b/lib/facter/resolvers/aix/disks.rb
@@ -47,7 +47,7 @@ module Facter
           end
 
           def compute_size(size_hash)
-            physical_partitions = size_hash['TOTAL PPs'].to_i + size_hash['FREE PPs'].to_i
+            physical_partitions = size_hash['TOTAL PPs'].to_i
             size_physical_partition = size_hash['PP SIZE']
             exp = if size_physical_partition[/mega/]
                     Facter::Util::Aix::InfoExtractor::MEGABYTES_EXPONENT

--- a/lib/facter/resolvers/aix/partitions.rb
+++ b/lib/facter/resolvers/aix/partitions.rb
@@ -56,14 +56,14 @@ module Facter
           end
 
           def compute_size(info_hash)
-            physical_partitions = info_hash['PPs'].to_i
+            logical_partitions = info_hash['LPs'].to_i
             size_physical_partition = info_hash['PP SIZE']
             exp = if size_physical_partition[/mega/]
                     Facter::Util::Aix::InfoExtractor::MEGABYTES_EXPONENT
                   else
                     Facter::Util::Aix::InfoExtractor::GIGABYTES_EXPONENT
                   end
-            size_physical_partition.to_i * physical_partitions * exp
+            size_physical_partition.to_i * logical_partitions * exp
           end
         end
       end

--- a/lib/facter/util/aix/info_extractor.rb
+++ b/lib/facter/util/aix/info_extractor.rb
@@ -61,7 +61,7 @@ module Facter
           properties = PROPERTIES[cmd]
           properties.each do |property|
             str = (properties - [property]).join('|')
-            matcher = content.match(/#{Regexp.escape(property)}([^\n]*?)(#{str}|\n|$)/s)
+            matcher = content.match(/(?:^|^[^:]+:[^:]+)#{Regexp.escape(property)}([^\n]*?)(#{str}|\n|$)/s)
             if matcher
               value = matcher[1].strip
               property_hash[property.split(':').first] = value

--- a/spec/facter/resolvers/aix/disks_spec.rb
+++ b/spec/facter/resolvers/aix/disks_spec.rb
@@ -28,7 +28,7 @@ describe Facter::Resolvers::Aix::Disks do
     let(:result) { load_fixture('lspv_output').read }
 
     let(:disks) do
-      { 'hdisk0' => { size: '30.00 GiB', size_bytes: 32_212_254_720 } }
+      { 'hdisk0' => { size: '29.97 GiB', size_bytes: 32_178_700_288 } }
     end
 
     before do


### PR DESCRIPTION
* disks.rb: TOTAL PPs = USED PPs + FREE PPs. Therefor adding FREE PPs to TOTAL PPs produces incorrect disk sizes.

* partitions.rb: Using physical_partitions (PPs) to calculate LV sizes are not suitable if there is more than one mirror (can be two or three). LPs * nr_of_mirrors = PPs.

* info_extractor.rb: Adjusted regexp because using property LPs also matched MAX LPs.
