### PR TITLE
Use bundler-cache to speed up CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,6 +21,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
-      - run: bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - run: bundle exec rubocop --parallel
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
-      - run: bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - run: bundle exec rake spec
 
       - name: Publish code coverage

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -24,6 +24,8 @@ jobs:
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}
+    env:
+      BUNDLE_SET: 'with integration'
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
@@ -32,7 +34,5 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
-      - run: gem update bundler
-      - run: bundle config set --local with integration
-      - run: bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - run: bundle exec rake spec_integration

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -33,8 +33,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: gem update bundler
-      - run: bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - run: bundle exec rake spec_random
 
   windows_unit_tests:
@@ -53,6 +52,5 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: gem update bundler
-      - run: bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - run: bundle exec rake spec_random


### PR DESCRIPTION
This updates the ruby based workflows to save/restore the bundler cache. See puppetlabs/puppet@86820eee25e428f7e667bf9529b97c32e6575d9b for details.

This intentionally doesn't use `bundler-cache` for the `mend` workflow, since we
want the latest versions of all of our dependencies that still satisfy our
constraints.

This doesn't update the `acceptance_tests` workflow because it does a bundle
install for both the top-level Gemfile and the one in the acceptance dir.

All of the workflows are more than twice as fast, except for JRuby:

| |Before|After|
|-|-|-|
|rubocop| 1m 16s |41s|
|integration-ubuntu-ruby-2.7|1m 28s|36s|
|integration-ubuntu-ruby-3.2|56s|27s|
|integration-ubuntu-jruby|3m 19s|3m 17s|
|integration-windows-ruby-2.7|6m 15s|3m 53s|
|integration-windows-ruby-3.2|4m 51s|2m 45s|
|unit-ruby-2.5|1m 13s|22s|
|unit-ruby-2.7|1m 10s|23s|
|unit-ruby-3.0|38s|18s|
|unit-ruby-3.2|39s|13s|
|unit-jruby-9.3|1m 20s|1m 13s|
|unit-jruby-9.4|1m 27s|1m 19s|
|unit-windows-2.7|5m 18s| 1m 58s|
|unit-windows-3.2|3m 52s|2m 37s|

Coverage didn't run because it [only triggers on push to `main`](https://github.com/puppetlabs/facter/blob/06c37a29d4e4b6225960a584e0aa6e02516d2902/.github/workflows/coverage.yaml#L7)