### PR TITLE
(FACT-3465) Order dependent failures

### DIFF
--- a/lib/facter/resolvers/uname.rb
+++ b/lib/facter/resolvers/uname.rb
@@ -3,6 +3,8 @@
 module Facter
   module Resolvers
     class Uname < BaseResolver
+      @log = Facter::Log.new(self)
+
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/xen.rb
+++ b/lib/facter/resolvers/xen.rb
@@ -66,6 +66,8 @@ module Facter
           return XEN_TOOLSTACK if num_stacks > 1 && File.exist?(XEN_TOOLSTACK)
 
           XEN_COMMANDS.each { |command| return command if File.exist?(command) }
+
+          nil
         end
       end
     end

--- a/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
+++ b/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
@@ -3,7 +3,7 @@
 describe Facter::Resolvers::Amzn::OsReleaseRpm do
   subject(:os_release_resolver) { Facter::Resolvers::Amzn::OsReleaseRpm }
 
-  let(:log_spy) { Facter::Log }
+  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
     os_release_resolver.instance_variable_set(:@log, log_spy)

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -11,6 +11,7 @@ describe Facter::Resolvers::Ec2 do
 
   before do
     Facter::Util::Resolvers::Http.instance_variable_set(:@log, log_spy)
+    allow(Socket).to receive(:tcp) if Gem.win_platform?
   end
 
   after do

--- a/spec/facter/resolvers/processors_spec.rb
+++ b/spec/facter/resolvers/processors_spec.rb
@@ -52,8 +52,10 @@ describe Facter::Resolvers::Linux::Processors do
         allow(Facter::Util::FileHelper).to receive(:safe_readlines)
           .with('/proc/cpuinfo')
           .and_return(load_fixture('cpuinfo_wo_physical_id').readlines)
+        allow(Dir).to receive(:entries).and_call_original
         allow(Dir).to receive(:entries).with('/sys/devices/system/cpu').and_return(%w[cpu0 cpu1 cpuindex])
 
+        allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?)
           .with('/sys/devices/system/cpu/cpu0/topology/physical_package_id')
           .and_return(true)
@@ -117,9 +119,13 @@ describe Facter::Resolvers::Linux::Processors do
         .with('/proc/cpuinfo')
         .and_return(load_fixture('cpuinfo_powerpc').readlines)
 
+      allow(Dir).to receive(:entries).and_call_original
       allow(Dir).to receive(:entries).with('/sys/devices/system/cpu').and_return(%w[cpu0 cpu1 cpuindex])
+
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/sys/devices/system/cpu/cpu0/topology/physical_package_id').and_return(true)
       allow(File).to receive(:exist?).with('/sys/devices/system/cpu/cpu1/topology/physical_package_id').and_return(true)
+
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/devices/system/cpu/cpu0/topology/physical_package_id')
         .and_return('0')
@@ -164,9 +170,13 @@ describe Facter::Resolvers::Linux::Processors do
         .with('/proc/cpuinfo')
         .and_return(load_fixture('cpuinfo_arm64').readlines)
 
+      allow(Dir).to receive(:entries).and_call_original
       allow(Dir).to receive(:entries).with('/sys/devices/system/cpu').and_return(%w[cpu0 cpu1 cpuindex])
+
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/sys/devices/system/cpu/cpu0/topology/physical_package_id').and_return(true)
       allow(File).to receive(:exist?).with('/sys/devices/system/cpu/cpu1/topology/physical_package_id').and_return(true)
+
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/sys/devices/system/cpu/cpu0/topology/physical_package_id')
         .and_return('0')

--- a/spec/facter/resolvers/uname_spec.rb
+++ b/spec/facter/resolvers/uname_spec.rb
@@ -22,6 +22,11 @@ describe Facter::Resolvers::Uname do
         Darwin Kernel Version 18.2.0: Fri Oct  5 19:41:49 PDT 2018; root:xnu-4903.221.2~2/RELEASE_X86_64')
   end
 
+  after do
+    uname_resolver.instance_variable_set(:@log, nil)
+    Facter::Resolvers::Uname.invalidate_cache
+  end
+
   it 'returns machine' do
     expect(uname_resolver.resolve(:machine)).to eq('x86_64')
   end

--- a/spec/facter/resolvers/uname_spec.rb
+++ b/spec/facter/resolvers/uname_spec.rb
@@ -3,7 +3,7 @@
 describe Facter::Resolvers::Uname do
   subject(:uname_resolver) { Facter::Resolvers::Uname }
 
-  let(:log_spy) { Facter::Log }
+  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
     uname_resolver.instance_variable_set(:@log, log_spy)

--- a/spec/facter/resolvers/xen_spec.rb
+++ b/spec/facter/resolvers/xen_spec.rb
@@ -10,6 +10,7 @@ describe Facter::Resolvers::Xen do
 
   before do
     xen_resolver.instance_variable_set(:@log, log_spy)
+    allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with('/dev/xen/evtchn').and_return(evtchn_file)
     allow(File).to receive(:exist?).with('/proc/xen').and_return(proc_xen_file)
     allow(File).to receive(:exist?).with('/dev/xvda1').and_return(xvda1_file)

--- a/spec/facter/resolvers/xen_spec.rb
+++ b/spec/facter/resolvers/xen_spec.rb
@@ -27,6 +27,18 @@ describe Facter::Resolvers::Xen do
     xen_resolver.invalidate_cache
   end
 
+  context 'when not xen' do
+    let(:evtchn_file) { false }
+    let(:proc_xen_file) { false }
+    let(:xvda1_file) { false }
+
+    it 'returns' do
+      allow(File).to receive(:exist?).with('/usr/sbin/xm').and_return(false)
+
+      expect(xen_resolver.resolve(:vm)).to be_nil
+    end
+  end
+
   context 'when xen is privileged' do
     context 'when /dev/xen/evtchn exists' do
       let(:domains) { load_fixture('xen_domains').read }

--- a/spec/facter/util/linux/if_inet6_spec.rb
+++ b/spec/facter/util/linux/if_inet6_spec.rb
@@ -28,6 +28,7 @@ describe Facter::Util::Linux::IfInet6 do
   describe '#read_flags' do
     context 'when only ipv6 link-local and lo ipv6 present' do
       before do
+        allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with('/proc/net/if_inet6').and_return(true)
         allow(Facter::Util::FileHelper).to receive(:safe_read)
           .with('/proc/net/if_inet6', nil).and_return(load_fixture('proc_net_if_inet6').read)
@@ -38,6 +39,7 @@ describe Facter::Util::Linux::IfInet6 do
 
     context 'when multiple IPv6 addresses present with different flags' do
       before do
+        allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with('/proc/net/if_inet6').and_return(true)
         allow(Facter::Util::FileHelper).to receive(:safe_read)
           .with('/proc/net/if_inet6', nil).and_return(load_fixture('proc_net_if_inet6_complex').read)


### PR DESCRIPTION
Previously, the uname resolver set an instance_spy logger, but didn't clear it. If the uname spec was run first, followed by another spec whose resolver relied on the uname resolver, then the instance_spy would leak across specs. This clears the logger and fixes several tests that were passing for the wrong reasons.

The "loggers leak across tests" is a general issue. It will be fixed in a separate issue:

```
$ git grep -l 'instance_variable_set(:@log' spec/facter/resolvers/ | xargs git grep -L 'instance_variable_set(:@log, nil)' 
spec/facter/resolvers/aix/disks_spec.rb
spec/facter/resolvers/aix/memory_spec.rb
spec/facter/resolvers/aix/mountpoints_spec.rb
spec/facter/resolvers/aix/networking_spec.rb
spec/facter/resolvers/aix/os_level_spec.rb
spec/facter/resolvers/aix/partitions_spec.rb
spec/facter/resolvers/aix/processors_spec.rb
spec/facter/resolvers/amzn/os_release_rpm_spec.rb
spec/facter/resolvers/augeas_spec.rb
spec/facter/resolvers/az_spec.rb
spec/facter/resolvers/bsd/processors_spec.rb
spec/facter/resolvers/freebsd/processors_spec.rb
spec/facter/resolvers/freebsd/swap_memory_spec.rb
spec/facter/resolvers/freebsd/system_memory_spec.rb
spec/facter/resolvers/hostname_spec.rb
spec/facter/resolvers/linux/docker_uptime_spec.rb
spec/facter/resolvers/linux/hostname_spec.rb
spec/facter/resolvers/linux/lscpu_spec.rb
spec/facter/resolvers/linux/networking_spec.rb
spec/facter/resolvers/lpar_spec.rb
spec/facter/resolvers/lspci_spec.rb
spec/facter/resolvers/macosx/dmi_spec.rb
spec/facter/resolvers/macosx/filesystems_spec.rb
spec/facter/resolvers/macosx/load_averages_spec.rb
spec/facter/resolvers/macosx/processors_spec.rb
spec/facter/resolvers/macosx/swap_memory_spec.rb
spec/facter/resolvers/macosx/system_memory_spec.rb
spec/facter/resolvers/mountpoints_spec.rb
spec/facter/resolvers/networking_spec.rb
spec/facter/resolvers/openbsd/mountpoints_spec.rb
spec/facter/resolvers/partitions_spec.rb
spec/facter/resolvers/selinux_spec.rb
spec/facter/resolvers/solaris/dmi_sparc_spec.rb
spec/facter/resolvers/solaris/dmi_spec.rb
spec/facter/resolvers/solaris/filesystem_spec.rb
spec/facter/resolvers/solaris/ipaddress_spec.rb
spec/facter/resolvers/solaris/ldom_spec.rb
spec/facter/resolvers/solaris/memory_spec.rb
spec/facter/resolvers/solaris/zone_name_spec.rb
spec/facter/resolvers/solaris/zone_spec.rb
spec/facter/resolvers/sw_vers_spec.rb
spec/facter/resolvers/system_profile_spec.rb
spec/facter/resolvers/virt_what_spec.rb
spec/facter/resolvers/vmware_spec.rb
spec/facter/resolvers/windows/dmi_bios_spec.rb
spec/facter/resolvers/windows/dmi_computersystem_spec.rb
spec/facter/resolvers/windows/kernel_spec.rb
spec/facter/resolvers/windows/memory_spec.rb
spec/facter/resolvers/windows/networking_spec.rb
spec/facter/resolvers/windows/processors_spec.rb
spec/facter/resolvers/windows/system32_spec.rb
spec/facter/resolvers/windows/uptime_spec.rb
spec/facter/resolvers/windows/virtualization_spec.rb
spec/facter/resolvers/windows/win_os_description_spec.rb
spec/facter/resolvers/wpar_spec.rb
spec/facter/resolvers/xen_spec.rb
spec/facter/resolvers/zfs_spec.rb
spec/facter/resolvers/zpool_spec.rb
```