### PR TITLE
Revert "(FACT-3428) Performance/RegexpMatch"

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,6 +6,12 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+# Offense count: 3
+# This cop supports safe autocorrection (--autocorrect).
+Performance/RegexpMatch:
+  Exclude:
+    - 'install.rb'
+
 # Offense count: 70
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*

--- a/install.rb
+++ b/install.rb
@@ -40,7 +40,7 @@ class Installer
 
   # Returns true if OS is windows (copied from facter/util/config.rb)
   def windows?
-    (defined?(RbConfig) ? RbConfig : Config)::CONFIG['host_os'].match?(/mswin|win32|dos|mingw|cygwin/i)
+    (defined?(RbConfig) ? RbConfig : Config)::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
   end
 
   def glob(list)
@@ -153,7 +153,7 @@ class Installer
     # /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin
     # which is not generally where people expect executables to be installed
     # These settings are appropriate defaults for all OS X versions.
-    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM.match?(/^universal-darwin[\d.]+$/)
+    RbConfig::CONFIG['bindir'] = '/usr/bin' if RUBY_PLATFORM =~ /^universal-darwin[\d.]+$/
 
     # if InstallOptions.configdir
     #   configdir = InstallOptions.configdir
@@ -173,10 +173,10 @@ class Installer
     else
       sitelibdir = RbConfig::CONFIG['sitelibdir']
       if sitelibdir.nil?
-        sitelibdir = $LOAD_PATH.find { |x| x.match?(/site_ruby/) }
+        sitelibdir = $LOAD_PATH.find { |x| x =~ /site_ruby/ }
         if sitelibdir.nil?
           sitelibdir = File.join(libdir, 'site_ruby')
-        elsif !sitelibdir.match?(Regexp.quote(version))
+        elsif sitelibdir !~ Regexp.quote(version)
           sitelibdir = File.join(sitelibdir, version)
         end
       end
@@ -232,7 +232,7 @@ class Installer
       File.open(tmp_file.path, 'w') do |op|
         op.puts "#!#{ruby}"
         contents = ip.readlines
-        contents.shift if contents[0].match?(/^#!/)
+        contents.shift if contents[0] =~ /^#!/
         op.write contents.join
       end
     end


### PR DESCRIPTION
This reverts commit c8c09efdc8aaa43aaa9bc501872c21ac8ab0678b.

Solaris 10 Intel & SPARC use old Ruby versions for OpenCSW and pl-build-tools that do not have the method match?