### PR TITLE
(FACT-3434) Accept ffi >= 1.16.3, < 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,9 @@ gem 'packaging', require: false
 local_gemfile = File.expand_path('Gemfile.local', __dir__)
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)
 
-# ffi >= 1.16.0 introduces breaking changes, so we pin to the version prior
-# for now
 group(:integration, optional: true) do
-  gem 'ffi', '1.15.5', require: false
+  # 1.16.0 - 1.16.2 are broken on Windows
+  gem 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2', require: false
 end
 
 group(:documentation) do

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
   # or indirectly contain native extensions. The intent behind excluding these
   # gems from runtime dependencies is to allow users to be able to install
   # Facter without a compiler.
-  spec.add_development_dependency 'ffi', '1.15.5'
+  # ffi 1.16.0 - 1.16.2 are broken on Windows
+  spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.28' # last version to support 2.5


### PR DESCRIPTION
ffi 1.16.0 - 1.16.2 had a bug when defining a layout in an FFI::Struct and it
was fixed in 1.16.3[1]:

    ERROR -- : Facter::InternalFactManager - can't modify frozen Hash: \
      {:void=>#<FFI::Type::Builtin::VOID...

However, we can't require a minimum version of 1.16.3, because facter is
required by puppet, which also has a strict ffi requirement on '1.15.5'.

So in order to gradually update, facter needs to accept the range from 1.15.5 to
1.17.0, but exclude the problematic ffi versions.

[1] https://github.com/ffi/ffi/issues/1056