### PR TITLE
Add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -21,8 +21,10 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
           - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
+          - {os: ubuntu-24.04, ruby: '3.3'} # with openssl 3
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.2'} # with openssl 3
+          - {os: windows-2022, ruby: '3.3'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}
     env:
       BUNDLE_SET: 'with integration'

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -22,6 +22,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.2'
+          - '3.3'
           - 'jruby-9.3.14.0'
           - 'jruby-9.4.8.0'
     runs-on: ubuntu-20.04
@@ -43,6 +44,7 @@ jobs:
         ruby:
           - '2.7'
           - '3.2'
+          - '3.3'
     runs-on: windows-2019
     steps:
       - name: Checkout current PR


### PR DESCRIPTION
Ruby 3.3 got released months ago and more and more distributions are picking it up and also building facter against it. So I think it makes sense to add it to the CI.