### PR TITLE
feat(processor.extensions) Add support for CPU flag detection

### DIFF
--- a/lib/facter/facts/linux/processors/extensions.rb
+++ b/lib/facter/facts/linux/processors/extensions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Linux
+    module Processors
+      class Extensions
+        FACT_NAME = 'processors.extensions'
+
+        def call_the_resolver
+          fact_value = Facter::Resolvers::Linux::Processors.resolve(:extensions)
+          Facter::ResolvedFact.new(FACT_NAME, fact_value)
+        end
+      end
+    end
+  end
+end

--- a/lib/facter/framework/core/file_loader.rb
+++ b/lib/facter/framework/core/file_loader.rb
@@ -482,6 +482,7 @@ os_hierarchy.each do |os|
     require_relative '../../facts/linux/processor'
     require_relative '../../facts/linux/processors/cores'
     require_relative '../../facts/linux/processors/count'
+    require_relative '../../facts/linux/processors/extensions'
     require_relative '../../facts/linux/processors/isa'
     require_relative '../../facts/linux/processors/models'
     require_relative '../../facts/linux/processors/physicalcount'

--- a/lib/facter/resolvers/processors.rb
+++ b/lib/facter/resolvers/processors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Facter
   module Resolvers
     module Linux
@@ -10,6 +12,7 @@ module Facter
 
         class << self
           # :count
+          # :extensions
           # :models
           # :physical_count
           # :speed
@@ -32,6 +35,7 @@ module Facter
           end
 
           def read_processors(cpuinfo_output)
+            @fact_list[:extensions] = Set[Facter::Resolvers::Uname.resolve(:processor)]
             @fact_list[:processors] = 0
             @fact_list[:models] = []
             @fact_list[:physical_processors] = []
@@ -41,7 +45,10 @@ module Facter
               construct_models_list(tokens)
               count_physical_processors(tokens)
               build_speed(tokens)
+              check_extensions(tokens)
             end
+            @fact_list[:extensions] = @fact_list[:extensions].to_a
+            @fact_list[:extensions].sort!
           end
 
           def count_processors(tokens)
@@ -81,6 +88,21 @@ module Facter
           def build_speed_for_x86(tokens)
             speed = tokens.last.strip.match(/^(\d+).*/)[1]
             @fact_list[:speed] = speed.to_i * MHZ_TO_HZ
+          end
+
+          def check_extensions(tokens)
+            return unless tokens.first.strip == 'flags'
+
+            flags = tokens.last.split(' ')
+
+            # TODO: As we gain support for other arches, change the guard
+            # so we only check the flags for the corosponding arches
+            return unless @fact_list[:extensions].include?('x86_64')
+
+            @fact_list[:extensions].add('x86_64-v1') if (%w[cmov cx8 fpu fxsr lm mmx syscall sse2] - flags).empty?
+            @fact_list[:extensions].add('x86_64-v2') if (%w[cx16 lahf_lm popcnt sse4_1 sse4_2 ssse3] - flags).empty?
+            @fact_list[:extensions].add('x86_64-v3') if (%w[abm avx avx2 bmi1 bmi2 f16c fma movbe xsave] - flags).empty?
+            @fact_list[:extensions].add('x86_64-v4') if (%w[avx512f avx512bw avx512cd avx512dq avx512vl] - flags).empty?
           end
         end
       end

--- a/spec/facter/resolvers/processors_spec.rb
+++ b/spec/facter/resolvers/processors_spec.rb
@@ -3,6 +3,7 @@
 describe Facter::Resolvers::Linux::Processors do
   after do
     Facter::Resolvers::Linux::Processors.invalidate_cache
+    Facter::Resolvers::Uname.invalidate_cache
   end
 
   context 'when on x86 architecture' do
@@ -21,6 +22,9 @@ describe Facter::Resolvers::Linux::Processors do
       end
 
       let(:speed) { 2_294_000_000 }
+      let(:extensions) do
+        %w[x86_64 x86_64-v1 x86_64-v2 x86_64-v3]
+      end
 
       it 'returns number of processors' do
         result = Facter::Resolvers::Linux::Processors.resolve(:processors)
@@ -44,6 +48,16 @@ describe Facter::Resolvers::Linux::Processors do
         result = Facter::Resolvers::Linux::Processors.resolve(:speed)
 
         expect(result).to eq(speed)
+      end
+
+      it 'returns extensions supported' do
+        allow(Facter::Resolvers::Uname).to receive(:resolve)
+          .with(:processor)
+          .and_return('x86_64')
+
+        result = Facter::Resolvers::Linux::Processors.resolve(:extensions)
+
+        expect(result).to eq(extensions)
       end
     end
 
@@ -75,6 +89,7 @@ describe Facter::Resolvers::Linux::Processors do
 
       after do
         Facter::Resolvers::Linux::Processors.invalidate_cache
+        Facter::Resolvers::Uname.invalidate_cache
       end
 
       let(:physical_processors) { 2 }
@@ -135,6 +150,11 @@ describe Facter::Resolvers::Linux::Processors do
         .and_return('1')
     end
 
+    after do
+      Facter::Resolvers::Linux::Processors.invalidate_cache
+      Facter::Resolvers::Uname.invalidate_cache
+    end
+
     let(:speed) { 2_926_000_000 }
     let(:physical_processors) { 2 }
 
@@ -184,6 +204,11 @@ describe Facter::Resolvers::Linux::Processors do
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/devices/system/cpu/cpu1/topology/physical_package_id')
         .and_return('0')
+    end
+
+    after do
+      Facter::Resolvers::Linux::Processors.invalidate_cache
+      Facter::Resolvers::Uname.invalidate_cache
     end
 
     let(:physical_processors) { 1 }


### PR DESCRIPTION
This should add in an extra set of attributes for finding your microarch or CPU extensions.

Addresses #2663

I'll probably need help with the tests...