### PR TITLE
Windows: Add `is_virtual` and `virtual` support for virtual machines hosted on Nutanix AHV

### DIFF
--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -12,8 +12,15 @@ module Facter
           # Virtual
           # Is_Virtual
 
-          MODEL_HASH = { 'VirtualBox' => 'virtualbox', 'VMware' => 'vmware', 'KVM' => 'kvm',
-                         'Bochs' => 'bochs', 'Google' => 'gce', 'OpenStack' => 'openstack', 'AHV' => 'ahv' }.freeze
+          MODEL_HASH = {
+            'VirtualBox' => 'virtualbox',
+            'VMware' => 'vmware',
+            'KVM' => 'kvm',
+            'Bochs' => 'bochs',
+            'Google' => 'gce',
+            'OpenStack' => 'openstack',
+            'AHV' => 'ahv'
+          }.freeze
 
           private
 

--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -13,7 +13,7 @@ module Facter
           # Is_Virtual
 
           MODEL_HASH = { 'VirtualBox' => 'virtualbox', 'VMware' => 'vmware', 'KVM' => 'kvm',
-                         'Bochs' => 'bochs', 'Google' => 'gce', 'OpenStack' => 'openstack' }.freeze
+                         'Bochs' => 'bochs', 'Google' => 'gce', 'OpenStack' => 'openstack', 'AHV' => 'ahv' }.freeze
 
           private
 

--- a/spec/facter/resolvers/windows/virtualization_spec.rb
+++ b/spec/facter/resolvers/windows/virtualization_spec.rb
@@ -103,6 +103,26 @@ describe Facter::Resolvers::Windows::Virtualization do
     end
   end
 
+  describe '#resolve AHV VM' do
+    before do
+      allow(win32ole).to receive(:Model).and_return(model)
+      allow(win32ole).to receive(:Manufacturer).and_return(manufacturer)
+      allow(win32ole).to receive(:OEMStringArray).and_return('')
+    end
+
+    let(:query_result) { [win32ole] }
+    let(:model) { 'AHV' }
+    let(:manufacturer) {}
+
+    it 'detects virtual machine model' do
+      expect(Facter::Resolvers::Windows::Virtualization.resolve(:virtual)).to eql('ahv')
+    end
+
+    it 'detects that is virtual' do
+      expect(Facter::Resolvers::Windows::Virtualization.resolve(:is_virtual)).to be(true)
+    end
+  end
+
   describe '#resolve Microsoft VM' do
     before do
       allow(win32ole).to receive(:Model).and_return(model)


### PR DESCRIPTION
- **Add is_virtual and virtual support for Nutanix AHV**
- **windows/virtualization: reformat MODEL_HASH for readability**
- **windows/virtualization_spec: add Nutanix AHV test case**

This PR just adds a test to #2589 and is rebased on current `main`.