### PR TITLE
(FACT-3451) extend amazon linux os release fact

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -119,6 +119,11 @@ Style/ClassVars:
   Exclude:
     - !ruby/regexp /(?:(?!.+_resolver.rb).)*$/
 
+Style/FormatStringToken:
+  Exclude:
+    - 'lib/facter/resolvers/amzn/os_release_rpm.rb'
+    - 'spec/facter/resolvers/amzn/os_release_rpm_spec.rb'
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'spec/custom_facts/util/normalization_spec.rb'

--- a/lib/facter/facts/amzn/os/distro/release.rb
+++ b/lib/facter/facts/amzn/os/distro/release.rb
@@ -20,10 +20,10 @@ module Facts
           end
 
           def determine_release_version
-            version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+            version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
             version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
 
-            Facter::Util::Facts.release_hash_from_string(version)
+            Facter::Util::Facts.release_hash_from_string(version, include_patch: true)
           end
         end
       end

--- a/lib/facter/facts/amzn/os/release.rb
+++ b/lib/facter/facts/amzn/os/release.rb
@@ -18,7 +18,7 @@ module Facts
         end
 
         def determine_release_version
-          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+          version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
           version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
 
           Facter::Util::Facts.release_hash_from_string(version)

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -244,6 +244,8 @@ os_hierarchy.each do |os|
     require_relative '../../facts/amzn/os/distro/release.rb'
     require_relative '../../facts/amzn/os/release.rb'
 
+    require_relative '../../resolvers/amzn/os_release_rpm'
+
   when 'bsd'
     require_relative '../../facts/bsd/kernelmajversion.rb'
     require_relative '../../facts/bsd/kernelversion.rb'

--- a/lib/facter/resolvers/amzn/os_release_rpm.rb
+++ b/lib/facter/resolvers/amzn/os_release_rpm.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Amzn
+      class OsReleaseRpm < BaseResolver
+        init_resolver
+
+        class << self
+          private
+
+          def post_resolve(fact_name, _options)
+            @fact_list.fetch(fact_name) { rpm_system_call(fact_name) }
+          end
+
+          def rpm_system_call(fact_name)
+            output = Facter::Core::Execution.execute(
+              'rpm -q --qf \'%{NAME}\n%{VERSION}\n%{RELEASE}\n%{VENDOR}\' -f /etc/os-release',
+              logger: log
+            )
+            build_fact_list(output)
+
+            @fact_list[fact_name]
+          end
+
+          def build_fact_list(output)
+            rpm_results = output.split("\n")
+
+            return if rpm_results.empty?
+
+            @fact_list[:package],
+              @fact_list[:version],
+              @fact_list[:release],
+              @fact_list[:vendor] = rpm_results.map(&:strip)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/util/facts/facts_utils.rb
+++ b/lib/facter/util/facts/facts_utils.rb
@@ -25,7 +25,7 @@ module Facter
           os
         end
 
-        def release_hash_from_string(output)
+        def release_hash_from_string(output, include_patch: false)
           return unless output
 
           versions = output.split('.')
@@ -33,6 +33,7 @@ module Facter
             release['full'] = output
             release['major'] = versions[0]
             release['minor'] = versions[1] if versions[1]
+            release['patch'] = versions[2] if versions[2] && include_patch
           end
         end
 

--- a/spec/facter/facts/amzn/os/distro/release_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/release_spec.rb
@@ -5,22 +5,22 @@ describe Facts::Amzn::Os::Distro::Release do
     subject(:fact) { Facts::Amzn::Os::Distro::Release.new }
 
     before do
-      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, { release_file: '/etc/system-release' })
+      allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
+        .with(:version)
         .and_return(value)
     end
 
-    context 'when version is retrieved from specific file' do
+    context 'when version is retrieved from rpm' do
       let(:value) { '2.13.0' }
-      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13', 'patch' => '0' } }
 
-      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+      it 'calls Facter::Resolvers::Amzn::OsReleaseRpm with version' do
         fact.call_the_resolver
-        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
-          .with(:release, release_file: '/etc/system-release')
+        expect(Facter::Resolvers::Amzn::OsReleaseRpm).to have_received(:resolve)
+          .with(:version)
       end
 
-      it 'returns operating system name fact' do
+      it 'returns os distro release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
                           an_object_having_attributes(name: 'lsbdistrelease',
@@ -46,7 +46,7 @@ describe Facts::Amzn::Os::Distro::Release do
         expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
       end
 
-      it 'returns operating system name fact' do
+      it 'returns os distro release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
                           an_object_having_attributes(name: 'lsbdistrelease',
@@ -60,7 +60,7 @@ describe Facts::Amzn::Os::Distro::Release do
       context 'when release can\'t be received' do
         let(:os_release) { nil }
 
-        it 'returns operating system name fact' do
+        it 'returns os distro release fact as nil' do
           expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
             have_attributes(name: 'os.distro.release', value: nil)
         end

--- a/spec/facter/facts/amzn/os/release_spec.rb
+++ b/spec/facter/facts/amzn/os/release_spec.rb
@@ -5,22 +5,22 @@ describe Facts::Amzn::Os::Release do
     subject(:fact) { Facts::Amzn::Os::Release.new }
 
     before do
-      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
-        .with(:release, { release_file: '/etc/system-release' })
+      allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
+        .with(:version)
         .and_return(value)
     end
 
-    context 'when version is retrieved from specific file' do
+    context 'when version is retrieved from rpm' do
       let(:value) { '2.13.0' }
       let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
 
-      it 'calls Facter::Resolvers::ReleaseFromFirstLine with version' do
+      it 'calls Facter::Resolvers::Amzn::OsReleaseRpm with version' do
         fact.call_the_resolver
-        expect(Facter::Resolvers::ReleaseFromFirstLine).to have_received(:resolve)
-          .with(:release, release_file: '/etc/system-release')
+        expect(Facter::Resolvers::Amzn::OsReleaseRpm).to have_received(:resolve)
+          .with(:version)
       end
 
-      it 'returns operating system name fact' do
+      it 'returns os release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
                           an_object_having_attributes(name: 'operatingsystemmajrelease',
@@ -44,7 +44,7 @@ describe Facts::Amzn::Os::Release do
         expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
       end
 
-      it 'returns operating system name fact' do
+      it 'returns os release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
                           an_object_having_attributes(name: 'operatingsystemmajrelease',
@@ -53,10 +53,10 @@ describe Facts::Amzn::Os::Release do
                                                       value: release['full'], type: :legacy))
       end
 
-      context 'when release can\'t be received' do
+      context 'when version can\'t be retrieved' do
         let(:os_release) { nil }
 
-        it 'returns operating system name fact' do
+        it 'returns os release fact as nil' do
           expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
             have_attributes(name: 'os.release', value: nil)
         end

--- a/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
+++ b/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Amzn::OsReleaseRpm do
+  subject(:os_release_resolver) { Facter::Resolvers::Amzn::OsReleaseRpm }
+
+  let(:log_spy) { Facter::Log }
+
+  before do
+    os_release_resolver.instance_variable_set(:@log, log_spy)
+    allow(Facter::Core::Execution).to receive(:execute)
+      .with("rpm -q --qf '%{NAME}\\n%{VERSION}\\n%{RELEASE}\\n%{VENDOR}' -f /etc/os-release", { logger: log_spy })
+      .and_return(os_release_content)
+  end
+
+  after do
+    os_release_resolver.invalidate_cache
+  end
+
+  context 'when on AmazonLinux 2023' do
+    let(:os_release_content) { "system-release\n2023.2.20231113\n1.amzn2023\nAmazon Linux" }
+
+    it 'returns os release package version' do
+      expect(os_release_resolver.resolve(:version)).to eq('2023.2.20231113')
+    end
+
+    it 'returns os release package release' do
+      expect(os_release_resolver.resolve(:release)).to eq('1.amzn2023')
+    end
+
+    it 'returns os release package vendor' do
+      expect(os_release_resolver.resolve(:vendor)).to eq('Amazon Linux')
+    end
+  end
+
+  context 'when on AmazonLinux 2' do
+    let(:os_release_content) { "system-release\n2\n16.amzn2\nAmazon Linux" }
+
+    it 'returns os release package version' do
+      expect(os_release_resolver.resolve(:version)).to eq('2')
+    end
+
+    it 'returns os release package release' do
+      expect(os_release_resolver.resolve(:release)).to eq('16.amzn2')
+    end
+  end
+
+  context 'when on os-release file missing' do
+    let(:os_release_content) { '' }
+
+    it 'returns nil VERSION' do
+      expect(os_release_resolver.resolve(:version)).to be_nil
+    end
+  end
+end

--- a/spec/facter/util/facts/facts_utils_spec.rb
+++ b/spec/facter/util/facts/facts_utils_spec.rb
@@ -62,6 +62,18 @@ describe Facter::Util::Facts do
       expect(facts_util.release_hash_from_string('6')['minor']).to be_nil
     end
 
+    it 'returns valid patch release if requested' do
+      expect(facts_util.release_hash_from_string('6.2.1', include_patch: true)['patch']).to eq('1')
+    end
+
+    it 'returns patch release as nil if not requested' do
+      expect(facts_util.release_hash_from_string('6.2.1')['patch']).to be_nil
+    end
+
+    it 'returns patch release as nil if requested but not in version' do
+      expect(facts_util.release_hash_from_string('6.2')['patch']).to be_nil
+    end
+
     it 'returns nil if data is nil' do
       expect(facts_util.release_hash_from_string(nil)).to be_nil
     end


### PR DESCRIPTION
Referencing a package version seems to be the only way to do this on Amazon Linux 2023.
Fixes #2647

Semi-related, there's no codename in AL 2023, should 'n/a' really be a default value?