### PR TITLE
Add error handling for older lsblk

### DIFF
--- a/lib/facter/resolvers/partitions.rb
+++ b/lib/facter/resolvers/partitions.rb
@@ -123,7 +123,8 @@ module Facter
           return {} unless available?('lsblk', blkid_and_lsblk)
 
           lsblk_version_raw = Facter::Core::Execution.execute('lsblk --version 2>&1', logger: log)
-          lsblk_version = lsblk_version_raw.match(/ \d\.\d+/)[0].to_f
+          # Return if the version of lsblk is too old (< 2.22) to support the --version flag
+          lsblk_version_raw.match?(/ \d\.\d+/) ? lsblk_version = lsblk_version_raw.match(/ \d\.\d+/)[0].to_f : (return {})
 
           # The -p/--paths option was added in lsblk 2.23, return early and fall back to blkid with earlier versions
           return {} if lsblk_version < 2.23


### PR DESCRIPTION
The partitions resolver uses `lsblk --version` to determine the version of lsblk and what features it has available to it. The --version flag was not added until lsblk 2.22 in 2012, so versions prior to that will respond with `lsblk: unrecognized option '--version'`.

Puppet still supports older operating systems like SUSE Enterprise Linux 11 that may ship versions of lsblk that do not support --version.

This commit updates the partitions resolver to handle errors when determining the version of lsblk and to fall back to blkid when lsblk is too old to support --version.