### PR TITLE
(PA-6427) Add rake tasks for building nightly gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,13 +16,36 @@ end
 
 namespace :pl_ci do
   desc 'build the gem and place it at the directory root'
-  task :gem_build do
-    stdout, stderr, status = Open3.capture3('gem build facter.gemspec')
+  task :gem_build, [:gemspec] do |_t, args|
+    args.with_defaults(gemspec: 'facter.gemspec')
+    stdout, stderr, status = Open3.capture3("gem build #{args.gemspec}")
     if !status.exitstatus.zero?
       puts "Error building facter.gemspec \n#{stdout} \n#{stderr}"
       exit(1)
     else
       puts stdout
+    end
+  end
+
+  desc 'build the nightly gem and place it at the directory root'
+  task :nightly_gem_build do
+    # this is taken from `rake package:nightly_gem`
+    extended_dot_version = `git describe --tags --dirty --abbrev=7`.chomp.tr('-', '.')
+
+    # we must create tempfile in the same directory as facter.gemspec, since
+    # it uses __dir__ to determine which files to include
+    require 'tempfile'
+    Tempfile.create('gemspec', __dir__) do |dst|
+      File.open('facter.gemspec', 'r') do |src|
+        src.readlines.each do |line|
+          if line.match?(/spec\.version\s*=\s*'[0-9.]+'/)
+            line = "spec.version = '#{extended_dot_version}'"
+          end
+          dst.puts line
+        end
+      end
+      dst.flush
+      Rake::Task['pl_ci:gem_build'].invoke(dst.path)
     end
   end
 end


### PR DESCRIPTION
The nightly gem's version (aka extended_dot_version) is generated from git describe as the last tag, plus some number of commits and abbreviated git ref:

    4.7.0-36-g2ab655b

Additionally, if there are changes in the worktree, then we add 'dirty' to the version.

    4.7.0-36-g2ab655b-dirty

The "extended_dot_version" is added to a temporary gemspec that's used to build the gem. That version determines the resulting filename, e.g.

    facter-4.7.0-36-g2ab655b.gem

Neither the packaging repo nor this commit update the version in `version.rb`, so running facter --version may return the "version to be released in the future".