### PR TITLE
(packaging) Add rake tasks for building nightly gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,16 @@ namespace :pl_ci do
       puts stdout
     end
   end
+
+  desc 'build the nightly gem and place it at the directory root'
+  task :nightly_gem_build => :gem_build do
+    # this is taken from `rake package:nightly_gem`
+    describe = %x{git describe --tags --dirty --abbrev=7}.chomp
+    extended_dot_version = describe.tr('-', '.')
+    src = "facter-#{Facter::VERSION}.gem"
+    dst = src.gsub(Facter::VERSION, extended_dot_version)
+    sh "mv #{src} #{dst}"
+  end
 end
 
 if Rake.application.top_level_tasks.grep(/^(pl:|package:)/).any?


### PR DESCRIPTION
The nightly gem's version is generated from git describe, so it's the last tag, plus some number of commits, the git ref, for example:

    4.7.0-36-g2ab655b

Additionally if there are changes in the worktree, then git adds 'dirty' to the version.

    4.7.0-36-g2ab655b-dirty