### PR TITLE
Add Puppet Server 8.x JRuby to unit tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,6 +23,7 @@ jobs:
           - '3.0'
           - '3.2'
           - 'jruby-9.3.14.0'
+          - 'jruby-9.4.7.0'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR

--- a/spec/facter/util/resolvers/networking/networking_spec.rb
+++ b/spec/facter/util/resolvers/networking/networking_spec.rb
@@ -54,6 +54,7 @@ describe Facter::Util::Resolvers::Networking do
       let(:address) { '::ffff:192.0.2.128' }
 
       it 'returns scope6' do
+        pending('JRuby 9.4.7.0 does not properly parse mixed IPv6 addresses https://github.com/jruby/jruby/issues/8248') if RUBY_PLATFORM == 'java' && RUBY_VERSION == '3.1.4'
         expect(networking_helper.get_scope(address)).to eql('global')
       end
     end


### PR DESCRIPTION
This commit adds JRuby 9.4.7.0 to unit tests, which is the same version of JRuby that Puppet Server 8.x uses. (See:
puppetlabs/jruby-utils@1180711.)