### PR TITLE
Remove Rubocop TODO action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,15 +24,3 @@ jobs:
       - run: bundle install --jobs 3 --retry 3
       - run: bundle exec rubocop --parallel
 
-  rtc:
-    runs-on: ubuntu-20.04
-    name: RuboCop TODO
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gimmyxd/rtc-action@0.3.1
-        env:
-          RTC_TOKEN: ${{ secrets.RTC_TOKEN }}
-          UPDATE_PR: false
-
-          # forces the job to fail if there are any new offences
-          FORCE_ERROR_EXIT: true


### PR DESCRIPTION
The Rubocop TODO action is an unmaintained action from a former Puppet employee that seems to have been silently failing for a while now with "fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree".

Recently, the action has started loudly failing because of incompatbility between Ruby, RubyGems, and bundler.

This commit removes the Rubocop TODO action.