### PR TITLE
make sure facts for windows server 2025 is discovered as 2025

### DIFF
--- a/lib/facter/util/facts/windows_release_finder.rb
+++ b/lib/facter/util/facts/windows_release_finder.rb
@@ -25,10 +25,12 @@ module Facter
           def check_version_10_11(consumerrel, kernel_version)
             build_number = kernel_version[/([^.]*)$/].to_i
 
-            return '11' if build_number >= 22_000
-            return '10' if consumerrel
+            return '11' if consumerrel && build_number >= 22_000
+            return '10' if consumerrel && build_number >= 20_348
 
-            if build_number >= 20_348
+            if build_number >= 26_100
+              '2025'
+            elsif build_number >= 20_348
               '2022'
             elsif build_number >= 17_623
               '2019'

--- a/spec/facter/util/facts/windows_release_finder_spec.rb
+++ b/spec/facter/util/facts/windows_release_finder_spec.rb
@@ -36,6 +36,17 @@ describe Facter::Util::Facts::WindowsReleaseFinder do
     end
   end
 
+  describe '#find windows release when version is 2025' do
+    let(:cons) { false }
+    let(:desc) {}
+    let(:k_version) { '10.0.26100' }
+    let(:version) { '10.0' }
+
+    it 'returns 2025' do
+      expect(Facter::Util::Facts::WindowsReleaseFinder.find_release(input)).to eql('2025')
+    end
+  end
+
   describe '#find windows release when version is 2022' do
     let(:cons) { false }
     let(:desc) {}


### PR DESCRIPTION
Windows Server 2025 was released 2024-11-01 and the current facts discovers 2025-servers as `11` instead of `2025`

This PR makes sure that 2025 server operating systems resolve to 2025 instead of 11

Manually tested on a Windows server 2025 server and Windows 11 client