### PR TITLE
(PA-4569) Changes to use bundled virt-what

### DIFF
--- a/lib/facter/resolvers/virt_what.rb
+++ b/lib/facter/resolvers/virt_what.rb
@@ -13,7 +13,12 @@ module Facter
         end
 
         def retrieve_from_virt_what(fact_name)
-          output = Facter::Core::Execution.execute('virt-what', logger: log)
+          command = if File.readable?('/opt/puppetlabs/puppet/bin/virt-what')
+                      '/opt/puppetlabs/puppet/bin/virt-what'
+                    else
+                      'virt-what'
+                    end
+          output = Facter::Core::Execution.execute(command, logger: log)
 
           @fact_list[:vm] = determine_xen(output)
           @fact_list[:vm] ||= determine_other(output)


### PR DESCRIPTION
This is to resolve issue with the jira: https://perforce.atlassian.net/browse/PA-4569.
Reporter has mentioned we are not using our bundled virt-what. Our bundled virt-what seems to be returning correct value for user, with this PR we can use our bundled virt-what. This change will help when there is no virt-what installed on the system(This is assumption based on the jira issue). The component is built only for linux systems.