### PR TITLE
(FACT-3451) Restore os facts for AmazonLinux 2

### DIFF
--- a/lib/facter/facts/amzn/os/distro/release.rb
+++ b/lib/facter/facts/amzn/os/distro/release.rb
@@ -20,7 +20,12 @@ module Facts
           end
 
           def determine_release_version
-            version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
+            # For backwards compatibility, use system-release for AL1/AL2
+            version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+            if !version.nil? && version != '2'
+              # Use os-release for AL2023 and up
+              version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
+            end
             version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
 
             Facter::Util::Facts.release_hash_from_string(version, include_patch: true)

--- a/lib/facter/facts/amzn/os/release.rb
+++ b/lib/facter/facts/amzn/os/release.rb
@@ -18,7 +18,12 @@ module Facts
         end
 
         def determine_release_version
-          version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
+          # For backwards compatibility, use system-release for AL1/AL2
+          version = Facter::Resolvers::ReleaseFromFirstLine.resolve(:release, release_file: '/etc/system-release')
+          if !version.nil? && version != '2'
+            # Use os-release for AL2023 and up
+            version = Facter::Resolvers::Amzn::OsReleaseRpm.resolve(:version)
+          end
           version ||= Facter::Resolvers::OsRelease.resolve(:version_id)
 
           Facter::Util::Facts.release_hash_from_string(version)

--- a/spec/facter/facts/amzn/os/distro/release_spec.rb
+++ b/spec/facter/facts/amzn/os/distro/release_spec.rb
@@ -5,16 +5,21 @@ describe Facts::Amzn::Os::Distro::Release do
     subject(:fact) { Facts::Amzn::Os::Distro::Release.new }
 
     before do
-      allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
-        .with(:version)
-        .and_return(value)
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, { release_file: '/etc/system-release' })
+        .and_return(system_release_value)
     end
 
-    context 'when version is retrieved from rpm' do
-      let(:value) { '2.13.0' }
-      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13', 'patch' => '0' } }
+    context 'when version is retrieved from rpm on AL2023' do
+      let(:system_release_value) { '2023' }
+      let(:os_release_value) { '2023.1.20230912' }
+      let(:release) { { 'full' => '2023.1.20230912', 'major' => '2023', 'minor' => '1', 'patch' => '20230912' } }
 
-      it 'returns os distro release fact' do
+      it 'returns os distro release fact including patch' do
+        allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
+          .with(:version)
+          .and_return(os_release_value)
+
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
                           an_object_having_attributes(name: 'lsbdistrelease',
@@ -26,15 +31,28 @@ describe Facts::Amzn::Os::Distro::Release do
       end
     end
 
-    context 'when version is retrieved from os-release file' do
-      let(:value) { nil }
-      let(:os_release) { '2' }
+    context 'when version is retrieved from os-release file on AL1' do
+      let(:system_release_value) { nil }
+      let(:os_release_value) { '2017.03' }
+      let(:release) { { 'full' => '2017.03', 'major' => '2017', 'minor' => '03' } }
+
+      it 'returns os distro release fact' do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release_value)
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
+                          an_object_having_attributes(name: 'lsbdistrelease',
+                                                      value: release['full'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'lsbminordistrelease',
+                                                      value: release['minor'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file on AL2' do
+      let(:system_release_value) { '2' }
       let(:release) { { 'full' => '2', 'major' => '2' } }
 
-      before do
-        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
-      end
-
       it 'returns os distro release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: release),
@@ -45,14 +63,17 @@ describe Facts::Amzn::Os::Distro::Release do
                           an_object_having_attributes(name: 'lsbminordistrelease',
                                                       value: release['minor'], type: :legacy))
       end
+    end
 
-      context 'when release can\'t be received' do
-        let(:os_release) { nil }
+    context 'when release can\'t be retrieved' do
+      let(:system_release_value) { nil }
+      let(:os_release_value) { nil }
 
-        it 'returns os distro release fact as nil' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'os.distro.release', value: nil)
-        end
+      it 'returns os distro release fact as nil' do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release_value)
+
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.release', value: nil)
       end
     end
   end

--- a/spec/facter/facts/amzn/os/release_spec.rb
+++ b/spec/facter/facts/amzn/os/release_spec.rb
@@ -5,16 +5,21 @@ describe Facts::Amzn::Os::Release do
     subject(:fact) { Facts::Amzn::Os::Release.new }
 
     before do
-      allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
-        .with(:version)
-        .and_return(value)
+      allow(Facter::Resolvers::ReleaseFromFirstLine).to receive(:resolve)
+        .with(:release, { release_file: '/etc/system-release' })
+        .and_return(system_release_value)
     end
 
-    context 'when version is retrieved from rpm' do
-      let(:value) { '2.13.0' }
-      let(:release) { { 'full' => '2.13.0', 'major' => '2', 'minor' => '13' } }
+    context 'when version is retrieved from rpm on AL2023' do
+      let(:system_release_value) { '2023' }
+      let(:os_release_value) { '2023.1.20230912' }
+      let(:release) { { 'full' => '2023.1.20230912', 'major' => '2023', 'minor' => '1' } }
 
-      it 'returns os release fact' do
+      it 'returns os release fact excluding patch' do
+        allow(Facter::Resolvers::Amzn::OsReleaseRpm).to receive(:resolve)
+          .with(:version)
+          .and_return(os_release_value)
+
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
                           an_object_having_attributes(name: 'operatingsystemmajrelease',
@@ -24,15 +29,27 @@ describe Facts::Amzn::Os::Release do
       end
     end
 
-    context 'when version is retrieved from os-release file' do
-      let(:value) { nil }
-      let(:os_release) { '2' }
+    context 'when version is retrieved from os-release file on AL1' do
+      let(:system_release_value) { nil }
+      let(:os_release_value) { '2017.03' }
+      let(:release) { { 'full' => '2017.03', 'major' => '2017', 'minor' => '03' } }
+
+      it 'returns os release fact' do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release_value)
+
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when version is retrieved from os-release file on AL2' do
+      let(:system_release_value) { '2' }
       let(:release) { { 'full' => '2', 'major' => '2' } }
 
-      before do
-        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release)
-      end
-
       it 'returns os release fact' do
         expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
           contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
@@ -41,14 +58,17 @@ describe Facts::Amzn::Os::Release do
                           an_object_having_attributes(name: 'operatingsystemrelease',
                                                       value: release['full'], type: :legacy))
       end
+    end
 
-      context 'when version can\'t be retrieved' do
-        let(:os_release) { nil }
+    context 'when version can\'t be retrieved' do
+      let(:system_release_value) { nil }
+      let(:os_release_value) { nil }
 
-        it 'returns os release fact as nil' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
-            have_attributes(name: 'os.release', value: nil)
-        end
+      it 'returns os release fact as nil' do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(os_release_value)
+
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.release', value: nil)
       end
     end
   end


### PR DESCRIPTION
Commit abba8950c changed the `os.release` and `os.distro.release` facts on Amazon Linux to query the os-release rpm, effectively running this command:

    # rpm -q --qf '%{VERSION}\n' -f /etc/os-release
    2023.1.20230912

This was appropriate for AL2023, but it introduced a regression on AL2 because the `os.release.major` and `os.distro.release.major` facts changed from "2" to a year-based version like:

    # rpm -q --qf '%{VERSION}\n' -f /etc/os-release
    2017.12

Since the `os.release.major` fact changed from 2 to 2017, the systemd service provider was no longer the default on AL2[1]

AL1 was seemingly unaffected because we were already using a year-based version string and both `VERSION` and `VERSION_ID` were the same:

    # rpm -q --qf '%{VERSION}\n' -f /etc/os-release
    2017.03
    # grep VERSION_ID /etc/os-release
    VERSION_ID="2017.03"

This commit restores the behavior for AL1 and AL2 to use `/etc/system-release`. On AL2, the `major` version will be reported as `2` instead of `20xx`.

This commit preserves the AL2023 behavior so it uses the os-release rpm to report the `major` version `2023`.

[1] https://github.com/puppetlabs/puppet/blob/8.3.1/lib/puppet/provider/service/systemd.rb#L22