### PR TITLE
(FACT-3468) Don't mutate global logger state

### DIFF
--- a/lib/facter/custom_facts/core/aggregate.rb
+++ b/lib/facter/custom_facts/core/aggregate.rb
@@ -109,7 +109,7 @@ module Facter
       # @api private
       def evaluate(&block)
         if @last_evaluated
-          msg = "Already evaluated #{@name}"
+          msg = +"Already evaluated #{@name}"
           msg << " at #{@last_evaluated}" if msg.is_a? String
           msg << ', reevaluating anyways'
           log.warn msg
@@ -196,6 +196,10 @@ module Facter
       end
 
       private
+
+      def log
+        @log ||= Facter::Log.new(self)
+      end
 
       def evaluate_params(name)
         raise ArgumentError, "#{self.class.name}#chunk requires a block" unless block_given?

--- a/lib/facter/resolvers/base_resolver.rb
+++ b/lib/facter/resolvers/base_resolver.rb
@@ -3,8 +3,8 @@
 module Facter
   module Resolvers
     class BaseResolver
-      def self.log
-        @log ||= Log.new(self)
+      class << self
+        attr_reader :log
       end
 
       def self.invalidate_cache
@@ -14,6 +14,7 @@ module Facter
       def self.init_resolver
         @fact_list = {}
         @semaphore = Mutex.new
+        @log = Log.new(self)
       end
 
       def self.subscribe_to_manager

--- a/lib/facter/resolvers/bsd/processors.rb
+++ b/lib/facter/resolvers/bsd/processors.rb
@@ -5,7 +5,6 @@ module Facter
     module Bsd
       class Processors < BaseResolver
         init_resolver
-        @log = Facter::Log.new(self)
 
         class << self
           private

--- a/lib/facter/resolvers/disks.rb
+++ b/lib/facter/resolvers/disks.rb
@@ -4,8 +4,6 @@ module Facter
   module Resolvers
     module Linux
       class Disks < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         DIR = '/sys/block'

--- a/lib/facter/resolvers/dmi.rb
+++ b/lib/facter/resolvers/dmi.rb
@@ -4,8 +4,6 @@ module Facter
   module Resolvers
     module Linux
       class DmiBios < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         class << self

--- a/lib/facter/resolvers/filesystems.rb
+++ b/lib/facter/resolvers/filesystems.rb
@@ -8,8 +8,6 @@ module Facter
 
         init_resolver
 
-        @log = Facter::Log.new(self)
-
         class << self
           private
 

--- a/lib/facter/resolvers/fips_enabled.rb
+++ b/lib/facter/resolvers/fips_enabled.rb
@@ -8,8 +8,6 @@ module Facter
 
         init_resolver
 
-        @log = Facter::Log.new(self)
-
         class << self
           private
 

--- a/lib/facter/resolvers/freebsd/processors.rb
+++ b/lib/facter/resolvers/freebsd/processors.rb
@@ -7,7 +7,6 @@ module Facter
     module Freebsd
       class Processors < BaseResolver
         init_resolver
-        @log = Facter::Log.new(self)
 
         class << self
           private

--- a/lib/facter/resolvers/hostname.rb
+++ b/lib/facter/resolvers/hostname.rb
@@ -19,6 +19,11 @@ module Facter
         def retrieve_info(fact_name)
           require 'socket'
           output = Socket.gethostname
+          unless output
+            log.debug('Socket.gethostname failed to return hostname')
+            return
+          end
+
           hostname, domain = retrieve_from_fqdn(output)
 
           fqdn = retrieve_with_addrinfo(hostname) if hostname_and_no_domain?(hostname, domain)

--- a/lib/facter/resolvers/identity.rb
+++ b/lib/facter/resolvers/identity.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class PosxIdentity < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/macosx/mountpoints.rb
+++ b/lib/facter/resolvers/macosx/mountpoints.rb
@@ -7,8 +7,6 @@ module Facter
         include Facter::Util::Resolvers::FilesystemHelper
         init_resolver
 
-        @log = Facter::Log.new(self)
-
         class << self
           private
 

--- a/lib/facter/resolvers/memory.rb
+++ b/lib/facter/resolvers/memory.rb
@@ -6,8 +6,6 @@ module Facter
       class Memory < BaseResolver
         init_resolver
 
-        @log = Facter::Log.new(self)
-
         class << self
           private
 

--- a/lib/facter/resolvers/mountpoints.rb
+++ b/lib/facter/resolvers/mountpoints.rb
@@ -7,8 +7,6 @@ module Facter
 
       init_resolver
 
-      @log = Facter::Log.new(self)
-
       class << self
         private
 

--- a/lib/facter/resolvers/processors.rb
+++ b/lib/facter/resolvers/processors.rb
@@ -4,8 +4,6 @@ module Facter
   module Resolvers
     module Linux
       class Processors < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         MHZ_TO_HZ = 1_000_000

--- a/lib/facter/resolvers/solaris/mountpoints.rb
+++ b/lib/facter/resolvers/solaris/mountpoints.rb
@@ -7,8 +7,6 @@ module Facter
         include Facter::Util::Resolvers::FilesystemHelper
         init_resolver
 
-        @log = Facter::Log.new(self)
-
         class << self
           private
 

--- a/lib/facter/resolvers/solaris/networking.rb
+++ b/lib/facter/resolvers/solaris/networking.rb
@@ -6,7 +6,6 @@ module Facter
     module Solaris
       class Networking < BaseResolver
         init_resolver
-        @log = Facter::Log.new(self)
 
         class << self
           private

--- a/lib/facter/resolvers/ssh.rb
+++ b/lib/facter/resolvers/ssh.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class Ssh < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       FILE_NAMES = %w[ssh_host_rsa_key.pub ssh_host_dsa_key.pub ssh_host_ecdsa_key.pub ssh_host_ed25519_key.pub].freeze

--- a/lib/facter/resolvers/uname.rb
+++ b/lib/facter/resolvers/uname.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class Uname < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/dmi_bios.rb
+++ b/lib/facter/resolvers/windows/dmi_bios.rb
@@ -3,7 +3,6 @@
 module Facter
   module Resolvers
     class DMIBios < BaseResolver
-      @log = Facter::Log.new(self)
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/dmi_computersystem.rb
+++ b/lib/facter/resolvers/windows/dmi_computersystem.rb
@@ -3,7 +3,6 @@
 module Facter
   module Resolvers
     class DMIComputerSystem < BaseResolver
-      @log = Facter::Log.new(self)
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/hardware_architecture.rb
+++ b/lib/facter/resolvers/windows/hardware_architecture.rb
@@ -24,7 +24,6 @@ module Facter
           build_facts_list(hardware: hard, architecture: arch)
           @fact_list[fact_name]
         rescue LoadError => e
-          log = Facter::Log.new(self)
           log.debug("The ffi gem has not been installed: #{e}")
         end
 

--- a/lib/facter/resolvers/windows/identity.rb
+++ b/lib/facter/resolvers/windows/identity.rb
@@ -4,7 +4,6 @@ module Facter
   module Resolvers
     class Identity < BaseResolver
       NAME_SAM_COMPATIBLE = 2
-      @log = Facter::Log.new(self)
 
       init_resolver
 

--- a/lib/facter/resolvers/windows/kernel.rb
+++ b/lib/facter/resolvers/windows/kernel.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class Kernel < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/memory.rb
+++ b/lib/facter/resolvers/windows/memory.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class Memory < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/networking.rb
+++ b/lib/facter/resolvers/windows/networking.rb
@@ -4,7 +4,6 @@ module Facter
   module Resolvers
     module Windows
       class Networking < BaseResolver
-        @log = Facter::Log.new(self)
         init_resolver
 
         class << self

--- a/lib/facter/resolvers/windows/ssh.rb
+++ b/lib/facter/resolvers/windows/ssh.rb
@@ -4,8 +4,6 @@ module Facter
   module Resolvers
     module Windows
       class Ssh < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         FILE_NAMES = %w[ssh_host_rsa_key.pub ssh_host_dsa_key.pub

--- a/lib/facter/resolvers/windows/system32.rb
+++ b/lib/facter/resolvers/windows/system32.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class System32 < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/lib/facter/resolvers/windows/timezone.rb
+++ b/lib/facter/resolvers/windows/timezone.rb
@@ -34,7 +34,6 @@ module Facter
             require_relative '../../../facter/resolvers/windows/ffi/winnls_ffi'
             WinnlsFFI.GetACP.to_s
           rescue LoadError => e
-            log = Facter::Log.new(self)
             log.debug("Could not retrieve codepage: #{e}")
           end
         end

--- a/lib/facter/resolvers/windows/uptime.rb
+++ b/lib/facter/resolvers/windows/uptime.rb
@@ -6,8 +6,6 @@ module Facter
   module Resolvers
     module Windows
       class Uptime < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         class << self

--- a/lib/facter/resolvers/windows/virtualization.rb
+++ b/lib/facter/resolvers/windows/virtualization.rb
@@ -4,8 +4,6 @@ module Facter
   module Resolvers
     module Windows
       class Virtualization < BaseResolver
-        @log = Facter::Log.new(self)
-
         init_resolver
 
         class << self

--- a/lib/facter/resolvers/windows/win_os_description.rb
+++ b/lib/facter/resolvers/windows/win_os_description.rb
@@ -3,8 +3,6 @@
 module Facter
   module Resolvers
     class WinOsDescription < BaseResolver
-      @log = Facter::Log.new(self)
-
       init_resolver
 
       class << self

--- a/spec/custom_facts/core/aggregate_spec.rb
+++ b/spec/custom_facts/core/aggregate_spec.rb
@@ -4,6 +4,7 @@ describe Facter::Core::Aggregate do
   subject(:aggregate_res) { Facter::Core::Aggregate.new('aggregated', fact) }
 
   let(:fact) { double('stub_fact', name: 'stub_fact') }
+  let(:logger) { Facter::Log.class_variable_get(:@@logger) }
 
   it 'can be resolved' do
     expect(aggregate_res).to be_a_kind_of LegacyFacter::Core::Resolvable
@@ -135,6 +136,12 @@ describe Facter::Core::Aggregate do
     it 'evaluates the block in the context of the aggregate' do
       expect(aggregate_res).to receive(:has_weight).with(5)
       aggregate_res.evaluate { has_weight(5) }
+    end
+
+    it 'warns if the block is evaluated more than once' do
+      expect(logger).to receive(:warn).with(/Already evaluated aggregated at.*reevaluating anyways/)
+      aggregate_res.evaluate {}
+      aggregate_res.evaluate {}
     end
   end
 end

--- a/spec/custom_facts/core/execution/fact_manager_spec.rb
+++ b/spec/custom_facts/core/execution/fact_manager_spec.rb
@@ -134,17 +134,15 @@ describe Facter::Core::Execution::Base do
       before do
         allow(Facter::Core::Execution::Popen3).to receive(:popen3e).with({ 'LC_ALL' => 'C', 'LANG' => 'C' }, command)
                                                                    .and_return(['', 'some error'])
-        allow(Facter::Log).to receive(:new).with(executor).and_return(logger)
-        allow(Facter::Log).to receive(:new).with('foo').and_return(logger)
 
         allow(File).to receive(:executable?).with(command).and_return(true)
         allow(FileTest).to receive(:file?).with(command).and_return(true)
       end
 
-      it 'loggs warning messages on stderr' do
-        executor.execute(command)
+      it 'logs warning messages on stderr' do
+        executor.execute(command, logger: logger)
         expect(logger).to have_received(:debug).with('Command /bin/foo completed with '\
-                                                                            'the following stderr message: some error')
+          'the following stderr message: some error')
       end
     end
 

--- a/spec/custom_facts/core/execution/posix_spec.rb
+++ b/spec/custom_facts/core/execution/posix_spec.rb
@@ -107,7 +107,7 @@ describe Facter::Core::Execution::Posix, unless: LegacyFacter::Util::Config.wind
   end
 
   context 'when calling execute_command' do
-    let(:logger) { instance_spy(Logger) }
+    let(:logger) { instance_spy(Facter::Log) }
 
     it 'executes a command' do
       expect(posix_executor.execute_command('/usr/bin/true', nil, logger)).to eq(['', ''])

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -50,7 +50,6 @@ describe Facter::Core::Execution do
     before do
       allow(impl).to receive(:which).with('waffles').and_return('/under/the/honey/are/the/waffles')
       allow(impl).to receive(:execute_command)
-      allow(logger).to receive(:warn)
     end
 
     context 'with default parameters' do
@@ -75,11 +74,20 @@ describe Facter::Core::Execution do
         end
       end
 
-      it 'emits a warning' do
-        execution.execute('waffles', time_limit: 90, bad_opt: true)
-        expect(logger).to have_received(:warn)
+      it 'emits a warning to the default logger' do
+        expect(logger).to receive(:warn)
           .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit,bad_opt' \
-                ' - valid keys: on_fail,expand,logger,timeout')
+            ' - valid keys: on_fail,expand,logger,timeout')
+
+        execution.execute('waffles', time_limit: 90, bad_opt: true)
+      end
+
+      it 'ignores the passed in logger when logging the warning' do
+        expect(logger).to receive(:warn)
+          .with('Unexpected key passed to Facter::Core::Execution.execute option: time_limit,bad_opt' \
+            ' - valid keys: on_fail,expand,logger,timeout')
+
+        execution.execute('waffles', time_limit: 90, bad_opt: true, logger: Facter::Log.new('ignored'))
       end
     end
   end

--- a/spec/custom_facts/core/resolvable_spec.rb
+++ b/spec/custom_facts/core/resolvable_spec.rb
@@ -49,22 +49,13 @@ describe LegacyFacter::Core::Resolvable do
     end
 
     context 'with a fact whose value is invalid UTF-8 string' do
-      let(:logger) { instance_spy(Facter::Log) }
-
-      before do
-        allow(Facter::Log).to receive(:new).and_return(logger)
-      end
-
-      after do
-        Facter.instance_variable_set(:@logger, nil)
-      end
+      let(:logger) { Facter.send(:logger) }
 
       it 'cannot resolve and logs error with fact name' do
+        expect(logger).to receive(:error).with(/Fact resolution fact='stub fact', resolution='resolvable' resolved to an invalid value: String "\\xC3\(" doesn't match the reported encoding UTF-8/)
+
         resolvable.resolve_value = "\xc3\x28"
         resolvable.value
-        expect(logger).to have_received(:error).with("Fact resolution fact='stub fact', resolution='resolvable' "\
-                                                     "resolved to an invalid value: String \"\\xC3(\" doesn't match "\
-                                                     'the reported encoding UTF-8')
       end
     end
   end

--- a/spec/custom_facts/util/collection_spec.rb
+++ b/spec/custom_facts/util/collection_spec.rb
@@ -23,17 +23,12 @@ describe LegacyFacter::Util::Collection do
     load
   end
   let(:collection) { LegacyFacter::Util::Collection.new(internal_loader, external_loader) }
-  let(:logger) { instance_spy(Facter::Log) }
+  let(:logger) { collection.send(:log) }
 
   before do
     Singleton.__init__(Facter::FactManager)
     Singleton.__init__(Facter::FactLoader)
     Singleton.__init__(Facter::ClassDiscoverer)
-    allow(Facter::Log).to receive(:new).and_return(logger)
-  end
-
-  after do
-    LegacyFacter::Util::Collection.instance_variable_set(:@log, nil)
   end
 
   it 'delegates its load_all method to its loader' do

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -5,11 +5,7 @@ describe Facter::Util::Resolution do
   subject(:resolution) { Facter::Util::Resolution.new(:foo, stub_fact) }
 
   let(:stub_fact) { double('fact', name: :stubfact) }
-  let(:logger) { instance_spy(Facter::Log) }
-
-  before do
-    allow(Facter::Log).to receive(:new).and_return(logger)
-  end
+  let(:logger) { Facter::Log.class_variable_get(:@@logger) }
 
   it 'requires a name' do
     expect { Facter::Util::Resolution.new }.to raise_error(ArgumentError)

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -14,8 +14,8 @@ describe Facter do
                              :core, 'mountpoints')
   end
 
-  let(:logger) { instance_spy(Facter::Log) }
   let(:config_reader_double) { class_spy(Facter::ConfigReader) }
+  let(:logger) { Facter.send(:logger) }
 
   sorted_fact_hash = { 'mountpoints' => { '/' => { 'device' => 'dev2', 'filesystem' => 'ext4' },
                                           '/boot' => { 'device' => 'dev1', 'filesystem' => 'ext4' } } }
@@ -32,13 +32,8 @@ describe Facter do
     allow(Facter::Options).to receive(:[]).with(:blocked_facts).and_return([])
     allow(Facter::Options).to receive(:[]).with(:block_list).and_return([])
 
-    allow(Facter::Log).to receive(:new).and_return(logger)
     Facter.clear
     allow(Facter::SessionCache).to receive(:invalidate_all_caches)
-  end
-
-  after do
-    Facter.instance_variable_set(:@logger, nil)
   end
 
   def stub_facts(resolved_facts)
@@ -366,9 +361,9 @@ describe Facter do
       end
 
       it 'logs a debug message' do
-        Facter.load_external(true)
+        expect(logger).to receive(:debug).with('Facter.load_external(true) called. External facts will be loaded')
 
-        expect(logger).to have_received(:debug).with('Facter.load_external(true) called. External facts will be loaded')
+        Facter.load_external(true)
       end
     end
 
@@ -501,9 +496,9 @@ describe Facter do
       let(:is_debug) { false }
 
       it "doesn't log anything" do
-        Facter.debug(message)
+        expect(logger).not_to receive(:debug).with(message)
 
-        expect(logger).not_to have_received(:debug).with(message)
+        Facter.debug(message)
       end
     end
   end
@@ -530,17 +525,17 @@ describe Facter do
       it 'logs exception message' do
         exception.set_backtrace(backtrace)
 
-        Facter.log_exception(exception, message)
+        expect(logger).to receive(:error).with(expected_message)
 
-        expect(logger).to have_received(:error).with(expected_message)
+        Facter.log_exception(exception, message)
       end
     end
 
     shared_examples 'when exception param is not an exception' do
       it 'logs exception message' do
-        Facter.log_exception(exception, message)
+        expect(logger).to receive(:error).with(expected_message)
 
-        expect(logger).to have_received(:error).with(expected_message)
+        Facter.log_exception(exception, message)
       end
     end
 
@@ -578,9 +573,9 @@ describe Facter do
         it 'logs exception message' do
           exception.set_backtrace(backtrace)
 
-          Facter.log_exception(exception)
+          expect(logger).to receive(:error).with(expected_message)
 
-          expect(logger).to have_received(:error).with(expected_message)
+          Facter.log_exception(exception)
         end
       end
 
@@ -651,9 +646,9 @@ describe Facter do
         it 'logs exception message' do
           exception.set_backtrace(backtrace)
 
-          Facter.log_exception(exception)
+          expect(logger).to receive(:error).with(expected_message)
 
-          expect(logger).to have_received(:error).with(expected_message)
+          Facter.log_exception(exception)
         end
       end
 
@@ -662,9 +657,9 @@ describe Facter do
         let(:expected_message) { 'FlushFakeError' }
 
         it 'logs exception message' do
-          Facter.log_exception(exception)
+          expect(logger).to receive(:error).with(expected_message)
 
-          expect(logger).to have_received(:error).with(expected_message)
+          Facter.log_exception(exception)
         end
       end
 
@@ -710,21 +705,21 @@ describe Facter do
       it 'calls logger with the debug message' do
         message = 'Some error message'
 
-        Facter.debugonce(message)
+        expect(logger).to receive(:debugonce).with(message)
 
-        expect(logger).to have_received(:debugonce).with(message)
+        Facter.debugonce(message)
       end
 
       it 'writes empty message when message is nil' do
-        Facter.debugonce(nil)
+        expect(logger).to receive(:debugonce).with(nil)
 
-        expect(logger).to have_received(:debugonce).with(nil)
+        Facter.debugonce(nil)
       end
 
       it 'when message is a hash' do
-        Facter.debugonce({ warn: 'message' })
+        expect(logger).to receive(:debugonce).with({ warn: 'message' })
 
-        expect(logger).to have_received(:debugonce).with({ warn: 'message' })
+        Facter.debugonce({ warn: 'message' })
       end
 
       it 'returns nil' do
@@ -740,9 +735,9 @@ describe Facter do
       end
 
       it 'does not call the logger' do
-        Facter.debugonce('message')
+        expect(logger).not_to receive(:debug)
 
-        expect(logger).not_to have_received(:debug)
+        Facter.debugonce('message')
       end
     end
   end
@@ -767,21 +762,21 @@ describe Facter do
     it 'calls logger with the warning message' do
       message = 'Some error message'
 
-      Facter.warnonce(message)
+      expect(logger).to receive(:warnonce).with(message)
 
-      expect(logger).to have_received(:warnonce).with(message)
+      Facter.warnonce(message)
     end
 
     it 'writes empty message when message is nil' do
-      Facter.warnonce(nil)
+      expect(logger).to receive(:warnonce).with(nil)
 
-      expect(logger).to have_received(:warnonce).with(nil)
+      Facter.warnonce(nil)
     end
 
     it 'when message is a hash' do
-      Facter.warnonce({ warn: 'message' })
+      expect(logger).to receive(:warnonce).with({ warn: 'message' })
 
-      expect(logger).to have_received(:warnonce).with({ warn: 'message' })
+      Facter.warnonce({ warn: 'message' })
     end
 
     it 'returns nil' do
@@ -792,39 +787,36 @@ describe Facter do
   end
 
   describe '#warn' do
-    before do
-      allow(logger).to receive(:warn)
-    end
-
     it 'calls logger' do
       message = 'Some error message'
 
-      Facter.warn(message)
+      expect(logger).to receive(:warn).with(message)
 
-      expect(logger).to have_received(:warn).with(message)
+      Facter.warn(message)
     end
 
     it 'when message is nil' do
-      Facter.warn(nil)
+      expect(logger).to receive(:warn).with('')
 
-      expect(logger).to have_received(:warn).with('')
+      Facter.warn(nil)
     end
 
     it 'when message is empty string' do
+      expect(logger).to receive(:warn).with('')
+
       Facter.warn('')
-      expect(logger).to have_received(:warn).with('')
     end
 
     it 'when message is a hash' do
-      Facter.warn({ warn: 'message' })
+      expect(logger).to receive(:warn).with('{:warn=>"message"}')
 
-      expect(logger).to have_received(:warn).with('{:warn=>"message"}')
+      Facter.warn({ warn: 'message' })
     end
 
     it 'when message is an array' do
-      Facter.warn([1, 2, 3])
+      expect(logger).to receive(:warn).with('[1, 2, 3]')
 
-      expect(logger).to have_received(:warn).with('[1, 2, 3]')
+      Facter.warn([1, 2, 3])
     end
 
     it 'returns nil' do

--- a/spec/facter/facts/freebsd/virtual_spec.rb
+++ b/spec/facter/facts/freebsd/virtual_spec.rb
@@ -5,10 +5,8 @@ describe Facts::Freebsd::Virtual do
     subject(:fact) { Facts::Freebsd::Virtual.new }
 
     let(:virtual_detector_double) { class_spy(Facter::Util::Facts::Posix::VirtualDetector) }
-    let(:log_spy) { instance_spy(Facter::Log) }
 
     before do
-      allow(Facter::Log).to receive(:new).and_return(log_spy)
       allow(Facter::Util::Facts::Posix::VirtualDetector).to receive(:platform).and_return(value)
     end
 

--- a/spec/facter/facts/linux/virtual_spec.rb
+++ b/spec/facter/facts/linux/virtual_spec.rb
@@ -5,10 +5,8 @@ describe Facts::Linux::Virtual do
     subject(:fact) { Facts::Linux::Virtual.new }
 
     let(:virtual_detector_double) { class_spy(Facter::Util::Facts::Posix::VirtualDetector) }
-    let(:log_spy) { instance_spy(Facter::Log) }
 
     before do
-      allow(Facter::Log).to receive(:new).and_return(log_spy)
       allow(Facter::Util::Facts::Posix::VirtualDetector).to receive(:platform).and_return(value)
     end
 

--- a/spec/facter/facts/openbsd/virtual_spec.rb
+++ b/spec/facter/facts/openbsd/virtual_spec.rb
@@ -5,10 +5,8 @@ describe Facts::Openbsd::Virtual do
     subject(:fact) { Facts::Openbsd::Virtual.new }
 
     let(:virtual_detector_double) { class_spy(Facter::Util::Facts::Posix::VirtualDetector) }
-    let(:log_spy) { instance_spy(Facter::Log) }
 
     before do
-      allow(Facter::Log).to receive(:new).and_return(log_spy)
       allow(Facter::Util::Facts::Posix::VirtualDetector).to receive(:platform).and_return(value)
     end
 

--- a/spec/facter/facts/openbsd/virtual_spec.rb.save
+++ b/spec/facter/facts/openbsd/virtual_spec.rb.save
@@ -5,10 +5,8 @@ describe Facts::Openbsd::Virtual do
     subject(:fact) { Facts::Openbsd::Virtual.new }
 
     let(:virtual_detector_double) { class_spy(Facter::Util::Facts::Posix::VirtualDetector) }
-    let(:log_spy) { instance_spy(Facter::Log) }
 
     before do
-      allow(Facter::Log).to receive(:new).and_return(log_spy)
       allow(Facter::Util::Facts::Posix::VirtualDetector).to receive(:platform).and_return(value)
     end
 

--- a/spec/facter/resolvers/aix/disks_spec.rb
+++ b/spec/facter/resolvers/aix/disks_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Aix::Disks do
   subject(:resolver) { Facter::Resolvers::Aix::Disks }
 
-  let(:logger_spy) { instance_spy(Facter::Log) }
-
   before do
-    resolver.instance_variable_set(:@log, logger_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('lspv', { logger: logger_spy })
+      .with('lspv', logger: an_instance_of(Facter::Log))
       .and_return(result)
   end
 
@@ -33,7 +30,7 @@ describe Facter::Resolvers::Aix::Disks do
 
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('lspv hdisk0', { logger: logger_spy })
+        .with('lspv hdisk0', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('lspv_disk_output').read)
     end
 
@@ -44,7 +41,7 @@ describe Facter::Resolvers::Aix::Disks do
     context 'when second lspv call fails' do
       before do
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('lspv hdisk0', { logger: logger_spy })
+          .with('lspv hdisk0', logger: an_instance_of(Facter::Log))
           .and_return('')
       end
 

--- a/spec/facter/resolvers/aix/memory_spec.rb
+++ b/spec/facter/resolvers/aix/memory_spec.rb
@@ -3,15 +3,12 @@
 describe Facter::Resolvers::Aix::Memory do
   subject(:resolver) { Facter::Resolvers::Aix::Memory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('svmon', { logger: log_spy })
+      .with('svmon', logger: an_instance_of(Facter::Log))
       .and_return(svmon_content)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('pagesize', { logger: log_spy })
+      .with('pagesize', logger: an_instance_of(Facter::Log))
       .and_return(pagesize_content)
   end
 

--- a/spec/facter/resolvers/aix/mountpoints_spec.rb
+++ b/spec/facter/resolvers/aix/mountpoints_spec.rb
@@ -16,15 +16,13 @@ describe Facter::Resolvers::Aix::Mountpoints do
                         device: '/var/share', filesystem: 'nfs3', options: [], size: '68.50 GiB',
                         size_bytes: 73_549_217_792, used: '4.93 GiB', used_bytes: 5_295_804_416 } }
   end
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    Facter::Resolvers::Aix::Mountpoints.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('mount', { logger: log_spy })
+      .with('mount', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('mount').read)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('df -P', { logger: log_spy })
+      .with('df -P', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('df').read)
   end
 

--- a/spec/facter/resolvers/aix/networking_spec.rb
+++ b/spec/facter/resolvers/aix/networking_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Aix::Networking do
   subject(:networking_resolver) { Facter::Resolvers::Aix::Networking }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:ffi_interfaces) do
     {
       'en0' => { bindings: [{ address: '10.32.77.1', netmask: '255.255.255.0', network: '10.32.77.0' }] },
@@ -13,13 +12,12 @@ describe Facter::Resolvers::Aix::Networking do
   end
 
   before do
-    networking_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('netstat -rn', { logger: log_spy })
+      .with('netstat -rn', logger: an_instance_of(Facter::Log))
       .and_return(netstat_rn)
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('netstat -in', { logger: log_spy })
+      .with('netstat -in', logger: an_instance_of(Facter::Log))
       .and_return(netstat_in)
 
     allow(Facter::Resolvers::Aix::FfiHelper).to receive(:read_interfaces).and_return(ffi_interfaces)
@@ -93,8 +91,9 @@ describe Facter::Resolvers::Aix::Networking do
     end
 
     it 'returns a nil MTU' do
+      expect(networking_resolver.log).not_to receive(:error).with(/undefined method/)
+
       expect(networking_resolver.resolve(:mtu)).to be_nil
-      expect(log_spy).not_to have_received(:debug).with(/undefined method/)
     end
   end
 end

--- a/spec/facter/resolvers/aix/os_level_spec.rb
+++ b/spec/facter/resolvers/aix/os_level_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Aix::OsLevel do
   subject(:os_level) { Facter::Resolvers::Aix::OsLevel }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    os_level.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/oslevel -s', { logger: log_spy })
+      .with('/usr/bin/oslevel -s', logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/aix/partitions_spec.rb
+++ b/spec/facter/resolvers/aix/partitions_spec.rb
@@ -4,10 +4,8 @@ describe Facter::Resolvers::Aix::Partitions do
   subject(:resolver) { Facter::Resolvers::Aix::Partitions }
 
   let(:odm_query_spy) { instance_spy(Facter::Util::Aix::ODMQuery) }
-  let(:logger_spy) { instance_spy(Facter::Log) }
 
   before do
-    resolver.instance_variable_set(:@log, logger_spy)
     allow(Facter::Util::Aix::ODMQuery).to receive(:new).and_return(odm_query_spy)
     allow(odm_query_spy).to receive(:equals).with('PdDvLn', 'logical_volume/lvsubclass/lvtype')
     allow(odm_query_spy).to receive(:execute).and_return(result)
@@ -38,10 +36,10 @@ describe Facter::Resolvers::Aix::Partitions do
 
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('lslv -L hd5', { logger: logger_spy })
+        .with('lslv -L hd5', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('lslv_output').read)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('lslv -L hd6', { logger: logger_spy })
+        .with('lslv -L hd6', logger: an_instance_of(Facter::Log))
         .and_return('')
     end
 

--- a/spec/facter/resolvers/aix/processors_spec.rb
+++ b/spec/facter/resolvers/aix/processors_spec.rb
@@ -7,10 +7,8 @@ describe Facter::Resolvers::Aix::Processors do
   let(:odm_query_spy2) { instance_spy(Facter::Util::Aix::ODMQuery) }
   let(:odm_query_spy3) { instance_spy(Facter::Util::Aix::ODMQuery) }
   let(:odm_query_spy4) { instance_spy(Facter::Util::Aix::ODMQuery) }
-  let(:logger_spy) { instance_spy(Facter::Log) }
 
   before do
-    resolver.instance_variable_set(:@log, logger_spy)
     allow(Facter::Util::Aix::ODMQuery).to receive(:new).and_return(odm_query_spy,
                                                                    odm_query_spy2,
                                                                    odm_query_spy3,

--- a/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
+++ b/spec/facter/resolvers/amzn/os_release_rpm_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Amzn::OsReleaseRpm do
   subject(:os_release_resolver) { Facter::Resolvers::Amzn::OsReleaseRpm }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    os_release_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with("rpm -q --qf '%<NAME>s\\n%<VERSION>s\\n%<RELEASE>s\\n%<VENDOR>s' -f /etc/os-release", { logger: log_spy })
+      .with("rpm -q --qf '%<NAME>s\\n%<VERSION>s\\n%<RELEASE>s\\n%<VENDOR>s' -f /etc/os-release", logger: an_instance_of(Facter::Log))
       .and_return(os_release_content)
   end
 

--- a/spec/facter/resolvers/augeas_spec.rb
+++ b/spec/facter/resolvers/augeas_spec.rb
@@ -3,11 +3,9 @@
 describe Facter::Resolvers::Augeas do
   subject(:augeas) { Facter::Resolvers::Augeas }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:readable) { false }
 
   before do
-    augeas.instance_variable_set(:@log, log_spy)
     allow(File).to receive(:readable?).with('/opt/puppetlabs/puppet/bin/augparse').and_return(readable)
   end
 
@@ -18,7 +16,7 @@ describe Facter::Resolvers::Augeas do
   context 'when augparse is installed' do
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('augparse --version 2>&1', { logger: log_spy })
+        .with('augparse --version 2>&1', logger: an_instance_of(Facter::Log))
         .and_return('augparse 1.12.0 <http://augeas.net/>')
     end
 
@@ -32,7 +30,7 @@ describe Facter::Resolvers::Augeas do
 
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/opt/puppetlabs/puppet/bin/augparse --version 2>&1', { logger: log_spy })
+        .with('/opt/puppetlabs/puppet/bin/augparse --version 2>&1', logger: an_instance_of(Facter::Log))
         .and_return('augparse 1.12.0 <http://augeas.net/>')
     end
 
@@ -44,7 +42,7 @@ describe Facter::Resolvers::Augeas do
   context 'when augparse is not installed' do
     before do
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('augparse --version 2>&1', { logger: log_spy })
+        .with('augparse --version 2>&1', logger: an_instance_of(Facter::Log))
         .and_return('sh: augparse: command not found')
     end
 
@@ -78,9 +76,10 @@ describe Facter::Resolvers::Augeas do
       end
 
       it 'rescues LoadError error and logs at debug level' do
-        augeas.resolve(:augeas_version)
+        allow(augeas.log).to receive(:debug)
+        expect(augeas.log).to receive(:debug).with(/Resolving fact augeas_version, but got load_error_message/)
 
-        expect(log_spy).to have_received(:debug).with(/Resolving fact augeas_version, but got load_error_message/)
+        augeas.resolve(:augeas_version)
       end
     end
   end

--- a/spec/facter/resolvers/az_spec.rb
+++ b/spec/facter/resolvers/az_spec.rb
@@ -4,12 +4,10 @@ describe Facter::Resolvers::Az do
   subject(:az) { Facter::Resolvers::Az }
 
   let(:uri) { 'http://169.254.169.254/metadata/instance?api-version=2020-09-01' }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
     allow(Facter::Util::Resolvers::Http).to receive(:get_request)
       .with(uri, { Metadata: 'true' }, { session: 5 }, false).and_return(output)
-    az.instance_variable_set(:@log, log_spy)
   end
 
   after do

--- a/spec/facter/resolvers/base_resolver_spec.rb
+++ b/spec/facter/resolvers/base_resolver_spec.rb
@@ -14,21 +14,12 @@ describe Facter::Resolvers::BaseResolver do
   end
 
   describe '#log' do
-    before do
-      allow(Facter::Log).to receive(:new).with(resolver).and_return('logger')
+    it 'returns the log' do
+      expect(resolver.log).to be_an_instance_of(Facter::Log)
     end
 
-    it 'initializes the log' do
-      resolver.log
-
-      expect(Facter::Log).to have_received(:new).with(resolver)
-    end
-
-    it 'initializes the log only once' do
-      resolver.log
-      resolver.log
-
-      expect(Facter::Log).to have_received(:new).with(resolver).once
+    it 'returns the same log instance each time' do
+      expect(resolver.log).to be_equal(resolver.log)
     end
   end
 
@@ -77,13 +68,12 @@ describe Facter::Resolvers::BaseResolver do
     context 'when Load Error is raised' do
       before do
         allow(resolver).to receive(:post_resolve).and_raise(LoadError)
-        allow(Facter::Log).to receive(:new).with(resolver).and_return(instance_double(Facter::Log, error: nil))
       end
 
       it 'logs the Load Error exception at the error level' do
-        resolver.resolve(fact)
+        expect(resolver.log).to receive(:error).with(/Resolving fact #{fact}, but got LoadError/)
 
-        expect(resolver.log).to have_received(:error).with(/Resolving fact #{fact}, but got LoadError/)
+        resolver.resolve(fact)
       end
 
       it 'sets the fact to nil' do

--- a/spec/facter/resolvers/bsd/processors_spec.rb
+++ b/spec/facter/resolvers/bsd/processors_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Bsd::Processors do
   subject(:resolver) { Facter::Resolvers::Bsd::Processors }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:logicalcount) { 2 }
   let(:models) do
     ['Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz', 'Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz']
@@ -23,8 +22,6 @@ describe Facter::Resolvers::Bsd::Processors do
       .to receive(:sysctl)
       .with(:uint32_t, [6, 12])
       .and_return(2592)
-
-    resolver.instance_variable_set(:@log, log_spy)
   end
 
   after do

--- a/spec/facter/resolvers/ec2_spec.rb
+++ b/spec/facter/resolvers/ec2_spec.rb
@@ -7,17 +7,14 @@ describe Facter::Resolvers::Ec2 do
   let(:userdata_uri) { "#{base_uri}/user-data/" }
   let(:metadata_uri) { "#{base_uri}/meta-data/" }
   let(:token_uri) { "#{base_uri}/api/token" }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    Facter::Util::Resolvers::Http.instance_variable_set(:@log, log_spy)
     allow(Socket).to receive(:tcp) if Gem.win_platform?
   end
 
   after do
     ec2.invalidate_cache
     Facter::Util::Resolvers::AwsToken.reset
-    Facter::Util::Resolvers::Http.instance_variable_set(:@log, nil)
   end
 
   shared_examples_for 'ec2' do

--- a/spec/facter/resolvers/freebsd/processors_spec.rb
+++ b/spec/facter/resolvers/freebsd/processors_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Freebsd::Processors do
   subject(:resolver) { Facter::Resolvers::Freebsd::Processors }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:logicalcount) { 2 }
   let(:models) do
     ['Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz', 'Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz']
@@ -23,8 +22,6 @@ describe Facter::Resolvers::Freebsd::Processors do
       .to receive(:sysctl_by_name)
       .with(:uint32_t, 'hw.clockrate')
       .and_return(2592)
-
-    resolver.instance_variable_set(:@log, log_spy)
   end
 
   after do

--- a/spec/facter/resolvers/freebsd/swap_memory_spec.rb
+++ b/spec/facter/resolvers/freebsd/swap_memory_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Freebsd::SwapMemory do
   subject(:swap_memory) { Facter::Resolvers::Freebsd::SwapMemory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:available_bytes) { 4_294_967_296 }
   let(:total_bytes) { 4_294_967_296 }
   let(:used_bytes) { 0 }
@@ -11,9 +10,8 @@ describe Facter::Resolvers::Freebsd::SwapMemory do
   let(:encrypted) { true }
 
   before do
-    swap_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('swapinfo -k', { logger: log_spy })
+      .with('swapinfo -k', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('freebsd_swapinfo').read)
   end
 

--- a/spec/facter/resolvers/freebsd/system_memory_spec.rb
+++ b/spec/facter/resolvers/freebsd/system_memory_spec.rb
@@ -3,14 +3,12 @@
 describe Facter::Resolvers::Freebsd::SystemMemory do
   subject(:system_memory) { Facter::Resolvers::Freebsd::SystemMemory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:available_bytes) { 2_696_462_336 }
   let(:total_bytes) { 17_043_554_304 }
   let(:used_bytes) { 14_347_091_968 }
   let(:capacity) { '84.18%' }
 
   before do
-    system_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Freebsd::FfiHelper).to receive(:sysctl_by_name)
       .with(:long, 'vm.stats.vm.v_page_size')
       .and_return(4096)

--- a/spec/facter/resolvers/hostname_spec.rb
+++ b/spec/facter/resolvers/hostname_spec.rb
@@ -3,11 +3,8 @@
 describe Facter::Resolvers::Hostname do
   subject(:hostname_resolver) { Facter::Resolvers::Hostname }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   describe '#resolve' do
     before do
-      hostname_resolver.instance_variable_set(:@log, log_spy)
       allow(Socket).to receive(:gethostname).and_return(host)
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/etc/resolv.conf')

--- a/spec/facter/resolvers/linux/docker_uptime_spec.rb
+++ b/spec/facter/resolvers/linux/docker_uptime_spec.rb
@@ -3,19 +3,13 @@
 describe Facter::Resolvers::Linux::DockerUptime do
   subject(:resolver) { Facter::Resolvers::Linux::DockerUptime }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   after { Facter::Resolvers::Linux::DockerUptime.invalidate_cache }
-
-  before do
-    resolver.instance_variable_set(:@log, log_spy)
-  end
 
   context 'when the uptime is less than 1 minutes' do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', { logger: log_spy })
+        .with('ps -o etime= -p "1"', logger: an_instance_of(Facter::Log))
         .and_return('20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -45,7 +39,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', { logger: log_spy })
+        .with('ps -o etime= -p "1"', logger: an_instance_of(Facter::Log))
         .and_return('10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -75,7 +69,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', { logger: log_spy })
+        .with('ps -o etime= -p "1"', logger: an_instance_of(Facter::Log))
         .and_return('3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -105,7 +99,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', { logger: log_spy })
+        .with('ps -o etime= -p "1"', logger: an_instance_of(Facter::Log))
         .and_return('1-3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)
@@ -135,7 +129,7 @@ describe Facter::Resolvers::Linux::DockerUptime do
     before do
       allow(Facter::Core::Execution)
         .to receive(:execute)
-        .with('ps -o etime= -p "1"', { logger: log_spy })
+        .with('ps -o etime= -p "1"', logger: an_instance_of(Facter::Log))
         .and_return('2-3:10:20')
 
       allow(Facter::Util::Resolvers::UptimeHelper)

--- a/spec/facter/resolvers/linux/hostname_spec.rb
+++ b/spec/facter/resolvers/linux/hostname_spec.rb
@@ -3,8 +3,6 @@
 describe Facter::Resolvers::Linux::Hostname do
   subject(:hostname_resolver) { Facter::Resolvers::Linux::Hostname }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   shared_examples 'detects values' do
     it 'detects hostname' do
       expect(hostname_resolver.resolve(:hostname)).to eq(hostname)
@@ -21,7 +19,6 @@ describe Facter::Resolvers::Linux::Hostname do
 
   describe '#resolve' do
     before do
-      hostname_resolver.instance_variable_set(:@log, log_spy)
       allow(Socket).to receive(:gethostname).and_return(host)
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/etc/resolv.conf')
@@ -94,8 +91,10 @@ describe Facter::Resolvers::Linux::Hostname do
           end
 
           it 'logs that ffi canot be loaded' do
+            allow(hostname_resolver.log).to receive(:debug)
+            expect(hostname_resolver.log).to receive(:debug).with('cannot load ffi')
+
             hostname_resolver.resolve(:hostname)
-            expect(log_spy).to have_received(:debug).with('cannot load ffi')
           end
 
           it 'does not resolve hostname' do
@@ -185,8 +184,10 @@ describe Facter::Resolvers::Linux::Hostname do
           end
 
           it 'logs that ffi canot be loaded' do
+            allow(hostname_resolver.log).to receive(:debug)
+            expect(hostname_resolver.log).to receive(:debug).with('cannot load ffi')
+
             hostname_resolver.resolve(:domain)
-            expect(log_spy).to have_received(:debug).with('cannot load ffi')
           end
 
           it_behaves_like 'detects values'
@@ -229,8 +230,10 @@ describe Facter::Resolvers::Linux::Hostname do
       end
 
       it 'logs that ffi canot be loaded' do
+        allow(hostname_resolver.log).to receive(:debug)
+        expect(hostname_resolver.log).to receive(:debug).with('cannot load ffi')
+
         hostname_resolver.resolve(:hostname)
-        expect(log_spy).to have_received(:debug).with('cannot load ffi')
       end
 
       it_behaves_like 'detects values'

--- a/spec/facter/resolvers/linux/lscpu_spec.rb
+++ b/spec/facter/resolvers/linux/lscpu_spec.rb
@@ -2,10 +2,9 @@
 
 describe Facter::Resolvers::Linux::Lscpu do
   before do
-    Facter::Resolvers::Linux::Lscpu.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with("lscpu | grep -e 'Thread(s)' -e 'Core(s)'", { logger: log_spy })
+      .with("lscpu | grep -e 'Thread(s)' -e 'Core(s)'", logger: an_instance_of(Facter::Log))
       .and_return(lscpu_output)
   end
 
@@ -13,7 +12,6 @@ describe Facter::Resolvers::Linux::Lscpu do
     Facter::Resolvers::Linux::Lscpu.invalidate_cache
   end
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:cores_per_socket) { 1 }
   let(:threads_per_core) { 2 }
   let(:lscpu_output) do

--- a/spec/facter/resolvers/lpar_spec.rb
+++ b/spec/facter/resolvers/lpar_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Lpar do
   subject(:lpar_resolver) { Facter::Resolvers::Lpar }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    lpar_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/lparstat -i', { logger: log_spy })
+      .with('/usr/bin/lparstat -i', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('lparstat_i').read)
     lpar_resolver.invalidate_cache
   end

--- a/spec/facter/resolvers/lspci_spec.rb
+++ b/spec/facter/resolvers/lspci_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Lspci do
   subject(:lspci_resolver) { Facter::Resolvers::Lspci }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    lspci_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('lspci', { logger: log_spy }).and_return(output)
+      .with('lspci', logger: an_instance_of(Facter::Log)).and_return(output)
   end
 
   after do

--- a/spec/facter/resolvers/macosx/dmi_spec.rb
+++ b/spec/facter/resolvers/macosx/dmi_spec.rb
@@ -3,13 +3,11 @@
 describe Facter::Resolvers::Macosx::DmiBios do
   subject(:dmi_resolver) { Facter::Resolvers::Macosx::DmiBios }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:macosx_model) { 'MacBookPro11,4' }
 
   before do
-    dmi_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n hw.model', { logger: log_spy })
+      .with('sysctl -n hw.model', logger: an_instance_of(Facter::Log))
       .and_return(macosx_model)
   end
 

--- a/spec/facter/resolvers/macosx/filesystems_spec.rb
+++ b/spec/facter/resolvers/macosx/filesystems_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Macosx::Filesystems do
   subject(:filesystems_resolver) { Facter::Resolvers::Macosx::Filesystems }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    filesystems_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('mount', { logger: log_spy })
+      .with('mount', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('macosx_filesystems').read)
   end
 

--- a/spec/facter/resolvers/macosx/load_averages_spec.rb
+++ b/spec/facter/resolvers/macosx/load_averages_spec.rb
@@ -3,13 +3,11 @@
 describe Facter::Resolvers::Macosx::LoadAverages do
   subject(:load_averages) { Facter::Resolvers::Macosx::LoadAverages }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:expected_result) { { '1m' => 0.00, '5m' => 0.03, '15m' => 0.03 } }
 
   before do
-    load_averages.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n vm.loadavg', { logger: log_spy })
+      .with('sysctl -n vm.loadavg', logger: an_instance_of(Facter::Log))
       .and_return('{ 0.00 0.03 0.03 }')
   end
 

--- a/spec/facter/resolvers/macosx/processors_spec.rb
+++ b/spec/facter/resolvers/macosx/processors_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Macosx::Processors do
   subject(:processors_resolver) { Facter::Resolvers::Macosx::Processors }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:logicalcount) { 4 }
   let(:models) do
     ['Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz', 'Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz',
@@ -15,11 +14,9 @@ describe Facter::Resolvers::Macosx::Processors do
   let(:threads_per_core) { 1 }
 
   before do
-    processors_resolver.instance_variable_set(:@log, log_spy)
-
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with(query_string, { logger: log_spy })
+      .with(query_string, logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/macosx/swap_memory_spec.rb
+++ b/spec/facter/resolvers/macosx/swap_memory_spec.rb
@@ -3,7 +3,6 @@
 describe Facter::Resolvers::Macosx::SwapMemory do
   subject(:swap_memory) { Facter::Resolvers::Macosx::SwapMemory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:available_bytes) { 1_729_363_968 }
   let(:total_bytes) { 3_221_225_472 }
   let(:used_bytes) { 1_491_861_504 }
@@ -11,9 +10,8 @@ describe Facter::Resolvers::Macosx::SwapMemory do
   let(:encrypted) { true }
 
   before do
-    swap_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n vm.swapusage', { logger: log_spy })
+      .with('sysctl -n vm.swapusage', logger: an_instance_of(Facter::Log))
       .and_return('total = 3072.00M  used = 1422.75M  free = 1649.25M  (encrypted)')
   end
 

--- a/spec/facter/resolvers/macosx/system_memory_spec.rb
+++ b/spec/facter/resolvers/macosx/system_memory_spec.rb
@@ -3,20 +3,18 @@
 describe Facter::Resolvers::Macosx::SystemMemory do
   subject(:system_memory) { Facter::Resolvers::Macosx::SystemMemory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:available_bytes) { 5_590_519_808 }
   let(:total_bytes) { 34_359_738_368 }
   let(:used_bytes) { 28_769_218_560 }
   let(:capacity) { '83.73%' }
 
   before do
-    system_memory.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('sysctl -n hw.memsize', { logger: log_spy })
+      .with('sysctl -n hw.memsize', logger: an_instance_of(Facter::Log))
       .and_return('34359738368')
 
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('vm_stat', { logger: log_spy })
+      .with('vm_stat', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('vm_stat').read)
   end
 

--- a/spec/facter/resolvers/networking_spec.rb
+++ b/spec/facter/resolvers/networking_spec.rb
@@ -3,24 +3,21 @@
 describe Facter::Resolvers::Networking do
   subject(:networking) { Facter::Resolvers::Networking }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   describe '#resolve' do
     before do
-      networking.instance_variable_set(:@log, log_spy)
       allow(Facter::Util::Resolvers::Networking::PrimaryInterface)
         .to receive(:read_from_route)
         .and_return(primary)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ifconfig -a', { logger: log_spy }).and_return(interfaces)
+        .to receive(:execute).with('ifconfig -a', logger: an_instance_of(Facter::Log)).and_return(interfaces)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption en0 server_identifier', { logger: log_spy }).and_return(dhcp)
+        .to receive(:execute).with('ipconfig getoption en0 server_identifier', logger: an_instance_of(Facter::Log)).and_return(dhcp)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption en0.1 server_identifier', { logger: log_spy }).and_return(dhcp)
+        .to receive(:execute).with('ipconfig getoption en0.1 server_identifier', logger: an_instance_of(Facter::Log)).and_return(dhcp)
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption llw0 server_identifier', { logger: log_spy }).and_return('')
+        .to receive(:execute).with('ipconfig getoption llw0 server_identifier', logger: an_instance_of(Facter::Log)).and_return('')
       allow(Facter::Core::Execution)
-        .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', { logger: log_spy }).and_return(dhcp)
+        .to receive(:execute).with('ipconfig getoption awdl0 server_identifier', logger: an_instance_of(Facter::Log)).and_return(dhcp)
     end
 
     after do

--- a/spec/facter/resolvers/openbsd/mountpoints_spec.rb
+++ b/spec/facter/resolvers/openbsd/mountpoints_spec.rb
@@ -13,15 +13,13 @@ describe Facter::Resolvers::Openbsd::Mountpoints do
                         size: '2.90 GiB', size_bytes: 3_114_448_896, used: '1.66 GiB',
                         used_bytes: 1_780_609_024 } }
   end
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    Facter::Resolvers::Openbsd::Mountpoints.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('mount', { logger: log_spy })
+      .with('mount', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('openbsd_filesystems').read)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('df -P', { logger: log_spy })
+      .with('df -P', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('openbsd_df').read)
   end
 

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -5,11 +5,9 @@ describe Facter::Resolvers::Partitions do
 
   let(:sys_block_path) { '/sys/block' }
   let(:sys_block_subdirs) { ['.', '..', 'sda'] }
-  let(:logger) { instance_spy(Facter::Log) }
 
   before do
     Facter::Resolvers::Partitions.invalidate_cache
-    Facter::Resolvers::Partitions.instance_variable_set(:@log, logger)
   end
 
   context 'when /sys/block is not readable' do
@@ -40,11 +38,11 @@ describe Facter::Resolvers::Partitions do
       allow(Facter::Core::Execution).to receive(:which)
         .with('blkid').and_return('/usr/bin/blkid')
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('blkid', { logger: logger }).and_return(load_fixture('blkid_output').read)
+        .with('blkid', logger: an_instance_of(Facter::Log)).and_return(load_fixture('blkid_output').read)
       allow(Facter::Core::Execution).to receive(:which)
         .with('lsblk').and_return('/usr/bin/lsblk')
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('lsblk -fp', { logger: logger }).and_return(load_fixture('lsblk_output').read)
+        .with('lsblk -fp', logger: an_instance_of(Facter::Log)).and_return(load_fixture('lsblk_output').read)
     end
 
     context 'when block has a device subdir' do

--- a/spec/facter/resolvers/redhat_release_spec.rb
+++ b/spec/facter/resolvers/redhat_release_spec.rb
@@ -3,8 +3,6 @@
 describe Facter::Resolvers::RedHatRelease do
   subject(:redhat_release) { Facter::Resolvers::RedHatRelease }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   after do
     Facter::Resolvers::RedHatRelease.invalidate_cache
   end

--- a/spec/facter/resolvers/selinux_spec.rb
+++ b/spec/facter/resolvers/selinux_spec.rb
@@ -3,16 +3,13 @@
 describe Facter::Resolvers::SELinux do
   subject(:selinux_resolver) { Facter::Resolvers::SELinux }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   after do
     selinux_resolver.invalidate_cache
   end
 
   before do
-    selinux_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('cat /proc/self/mounts', { logger: log_spy })
+      .with('cat /proc/self/mounts', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture(file).read)
   end
 

--- a/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
+++ b/spec/facter/resolvers/solaris/dmi_sparc_spec.rb
@@ -4,17 +4,14 @@ describe Facter::Resolvers::Solaris::DmiSparc do
   describe '#resolve' do
     subject(:resolver) { Facter::Resolvers::Solaris::DmiSparc }
 
-    let(:log_spy) { instance_spy(Facter::Log) }
-
     before do
-      resolver.instance_variable_set(:@log, log_spy)
       allow(File).to receive(:executable?).with('/usr/sbin/prtdiag').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/prtdiag', { logger: log_spy })
+        .with('/usr/sbin/prtdiag', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('prtdiag').read)
       allow(File).to receive(:executable?).with('/usr/sbin/sneep').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/sneep', { logger: log_spy }).and_return('random_string')
+        .with('/usr/sbin/sneep', logger: an_instance_of(Facter::Log)).and_return('random_string')
     end
 
     after do
@@ -37,13 +34,10 @@ describe Facter::Resolvers::Solaris::DmiSparc do
   describe '#reolve under a non-global zone' do
     subject(:resolver) { Facter::Resolvers::Solaris::DmiSparc }
 
-    let(:log_spy) { instance_spy(Facter::Log) }
-
     before do
-      resolver.instance_variable_set(:@log, log_spy)
       allow(File).to receive(:executable?).with('/usr/sbin/prtdiag').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/prtdiag', { logger: log_spy })
+        .with('/usr/sbin/prtdiag', logger: an_instance_of(Facter::Log))
         .and_return('prtdiag can only be run in the global zone')
     end
 

--- a/spec/facter/resolvers/solaris/dmi_spec.rb
+++ b/spec/facter/resolvers/solaris/dmi_spec.rb
@@ -4,19 +4,16 @@ describe Facter::Resolvers::Solaris::Dmi do
   describe '#resolve' do
     subject(:resolver) { Facter::Resolvers::Solaris::Dmi }
 
-    let(:log_spy) { instance_spy(Facter::Log) }
-
     before do
-      resolver.instance_variable_set(:@log, log_spy)
       allow(File).to receive(:executable?).with('/usr/sbin/smbios').and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_BIOS', { logger: log_spy })
+        .with('/usr/sbin/smbios -t SMB_TYPE_BIOS', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('smbios_bios').read)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_SYSTEM', { logger: log_spy })
+        .with('/usr/sbin/smbios -t SMB_TYPE_SYSTEM', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('smbios_system').read)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('/usr/sbin/smbios -t SMB_TYPE_CHASSIS', { logger: log_spy })
+        .with('/usr/sbin/smbios -t SMB_TYPE_CHASSIS', logger: an_instance_of(Facter::Log))
         .and_return(load_fixture('smbios_chassis').read)
     end
 

--- a/spec/facter/resolvers/solaris/filesystem_spec.rb
+++ b/spec/facter/resolvers/solaris/filesystem_spec.rb
@@ -4,13 +4,11 @@ describe Facter::Resolvers::Solaris::Filesystem do
   subject(:filesystems_resolver) { Facter::Resolvers::Solaris::Filesystem }
 
   let(:filesystems) { 'hsfs,nfs,pcfs,udfs,ufs' }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    filesystems_resolver.instance_variable_set(:@log, log_spy)
     allow(File).to receive(:executable?).with('/usr/sbin/sysdef').and_return(true)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/sbin/sysdef', { logger: log_spy })
+      .with('/usr/sbin/sysdef', logger: an_instance_of(Facter::Log))
       .and_return(load_fixture('solaris_filesystems').read)
   end
 

--- a/spec/facter/resolvers/solaris/ipaddress_spec.rb
+++ b/spec/facter/resolvers/solaris/ipaddress_spec.rb
@@ -3,17 +3,14 @@
 describe Facter::Resolvers::Solaris::Ipaddress do
   subject(:ipaddress) { Facter::Resolvers::Solaris::Ipaddress }
 
-  let(:log) { instance_spy(Facter::Log) }
-
   describe '#resolve' do
     after do
       ipaddress.invalidate_cache
     end
 
     before do
-      ipaddress.instance_variable_set(:@log, log)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('route -n get default | grep interface', { logger: log })
+        .with('route -n get default | grep interface', logger: an_instance_of(Facter::Log))
         .and_return(route)
     end
 
@@ -23,7 +20,7 @@ describe Facter::Resolvers::Solaris::Ipaddress do
 
       before do
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ifconfig net0', { logger: log })
+          .with('ifconfig net0', logger: an_instance_of(Facter::Log))
           .and_return(ifconfig)
       end
 

--- a/spec/facter/resolvers/solaris/ldom_spec.rb
+++ b/spec/facter/resolvers/solaris/ldom_spec.rb
@@ -3,13 +3,10 @@
 describe Facter::Resolvers::Solaris::Ldom do
   subject(:resolver) { Facter::Resolvers::Solaris::Ldom }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/sbin/virtinfo  -a  -p', { logger: log_spy })
+      .with('/usr/sbin/virtinfo  -a  -p', logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/solaris/memory_spec.rb
+++ b/spec/facter/resolvers/solaris/memory_spec.rb
@@ -3,21 +3,18 @@
 describe Facter::Resolvers::Solaris::Memory do
   subject(:resolver) { Facter::Resolvers::Solaris::Memory }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/bin/kstat -m unix -n system_pages', { logger: log_spy })
+      .with('/usr/bin/kstat -m unix -n system_pages', logger: an_instance_of(Facter::Log))
       .and_return(kstat_output)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('pagesize', { logger: log_spy })
+      .with('pagesize', logger: an_instance_of(Facter::Log))
       .and_return(pagesize)
     allow(Facter::Core::Execution)
       .to receive(:execute)
-      .with('/usr/sbin/swap -l', { logger: log_spy })
+      .with('/usr/sbin/swap -l', logger: an_instance_of(Facter::Log))
       .and_return(swap_output)
   end
 

--- a/spec/facter/resolvers/solaris/zone_name_spec.rb
+++ b/spec/facter/resolvers/solaris/zone_name_spec.rb
@@ -4,15 +4,13 @@ describe Facter::Resolvers::Solaris::ZoneName do
   subject(:solaris_zone) { Facter::Resolvers::Solaris::ZoneName }
 
   let(:zone_name_output) { 'global' }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    solaris_zone.instance_variable_set(:@log, log_spy)
     allow(File).to receive(:executable?)
       .with('/bin/zonename')
       .and_return(true)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/bin/zonename', { logger: log_spy })
+      .with('/bin/zonename', logger: an_instance_of(Facter::Log))
       .and_return(zone_name_output)
   end
 

--- a/spec/facter/resolvers/solaris/zone_spec.rb
+++ b/spec/facter/resolvers/solaris/zone_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Solaris::Zone do
   subject(:solaris_zone) { Facter::Resolvers::Solaris::Zone }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    solaris_zone.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/sbin/zoneadm list -cp', { logger: log_spy })
+      .with('/usr/sbin/zoneadm list -cp', logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 
@@ -37,9 +34,10 @@ describe Facter::Resolvers::Solaris::Zone do
     let(:output) { '' }
 
     it 'prints debug message' do
-      solaris_zone.resolve(:zone)
-      expect(log_spy).to have_received(:debug)
+      expect(solaris_zone.log).to receive(:debug)
         .with('Command /usr/sbin/zoneadm list -cp returned an empty result')
+
+      solaris_zone.resolve(:zone)
     end
   end
 end

--- a/spec/facter/resolvers/suse_release_spec.rb
+++ b/spec/facter/resolvers/suse_release_spec.rb
@@ -3,8 +3,6 @@
 describe Facter::Resolvers::SuseRelease do
   subject(:suse_release) { Facter::Resolvers::SuseRelease }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
     allow(Facter::Util::FileHelper).to receive(:safe_read)
       .with('/etc/SuSE-release', nil)

--- a/spec/facter/resolvers/sw_vers_spec.rb
+++ b/spec/facter/resolvers/sw_vers_spec.rb
@@ -3,14 +3,11 @@
 describe Facter::Resolvers::SwVers do
   subject(:sw_vers) { Facter::Resolvers::SwVers }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   context 'with ProductVersionExtra' do
     before do
       Facter::Resolvers::SwVers.invalidate_cache
-      sw_vers.instance_variable_set(:@log, log_spy)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('sw_vers', { logger: log_spy })
+        .with('sw_vers', logger: an_instance_of(Facter::Log))
         .and_return("ProductName:\tmacOS\nProductVersion:\t13.3.1\n"\
           "ProductVersionExtra:\t(a)\nBuildVersion:\t22E772610a\n")
     end
@@ -35,9 +32,8 @@ describe Facter::Resolvers::SwVers do
   context 'without ProductVersionExtra' do
     before do
       Facter::Resolvers::SwVers.invalidate_cache
-      sw_vers.instance_variable_set(:@log, log_spy)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('sw_vers', { logger: log_spy })
+        .with('sw_vers', logger: an_instance_of(Facter::Log))
         .and_return("ProductName:\tMac OS X\nProductVersion:\t10.14.1\n"\
           "BuildVersion:\t18B75\n")
     end

--- a/spec/facter/resolvers/system_profile_spec.rb
+++ b/spec/facter/resolvers/system_profile_spec.rb
@@ -3,8 +3,6 @@
 describe Facter::Resolvers::Macosx::SystemProfiler do
   subject(:system_profiler) { Facter::Resolvers::Macosx::SystemProfiler }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   let(:sp_hardware_data_type_hash) do
     {
       model_name: 'MacBook Pro',
@@ -53,10 +51,6 @@ describe Facter::Resolvers::Macosx::SystemProfiler do
       location: '/System/Library/Extensions/IONetworkingFamily.kext/Contents/PlugIns/AppleIntel8254XEthernet.kext',
       version: '3.1.5'
     }
-  end
-
-  before do
-    system_profiler.instance_variable_set(:@log, log_spy)
   end
 
   context 'when information is obtain from SPHardwareDataType' do

--- a/spec/facter/resolvers/uname_spec.rb
+++ b/spec/facter/resolvers/uname_spec.rb
@@ -3,17 +3,14 @@
 describe Facter::Resolvers::Uname do
   subject(:uname_resolver) { Facter::Resolvers::Uname }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    uname_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
       .with('uname -m &&
             uname -n &&
             uname -p &&
             uname -r &&
             uname -s &&
-            uname -v', { logger: log_spy })
+            uname -v', logger: an_instance_of(Facter::Log))
       .and_return('x86_64
         wifi.tsr.corp.puppet.net
         i386
@@ -23,7 +20,6 @@ describe Facter::Resolvers::Uname do
   end
 
   after do
-    uname_resolver.instance_variable_set(:@log, nil)
     Facter::Resolvers::Uname.invalidate_cache
   end
 

--- a/spec/facter/resolvers/virt_what_spec.rb
+++ b/spec/facter/resolvers/virt_what_spec.rb
@@ -3,15 +3,12 @@
 describe Facter::Resolvers::VirtWhat do
   subject(:virt_what_resolver) { Facter::Resolvers::VirtWhat }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   after do
     virt_what_resolver.invalidate_cache
   end
 
   before do
-    virt_what_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('virt-what', { logger: log_spy }).and_return(content)
+    allow(Facter::Core::Execution).to receive(:execute).with('virt-what', logger: an_instance_of(Facter::Log)).and_return(content)
   end
 
   context 'when virt-what fails' do

--- a/spec/facter/resolvers/vmware_spec.rb
+++ b/spec/facter/resolvers/vmware_spec.rb
@@ -3,11 +3,8 @@
 describe Facter::Resolvers::Vmware do
   subject(:vmware_resolver) { Facter::Resolvers::Vmware }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    vmware_resolver.instance_variable_set(:@log, log_spy)
-    allow(Facter::Core::Execution).to receive(:execute).with('vmware -v', { logger: log_spy }).and_return(output)
+    allow(Facter::Core::Execution).to receive(:execute).with('vmware -v', logger: an_instance_of(Facter::Log)).and_return(output)
   end
 
   after do

--- a/spec/facter/resolvers/windows/aio_agent_version_spec.rb
+++ b/spec/facter/resolvers/windows/aio_agent_version_spec.rb
@@ -6,7 +6,6 @@ describe Facter::Resolvers::Windows::AioAgentVersion do
 
     let(:puppet_version) { '7.0.1' }
     let(:reg) { instance_spy(Win32::Registry::HKEY_LOCAL_MACHINE) }
-    let(:log) { instance_spy(Facter::Log) }
 
     before do
       allow(Win32::Registry::HKEY_LOCAL_MACHINE).to receive(:open).with('SOFTWARE\\Puppet Labs\\Puppet').and_yield(reg)
@@ -14,7 +13,6 @@ describe Facter::Resolvers::Windows::AioAgentVersion do
         .to receive(:safe_read)
         .with('path_to_puppet/VERSION', nil)
         .and_return(puppet_version)
-      allow(Facter::Resolvers::BaseResolver).to receive(:log).and_return(log)
     end
 
     after do
@@ -30,9 +28,9 @@ describe Facter::Resolvers::Windows::AioAgentVersion do
       end
 
       it 'logs debug message specific to none existent path' do
-        aio_agent_resolver.resolve(:aio_agent_version)
+        expect(aio_agent_resolver.log).to receive(:debug).with('The registry path SOFTWARE\Puppet Labs\Puppet does not exist')
 
-        expect(log).to have_received(:debug).with('The registry path SOFTWARE\Puppet Labs\Puppet does not exist')
+        aio_agent_resolver.resolve(:aio_agent_version)
       end
     end
 
@@ -76,9 +74,9 @@ describe Facter::Resolvers::Windows::AioAgentVersion do
       end
 
       it 'logs debug message for 64 bit register' do
-        aio_agent_resolver.resolve(:aio_agent_version)
+        expect(aio_agent_resolver.log).to receive(:debug).with('Could not read Puppet AIO path from 64 bit registry')
 
-        expect(log).to have_received(:debug).with('Could not read Puppet AIO path from 64 bit registry')
+        aio_agent_resolver.resolve(:aio_agent_version)
       end
 
       it 'returns path from registry specific to 32 bit windows' do
@@ -91,9 +89,10 @@ describe Facter::Resolvers::Windows::AioAgentVersion do
         end
 
         it 'logs debug error for 32 bit registry' do
-          aio_agent_resolver.resolve(:aio_agent_version)
+          allow(aio_agent_resolver.log).to receive(:debug)
+          expect(aio_agent_resolver.log).to receive(:debug).with('Could not read Puppet AIO path from 32 bit registry')
 
-          expect(log).to have_received(:debug).with('Could not read Puppet AIO path from 32 bit registry')
+          aio_agent_resolver.resolve(:aio_agent_version)
         end
       end
     end

--- a/spec/facter/resolvers/windows/dmi_bios_spec.rb
+++ b/spec/facter/resolvers/windows/dmi_bios_spec.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::DMIBios do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     win = double('Facter::Util::Windows::Win32Ole')
 
     allow(Facter::Util::Windows::Win32Ole).to receive(:new).and_return(win)
     allow(win).to receive(:return_first).with('SELECT Manufacturer,SerialNumber from Win32_BIOS').and_return(comp)
-    Facter::Resolvers::DMIBios.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -35,7 +32,7 @@ describe Facter::Resolvers::DMIBios do
     let(:comp) {}
 
     it 'logs debug message and serial_number is nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::DMIBios.log).to receive(:debug)
         .with('WMI query returned no results for Win32_BIOS with values Manufacturer and SerialNumber.')
       expect(Facter::Resolvers::DMIBios.resolve(:serial_number)).to be(nil)
     end

--- a/spec/facter/resolvers/windows/dmi_computersystem_spec.rb
+++ b/spec/facter/resolvers/windows/dmi_computersystem_spec.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::DMIComputerSystem do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     win = double('Facter::Util::Windows::Win32Ole')
 
     allow(Facter::Util::Windows::Win32Ole).to receive(:new).and_return(win)
     allow(win).to receive(:return_first).with('SELECT Name,UUID FROM Win32_ComputerSystemProduct').and_return(comp)
-
-    Facter::Resolvers::DMIComputerSystem.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -32,7 +28,7 @@ describe Facter::Resolvers::DMIComputerSystem do
     let(:comp) {}
 
     it 'logs debug message and name is nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::DMIComputerSystem.log).to receive(:debug)
         .with('WMI query returned no results for Win32_ComputerSystemProduct with values Name and UUID.')
       expect(Facter::Resolvers::DMIComputerSystem.resolve(:name)).to be(nil)
     end

--- a/spec/facter/resolvers/windows/identity_spec.rb
+++ b/spec/facter/resolvers/windows/identity_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Identity do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     size_ptr = double('FFI::MemoryPointer', read_uint32: 1)
     name_ptr = double('FFI::MemoryPointer', read_wide_string_with_length: user_name)
@@ -13,13 +11,10 @@ describe Facter::Resolvers::Identity do
     allow(FFI::MemoryPointer).to receive(:new).with(:wchar, size_ptr.read_uint32).and_return(name_ptr)
     allow(IdentityFFI).to receive(:GetUserNameExW).with(2, name_ptr, size_ptr).and_return(error_geting_user?)
     allow(IdentityFFI).to receive(:IsUserAnAdmin).and_return(admin?)
-
-    Facter::Resolvers::Identity.instance_variable_set(:@log, logger)
   end
 
   after do
     Facter::Resolvers::Identity.invalidate_cache
-    Facter::Resolvers::Identity.instance_variable_set(:@log, nil)
   end
 
   describe '#resolve when user is administrator' do
@@ -74,13 +69,13 @@ describe Facter::Resolvers::Identity do
     let(:admin?) { 0 }
 
     it 'logs debug message when trying to resolve user' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Identity.log).to receive(:debug)
         .with("failure resolving identity facts: #{error_number}")
       expect(Facter::Resolvers::Identity.resolve(:user)).to be(nil)
     end
 
     it 'logs debug message when trying to find if user is privileged' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Identity.log).to receive(:debug)
         .with("failure resolving identity facts: #{error_number}")
       expect(Facter::Resolvers::Identity.resolve(:privileged)).to be(nil)
     end
@@ -93,13 +88,13 @@ describe Facter::Resolvers::Identity do
     let(:admin?) { 0 }
 
     it 'logs debug message when trying to resolve user' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Identity.log).to receive(:debug)
         .with("failure resolving identity facts: #{error_number}")
       expect(Facter::Resolvers::Identity.resolve(:user)).to be(nil)
     end
 
     it 'logs debug message when trying to find if user is privileged' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Identity.log).to receive(:debug)
         .with("failure resolving identity facts: #{error_number}")
       expect(Facter::Resolvers::Identity.resolve(:privileged)).to be(nil)
     end

--- a/spec/facter/resolvers/windows/kernel_spec.rb
+++ b/spec/facter/resolvers/windows/kernel_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Kernel do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     ver_ptr = double('FFI::MemoryPointer')
     ver = double('OsVersionInfoEx', size: nil)
@@ -16,8 +14,6 @@ describe Facter::Resolvers::Kernel do
     allow(ver).to receive(:[]).with(:dwMajorVersion).and_return(maj)
     allow(ver).to receive(:[]).with(:dwMinorVersion).and_return(min)
     allow(ver).to receive(:[]).with(:dwBuildNumber).and_return(buildnr)
-
-    Facter::Resolvers::Kernel.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -50,7 +46,7 @@ describe Facter::Resolvers::Kernel do
     let(:buildnr) { 123 }
 
     it 'logs debug message and kernel version nil' do
-      allow(logger).to receive(:debug).with('Calling Windows RtlGetVersion failed')
+      allow(Facter::Resolvers::Kernel.log).to receive(:debug).with('Calling Windows RtlGetVersion failed')
       expect(Facter::Resolvers::Kernel.resolve(:kernelversion)).to be(nil)
     end
 

--- a/spec/facter/resolvers/windows/memory_spec.rb
+++ b/spec/facter/resolvers/windows/memory_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Memory do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     state_ptr = double('FFI::MemoryPointer', size: nil)
     state = double('PerformanceInformation', size: nil)
@@ -15,8 +13,6 @@ describe Facter::Resolvers::Memory do
     allow(state).to receive(:[]).with(:PhysicalTotal).and_return(total)
     allow(state).to receive(:[]).with(:PageSize).and_return(page_size)
     allow(state).to receive(:[]).with(:PhysicalAvailable).and_return(available)
-
-    Facter::Resolvers::Memory.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -53,7 +49,7 @@ describe Facter::Resolvers::Memory do
     let(:available) { 23 }
 
     it 'detects total_bytes as nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Memory.log).to receive(:debug)
         .with('Available or Total bytes are zero could not proceed further')
       expect(Facter::Resolvers::Memory.resolve(:total_bytes)).to be(nil)
     end
@@ -78,7 +74,7 @@ describe Facter::Resolvers::Memory do
     let(:available) { 0 }
 
     it 'detects total bytes as nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Memory.log).to receive(:debug)
         .with('Available or Total bytes are zero could not proceed further')
       expect(Facter::Resolvers::Memory.resolve(:total_bytes)).to be(nil)
     end
@@ -103,7 +99,7 @@ describe Facter::Resolvers::Memory do
     let(:available) { 4096 }
 
     it 'detects total bytes as nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Memory.log).to receive(:debug)
         .with('Available or Total bytes are zero could not proceed further')
       expect(Facter::Resolvers::Memory.resolve(:total_bytes)).to be(nil)
     end
@@ -128,7 +124,7 @@ describe Facter::Resolvers::Memory do
     let(:available) { 824_031 }
 
     it 'logs debug message and detects total bytes as nil' do
-      allow(logger).to receive(:debug).with('Resolving memory facts failed')
+      allow(Facter::Resolvers::Memory.log).to receive(:debug).with('Resolving memory facts failed')
       expect(Facter::Resolvers::Memory.resolve(:total_bytes)).to be(nil)
     end
 

--- a/spec/facter/resolvers/windows/networking_spec.rb
+++ b/spec/facter/resolvers/windows/networking_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 describe Facter::Resolvers::Windows::Networking do
   subject(:resolver) { Facter::Resolvers::Windows::Networking }
 
   describe '#resolve' do
-    let(:logger) { instance_spy(Facter::Log) }
     let(:size_ptr) { instance_spy(FFI::MemoryPointer) }
     let(:adapter_address) { instance_spy(FFI::MemoryPointer) }
     let(:reg) { instance_spy('Win32::Registry::HKEY_LOCAL_MACHINE') }
@@ -26,8 +27,6 @@ describe Facter::Resolvers::Windows::Networking do
         .and_yield(reg)
       allow(reg).to receive(:[]).with('Domain').and_return(domain)
       allow(reg).to receive(:close)
-
-      resolver.instance_variable_set(:@log, logger)
     end
 
     after do
@@ -38,7 +37,7 @@ describe Facter::Resolvers::Windows::Networking do
       let(:error_code) { NetworkingFFI::ERROR_NO_DATA }
 
       before do
-        allow(logger).to receive(:debug).with('Unable to retrieve networking facts!')
+        allow(resolver.log).to receive(:debug).with('Unable to retrieve networking facts!')
       end
 
       it 'returns interfaces fact as nil' do
@@ -48,7 +47,7 @@ describe Facter::Resolvers::Windows::Networking do
       it 'logs debug message' do
         resolver.resolve(:interfaces)
 
-        expect(logger).to have_received(:debug).with('Unable to retrieve networking facts!')
+        expect(resolver.log).to have_received(:debug).with('Unable to retrieve networking facts!')
       end
 
       it 'returns nil for domain' do

--- a/spec/facter/resolvers/windows/processors_spec.rb
+++ b/spec/facter/resolvers/windows/processors_spec.rb
@@ -3,8 +3,6 @@
 describe Facter::Resolvers::Processors do
   subject(:resolver) { Facter::Resolvers::Processors }
 
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     win = double('Facter::Util::Windows::Win32Ole')
     query_string = 'SELECT Name,'\
@@ -16,7 +14,6 @@ describe Facter::Resolvers::Processors do
     allow(win).to receive(:exec_query)
       .with(query_string)
       .and_return(proc)
-    resolver.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -108,7 +105,7 @@ describe Facter::Resolvers::Processors do
     end
 
     it 'logs that is unknown architecture' do
-      allow(logger).to receive(:debug)
+      allow(resolver.log).to receive(:debug)
         .with('Unable to determine processor type: unknown architecture')
       expect(resolver.resolve(:isa)).to be(nil)
     end
@@ -118,7 +115,7 @@ describe Facter::Resolvers::Processors do
     let(:proc) { nil }
 
     it 'logs that query failed and isa nil' do
-      allow(logger).to receive(:debug)
+      allow(resolver.log).to receive(:debug)
         .with('WMI query returned no results'\
         'for Win32_Processor with values Name, Architecture and NumberOfLogicalProcessors.')
       expect(resolver.resolve(:isa)).to be(nil)
@@ -159,7 +156,7 @@ describe Facter::Resolvers::Processors do
     end
 
     it 'detects that isa is nil' do
-      allow(logger).to receive(:debug)
+      allow(resolver.log).to receive(:debug)
         .with('Unable to determine processor type: unknown architecture')
       expect(resolver.resolve(:isa)).to be(nil)
     end

--- a/spec/facter/resolvers/windows/system32_spec.rb
+++ b/spec/facter/resolvers/windows/system32_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::System32 do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     allow(ENV).to receive(:[]).with('SystemRoot').and_return(win_path)
 
@@ -10,8 +8,6 @@ describe Facter::Resolvers::System32 do
     allow(FFI::MemoryPointer).to receive(:new).with(:win32_bool, 1).and_return(bool_ptr)
     allow(System32FFI).to receive(:GetCurrentProcess).and_return(2)
     allow(System32FFI).to receive(:IsWow64Process).with(2, bool_ptr).and_return(bool)
-
-    Facter::Resolvers::System32.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -44,8 +40,8 @@ describe Facter::Resolvers::System32 do
     let(:is_wow) { false }
 
     it 'detects system32 dir is nil and prints debug message' do
-      allow(logger).to receive(:debug).with('Unable to find correct value for SystemRoot'\
-                                                                                            ' enviroment variable')
+      allow(Facter::Resolvers::System32.log).to receive(:debug)
+        .with('Unable to find correct value for SystemRoot enviroment variable')
       expect(Facter::Resolvers::System32.resolve(:system32)).to be(nil)
     end
   end
@@ -56,7 +52,7 @@ describe Facter::Resolvers::System32 do
     let(:is_wow) { false }
 
     it 'detects system32 dir is nil and prints debug message' do
-      allow(logger).to receive(:debug).with('Unable to find correct value for SystemRoot'\
+      allow(Facter::Resolvers::System32.log).to receive(:debug).with('Unable to find correct value for SystemRoot'\
                                                                                             ' enviroment variable')
       expect(Facter::Resolvers::System32.resolve(:system32)).to be(nil)
     end
@@ -68,7 +64,7 @@ describe Facter::Resolvers::System32 do
     let(:is_wow) { false }
 
     it 'detects system32 dir is nil and prints debug message' do
-      allow(logger).to receive(:debug).with('IsWow64Process failed')
+      allow(Facter::Resolvers::System32.log).to receive(:debug).with('IsWow64Process failed')
       expect(Facter::Resolvers::System32.resolve(:system32)).to be(nil)
     end
   end

--- a/spec/facter/resolvers/windows/uptime_spec.rb
+++ b/spec/facter/resolvers/windows/uptime_spec.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Windows::Uptime do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     win = double('Facter::Util::Windows::Win32Ole')
 
     allow(Facter::Util::Windows::Win32Ole).to receive(:new).and_return(win)
     allow(win).to receive(:return_first).with('SELECT LocalDateTime,LastBootUpTime FROM Win32_OperatingSystem')
                                         .and_return(comp)
-
-    Facter::Resolvers::Windows::Uptime.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -134,13 +130,13 @@ describe Facter::Resolvers::Windows::Uptime do
       let(:last_bootup_time) { '20010201120506+0700' }
 
       before do
-        allow(logger).to receive(:debug).with('Unable to determine system uptime!')
+        allow(Facter::Resolvers::Windows::Uptime.log).to receive(:debug).with('Unable to determine system uptime!')
       end
 
       it 'logs that is unable to determine system uptime and all facts are nil' do
         Facter::Resolvers::Windows::Uptime.resolve(:days)
 
-        expect(logger).to have_received(:debug).with('Unable to determine system uptime!')
+        expect(Facter::Resolvers::Windows::Uptime.log).to have_received(:debug).with('Unable to determine system uptime!')
       end
 
       it 'uptime fact is nil' do
@@ -152,10 +148,10 @@ describe Facter::Resolvers::Windows::Uptime do
       let(:comp) { nil }
 
       it 'logs that query failed and days nil' do
-        allow(logger).to receive(:debug)
+        allow(Facter::Resolvers::Windows::Uptime.log).to receive(:debug)
           .with('WMI query returned no results'\
                 'for Win32_OperatingSystem with values LocalDateTime and LastBootUpTime.')
-        allow(logger).to receive(:debug)
+        allow(Facter::Resolvers::Windows::Uptime.log).to receive(:debug)
           .with('Unable to determine system uptime!')
         expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
       end
@@ -177,7 +173,7 @@ describe Facter::Resolvers::Windows::Uptime do
       let(:comp) { double('WIN32OLE', LocalDateTime: nil, LastBootUpTime: nil) }
 
       it 'logs that is unable to determine system uptime and days fact is nil' do
-        allow(logger).to receive(:debug)
+        allow(Facter::Resolvers::Windows::Uptime.log).to receive(:debug)
           .with('Unable to determine system uptime!')
         expect(Facter::Resolvers::Windows::Uptime.resolve(:days)).to be(nil)
       end

--- a/spec/facter/resolvers/windows/virtualization_spec.rb
+++ b/spec/facter/resolvers/windows/virtualization_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Windows::Virtualization do
-  let(:logger) { instance_spy(Facter::Log) }
   let(:win32ole) { instance_spy('WIN32OLE') }
   let(:win32ole2) { instance_spy('WIN32OLE') }
   let(:win) { instance_spy('Facter::Util::Windows::Win32Ole') }
@@ -10,7 +9,6 @@ describe Facter::Resolvers::Windows::Virtualization do
     allow(Facter::Util::Windows::Win32Ole).to receive(:new).and_return(win)
     allow(win).to receive(:exec_query).with('SELECT Manufacturer,Model,OEMStringArray FROM Win32_ComputerSystem')
                                       .and_return(query_result)
-    Facter::Resolvers::Windows::Virtualization.instance_variable_set(:@log, logger)
     Facter::Resolvers::Windows::Virtualization.invalidate_cache
   end
 
@@ -223,7 +221,7 @@ describe Facter::Resolvers::Windows::Virtualization do
     let(:query_result) { nil }
 
     it 'logs that query failed and virtual nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::Windows::Virtualization.log).to receive(:debug)
         .with('WMI query returned no results'\
                                       ' for Win32_ComputerSystem with values Manufacturer, Model and OEMStringArray.')
       expect(Facter::Resolvers::Windows::Virtualization.resolve(:virtual)).to be(nil)

--- a/spec/facter/resolvers/windows/win_os_description_spec.rb
+++ b/spec/facter/resolvers/windows/win_os_description_spec.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::WinOsDescription do
-  let(:logger) { instance_spy(Facter::Log) }
-
   before do
     win = double('Facter::Util::Windows::Win32Ole')
 
     allow(Facter::Util::Windows::Win32Ole).to receive(:new).and_return(win)
     allow(win).to receive(:return_first).with('SELECT ProductType,OtherTypeDescription FROM Win32_OperatingSystem')
                                         .and_return(comp)
-    Facter::Resolvers::WinOsDescription.instance_variable_set(:@log, logger)
   end
 
   after do
@@ -20,7 +17,7 @@ describe Facter::Resolvers::WinOsDescription do
     let(:comp) { nil }
 
     it 'logs debug message and facts are nil' do
-      allow(logger).to receive(:debug)
+      allow(Facter::Resolvers::WinOsDescription.log).to receive(:debug)
         .with('WMI query returned no results for Win32_OperatingSystem'\
                    'with values ProductType and OtherTypeDescription.')
 

--- a/spec/facter/resolvers/wpar_spec.rb
+++ b/spec/facter/resolvers/wpar_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Wpar do
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    Facter::Resolvers::Wpar.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/bin/lparstat -W', { logger: log_spy })
+      .with('/usr/bin/lparstat -W', logger: an_instance_of(Facter::Log))
       .and_return(open3_result)
   end
 

--- a/spec/facter/resolvers/xen_spec.rb
+++ b/spec/facter/resolvers/xen_spec.rb
@@ -5,11 +5,9 @@ describe Facter::Resolvers::Xen do
 
   let(:proc_xen_file) { false }
   let(:xvda1_file) { false }
-  let(:log_spy) { instance_spy(Facter::Log) }
   let(:domains) { '' }
 
   before do
-    xen_resolver.instance_variable_set(:@log, log_spy)
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with('/dev/xen/evtchn').and_return(evtchn_file)
     allow(File).to receive(:exist?).with('/proc/xen').and_return(proc_xen_file)
@@ -18,7 +16,7 @@ describe Facter::Resolvers::Xen do
     allow(File).to receive(:exist?).with('/usr/sbin/xl').and_return(false)
     allow(File).to receive(:exist?).with('/usr/sbin/xm').and_return(true)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('/usr/sbin/xm list', { logger: log_spy }).and_return(domains)
+      .with('/usr/sbin/xm list', logger: an_instance_of(Facter::Log)).and_return(domains)
 
     xen_resolver.invalidate_cache
   end

--- a/spec/facter/resolvers/zfs_spec.rb
+++ b/spec/facter/resolvers/zfs_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::ZFS do
   subject(:zfs_resolver) { Facter::Resolvers::ZFS }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    zfs_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('zfs upgrade -v', { logger: log_spy })
+      .with('zfs upgrade -v', logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 

--- a/spec/facter/resolvers/zpool_spec.rb
+++ b/spec/facter/resolvers/zpool_spec.rb
@@ -3,12 +3,9 @@
 describe Facter::Resolvers::Zpool do
   subject(:zpool_resolver) { Facter::Resolvers::Zpool }
 
-  let(:log_spy) { instance_spy(Facter::Log) }
-
   before do
-    zpool_resolver.instance_variable_set(:@log, log_spy)
     allow(Facter::Core::Execution).to receive(:execute)
-      .with('zpool upgrade -v', { logger: log_spy })
+      .with('zpool upgrade -v', logger: an_instance_of(Facter::Log))
       .and_return(output)
   end
 

--- a/spec/facter/util/aix/odm_query_spec.rb
+++ b/spec/facter/util/aix/odm_query_spec.rb
@@ -2,17 +2,15 @@
 
 describe Facter::Util::Aix::ODMQuery do
   let(:odm_query) { Facter::Util::Aix::ODMQuery.new }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    odm_query.instance_variable_set(:@log, log_spy)
     stub_const('Facter::Util::Aix::ODMQuery::REPOS', ['CuAt'])
   end
 
   it 'creates a query' do
     odm_query.equals('name', '12345')
 
-    expect(Facter::Core::Execution).to receive(:execute).with("odmget -q \"name='12345'\" CuAt", { logger: log_spy })
+    expect(Facter::Core::Execution).to receive(:execute).with("odmget -q \"name='12345'\" CuAt", logger: an_instance_of(Facter::Log))
     odm_query.execute
   end
 
@@ -20,7 +18,7 @@ describe Facter::Util::Aix::ODMQuery do
     odm_query.equals('field1', 'value').like('field2', 'value*')
 
     expect(Facter::Core::Execution).to receive(:execute)
-      .with("odmget -q \"field1='value' AND field2 like 'value*'\" CuAt", { logger: log_spy })
+      .with("odmget -q \"field1='value' AND field2 like 'value*'\" CuAt", logger: an_instance_of(Facter::Log))
     odm_query.execute
   end
 end

--- a/spec/facter/util/facts/posix/virtual_detector_spec.rb
+++ b/spec/facter/util/facts/posix/virtual_detector_spec.rb
@@ -279,6 +279,7 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
       before do
         allow(Facter::Resolvers::Containers).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Freebsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
+        allow(Facter::Resolvers::Openbsd::Virtual).to receive(:resolve).with(:vm).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:bios_vendor).and_return(nil)
         allow(Facter::Resolvers::Linux::DmiBios).to receive(:resolve).with(:product_name).and_return(nil)
         allow(Facter::Resolvers::VirtWhat).to receive(:resolve).with(:vm).and_return('lxc')

--- a/spec/facter/util/facts/posix/virtual_detector_spec.rb
+++ b/spec/facter/util/facts/posix/virtual_detector_spec.rb
@@ -4,11 +4,8 @@ describe Facter::Util::Facts::Posix::VirtualDetector do
   subject(:detector) { Facter::Util::Facts::Posix::VirtualDetector }
 
   describe '#platform' do
-    let(:logger_mock) { instance_spy(Facter::Log) }
-
     before do
       Facter::Util::Facts::Posix::VirtualDetector.instance_variable_set(:@fact_value, nil)
-      allow(Facter::Log).to receive(:new).and_return(logger_mock)
     end
 
     context 'when in docker' do

--- a/spec/facter/util/facts/uptime_parser_spec.rb
+++ b/spec/facter/util/facts/uptime_parser_spec.rb
@@ -5,11 +5,6 @@ describe Facter::Util::Facts::UptimeParser do
     let(:uptime_proc_file_cmd) { '/bin/cat /proc/uptime' }
     let(:kern_boottime_cmd) { 'sysctl -n kern.boottime' }
     let(:uptime_cmd) { 'uptime' }
-    let(:log_spy) { instance_spy(Facter::Log) }
-
-    before do
-      Facter::Util::Facts::UptimeParser.instance_variable_set(:@log, log_spy)
-    end
 
     context 'when a /proc/uptime file exists' do
       let(:proc_uptime_value) { '2672.69 20109.75' }
@@ -17,7 +12,7 @@ describe Facter::Util::Facts::UptimeParser do
       it 'returns the correct result' do
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, { logger: log_spy })
+          .with(uptime_proc_file_cmd, logger: an_instance_of(Facter::Log))
           .and_return(proc_uptime_value)
 
         expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(2672)
@@ -36,12 +31,12 @@ describe Facter::Util::Facts::UptimeParser do
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, { logger: log_spy })
+          .with(uptime_proc_file_cmd, logger: an_instance_of(Facter::Log))
           .and_return('')
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(kern_boottime_cmd, { logger: log_spy })
+          .with(kern_boottime_cmd, logger: an_instance_of(Facter::Log))
           .and_return(kern_boottime_value)
 
         expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(60)
@@ -52,12 +47,12 @@ describe Facter::Util::Facts::UptimeParser do
       before do
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(uptime_proc_file_cmd, { logger: log_spy })
+          .with(uptime_proc_file_cmd, logger: an_instance_of(Facter::Log))
           .and_return('')
 
         allow(Facter::Core::Execution)
           .to receive(:execute)
-          .with(kern_boottime_cmd, { logger: log_spy })
+          .with(kern_boottime_cmd, logger: an_instance_of(Facter::Log))
           .and_return('')
       end
 
@@ -65,7 +60,7 @@ describe Facter::Util::Facts::UptimeParser do
         it 'returns the correct result' do
           allow(Facter::Core::Execution)
             .to receive(:execute)
-            .with(uptime_cmd, { logger: log_spy })
+            .with(uptime_cmd, logger: an_instance_of(Facter::Log))
             .and_return(cmd_output)
 
           expect(Facter::Util::Facts::UptimeParser.uptime_seconds_unix).to eq(result)

--- a/spec/facter/util/file_helper_spec.rb
+++ b/spec/facter/util/file_helper_spec.rb
@@ -10,10 +10,9 @@ describe Facter::Util::FileHelper do
     "Facter::Util::FileHelper - #{Facter::CYAN}File at: /Users/admin/file.txt is not accessible.#{Facter::RESET}"
   end
   let(:array_content) { ['line 1', 'line 2', 'line 3'] }
-  let(:logger_double) { instance_spy(Facter::Log) }
+  let(:log) { Facter::Log.class_variable_get(:@@logger) }
 
   before do
-    Facter::Log.class_variable_set(:@@logger, logger_double)
     allow(Facter).to receive(:debugging?).and_return(true)
     allow(Facter::OptionStore).to receive(:color).and_return(true)
   end
@@ -59,9 +58,9 @@ describe Facter::Util::FileHelper do
       end
 
       it "doesn't log anything" do
-        file_helper.safe_read(path)
+        expect(log).not_to receive(:debug)
 
-        expect(logger_double).not_to have_received(:debug)
+        file_helper.safe_read(path)
       end
     end
 
@@ -89,10 +88,10 @@ describe Facter::Util::FileHelper do
       end
 
       it 'logs a debug message' do
-        file_helper.safe_read(path)
+        allow(log).to receive(:debug)
+        expect(log).to receive(:debug).with(error_message)
 
-        expect(logger_double).to have_received(:debug)
-          .with(error_message)
+        file_helper.safe_read(path)
       end
     end
   end
@@ -138,9 +137,9 @@ describe Facter::Util::FileHelper do
       end
 
       it "doesn't log anything" do
-        file_helper.safe_readlines(path)
+        expect(log).not_to receive(:debug)
 
-        expect(logger_double).not_to have_received(:debug)
+        file_helper.safe_readlines(path)
       end
     end
 
@@ -168,9 +167,9 @@ describe Facter::Util::FileHelper do
       end
 
       it 'logs a debug message' do
-        file_helper.safe_read(path)
+        expect(log).to receive(:debug).with(error_message)
 
-        expect(logger_double).to have_received(:debug).with(error_message)
+        file_helper.safe_read(path)
       end
     end
   end

--- a/spec/facter/util/linux/dhcp_spec.rb
+++ b/spec/facter/util/linux/dhcp_spec.rb
@@ -71,7 +71,7 @@ describe Facter::Util::Linux::Dhcp do
         allow(Facter::Core::Execution).to receive(:which)
           .with('dhcpcd').and_return('/usr/bin/dhcpcd')
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('/usr/bin/dhcpcd -U ens160', { logger: log_spy }).and_return(load_fixture('dhcpcd').read)
+          .with('/usr/bin/dhcpcd -U ens160', logger: log_spy).and_return(load_fixture('dhcpcd').read)
 
         dhcp_search.instance_eval { @dhcpcd_command = nil }
       end

--- a/spec/facter/util/linux/routing_table_spec.rb
+++ b/spec/facter/util/linux/routing_table_spec.rb
@@ -9,9 +9,9 @@ describe Facter::Util::Linux::RoutingTable do
     context 'when ip route show finds an IP, Socket lib did not retrieve' do
       before do
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ip route show', { logger: log_spy }).and_return(load_fixture('ip_route_show').read)
+          .with('ip route show', logger: log_spy).and_return(load_fixture('ip_route_show').read)
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ip -6 route show', { logger: log_spy }).and_return(load_fixture('ip_-6_route_show').read)
+          .with('ip -6 route show', logger: log_spy).and_return(load_fixture('ip_-6_route_show').read)
       end
 
       it 'returns the ipv4 info' do

--- a/spec/facter/util/linux/socket_parser_spec.rb
+++ b/spec/facter/util/linux/socket_parser_spec.rb
@@ -27,7 +27,7 @@ describe Facter::Util::Linux::SocketParser do
       allow(Socket).to receive(:getifaddrs).and_return(ifaddrs)
       allow(Socket).to receive(:const_defined?).with(:PF_LINK).and_return(true)
       allow(Facter::Core::Execution).to receive(:execute)
-        .with('ip -o link show', { logger: log_spy }).and_return(load_fixture('ip_link_show_all').read)
+        .with('ip -o link show', logger: log_spy).and_return(load_fixture('ip_link_show_all').read)
     end
 
     let(:result) do
@@ -77,9 +77,11 @@ describe Facter::Util::Linux::SocketParser do
 
       before do
         allow(Facter::Core::Execution).to receive(:execute)
-          .with('ip -o link show', logger: log_spy).and_return(load_fixture('ip_link_show_all').read)
+          .with('ip -o link show', logger: log_spy)
+          .and_return(load_fixture('ip_link_show_all').read)
         allow(Facter::Util::FileHelper).to receive(:safe_read)
-          .with('/proc/net/bonding/bond0', nil).and_return(load_fixture('bond_interface_data').read)
+          .with('/proc/net/bonding/bond0', nil)
+          .and_return(load_fixture('bond_interface_data').read)
       end
 
       it 'retrieves eth2 interface' do

--- a/spec/facter/util/resolvers/http_spec.rb
+++ b/spec/facter/util/resolvers/http_spec.rb
@@ -4,10 +4,8 @@ describe Facter::Util::Resolvers::Http do
   subject(:http) { Facter::Util::Resolvers::Http }
 
   let(:url) { 'http://169.254.169.254/meta-data/' }
-  let(:log_spy) { instance_spy(Facter::Log) }
 
   before do
-    http.instance_variable_set(:@log, log_spy)
     allow(Gem).to receive(:win_platform?).and_return(false)
   end
 
@@ -44,8 +42,10 @@ describe Facter::Util::Resolvers::Http do
       end
 
       it 'logs error code' do
+        allow(http.instance_variable_get(:@log)).to receive(:debug)
+        expect(http.instance_variable_get(:@log)).to receive(:debug).with("Request to #{url} failed with error code 500")
+
         http.send(client_method, url)
-        expect(log_spy).to have_received(:debug).with("Request to #{url} failed with error code 500")
       end
     end
 
@@ -59,9 +59,10 @@ describe Facter::Util::Resolvers::Http do
       end
 
       it 'logs error message' do
+        allow(http.instance_variable_get(:@log)).to receive(:debug)
+        expect(http.instance_variable_get(:@log)).to receive(:debug).with("Trying to connect to #{url} but got: execution expired")
+
         http.send(client_method, url)
-        expect(log_spy).to have_received(:debug)
-          .with("Trying to connect to #{url} but got: execution expired")
       end
     end
 
@@ -75,8 +76,10 @@ describe Facter::Util::Resolvers::Http do
       end
 
       it 'logs error message' do
+        allow(http.instance_variable_get(:@log)).to receive(:debug)
+        expect(http.instance_variable_get(:@log)).to receive(:debug).with("Trying to connect to #{url} but got: some error")
+
         http.send(client_method, url)
-        expect(log_spy).to have_received(:debug).with("Trying to connect to #{url} but got: some error")
       end
     end
 
@@ -112,9 +115,11 @@ describe Facter::Util::Resolvers::Http do
       end
 
       it 'logs error message' do
-        http.send(client_method, url)
-        expect(log_spy).to have_received(:debug)
+        allow(http.instance_variable_get(:@log)).to receive(:debug)
+        expect(http.instance_variable_get(:@log)).to receive(:debug)
           .with(/((Operation|Connection) timed out)|(A connection attempt.*)/)
+
+        http.send(client_method, url)
       end
     end
 

--- a/spec/facter/util/windows/network_utils_spec.rb
+++ b/spec/facter/util/windows/network_utils_spec.rb
@@ -3,8 +3,8 @@
 Ps = Struct.new(:PhysicalAddress, :PhysicalAddressLength)
 
 describe NetworkUtils do
-  describe '#address_to_strig' do
-    let(:logger) { instance_spy(Facter::Log) }
+  describe '#address_to_string' do
+    let(:logger) { NetworkUtils.instance_variable_get(:@log) }
     let(:addr) { instance_spy('SocketAddress') }
     let(:size) { instance_spy(FFI::MemoryPointer) }
     let(:buffer) { instance_spy(FFI::MemoryPointer) }
@@ -19,8 +19,6 @@ describe NetworkUtils do
       allow(NetworkingFFI).to receive(:WSAAddressToStringW)
         .with(address, length, FFI::Pointer::NULL, buffer, size).and_return(error)
       allow(NetworkUtils).to receive(:extract_address).with(buffer).and_return('10.123.0.2')
-
-      NetworkUtils.instance_variable_set(:@log, logger)
     end
 
     context 'when lpSockaddr is null' do

--- a/spec/framework/config/config_reader_spec.rb
+++ b/spec/framework/config/config_reader_spec.rb
@@ -143,18 +143,17 @@ describe Facter::ConfigReader do
 
     context 'with invalid config file' do
       let(:config) { 'some corrupt information' }
-      let(:log) { instance_spy(Facter::Log) }
+      let(:log) { Facter::Log.class_variable_get(:@@logger) }
 
       before do
-        allow(Facter::Log).to receive(:new).and_return(log)
         allow(Hocon).to receive(:load).and_raise(StandardError)
         allow(log).to receive(:warn)
       end
 
       it 'loggs a warning' do
-        config_reader.init
+        expect(log).to receive(:warn).with(/Facter failed to read config file/)
 
-        expect(log).to have_received(:warn).with(/Facter failed to read config file/)
+        config_reader.init
       end
     end
 

--- a/spec/framework/config/fact_groups_spec.rb
+++ b/spec/framework/config/fact_groups_spec.rb
@@ -132,16 +132,18 @@ describe Facter::FactGroups do
 
     context 'when ttls has hour instead of hour' do
       let(:ttls) { ['operating system' => '1 hour', 'memory' => '1 day', 'hostname' => '30 invalid_unit'] }
-      let(:logger) { instance_spy(Facter::Log) }
+      let(:logger) { Facter::Log.class_variable_get(:@@logger) }
 
       before do
         allow(Facter::Log).to receive(:new).and_return(logger)
       end
 
       it 'logs an error message' do
+        allow(logger).to receive(:error)
+        expect(logger).to receive(:error).with('Could not parse time unit invalid_units '\
+          "(try #{Facter::FactGroups::STRING_TO_SECONDS.keys.reject(&:empty?).join(', ')})").twice
+
         fg.get_group_ttls('hostname')
-        expect(logger).to have_received(:error).with('Could not parse time unit invalid_units '\
-                                "(try #{Facter::FactGroups::STRING_TO_SECONDS.keys.reject(&:empty?).join(', ')})").twice
       end
 
       it 'returns os ttl in seconds' do

--- a/spec/framework/config/fact_groups_spec.rb
+++ b/spec/framework/config/fact_groups_spec.rb
@@ -130,8 +130,21 @@ describe Facter::FactGroups do
       end
     end
 
-    context 'when ttls has hour instead of hour' do
-      let(:ttls) { ['operating system' => '1 hour', 'memory' => '1 day', 'hostname' => '30 invalid_unit'] }
+    context 'when ttls has singular hour instead of plural hours' do
+      let(:ttls) { ['operating system' => '1 hour', 'memory' => '1 day'] }
+
+      it 'returns os ttl in seconds' do
+        expect(fg.get_group_ttls('operating system')).to eq(3600)
+      end
+
+      it 'returns memory ttl in seconds' do
+        expect(fg.get_group_ttls('memory')).to eq(86_400)
+      end
+    end
+
+    context 'when ttls are invalid' do
+      let(:ttls) { ['hostname' => '30 invalid_unit'] }
+
       let(:logger) { Facter::Log.class_variable_get(:@@logger) }
 
       before do
@@ -144,14 +157,6 @@ describe Facter::FactGroups do
           "(try #{Facter::FactGroups::STRING_TO_SECONDS.keys.reject(&:empty?).join(', ')})").twice
 
         fg.get_group_ttls('hostname')
-      end
-
-      it 'returns os ttl in seconds' do
-        expect(fg.get_group_ttls('operating system')).to eq(3600)
-      end
-
-      it 'returns memory ttl in seconds' do
-        expect(fg.get_group_ttls('memory')).to eq(86_400)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before(:all) do
+    Facter::Log.class_variable_set(:@@logger, Logger.new(StringIO.new)) # rubocop:disable Style/ClassVars
+  end
+
   config.before do
     LegacyFacter.clear
     Facter.clear_messages


### PR DESCRIPTION
* Resolvers now create their `Facter::Log` the same way, in the BaseResolver.
* We now set expectations on the `Logger` and `Facter::Log` class variables instead of replacing them with instance spies.
* Fixes a NoMethodError when an aggregate fact is evaluated more than once

See commits for details

Fixes https://github.com/puppetlabs/facter/issues/2721