### PR TITLE
Update macOS GitHub Actions runner

### DIFF
--- a/.github/actions/presuite.rb
+++ b/.github/actions/presuite.rb
@@ -32,7 +32,7 @@ end
 def beaker_platform
   {
     'ubuntu-20.04' => 'ubuntu2004-64a',
-    'macos-11' => 'osx11-64a',
+    'macos-12' => 'osx12-64a',
     'windows-2016' => 'windows2016-64a',
     'windows-2019' => 'windows2019-64a'
   }[HOST_PLATFORM]

--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Platform
     strategy:
       matrix:
-        os: [ windows-2019, ubuntu-20.04, macos-11 ]
+        os: [ windows-2019, ubuntu-20.04, macos-12 ]
     runs-on: ${{ matrix.os }}
     env:
       BEAKER_debug: true


### PR DESCRIPTION
Currently, Facter uses a macOS 11 (Big Sur) runner in GitHub Actions for acceptance tests. That platform went end-of-life at the end of 2023 and the runner has been deprecated by GitHub.

This commit updates the runner and presuite action to use macOS 12 (Monterey).