### PR TITLE
Restrict to rexml 3.0 - 3.2.6

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   # ffi 1.16.0 - 1.16.2 are broken on Windows
   spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
+  spec.add_development_dependency 'rexml', '>= 3.2.0', '<= 3.2.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.28' # last version to support 2.5
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'


### PR DESCRIPTION
rexml 3.2.7 added a runtime dependency on strscan, which requires native extensions on MRI Ruby and whose StringScanner.match method behaves differently depending on whether you're using the native or Java extension.

See https://github.com/ruby/rexml/issues/131