### PR TITLE
facter: change sys-filesystem to a runtime dep

### DIFF
--- a/facter.gemspec
+++ b/facter.gemspec
@@ -29,23 +29,25 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # While we require both ffi and sys-filesystem in parts of Facter, we specify
-  # them as development, not runtime, dependencies. Both gems either directly
-  # or indirectly contain native extensions. The intent behind excluding these
-  # gems from runtime dependencies is to allow users to be able to install
-  # Facter without a compiler.
-  # ffi 1.16.0 - 1.16.2 are broken on Windows
-  spec.add_development_dependency 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.28' # last version to support 2.5
   spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.10' # last version to support 2.5
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'sys-filesystem', '~> 1.4'
   spec.add_development_dependency 'webmock', '~> 3.12'
   spec.add_development_dependency 'yard', '~> 0.9'
 
+  # ffi 1.16.0 - 1.16.2 are broken on Windows
+  spec.add_runtime_dependency 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2'
   spec.add_runtime_dependency 'hocon', '~> 1.3'
+  # Without sys-filesystem the mountpoints fact returns no data and the
+  # partitions fact reports incorrect data, as it is missing the mount
+  # information for partitions. Though adding sys-filesystem as a runtime
+  # dependency requires gem install invocations to have a C compiler available,
+  # this requirement is preferred to producing a broken gem. Adding as a
+  # runtime dependency also ensures that tools such as gem2deb properly include
+  # sys-filesystem as a dependency.
+  spec.add_runtime_dependency 'sys-filesystem', '~> 1.4'
   spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 1.3'] # Thor 1.3.0 drops support for Ruby 2.5
 end


### PR DESCRIPTION
Prior to this change sys-filesystem was listed as a development dependency, to avoid requiring a C compiler when performing a gem install. However, this produces a version of facter whose mountpoints fact and partitions facts are broken. Re-visit the decision and prefer to produce a fully functional facter version.

This issue was discovered when using facter in Debian, where the lack of a dependency on sys-filesystem produces a package with broken mountpoints and partitions facts.