### PR TITLE
Relax os.macosx.version.full requirement

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -263,6 +263,9 @@ module Facter
           'os.macosx.product' => 'macOS',
           'os.macosx.version.major' => major_version,
           'os.macosx.version.minor' => /\d+/,
+          'os.macosx.version.patch' => /\d+/,
+          # If "patch" is 0, then the third component will be omitted
+          'os.macosx.version.full' => /^#{major_version}\.\d+(\.\d+)?$/,
           'os.release.full' => /\d+\.\d+\.\d+/,
           'os.release.major' => /\d+/,
           'os.release.minor' => /\d+/,
@@ -275,13 +278,6 @@ module Facter
           'kernelversion' => /\d+\.\d+\.\d+/,
           'kernelmajversion' => /\d+\.\d+/
         }
-
-        expected_facts['os.macosx.version.patch'] = /\d+/
-        if agent['platform'] =~ /arm64/ && agent['platform'].split('-')[1].to_i < 13
-          expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}$/
-        else
-          expected_facts['os.macosx.version.full'] = /^#{expected_facts['os.macosx.version.major']}\.#{expected_facts['os.macosx.version.minor']}\.*#{expected_facts['os.macosx.version.patch']}*$/
-        end
         expected_facts
       end
 


### PR DESCRIPTION
The os_processors_and_kernel test passed on macOS 12 ARM when "os.macosx.version.full" was "12.4", but failed when it was "12.6.1".

The "full" fact is populated from the result of `sw_vers -productVersion`. If the patch component is 0, then the patch component is omitted from "full". Otherwise, it is included.

It just so happens some of our macOS 12 ARM hosts have a mix of patch 0 and non-zero. However, the issue isn't limited to just that OS and arch. So relax the requirement for the "patch" component for all macOS hosts.