### PR TITLE
Add support for OmniOS (OpenSolaris derivative)

### DIFF
--- a/lib/facter/facts/solaris/os/name.rb
+++ b/lib/facter/facts/solaris/os/name.rb
@@ -9,7 +9,8 @@ module Facts
 
         def call_the_resolver
           value = Facter::Resolvers::Uname.resolve(:kernelname)
-          fact_value = value == 'SunOS' ? 'Solaris' : value
+          version = Facter::Resolvers::Uname.resolve(:kernelversion)
+          fact_value = value == 'SunOS' ? (version =~ /^omnios-/ ? 'OmniOS' : 'Solaris') : value
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facter/resolvers/solaris/os_release.rb
+++ b/lib/facter/resolvers/solaris/os_release.rb
@@ -7,7 +7,8 @@ module Facter
         init_resolver
 
         OS_VERSION_REGEX_PATTERNS = ['Solaris \d+ \d+/\d+ s(\d+)[sx]?_u(\d+)wos_',
-                                     'Solaris (\d+)[.](\d+)', 'Solaris (\d+)'].freeze
+                                     'Solaris (\d+)[.](\d+)', 'Solaris (\d+)',
+                                     'OmniOS v(\d+) (r\d+)'].freeze
 
         class << self
           private


### PR DESCRIPTION
A couple of small fixes that enables "facter os" to give relevant info in the release hash instead of null, null, null (so other facts won't fail) and gives the OS name as "OmniOS" instead of "Solaris"..

Before:
# facter os
{
  architecture => "i86pc",
  family => "Solaris",
  hardware => "i86pc",
  name => "Solaris",
  release => {
    full => null,
    major => null,
    minor => null
  }
}

After:
# facter os
{
  architecture => "i86pc",
  family => "Solaris",
  hardware => "i86pc",
  name => "OmniOS",
  release => {
    full => "11.r151048",
    major => "11",
    minor => "r151048"
  }
}


# cat /etc/release 
  OmniOS v11 r151048m
  Copyright (c) 2012-2017 OmniTI Computer Consulting, Inc.
  Copyright (c) 2017-2024 OmniOS Community Edition (OmniOSce) Association.
  All rights reserved. Use is subject to licence terms.

# uname -a
SunOS servername 5.11 omnios-r151048-4a265be889 i86pc i386 i86pc
