### PR TITLE
Fix `virtual` resolution on Illumos LX

### DIFF
--- a/lib/facter/resolvers/containers.rb
+++ b/lib/facter/resolvers/containers.rb
@@ -51,6 +51,8 @@ module Facter
             vm = 'podman'
           when 'crio'
             vm = 'crio'
+          when 'zone'
+            return nil
           when 'systemd-nspawn'
             vm = 'systemd_nspawn'
             info = { 'id' => Facter::Util::FileHelper.safe_read('/etc/machine-id', nil).strip }

--- a/spec/facter/resolvers/containers_spec.rb
+++ b/spec/facter/resolvers/containers_spec.rb
@@ -92,6 +92,16 @@ describe Facter::Resolvers::Containers do
     end
   end
 
+  context 'when hypervisor is illumos' do
+    let(:cgroup_output) { nil }
+    let(:environ_output) { ['container=zone'] }
+
+    it 'return nil' do
+      expect(containers_resolver.resolve(:vm)).to eq(nil)
+      expect(containers_resolver.resolve(:hypervisor)).to eq(nil)
+    end
+  end
+
   context 'when hypervisor is neighter lxc nor docker' do
     let(:cgroup_output) { load_fixture('cgroup_file').read }
     let(:environ_output) { ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin'] }


### PR DESCRIPTION
On an Illumos LX zone, prior to 7bc38ccb:
```console
# facter virtual
illumos-lx
```

After 7bc38ccb:
```console
# facter virtual
[2024-10-20 18:26:01.740952 ] WARN Facter::Resolvers::Containers - Container runtime, 'zone', is unsupported, setting to, 'container_other'
container_other
```

The problem is that `Facter::Resolvers::Containers` now returns a value, causing `Facter::Util::Facts::Posix::VirtualDetector#platform` to return that value instead of executing `#check_illumos_lx`.

This PR fixes that, and adds a test.

With this PR:
```console
# facter virtual
illumos-lx
```