### PR TITLE
(FACT-3448) Add Amazon to base fact utility

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -10,7 +10,7 @@ module Facter
           aix_expected_facts(agent)
         elsif agent['platform'] =~ /debian-/
           debian_expected_facts(agent)
-        elsif agent['platform'] =~ /el-|centos-/
+        elsif agent['platform'] =~ /amazon-|el-|centos-/
           el_expected_facts(agent)
         elsif agent['platform'] =~ /fedora-/
           fedora_expected_facts(agent)


### PR DESCRIPTION
This commit adds Amazon as a condition to the os_processors_and_kernel_expected_facts method.