### PR TITLE
(FACT-3481) Skip Schema tests for a few OSes

### DIFF
--- a/acceptance/tests/facts/schema.rb
+++ b/acceptance/tests/facts/schema.rb
@@ -1,6 +1,10 @@
 test_name "Validate facter output conforms to schema" do
   tag 'risk:high'
   confine :except, :platform => 'windows' # See FACT-3479, once resolved this line can be removed
+  confine :except, :platform => 'aix-7.3' # FACT-3481 for fixing these
+  confine :except, :platform => 'ubuntu-22.04' # FACT-3481
+  confine :except, :platform => 'fedora-36' # FACT-3481
+  confine :except, :platform => 'el-8-ppc64le' # FACT-3481
 
   require 'yaml'
   require 'ipaddr'


### PR DESCRIPTION
While we look into cause of the failure on the new test lets skip the few OSes is failing.