### PR TITLE
rework cache_manager logic about cached facts and groups

### DIFF
--- a/lib/facter/framework/core/cache_manager.rb
+++ b/lib/facter/framework/core/cache_manager.rb
@@ -95,8 +95,9 @@ module Facter
       unless searched_fact.file
         return unless valid_format_version?(searched_fact, data, fact_group)
 
-        delete_cache(fact_group) unless data.keys.grep(/#{searched_fact.name}/).any?
-        # data.fetch(searched_fact.name) { delete_cache(fact_group) }
+        unless data.keys.grep(/#{searched_fact.name}/).any?
+          @log.debug("Fact '#{searched_fact.name}' missing from group '#{fact_group}', skipping cache removal.")
+        end
       end
 
       @log.debug("loading cached values for #{searched_fact.name} facts")


### PR DESCRIPTION
If one fact is missing in group - we don't want to delete whole facts group - only recalculate missing fact if we need. Should fix
https://github.com/puppetlabs/facter/issues/2712