### PR TITLE
(FACT-3452) Make Xen resolver more strict

### DIFF
--- a/lib/facter/resolvers/xen.rb
+++ b/lib/facter/resolvers/xen.rb
@@ -26,7 +26,9 @@ module Facter
 
         def detect_xen_type
           xen_type = 'xen0' if File.exist?('/dev/xen/evtchn')
-          xen_type = 'xenu' if !xen_type && (File.exist?('/proc/xen') || File.exist?('/dev/xvda1'))
+          if !xen_type && (File.exist?('/proc/xen') || (File.exist?('/dev/xvda1') && !File.symlink?('/dev/xvda1')))
+            xen_type = 'xenu'
+          end
 
           xen_type
         end

--- a/spec/facter/resolvers/xen_spec.rb
+++ b/spec/facter/resolvers/xen_spec.rb
@@ -87,4 +87,16 @@ describe Facter::Resolvers::Xen do
       expect(xen_resolver.resolve(:domains)).to be_nil
     end
   end
+
+  context 'when /dev/xvda1 is a symlink' do
+    let(:evtchn_file) { false }
+
+    before do
+      allow(File).to receive(:symlink?).with('/dev/xvda1').and_return(true)
+    end
+
+    it 'returns nil' do
+      expect(xen_resolver.resolve(:vm)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, Facter could misidentify non-Xen systems as being Xen-based.

In some circumstances, a non-Xen system will have /dev/xvd* files present as symlinks to other devices. This was observed on an Amazon Linux 2023 machine, which was running on a Nitro (KVM-based) hypervisor but symlinked /dev/xvda1 to an nvme device.

This commit updates the Xen resolver to check if /dev/xvda1 is a symlink to avoid misidentifying if a system is Xen-based.