### PR TITLE
Allow facter test log to be written to a file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,10 @@ end
 require 'webmock/rspec'
 WebMock.disable_net_connect!
 
+# Configure test logger
+logdest = ENV['FACTER_TEST_LOG'] ? File.new(ENV['FACTER_TEST_LOG'], 'w') : StringIO.new
+logger = Logger.new(logdest)
+
 # Configure RSpec
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -77,10 +81,13 @@ RSpec.configure do |config|
   end
 
   config.before(:all) do
-    Facter::Log.class_variable_set(:@@logger, Logger.new(StringIO.new)) # rubocop:disable Style/ClassVars
+    Facter::Log.class_variable_set(:@@logger, logger) # rubocop:disable Style/ClassVars
   end
 
-  config.before do
+  config.before do |test|
+    m = test.metadata
+    logger.info("*** BEGIN TEST #{m[:file_path]}:#{m[:line_number]}")
+
     LegacyFacter.clear
     Facter.clear_messages
   end


### PR DESCRIPTION
If the FACTER_TEST_LOG environment variable is set, then use it as the log
destination when running facter tests. This is borrowed from puppet's
PUPPET_TEST_LOG. The test file path and line number are written so you can tell
which test generated the log output:

    I, [2024-05-20T16:26:04.852790 #3073378]  INFO -- : *** BEGIN TEST ./spec/custom_facts/core/execution_spec.rb:63
    I, [2024-05-20T16:26:04.853239 #3073378]  INFO -- : *** BEGIN TEST ./spec/custom_facts/core/execution_spec.rb:71
    W, [2024-05-20T16:26:04.853473 #3073378]  WARN -- : Facter::Core::Execution::Posix - Unexpected key passed to Facter::Core::Execution.execute option: time_limit - valid keys: on_fail,expand,logger,timeout
    I, [2024-05-20T16:26:04.853680 #3073378]  INFO -- : *** BEGIN TEST ./spec/custom_facts/core/execution_spec.rb:71


