### PR TITLE
(packaging) Bump to version '4.8.0' [no-promote]

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'facter'
-  spec.version       = '4.7.2'
+  spec.version       = '4.8.0'
   spec.authors       = ['Puppet']
   spec.email         = ['team-nw@puppet.com']
   spec.homepage      = 'https://github.com/puppetlabs/facter'

--- a/lib/facter/version.rb
+++ b/lib/facter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Facter
-  VERSION = '4.7.2' unless defined?(VERSION)
+  VERSION = '4.8.0' unless defined?(VERSION)
 end


### PR DESCRIPTION
There have been enough features added to Facter since the 4.7.1 release (such as https://github.com/puppetlabs/facter/pull/2664 and https://github.com/puppetlabs/facter/pull/2483) that it warrants the next release be a minor, not patch, release.