### PR TITLE
(FACT-3205) Ignore ENOENT when cleaning up temporary test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,9 +53,6 @@ Naming/VariableNumber:
     - 'lib/facter/resolvers/windows/ffi/networking_ffi.rb'
     - 'lib/facter/util/facts/windows_release_finder.rb'
 
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-
 RSpec/StubbedMock:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,24 +53,6 @@ Naming/VariableNumber:
     - 'lib/facter/resolvers/windows/ffi/networking_ffi.rb'
     - 'lib/facter/util/facts/windows_release_finder.rb'
 
-RSpec/StubbedMock:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-# $stdout is preferred because it refers to the *current* stdout stream, while
-# STDOUT refers to the original stream. However, we can't just switch to using
-# $stdout, because it may have been assigned to a different object than STDOUT,
-# such as a IO to a file.
-Style/GlobalStdStream:
-  Exclude:
-    - 'lib/facter.rb'
-    - 'lib/facter/framework/cli/cli_launcher.rb'
-    - 'lib/facter/framework/logging/logger.rb'
-    - 'spec/framework/core/fact/internal/internal_fact_manager_spec.rb'
-    - 'spec/framework/logging/logger_spec.rb'
-
 RSpec/DescribedClass:
   EnforcedStyle: explicit
 
@@ -91,6 +73,9 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Enabled: 6
 
+RSpec/StubbedMock:
+  Enabled: false
+
 RSpec/SubjectStub:
   Exclude:
     - 'spec/custom_facts/core/aggregate_spec.rb'
@@ -110,3 +95,18 @@ RSpec/VerifiedDoubles:
     - 'spec/facter/resolvers/windows/*'
     - 'spec/facter/util/windows/network_utils_spec.rb'
     - 'spec/facter/util/windows/win32ole_spec.rb'
+
+# $stdout is preferred because it refers to the *current* stdout stream, while
+# STDOUT refers to the original stream. However, we can't just switch to using
+# $stdout, because it may have been assigned to a different object than STDOUT,
+# such as a IO to a file.
+Style/GlobalStdStream:
+  Exclude:
+    - 'lib/facter.rb'
+    - 'lib/facter/framework/cli/cli_launcher.rb'
+    - 'lib/facter/framework/logging/logger.rb'
+    - 'spec/framework/core/fact/internal/internal_fact_manager_spec.rb'
+    - 'spec/framework/logging/logger_spec.rb'
+
+Style/IfUnlessModifier:
+  Enabled: false

--- a/spec/custom_facts/puppetlabs_spec/files.rb
+++ b/spec/custom_facts/puppetlabs_spec/files.rb
@@ -27,7 +27,7 @@ module PuppetlabsSpec
         begin
           FileUtils.rm_r path, secure: true
         rescue Errno::ENOENT
-          puts 'failed to recursively delete files'
+          # nothing to do
         end
       end
     end


### PR DESCRIPTION
Facter tests sometimes fail on JRuby with the following, even when using
the same seed:

    $ bundle exec rspec --order random:22464 spec_integration
    ...
    Errno::ENOENT:
      No such file or directory - /tmp/external_facts20240617-2780089-h18bte/XFZQDAMC_data.yaml
    # ./spec_integration/facter_spec.rb:13:in `write_to_file'
    # ./spec_integration/facter_spec.rb:752:in `block in <main>'

Since ENOENT means the entry doesn't exist, ignore it like puppet does[1].
However, we don't want to use `rm_rf` because that will ignore all
StandardErrors, not just ENOENT[2].

[1] https://github.com/puppetlabs/puppet/blob/8.6.0/spec/lib/puppet_spec/files.rb#L11-L15
[2] https://bugs.ruby-lang.org/issues/18784