### PR TITLE
Drop unused reference to test forge

### DIFF
--- a/acceptance/.beaker.yml
+++ b/acceptance/.beaker.yml
@@ -7,7 +7,6 @@ xml:                         true
 timesync:                    false
 repo_proxy:                  true
 add_el_extras:               false
-forge_host:                  api-forge-aio02-petest.puppet.com
 'master-start-curl-retries': 30
 log_level:                   debug
 preserve_hosts:              onfail


### PR DESCRIPTION
We no longer use the test forge, remove this reference.