### PR TITLE
Bump to JRuby 9.3.14

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.2'
-          - 'jruby-9.3.9.0'
+          - 'jruby-9.3.14.0'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   # ffi 1.16.0 - 1.16.2 are broken on Windows
   spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
-  spec.add_development_dependency 'rexml', '>= 3.2.0', '<= 3.2.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.28' # last version to support 2.5
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'


### PR DESCRIPTION
Revert rexml pin and bump JRuby to match what we're shipping in puppetserver 7.x