### PR TITLE
(maint) ensure no nil dereference in find_in_interfaces

### DIFF
--- a/lib/facter/util/resolvers/networking/primary_interface.rb
+++ b/lib/facter/util/resolvers/networking/primary_interface.rb
@@ -57,6 +57,8 @@ module Facter
             end
 
             def find_in_interfaces(interfaces)
+              return if interfaces.nil?
+
               interfaces.each do |iface_name, interface|
                 interface[:bindings]&.each do |binding|
                   return iface_name unless Facter::Util::Resolvers::Networking.ignored_ip_address(binding[:address])


### PR DESCRIPTION
This adds a simple check to ensure that `find_in_interfaces` does not attempt to dereference a nil argument.  It resolves https://github.com/puppetlabs/facter/issues/2637