### PR TITLE
(PA-6392) Let 'unknown' be an acceptable processor.isa fact value for Fedora

### DIFF
--- a/acceptance/lib/facter/acceptance/base_fact_utils.rb
+++ b/acceptance/lib/facter/acceptance/base_fact_utils.rb
@@ -229,7 +229,7 @@ module Facter
           'os.release.major' => os_version,
           'processors.count' => /[1-9]/,
           'processors.physicalcount' => /[1-9]/,
-          'processors.isa' => os_hardware,
+          'processors.isa' => /unknown|#{os_hardware}/,
           'processors.models' => /(Intel\(R\).*)|(AMD.*)/,
           'kernel' => 'Linux',
           'kernelrelease' => /\d+\.\d+\.\d+/,


### PR DESCRIPTION

 - In os_processors_and_kernel test case, for fedora (intel) we expect processor.isa fact to be x86_64.
 - This value is derived from 'uname -p' command on the system.
 - But Fedora 40 returns 'unknown' for 'uname -p', so we make the test case accept 'unknown' as well.