### PR TITLE
(PA-6393) Let '' (empty string) be an acceptable networking dhcp fact for all fedora versions

### DIFF
--- a/acceptance/tests/facts/networking_facts.rb
+++ b/acceptance/tests/facts/networking_facts.rb
@@ -11,7 +11,7 @@ test_name 'C59029: networking facts should be fully populated' do
 
   agents.each do |agent|
     expected_networking = {
-      %w[networking dhcp] => agent['platform'] =~ /fedora-32|fedora-34|fedora-36|el-8-|el-9-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
+      %w[networking dhcp] => agent['platform'] =~ /fedora-|el-8-|el-9-/ ? '' : @ip_regex, # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/426
       %w[networking ip] => @ip_regex,
       %w[networking ip6] => /[a-f0-9]+:+/,
       %w[networking mac] => /[a-f0-9]{2}:/,


### PR DESCRIPTION
- Fedora is susceptible to a bug in NetworkManager that causes it to fail networking_facts acceptance test.
 - This commit makes '' the acceptable value for networking dhcp fact in Fedora, so CI passes the test.
 - Since all Fedora versions seem to be having the issue, its been made generic to all versions in this commit.
 - See https://github.com/puppetlabs/facter/pull/2515