### PR TITLE
(FACT-3436) Revert Debian ARM architecture change

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -81,7 +81,7 @@ module Facter
           os_hardware = 'x86_64'
           processor_model_pattern = /(Intel\(R\).*)|(AMD.*)/
         elsif agent['platform'] =~ /aarch64/
-          os_arch     = 'arm64'
+          os_arch     = 'aarch64'
           os_hardware = 'aarch64'
           processor_model_pattern = // # FACT-3439 - facter doesn't figure out the processor type on these machines 
         else
@@ -391,7 +391,7 @@ module Facter
           os_hardware = 'x86_64'
           processor_model_pattern = /(Intel\(R\).*)|(AMD.*)/
         elsif agent['platform'] =~ /aarch64/
-          os_arch                 = 'arm64'
+          os_arch                 = 'aarch64'
           os_hardware             = 'aarch64'
           processor_model_pattern = // # facter doesn't figure out the processor type on these machines
         else

--- a/lib/facter/facts/debian/architecture.rb
+++ b/lib/facter/facts/debian/architecture.rb
@@ -8,7 +8,9 @@ module Facts
         ALIASES = 'architecture'
 
         def call_the_resolver
-          fact_value = Facter::Core::Execution.execute('dpkg --print-architecture')
+          fact_value = Facter::Resolvers::Uname.resolve(:machine)
+          fact_value = 'amd64' if fact_value == 'x86_64'
+          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/spec/facter/facts/debian/os/architecture_spec.rb
+++ b/spec/facter/facts/debian/os/architecture_spec.rb
@@ -4,16 +4,61 @@ describe Facts::Debian::Os::Architecture do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Debian::Os::Architecture.new }
 
-    %w[amd64 arm64 i386].each do |arch|
-      it 'calls Facter::Core::Execution and returns architecture fact' do
-        allow(Facter::Core::Execution).to receive(:execute).and_return(arch)
+    context 'when resolver does not return x86_64' do
+      let(:value) { 'i86pc' }
 
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
         fact.call_the_resolver
-        expect(Facter::Core::Execution).to have_received(:execute).with('dpkg --print-architecture')
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
 
+      it 'returns architecture fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: arch),
-                          an_object_having_attributes(name: 'architecture', value: arch, type: :legacy))
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                          an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
+      end
+    end
+
+    context 'when os is 32-bit' do
+      let(:value) { 'i586' }
+      let(:fact_value) { 'i386' }
+
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: fact_value),
+                          an_object_having_attributes(name: 'architecture', value: fact_value, type: :legacy))
+      end
+    end
+
+    context 'when resolver returns x86_64' do
+      let(:value) { 'x86_64' }
+
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: 'amd64'),
+                          an_object_having_attributes(name: 'architecture', value: 'amd64', type: :legacy))
       end
     end
   end


### PR DESCRIPTION
The `os.architecture` fact has historically resolved differently for Debian for `x86` and `x86_64` to use Debian's architecture convention, i.e. using `i386` and `amd64`, respectively.

We attempted to continue that convention for AARCH/ARM prior to official Puppet support for Debian on ARM in https://github.com/puppetlabs/facter/pull/2621. However, Debian-based Ubuntu on ARM has been officially supported by Puppet since 2021 and this change to `os.architecture` has the potential to break existing code.

This change reverts changes made in https://github.com/puppetlabs/facter/pull/2621 and https://github.com/puppetlabs/facter/pull/2627 to return Facter to its prior behavior of the `os.architecture` fact resolving to `aarch64` on Debian.