### PR TITLE
(bug) ensure avoid nil dereference

### DIFF
--- a/lib/facter/facts/linux/cloud/provider.rb
+++ b/lib/facter/facts/linux/cloud/provider.rb
@@ -9,11 +9,14 @@ module Facts
         def call_the_resolver
           provider = case Facter::Util::Facts::Posix::VirtualDetector.platform
                      when 'hyperv'
-                       'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Az.resolve(:metadata)
+                       'azure' unless metadata.nil? || metadata.empty?
                      when 'kvm', 'xen'
-                       'aws' unless Facter::Resolvers::Ec2.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Ec2.resolve(:metadata)
+                       'aws' unless metadata.nil? || metadata.empty?
                      when 'gce'
-                       'gce' unless Facter::Resolvers::Gce.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Gce.resolve(:metadata)
+                       'gce' unless metadata.nil? || metadata.empty?
                      end
 
           Facter::ResolvedFact.new(FACT_NAME, provider)

--- a/lib/facter/facts/windows/cloud/provider.rb
+++ b/lib/facter/facts/windows/cloud/provider.rb
@@ -10,11 +10,14 @@ module Facts
           virtual = Facter::Resolvers::Windows::Virtualization.resolve(:virtual)
           provider = case virtual
                      when 'hyperv'
-                       'azure' unless Facter::Resolvers::Az.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Az.resolve(:metadata)
+                       'azure' unless metadata.nil? || metadata.empty?
                      when 'kvm', 'xen'
-                       'aws' unless Facter::Resolvers::Ec2.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Ec2.resolve(:metadata)
+                       'aws' unless metadata.nil? || metadata.empty?
                      when 'gce'
-                       'gce' unless Facter::Resolvers::Gce.resolve(:metadata).empty?
+                       metadata = Facter::Resolvers::Gce.resolve(:metadata)
+                       'gce' unless metadata.nil? || metadata.empty?
                      end
 
           Facter::ResolvedFact.new(FACT_NAME, provider)


### PR DESCRIPTION
See https://github.com/puppetlabs/facter/issues/2696

This paches the two cloud providers accesses to metadata to avoid nil dereferences which have been seen in production.