### PR TITLE
Update deprecated Beaker methods

### DIFF
--- a/acceptance/tests/api/value/custom_fact_in_same_file_as_fact_name.rb
+++ b/acceptance/tests/api/value/custom_fact_in_same_file_as_fact_name.rb
@@ -31,7 +31,7 @@ test_name 'Facter.value(custom_fact) in the same file as fact name' do
       on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
         output = result.stdout.strip
         assert_match(/has resolved to: #{fact_name}/, output, 'Incorrect fact value for custom fact')
-        assert_no_match(/Searching fact: #{fact_name} in all custom facts/, output, 'Loaded all custom facts')
+        refute_match(/Searching fact: #{fact_name} in all custom facts/, output, 'Loaded all custom facts')
       end
     end
   end

--- a/acceptance/tests/api/value/external_fact.rb
+++ b/acceptance/tests/api/value/external_fact.rb
@@ -27,7 +27,7 @@ test_name 'Facter.value(external_fact)' do
       on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
         output = result.stdout.strip
         assert_match(/has resolved to: 123/, output, 'Incorrect fact value for external fact')
-        assert_no_match(/in all custom facts/, output, 'Loaded all custom facts')
+        refute_match(/in all custom facts/, output, 'Loaded all custom facts')
       end
     end
   end

--- a/acceptance/tests/api/value/non_existent_fact.rb
+++ b/acceptance/tests/api/value/non_existent_fact.rb
@@ -27,7 +27,7 @@ test_name 'Facter.value(not_existent)' do
 
       on(agent, "#{ruby_command(agent)} #{facter_rb}") do |result|
         output = result.stdout.strip
-        assert_no_match(/has resolved to: /, output, 'Fact was found')
+        refute_match(/has resolved to: /, output, 'Fact was found')
         assert_match(
           /Searching fact: #{fact_name} in file: #{fact_name}.rb/,
           output,

--- a/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
+++ b/acceptance/tests/custom_facts/error_in_custom_file_does_not_affect_api.rb
@@ -72,14 +72,14 @@ test_name 'Facter api works when there is an error inside a custom fact file' do
     step "Agent #{agent}: Verify that custom fact 2 is missing" do
       create_api_call_file(test_vars, "puts Facter.value('custom_fact_2')")
       on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
-        assert_no_match(/custom_fact_2_value/, ruby_result.stdout.chomp)
+        refute_match(/custom_fact_2_value/, ruby_result.stdout.chomp)
       end
     end
 
     step "Agent #{agent}: Verify that custom fact 3 is missing" do
       create_api_call_file(test_vars, "puts Facter.value('custom_fact_3')")
       on(agent, "#{ruby_command(agent)} #{test_vars[:test_script_path]}") do |ruby_result|
-        assert_no_match(/custom_fact_3_value/, ruby_result.stdout.chomp)
+        refute_match(/custom_fact_3_value/, ruby_result.stdout.chomp)
       end
     end
 

--- a/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
+++ b/acceptance/tests/custom_facts/time_limit_for_execute_command.rb
@@ -31,14 +31,14 @@ test_name 'Facter::Core::Execution accepts and correctly sets a time limit optio
     end
 
     step "Facter: Logs that command of the first custom fact had timeout after setted time limit" do
-      on agent, facter('--custom-dir', custom_dir, 'foo --debug') do |output|
+      on(agent, facter('--custom-dir', custom_dir, 'foo --debug')) do |output|
         assert_match(/DEBUG Facter::Core::Execution.*Timeout encounter after 2s, killing process with pid:/,
                      output.stderr.chomp)
       end
     end
 
     step "Facter: Logs an error stating that the command of the second custom fact had timeout" do
-      on(agent, facter('--custom-dir', custom_dir, 'custom_fact --debug'), acceptable_exit_codes: 1) do |output|
+      on(agent, facter('--custom-dir', custom_dir, 'custom_fact --debug'), acceptable_exit_codes: [1]) do |output|
         assert_match(/ERROR\s+.*Failed while executing '.*sleep.*2': Timeout encounter after 1s, killing process/,
                      output.stderr.chomp)
       end

--- a/acceptance/tests/external_facts/block_external_facts.rb
+++ b/acceptance/tests/external_facts/block_external_facts.rb
@@ -30,7 +30,7 @@ test_name 'custom facts included in blocklist will not be displayed' do
     step "agent #{agent}: resolve the external fact" do
       on(agent, facter("--debug --external-dir \"#{facts_dir}\" --config \"#{config_file}\"")) do |facter_output|
         assert_match(/External fact file external_fact_1#{ext} blocked./, facter_output.stderr.chomp, 'Expected to block the external_fact')
-        refute_match(/external_fact => external_value/, stdout, 'Expected fact not to match fact')
+        refute_match(/external_fact => external_value/, facter_output.stdout, 'Expected fact not to match fact')
       end
     end
   end

--- a/acceptance/tests/external_facts/block_external_facts.rb
+++ b/acceptance/tests/external_facts/block_external_facts.rb
@@ -30,7 +30,7 @@ test_name 'custom facts included in blocklist will not be displayed' do
     step "agent #{agent}: resolve the external fact" do
       on(agent, facter("--debug --external-dir \"#{facts_dir}\" --config \"#{config_file}\"")) do |facter_output|
         assert_match(/External fact file external_fact_1#{ext} blocked./, facter_output.stderr.chomp, 'Expected to block the external_fact')
-        assert_no_match(/external_fact => external_value/, stdout, 'Expected fact not to match fact')
+        refute_match(/external_fact => external_value/, stdout, 'Expected fact not to match fact')
       end
     end
   end

--- a/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
+++ b/acceptance/tests/external_facts/handle_same_filename_in_different_dirs.rb
@@ -34,8 +34,8 @@ test_name 'Should handle same filename in two external directories only if ttl i
 
     step 'works if ttl is not enabled' do
       on(agent, facter("--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" --debug #{fact1} #{fact2}")) do |facter_output|
-        assert_match(/#{fact1} => #{fact1_value}/, stdout, 'Expected fact to match first fact')
-        assert_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact to match second fact')
+        assert_match(/#{fact1} => #{fact1_value}/, facter_output.stdout, 'Expected fact to match first fact')
+        assert_match(/#{fact2} => #{fact2_value}/, facter_output.stdout, 'Expected fact to match second fact')
       end
     end
 
@@ -50,9 +50,9 @@ EOM
       agent.mkdir_p(config_dir)
       create_remote_file(agent, config_file, config)
       on(agent, facter("--external-dir \"#{external_dir1}\" --external-dir \"#{external_dir2}\" --debug #{fact1} #{fact2}"), :acceptable_exit_codes => 1) do |facter_output|
-        assert_match(/ERROR.*Caching is enabled for group "#{external_filename}" while there are at least two external facts files with the same filename/, stderr, 'Expected error message')
-        assert_match(/#{fact1} => #{fact1_value}/, stdout, 'Expected fact to match first fact')
-        refute_match(/#{fact2} => #{fact2_value}/, stdout, 'Expected fact not to match second fact')
+        assert_match(/ERROR.*Caching is enabled for group "#{external_filename}" while there are at least two external facts files with the same filename/, facter_output.stderr, 'Expected error message')
+        assert_match(/#{fact1} => #{fact1_value}/, facter_output.stdout, 'Expected fact to match first fact')
+        refute_match(/#{fact2} => #{fact2_value}/, facter_output.stdout, 'Expected fact not to match second fact')
       end
     end
 

--- a/acceptance/tests/external_facts/structured_executable_facts.rb
+++ b/acceptance/tests/external_facts/structured_executable_facts.rb
@@ -94,8 +94,8 @@ EOM
       agent.chmod('+x', yaml_fact)
 
       step "YAML output should produce a structured fact" do
-        on(agent, facter("yaml_fact")) do
-          assert_match(/#{yaml_structured_output}/, stdout, "Expected properly structured fact")
+        on(agent, facter("yaml_fact")) do |facter_output|
+          assert_match(/#{yaml_structured_output}/, facter_output.stdout, "Expected properly structured fact")
         end
       end
     end
@@ -106,8 +106,8 @@ EOM
       agent.chmod('+x', json_fact)
 
       step "JSON output should produce a structured fact" do
-        on(agent, facter("json_fact")) do
-          assert_match(/#{json_structured_output}/, stdout, "Expected properly structured fact")
+        on(agent, facter("json_fact")) do |facter_output|
+          assert_match(/#{json_structured_output}/, facter_output.stdout, "Expected properly structured fact")
         end
       end
     end
@@ -118,8 +118,8 @@ EOM
       agent.chmod('+x', kv_fact)
 
       step "output that is neither yaml nor json should not produce a structured fact" do
-        on(agent, facter("kv_fact")) do
-          assert_match(/#{kv_output}/, stdout, "Expected a simple key-value fact")
+        on(agent, facter("kv_fact")) do |facter_output|
+          assert_match(/#{kv_output}/, facter_output.stdout, "Expected a simple key-value fact")
         end
       end
     end
@@ -130,8 +130,8 @@ EOM
       agent.chmod('+x', bad_fact)
 
       step "should error when output is not in a supported format" do
-        on(agent, facter("bad_fact --debug")) do
-          assert_match(/Could not parse executable fact/, stderr, "Expected parsing the malformed fact to fail")
+        on(agent, facter("bad_fact --debug")) do |facter_output|
+          assert_match(/Could not parse executable fact/, facter_output.stderr, "Expected parsing the malformed fact to fail")
         end
       end
     end

--- a/acceptance/tests/facts/mountpoints_fact.rb
+++ b/acceptance/tests/facts/mountpoints_fact.rb
@@ -5,7 +5,7 @@ test_name '(FACT-1964) Facter mountpoints does not show rootfs as type for root 
   agents.each do |agent|
     step 'Ensure that mountpoints does not contain rootfs as type for root directory' do
       on(agent, facter("mountpoints")) do |facter_result|
-        assert_no_match(/rootfs/, facter_result.stdout.chomp, "Expected mountpoint with rootfs type to not be present")
+        refute_match(/rootfs/, facter_result.stdout.chomp, "Expected mountpoint with rootfs type to not be present")
       end
     end
   end

--- a/acceptance/tests/facts/verify_tmpfs_file_system.rb
+++ b/acceptance/tests/facts/verify_tmpfs_file_system.rb
@@ -39,8 +39,8 @@ test_name 'C98163: mountpoints fact should show mounts on tmpfs' do
 
     step "Apply the manifest to mount directory '#{mount_point}'" do
       on(agent, puppet("apply #{manifest}"), :acceptable_exit_codes => [0,2]) do |puppet_apply|
-        assert_no_match(/Error/, puppet_apply.stdout, 'Unexpected error on stdout was detected!')
-        assert_no_match(/ERROR/, puppet_apply.stderr, 'Unexpected error on stderr was detected!')
+        refute_match(/Error/, puppet_apply.stdout, 'Unexpected error on stdout was detected!')
+        refute_match(/ERROR/, puppet_apply.stderr, 'Unexpected error on stderr was detected!')
       end
     end
 

--- a/acceptance/tests/options/config_file/blocklist.rb
+++ b/acceptance/tests/options/config_file/blocklist.rb
@@ -25,9 +25,9 @@ test_name "C99972: facts can be blocked via a blocklist in the config file" do
           assert_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected stderr to contain statement about blocking fact collection")
 
           # on some platforms, file system facts are never resolved, so this will also be true in those cases
-          assert_no_match(/filesystems/, facter_output.stdout, "filesystems fact should have been blocked")
-          assert_no_match(/mountpoints/, facter_output.stdout, "mountpoints fact should have been blocked")
-          assert_no_match(/partitions/, facter_output.stdout, "partitions fact should have been blocked")
+          refute_match(/filesystems/, facter_output.stdout, "filesystems fact should have been blocked")
+          refute_match(/mountpoints/, facter_output.stdout, "mountpoints fact should have been blocked")
+          refute_match(/partitions/, facter_output.stdout, "partitions fact should have been blocked")
         end
       end
     end

--- a/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
+++ b/acceptance/tests/options/config_file/blocklist_from_puppet_facts.rb
@@ -30,9 +30,9 @@ test_name "C100036: when run from puppet facts, facts can be blocked via a list 
           assert_match(/blocking collection of .+ facts/, puppet_facts_output.stdout, "Expected stderr to contain statement about blocking fact collection")
 
           # on some platforms, file system facts are never resolved, so this will also be true in those cases
-          assert_no_match(/filesystems/, puppet_facts_output.stdout, "filesystems fact should have been blocked")
-          assert_no_match(/mountpoints/, puppet_facts_output.stdout, "mountpoints fact should have been blocked")
-          assert_no_match(/partitions/, puppet_facts_output.stdout, "partitions fact should have been blocked")
+          refute_match(/filesystems/, puppet_facts_output.stdout, "filesystems fact should have been blocked")
+          refute_match(/mountpoints/, puppet_facts_output.stdout, "mountpoints fact should have been blocked")
+          refute_match(/partitions/, puppet_facts_output.stdout, "partitions fact should have been blocked")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls/cached_nested_external_facts.rb
+++ b/acceptance/tests/options/config_file/ttls/cached_nested_external_facts.rb
@@ -71,8 +71,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{first_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for #{external_cachegroup}#{ext} facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for #{external_cachegroup}#{ext} facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls/empty_ttls_does_not_delete_cache.rb
+++ b/acceptance/tests/options/config_file/ttls/empty_ttls_does_not_delete_cache.rb
@@ -97,7 +97,7 @@ EOM
 
         on(agent, facter("--config \"#{no_cache_config_file}\" --external-dir \"#{external_dir}\"", environment: env)) do |facter_output|
           assert_match(/#{cached_fact_name}/, facter_output.stdout, "Expected to see the fact in output")
-          assert_no_match(/#{cached_fact_value}/, facter_output.stdout, "Expected to not see the cached fact value")
+          refute_match(/#{cached_fact_value}/, facter_output.stdout, "Expected to not see the cached fact value")
         end
 
         assert_equal(true, agent.file_exist?("#{cached_facts_dir}/cached-custom-facts"))

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_json_output.rb
@@ -84,8 +84,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_text_output.rb
@@ -67,8 +67,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_execution_resolver_with_yaml_output.rb
@@ -82,8 +82,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_json_resolver.rb
@@ -72,8 +72,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_text_resolver.rb
@@ -71,8 +71,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_external_yaml_resolver.rb
@@ -71,8 +71,8 @@ EOM
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
         on(agent, facter("--external-dir \"#{external_dir}\" --debug #{cached_fact_name}")) do |facter_output|
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_expire_facts_refresh_the_cached_value.rb
@@ -53,7 +53,7 @@ EOM
 
         # Read cached fact file content
         cat_output = agent.cat(cached_fact_file)
-        assert_no_match(/#{cached_fact_value}/, cat_output.strip, "Expected cached fact file to be refreshed")
+        refute_match(/#{cached_fact_value}/, cat_output.strip, "Expected cached fact file to be refreshed")
       end
     end
   end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_read_from_the_cached_value.rb
@@ -48,9 +48,9 @@ EOM
         on(agent, facter(""))
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("#{cached_factname} --debug")) do
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+        on(agent, facter("#{cached_factname} --debug")) do |facter_output|
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_resolved_by_empty_ttls_cache_list.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_resolved_by_empty_ttls_cache_list.rb
@@ -60,7 +60,7 @@ EOM
 
         on(agent, facter("--config \"#{no_cache_config_file}\"")) do |facter_output|
           assert_match(/#{cached_fact_name}/, facter_output.stdout, "Expected to see the fact in output")
-          assert_no_match(/#{cached_fact_value}/, facter_output.stdout, "Expected to not see the cached fact value")
+          refute_match(/#{cached_fact_value}/, facter_output.stdout, "Expected to not see the cached fact value")
         end
       end
     end

--- a/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_facts_that_are_corrupt_are_refreshed.rb
@@ -41,8 +41,8 @@ EOM
         # Corrupt the cached fact file
         create_remote_file(agent, cached_fact_file, 'ThisIsNotvalidJSON')
 
-        on(agent, facter("#{cached_factname}")) do
-          assert_match(/.+/, stdout, "Expected fact to be resolved")
+        on(agent, facter("#{cached_factname}")) do |facter_output|
+          assert_match(/.+/, facter_output.stdout, "Expected fact to be resolved")
         end
         cat_output = agent.cat(cached_fact_file)
         assert_match(/#{cached_factname}/, cat_output.strip, "Expected cachced fact to contain the fact name")

--- a/acceptance/tests/options/config_file/ttls_cached_individual_fact_name.rb
+++ b/acceptance/tests/options/config_file/ttls_cached_individual_fact_name.rb
@@ -54,9 +54,9 @@ EOM
         agent.mkdir_p(cached_facts_dir)
         create_remote_file(agent, cached_fact_file, cached_fact_content)
 
-        on(agent, facter("#{cached_fact_name} --debug")) do
-          assert_match(/loading cached values for .+ facts/, stderr, "Expected debug message to state that values are read from cache")
-          assert_match(/#{cached_fact_value}/, stdout, "Expected fact to match the cached fact file")
+        on(agent, facter("#{cached_fact_name} --debug")) do |facter_output|
+          assert_match(/loading cached values for .+ facts/, facter_output.stderr, "Expected debug message to state that values are read from cache")
+          assert_match(/#{cached_fact_value}/, facter_output.stdout, "Expected fact to match the cached fact file")
         end
       end
     end

--- a/acceptance/tests/options/debug.rb
+++ b/acceptance/tests/options/debug.rb
@@ -4,8 +4,8 @@ test_name "C63191: --debug command-line option prints debugging information to s
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using --debug option" do
-      on(agent, facter('--debug')) do
-        assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
+      on(agent, facter('--debug')) do |facter_output|
+        assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
       end
     end
   end

--- a/acceptance/tests/options/empty_string_in_blocklist.rb
+++ b/acceptance/tests/options/empty_string_in_blocklist.rb
@@ -26,7 +26,7 @@ test_name "empty string in blocklist does not block facts" do
 
     step "no facts should be blocked is specified" do
       on(agent, facter) do |facter_output|
-        assert_no_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
+        refute_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
       end
     end
   end

--- a/acceptance/tests/options/help.rb
+++ b/acceptance/tests/options/help.rb
@@ -5,8 +5,8 @@ test_name 'C99984: --help command-line option prints usage information to stdout
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve usage info from stdout using --help option" do
-      on(agent, facter('--help')) do
-        assert_match(/facter \[options\] \[query\] \[query\] \[...\]/, stdout, 'Expected stdout to contain usage information')
+      on(agent, facter('--help')) do |facter_output|
+        assert_match(/facter \[options\] \[query\] \[query\] \[...\]/, facter_output.stdout, 'Expected stdout to contain usage information')
       end
     end
 
@@ -25,9 +25,9 @@ test_name 'C99984: --help command-line option prints usage information to stdout
         --list-block-groups
         --list-cache-groups
       ]
-      on(agent, facter('--help')) do
+      on(agent, facter('--help')) do |facter_output|
         options.each do |option|
-          assert_match(/#{option}/, stdout, "Key: #{option} not found in help description")
+          assert_match(/#{option}/, facter_output.stdout, "Key: #{option} not found in help description")
         end
       end
     end

--- a/acceptance/tests/options/hocon.rb
+++ b/acceptance/tests/options/hocon.rb
@@ -10,9 +10,9 @@ test_name "--hocon command-line option results in valid HOCON output" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve os fact data using the --hocon option" do
-      on(agent, facter('--hocon os')) do
+      on(agent, facter('--hocon os')) do |facter_output|
         begin
-          parsing_successful = Hocon::Parser::ConfigDocumentFactory.parse_string(stdout.chomp, options =
+          parsing_successful = Hocon::Parser::ConfigDocumentFactory.parse_string(facter_output.stdout.chomp, options =
             Hocon::ConfigParseOptions.defaults) != nil
           assert_equal(true, parsing_successful, "Output is not HOCON compatible.")
         rescue

--- a/acceptance/tests/options/json.rb
+++ b/acceptance/tests/options/json.rb
@@ -29,10 +29,10 @@ EOM
       end
 
       step "Agent #{agent}: retrieve output using the --json option" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" --json structured_fact")) do
+        on(agent, facter("--custom-dir \"#{custom_dir}\" --json structured_fact")) do |facter_output|
           begin
             expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3", "true" => true, "false" => false}}
-            assert_equal(expected, JSON.parse(stdout.chomp), "JSON output does not match expected output")
+            assert_equal(expected, JSON.parse(facter_output.stdout.chomp), "JSON output does not match expected output")
           rescue
             fail_test "Couldn't parse output as JSON"
           end

--- a/acceptance/tests/options/list_cache_groups.rb
+++ b/acceptance/tests/options/list_cache_groups.rb
@@ -58,7 +58,7 @@ test_name "C99970: the `--list-cache-groups` command line flag prints available 
         assert_match(/#{filename}/, facter_output.stdout, "external facts script files should be listed as cacheable")
       end
       on(agent, facter("--list-cache-groups --no-external-facts")) do |facter_output|
-        assert_no_match(/#{filename}/, facter_output.stdout, "external facts script files should now be listed as cacheable when --no-external-facts is used")
+        refute_match(/#{filename}/, facter_output.stdout, "external facts script files should now be listed as cacheable when --no-external-facts is used")
       end
       agent.rm_rf(etc_factsd_path)
     end

--- a/acceptance/tests/options/log_level.rb
+++ b/acceptance/tests/options/log_level.rb
@@ -5,8 +5,8 @@ test_name "C99985: --log-level command-line option can be used to specify loggin
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve debug info from stderr using `--log-level debug` option" do
-      on(agent, facter('--log-level debug')) do
-        assert_match(/DEBUG/, stderr, "Expected DEBUG information in stderr")
+      on(agent, facter('--log-level debug')) do |facter_output|
+        assert_match(/DEBUG/, facter_output.stderr, "Expected DEBUG information in stderr")
       end
     end
   end

--- a/acceptance/tests/options/no_block.rb
+++ b/acceptance/tests/options/no_block.rb
@@ -27,7 +27,7 @@ test_name "C99971: the `--no-block` command line flag prevents facts from being 
 
     step "no facts should be blocked when `--no-block` is specified" do
       on(agent, facter("--no-block")) do |facter_output|
-        assert_no_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
+        refute_match(/blocking collection of .+ facts/, facter_output.stderr, "Expected no facts to be blocked")
       end
     end
   end

--- a/acceptance/tests/options/no_cache_should_not_cache_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_cache_facts.rb
@@ -36,7 +36,7 @@ test_name "C99968: --no-cache command-line option causes facter to not cache fac
 
     step "facter should not cache facts when --no-cache is specified" do
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to cache any facts")
+        refute_match(/caching values for/, facter_output.stderr, "facter should not have tried to cache any facts")
       end
     end
   end

--- a/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_load_cached_facts.rb
@@ -50,8 +50,8 @@ EOM
       create_remote_file(agent, cached_fact_file, bad_cached_content)
 
       on(agent, facter("--no-cache #{cached_fact_name}")) do |facter_output|
-        assert_no_match(/loading cached values for .+ fact/, facter_output.stderr, "facter should not have tried to load any cached facts")
-        assert_no_match(/#{bad_cached_fact_value}/, facter_output.stdout, "facter should not have loaded the cached value")
+        refute_match(/loading cached values for .+ fact/, facter_output.stderr, "facter should not have tried to load any cached facts")
+        refute_match(/#{bad_cached_fact_value}/, facter_output.stdout, "facter should not have loaded the cached value")
       end
     end
   end

--- a/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
+++ b/acceptance/tests/options/no_cache_should_not_refresh_cached_facts.rb
@@ -52,7 +52,7 @@ FILE
       agent.modified_at(cached_fact_file, '198001010000')
 
       on(agent, facter("--no-cache")) do |facter_output|
-        assert_no_match(/caching values for/, facter_output.stderr, "facter should not have tried to refresh the cache")
+        refute_match(/caching values for/, facter_output.stderr, "facter should not have tried to refresh the cache")
       end
 
       cat_output = agent.cat(cached_fact_file)

--- a/acceptance/tests/options/no_ruby.rb
+++ b/acceptance/tests/options/no_ruby.rb
@@ -18,9 +18,9 @@ EOM
 
   agents.each do |agent|
     step "--no-ruby option should disable Ruby and facts requiring ruby from being loaded" do
-      on(agent, facter("--no-ruby ruby")) do
-        assert_equal("", stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{stdout.chomp}")
-        assert_equal("", stderr.chomp, "Expected no warnings about Ruby on stderr, but got output: #{stderr.chomp}")
+      on(agent, facter("--no-ruby ruby")) do |facter_output|
+        assert_equal("", facter_output.stdout.chomp, "Expected Ruby and Ruby fact to be disabled, but got output: #{facter_output.stdout.chomp}")
+        assert_equal("", facter_output.stderr.chomp, "Expected no warnings about Ruby on stderr, but got output: #{facter_output.stderr.chomp}")
       end
     end
 
@@ -35,8 +35,8 @@ EOM
           agent.rm_rf(custom_fact)
         end
 
-        on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do
-          assert_equal("", stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{stdout.chomp}")
+        on(agent, facter('--no-ruby custom_fact', :environment => { 'FACTERLIB' => custom_dir })) do |facter_output|
+          assert_equal("", facter_output.stdout.chomp, "Expected custom fact to be disabled while using --no-ruby option, but it resolved as #{facter_output.stdout.chomp}")
         end
       end
     end

--- a/acceptance/tests/options/show_legacy.rb
+++ b/acceptance/tests/options/show_legacy.rb
@@ -4,14 +4,14 @@ test_name "C87580: --show-legacy command-line option results in output with lega
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve legacy output using a hash" do
-      on(agent, facter("--show-legacy")) do
-        assert_match(/^rubyversion => [0-9]+\.[0-9]+\.[0-9]+$/, stdout.chomp, 'hash legacy output does not contain legacy fact rubyversion')
+      on(agent, facter("--show-legacy")) do |facter_output|
+        assert_match(/^rubyversion => [0-9]+\.[0-9]+\.[0-9]+$/, facter_output.stdout.chomp, 'hash legacy output does not contain legacy fact rubyversion')
       end
     end
 
     step "Agent #{agent}: retrieve legacy output using the --json option" do
-      on(agent, facter("--show-legacy --json")) do
-        assert_match(/^  "rubyversion": "[0-9]+\.[0-9]+\.[0-9]+",$/, stdout.chomp, 'json legacy output does not contain legacy fact rubyversion')
+      on(agent, facter("--show-legacy --json")) do |facter_output|
+        assert_match(/^  "rubyversion": "[0-9]+\.[0-9]+\.[0-9]+",$/, facter_output.stdout.chomp, 'json legacy output does not contain legacy fact rubyversion')
       end
     end
   end

--- a/acceptance/tests/options/trace.rb
+++ b/acceptance/tests/options/trace.rb
@@ -27,8 +27,8 @@ EOM
       end
 
       step "--trace option should provide a backtrace for a custom fact with errors" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" --trace custom_fact_trace"), :acceptable_exit_codes => [1]) do
-          assert_match(/backtrace:\s+#{custom_fact}/, stderr, "Expected a backtrace for erroneous custom fact")
+        on(agent, facter("--custom-dir \"#{custom_dir}\" --trace custom_fact_trace"), :acceptable_exit_codes => [1]) do |facter_output|
+          assert_match(/backtrace:\s+#{custom_fact}/, facter_output.stderr, "Expected a backtrace for erroneous custom fact")
         end
       end
     end

--- a/acceptance/tests/options/verbose.rb
+++ b/acceptance/tests/options/verbose.rb
@@ -4,8 +4,8 @@ test_name "C99986: --verbose command-line option prints verbose information to s
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve verbose info from stderr using --verbose option" do
-      on(agent, facter('--verbose')) do
-        assert_match(/INFO .*executed with command line: --verbose/, stderr, "Expected stderr to contain verbose (INFO) statements")
+      on(agent, facter('--verbose')) do |facter_output|
+        assert_match(/INFO .*executed with command line: --verbose/, facter_output.stderr, "Expected stderr to contain verbose (INFO) statements")
       end
     end
   end

--- a/acceptance/tests/options/version.rb
+++ b/acceptance/tests/options/version.rb
@@ -4,8 +4,8 @@ test_name "C99983: --version command-line option returns the version string" do
 
   agents.each do |agent|
     step "Agent #{agent}: retrieve version info using the --version option" do
-      on(agent, facter('--version')) do
-        assert_match(/\d+\.\d+\.\d+/, stdout, "Output #{stdout} is not a recognized version string")
+      on(agent, facter('--version')) do |facter_output|
+        assert_match(/\d+\.\d+\.\d+/, facter_output.stdout, "Output #{facter_output.stdout} is not a recognized version string")
       end
     end
   end

--- a/acceptance/tests/options/yaml.rb
+++ b/acceptance/tests/options/yaml.rb
@@ -29,10 +29,10 @@ EOM
       end
 
       step "Agent #{agent}: retrieve output using the --yaml option" do
-        on(agent, facter("--custom-dir \"#{custom_dir}\" --yaml structured_fact")) do
+        on(agent, facter("--custom-dir \"#{custom_dir}\" --yaml structured_fact")) do |facter_output|
           begin
             expected = {"structured_fact" => {"foo" => {"nested" => "value1"}, "bar" => "value2", "baz" => "value3" }}
-            assert_equal(expected, YAML.load(stdout), "YAML output does not match expected output")
+            assert_equal(expected, YAML.load(facter_output.stdout), "YAML output does not match expected output")
           rescue
             fail_test "Couldn't parse output as YAML"
           end


### PR DESCRIPTION
This PR updates several deprecated Beaker methods that were removed entirely in Beaker 5. This is in preparation for moving Facter to using Beaker 5 for tests.