### PR TITLE
Fix: IMDSv2 token cannot be retrieved through a proxy

### DIFF
--- a/lib/facter/util/resolvers/aws_token.rb
+++ b/lib/facter/util/resolvers/aws_token.rb
@@ -23,7 +23,7 @@ module Facter
               'X-aws-ec2-metadata-token-ttl-seconds' => lifetime.to_s
             }
 
-            @token = Facter::Util::Resolvers::Http.put_request(AWS_API_TOKEN_URL, headers)
+            @token = Facter::Util::Resolvers::Http.put_request(AWS_API_TOKEN_URL, headers, {}, false)
           end
 
           def reset


### PR DESCRIPTION
AWS instance metadata V2 requires a token, but if a proxy is used, the token cannot be obtained.