### PR TITLE
Revert "Merge pull request #2765 from AriaXLi/maint/jruby_ubuntu_inte…

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.10' # last version to support 2.5
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'sys-filesystem', ['>= 1.4.0', '<= 1.5.0']
+  spec.add_development_dependency 'sys-filesystem', '~> 1.4'
   spec.add_development_dependency 'webmock', '~> 3.12'
   spec.add_development_dependency 'yard', '~> 0.9'
 


### PR DESCRIPTION
…gration_failure"

This reverts commit 92a648435888ada9cb907bb173d80734a5494d8b, reversing changes made to bbb2d353a81cb9e209839bf05984e442870ad1a5.

Previously, sys-filesystem 1.5.2 caused some integration check failures, but after the release of [sys-filesystem 1.5.3](https://github.com/djberg96/sys-filesystem/releases/tag/sys-filesystem-1.5.3), these failures went away.