### PR TITLE
Remove unnecessary variable initializaiton

### DIFF
--- a/lib/facter/resolvers/solaris/mountpoints.rb
+++ b/lib/facter/resolvers/solaris/mountpoints.rb
@@ -33,7 +33,6 @@ module Facter
 
                 next if fs.mount_type == 'autofs'
 
-                mounts = {}
                 device = fs.name
                 filesystem = fs.mount_type
                 path = fs.mount_point


### PR DESCRIPTION
5abc69f added new rescue behavior for the Solaris mountpoint resovler but, in doing so, also added unnecessary variable initialization. This commit removes declaring the mount variable as an empty hash.