### PR TITLE
fix spelling in warn message

### DIFF
--- a/lib/facter/resolvers/containers.rb
+++ b/lib/facter/resolvers/containers.rb
@@ -54,7 +54,7 @@ module Facter
             info = { 'id' => Facter::Util::FileHelper.safe_read('/etc/machine-id', nil).strip }
           else
             vm = 'container_other'
-            log.warn("Container runtime, '#{container}', is unsupported, setting to, '#{vm}'")
+            log.warn("Container runtime, '#{container}', is unsupported, setting to '#{vm}'")
           end
           @fact_list[:vm] = vm
           @fact_list[:hypervisor] = { vm.to_sym => info } if vm

--- a/spec/facter/resolvers/containers_spec.rb
+++ b/spec/facter/resolvers/containers_spec.rb
@@ -98,7 +98,7 @@ describe Facter::Resolvers::Containers do
     let(:logger) { Facter::Log.class_variable_get(:@@logger) }
 
     it 'return container_other for vm' do
-      expect(logger).to receive(:warn).with(/Container runtime, 'UNKNOWN', is unsupported, setting to, 'container_other'/)
+      expect(logger).to receive(:warn).with(/Container runtime, 'UNKNOWN', is unsupported, setting to 'container_other'/)
       expect(containers_resolver.resolve(:vm)).to eq('container_other')
     end
   end


### PR DESCRIPTION
previously this was:

```
Warning: Facter: Container runtime, 'docker', is unsupported, setting to, 'container_other'
```

But I think that is wrong? And it should be:

```
Warning: Facter: Container runtime, 'docker', is unsupported, setting to 'container_other'
```