### PR TITLE
Fix lxc container detection

### DIFF
--- a/lib/facter/resolvers/containers.rb
+++ b/lib/facter/resolvers/containers.rb
@@ -43,7 +43,7 @@ module Facter
 
           info = {}
           case container
-          when 'lxcroot'
+          when 'lxc'
             vm = 'lxc'
           when 'podman'
             vm = 'podman'

--- a/spec/facter/resolvers/containers_spec.rb
+++ b/spec/facter/resolvers/containers_spec.rb
@@ -66,7 +66,7 @@ describe Facter::Resolvers::Containers do
 
   context 'when hypervisor is lxc and it is discovered by environ' do
     let(:cgroup_output) { load_fixture('cgroup_file').read }
-    let(:environ_output) { ['container=lxcroot'] }
+    let(:environ_output) { ['container=lxc'] }
     let(:result) { { lxc: {} } }
 
     it 'return lxc for vm' do


### PR DESCRIPTION
Commit 7bc38ccb58e6abf66d6141a3b2e9f60eb0077d71 removed the regex matching for lxc, /container=lxc/, and instead matched the env var exactly, using the value lxcroot from the rspec test. However, I can find no evidence that lxc ever sets container to anything other than lxc, so change lxcroot to lxc [1][2].

[1]: https://codesearch.debian.net/search?q=container%3Dlxc&literal=1
[2]: https://github.com/search?q=container%3Dlxcroot&type=code

Fixes: #2737