### PR TITLE
JRuby test bumps

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -20,7 +20,7 @@ jobs:
         cfg:
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
-          - {os: ubuntu-22.04, ruby: 'jruby-9.3.9.0'}
+          - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - '3.0'
           - '3.2'
           - 'jruby-9.3.14.0'
-          - 'jruby-9.4.7.0'
+          - 'jruby-9.4.8.0'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout current PR


### PR DESCRIPTION
The JRuby versions in both streams of puppetserver were recently updated. This PR bumps the versions of JRuby used in tests accordingly.