### PR TITLE
Add JRuby 9.4.8.0 integration tests

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -21,6 +21,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-22.04, ruby: '3.2'} # with openssl 3
           - {os: ubuntu-22.04, ruby: 'jruby-9.3.14.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.4.8.0'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.2'} # with openssl 3
     runs-on: ${{ matrix.cfg.os }}


### PR DESCRIPTION
Facter currently runs integration tests against JRuby 9.3.14.0, which is the version of Ruby that puppetserver 7 uses. However, puppetserver 8 runs on JRuby 9.4.8.0 and Facter does not run integration tests against that version.

This commit adds integration tests on JRuby 9.4.8.0.